### PR TITLE
Lore hints for items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Changed: The Slope Jump method in Great Bridge for Abandoned Worksite is now Hard
     and above, from Normal.
     
+-   Added: Luminoth Lore scans now includes hints for where major items are located,
+    as well as what the Temple Guardians bosses drop and vanilla Light Suit.
+    
 -   Added: Option to disable the Sky Temple Key hints or to hide the Area name.    
     
 -   Changed: The location in the Sky Temple Key hint is now colored.

--- a/randovania/games/prime/patcher_file.py
+++ b/randovania/games/prime/patcher_file.py
@@ -16,7 +16,7 @@ from randovania.game_description.resources.resource_database import ResourceData
 from randovania.game_description.resources.resource_info import ResourceGainTuple, ResourceGain
 from randovania.game_description.resources.resource_type import ResourceType
 from randovania.game_description.world_list import WorldList
-from randovania.games.prime.patcher_file_lib import sky_temple_key_hint
+from randovania.games.prime.patcher_file_lib import sky_temple_key_hint, item_hints
 from randovania.interface_common.cosmetic_patches import CosmeticPatches
 from randovania.layout.hint_configuration import HintConfiguration, SkyTempleKeyHintMode
 from randovania.layout.layout_description import LayoutDescription
@@ -344,6 +344,7 @@ def _apply_translator_gate_patches(specific_patches: dict, translator_gates: Tra
 def _create_string_patches(hint_config: HintConfiguration,
                            game: GameDescription,
                            patches: GamePatches,
+                           rng: Random,
                            ) -> list:
     """
 
@@ -353,6 +354,11 @@ def _create_string_patches(hint_config: HintConfiguration,
     :return:
     """
     string_patches = []
+
+    # Location Hints
+    string_patches.extend(
+        item_hints.create_hints(patches, game.world_list, False, rng)
+    )
 
     # Sky Temple Keys
     stk_mode = hint_config.sky_temple_keys
@@ -408,7 +414,7 @@ def create_patcher_file(description: LayoutDescription,
     result["translator_gates"] = _create_translator_gates_field(patches.translator_gates)
 
     # Scan hints
-    result["string_patches"] = _create_string_patches(layout.hints, game, patches)
+    result["string_patches"] = _create_string_patches(layout.hints, game, patches, rng)
 
     # TODO: if we're starting at ship, needs to collect 8 sky temple keys and want item loss,
     # we should disable hive_chamber_b_post_state

--- a/randovania/games/prime/patcher_file_lib/hint_name_creator.py
+++ b/randovania/games/prime/patcher_file_lib/hint_name_creator.py
@@ -1,0 +1,41 @@
+from typing import Dict
+
+from randovania.game_description.node import PickupNode
+from randovania.game_description.resources.pickup_entry import PickupEntry
+from randovania.game_description.resources.pickup_index import PickupIndex
+from randovania.game_description.world_list import WorldList
+
+
+def _color_text_as_red(text: str) -> str:
+    return "&push;&main-color=#784784;{}&pop;".format(text)
+
+
+class HintNameCreator:
+    world_list: WorldList
+    hide_area: bool
+    index_to_node: Dict[PickupIndex, PickupNode]
+
+    def __init__(self, world_list: WorldList, hide_area: bool):
+        self.world_list = world_list
+        self.hide_area = hide_area
+        self.index_to_node = {
+            node.pickup_index: node
+            for node in world_list.all_nodes
+            if isinstance(node, PickupNode)
+        }
+
+    def index_node_name(self, pickup_index: PickupIndex) -> str:
+        return self.node_name(self.index_to_node[pickup_index])
+
+    def node_name(self, pickup_node: PickupNode) -> str:
+        return _color_text_as_red(
+            self.world_list.nodes_to_world(pickup_node).name
+            if self.hide_area else
+            self.world_list.area_name(
+                self.world_list.nodes_to_area(pickup_node),
+                " - "
+            )
+        )
+
+    def item_name(self, pickup: PickupEntry) -> str:
+        return _color_text_as_red(pickup.name)

--- a/randovania/games/prime/patcher_file_lib/hint_name_creator.py
+++ b/randovania/games/prime/patcher_file_lib/hint_name_creator.py
@@ -7,7 +7,7 @@ from randovania.game_description.world_list import WorldList
 
 
 def _color_text_as_red(text: str) -> str:
-    return "&push;&main-color=#784784;{}&pop;".format(text)
+    return "&push;&main-color=#a84343;{}&pop;".format(text)
 
 
 class HintNameCreator:

--- a/randovania/games/prime/patcher_file_lib/hint_name_creator.py
+++ b/randovania/games/prime/patcher_file_lib/hint_name_creator.py
@@ -39,3 +39,10 @@ class HintNameCreator:
 
     def item_name(self, pickup: PickupEntry) -> str:
         return _color_text_as_red(pickup.name)
+
+
+def create_simple_logbook_hint(asset_id: int, hint: str) -> dict:
+    return {
+        "asset_id": asset_id,
+        "strings": [hint, "", hint],
+    }

--- a/randovania/games/prime/patcher_file_lib/item_hints.py
+++ b/randovania/games/prime/patcher_file_lib/item_hints.py
@@ -4,7 +4,7 @@ from typing import Tuple, List
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.game_description.world_list import WorldList
-from randovania.games.prime.patcher_file_lib.hint_name_creator import HintNameCreator
+from randovania.games.prime.patcher_file_lib.hint_name_creator import HintNameCreator, create_simple_logbook_hint
 
 _LORE_SCANS = {
     0x987884FB: "Luminoth Lore translated. (Age of Anxiety)",
@@ -88,10 +88,7 @@ def create_hints(patches: GamePatches,
         hints.append((asset_id, message))
 
     return [
-        {
-            "asset_id": asset_id,
-            "strings": [message, "", message],
-        }
+        create_simple_logbook_hint(asset_id, message)
         for asset_id, message in hints
     ]
 
@@ -104,13 +101,6 @@ def hide_hints() -> list:
     """
 
     return [
-        {
-            "asset_id": asset_id,
-            "strings": [
-                "Some item was placed somewhere.",
-                "",
-                "Some item was placed somewhere."
-            ]
-        }
+        create_simple_logbook_hint(asset_id, "Some item was placed somewhere.")
         for asset_id in _LORE_SCANS.keys()
     ]

--- a/randovania/games/prime/patcher_file_lib/item_hints.py
+++ b/randovania/games/prime/patcher_file_lib/item_hints.py
@@ -74,12 +74,12 @@ def create_hints(patches: GamePatches,
         if index is not None:
             pickup = patches.pickup_assignment.get(index)
             if pickup is not None:
-                message = "The '{pickup}' can be found at '{node}'.".format(
+                message = "A {pickup} can be found at {node}.".format(
                     pickup=hint_name_creator.item_name(pickup),
                     node=hint_name_creator.index_node_name(index),
                 )
             else:
-                message = "'{node}' has nothing.".format(
+                message = "{node} has nothing.".format(
                     node=hint_name_creator.index_node_name(index),
                 )
         else:

--- a/randovania/games/prime/patcher_file_lib/item_hints.py
+++ b/randovania/games/prime/patcher_file_lib/item_hints.py
@@ -1,0 +1,116 @@
+from random import Random
+from typing import Tuple, List
+
+from randovania.game_description.game_patches import GamePatches
+from randovania.game_description.resources.pickup_index import PickupIndex
+from randovania.game_description.world_list import WorldList
+from randovania.games.prime.patcher_file_lib.hint_name_creator import HintNameCreator
+
+_LORE_SCANS = {
+    0x987884FB: "Luminoth Lore translated. (Age of Anxiety)",
+    0x3E0F8F4F: "Luminoth Lore translated. (Agon Falls)",
+    0x5324575E: "Luminoth Lore translated. (Cataclysm)",
+    0xD25C0D22: "Luminoth Lore translated. (Dark Aether)",
+    0x692E362E: "Luminoth Lore translated. (Light of Aether)",
+    0x49CD4F34: "Luminoth Lore translated. (New Weapons)",
+    0xC3576EA5: "Luminoth Lore translated. (Origins)",
+    0x39E3A79D: "Luminoth Lore translated. (Our Heritage)",
+    0x54C87F8C: "Luminoth Lore translated. (Our War Begins)",
+    0x24E69725: "Luminoth Lore translated. (Paradise)",
+    0x9F94AC29: "Luminoth Lore translated. (Recovering Energy)",
+    0x742B0696: "Luminoth Lore translated. (Sanctuary Falls)",
+    0xEFBA4480: "Luminoth Lore translated. (Saving Aether)",
+    0xF5535CEA: "Luminoth Lore translated. (Shattered Hope)",
+    0x0405EE3F: "Luminoth Lore translated. (The Final Crusade)",
+    0x45C31C0B: "Luminoth Lore translated. (The Ing Attack)",
+    0x82919C91: "Luminoth Lore translated. (The New Terror)",
+    0xCF593D9A: "Luminoth Lore translated. (The Sky Temple)",
+    0xA272E58B: "Luminoth Lore translated. (The Stellar Object)",
+    0x8E9FCFAE: "Luminoth Lore translated. (The World Warped)",
+    0xBF77D533: "Luminoth Lore translated. (Torvus Falls)",
+    0xF2BF7438: "Luminoth Lore translated. (Twilight)",
+}
+
+
+def create_hints(patches: GamePatches,
+                 world_list: WorldList,
+                 hide_area: bool,
+                 rng: Random,
+                 ) -> list:
+    """
+    Creates the string patches entries that changes the Lore scans in the game for item pickups
+    :param patches:
+    :param world_list:
+    :param hide_area: Should the hint include only the world?
+    :param rng:
+    :return:
+    """
+
+    hint_name_creator = HintNameCreator(world_list, hide_area)
+    indicies_to_give_a_hint = [
+        PickupIndex(24),  # Light Suit
+        PickupIndex(43),  # Dark Suit
+        PickupIndex(79),  # Dark Visor
+        PickupIndex(115),  # Annihilator Beam
+    ]
+
+    additional_hints_needed = len(_LORE_SCANS) - len(indicies_to_give_a_hint)
+    potential_hints = [
+        index
+        for index, pickup in patches.pickup_assignment.items()
+        if pickup.item_category.is_major_category
+    ]
+    indicies_to_give_a_hint.extend(potential_hints[:additional_hints_needed])
+
+    additional_hints_needed = len(_LORE_SCANS) - len(indicies_to_give_a_hint)
+    if additional_hints_needed > 0:
+        indicies_to_give_a_hint.extend([None] * additional_hints_needed)
+
+    rng.shuffle(indicies_to_give_a_hint)
+
+    hints: List[Tuple[int, str]] = []
+
+    for asset_id, index in zip(_LORE_SCANS.keys(), indicies_to_give_a_hint):
+        if index is not None:
+            pickup = patches.pickup_assignment.get(index)
+            if pickup is not None:
+                message = "The '{pickup}' can be found at '{node}'.".format(
+                    pickup=hint_name_creator.item_name(pickup),
+                    node=hint_name_creator.index_node_name(index),
+                )
+            else:
+                message = "'{node}' has nothing.".format(
+                    node=hint_name_creator.index_node_name(index),
+                )
+        else:
+            message = "Aether lacks equipment."
+
+        hints.append((asset_id, message))
+
+    return [
+        {
+            "asset_id": asset_id,
+            "strings": [message, "", message],
+        }
+        for asset_id, message in hints
+    ]
+
+
+def hide_hints() -> list:
+    """
+    Creates the string patches entries that changes the Lore scans in the game
+    completely useless text.
+    :return:
+    """
+
+    return [
+        {
+            "asset_id": asset_id,
+            "strings": [
+                "Some item was placed somewhere.",
+                "",
+                "Some item was placed somewhere."
+            ]
+        }
+        for asset_id in _LORE_SCANS.keys()
+    ]

--- a/randovania/games/prime/patcher_file_lib/sky_temple_key_hint.py
+++ b/randovania/games/prime/patcher_file_lib/sky_temple_key_hint.py
@@ -1,11 +1,10 @@
 import num2words
 
 from randovania.game_description.game_patches import GamePatches
-from randovania.game_description.node import PickupNode
 from randovania.game_description.resources import resource_info
 from randovania.game_description.world_list import WorldList
 from randovania.games.prime import echoes_items
-from randovania.games.prime.patcher_file_lib.hint_name_creator import HintNameCreator
+from randovania.games.prime.patcher_file_lib.hint_name_creator import HintNameCreator, create_simple_logbook_hint
 
 _SKY_TEMPLE_KEY_SCAN_ASSETS = [
     0xD97685FE,
@@ -79,12 +78,7 @@ def create_hints(patches: GamePatches,
             ))
 
     return [
-        {
-            "asset_id": _SKY_TEMPLE_KEY_SCAN_ASSETS[key_number],
-            "strings": [
-                sky_temple_key_hints[key_index]
-            ]
-        }
+        create_simple_logbook_hint(_SKY_TEMPLE_KEY_SCAN_ASSETS[key_number], sky_temple_key_hints[key_index])
         for key_number, key_index in enumerate(echoes_items.SKY_TEMPLE_KEY_ITEMS)
     ]
 
@@ -97,13 +91,9 @@ def hide_hints() -> list:
     """
 
     return [
-        {
-            "asset_id": _SKY_TEMPLE_KEY_SCAN_ASSETS[key_number],
-            "strings": [
-                "The {} Sky Temple Key is lost somewhere in Aether.".format(
-                    _sky_temple_key_name(key_number + 1),
-                )
-            ]
-        }
+        create_simple_logbook_hint(
+            _SKY_TEMPLE_KEY_SCAN_ASSETS[key_number],
+            "The {} Sky Temple Key is lost somewhere in Aether.".format(_sky_temple_key_name(key_number + 1)),
+        )
         for key_number in range(9)
     ]

--- a/randovania/games/prime/patcher_file_lib/sky_temple_key_hint.py
+++ b/randovania/games/prime/patcher_file_lib/sky_temple_key_hint.py
@@ -5,6 +5,7 @@ from randovania.game_description.node import PickupNode
 from randovania.game_description.resources import resource_info
 from randovania.game_description.world_list import WorldList
 from randovania.games.prime import echoes_items
+from randovania.games.prime.patcher_file_lib.hint_name_creator import HintNameCreator
 
 _SKY_TEMPLE_KEY_SCAN_ASSETS = [
     0xD97685FE,
@@ -23,10 +24,6 @@ def _sky_temple_key_name(key_number: int) -> str:
     return num2words.num2words(key_number, lang='en', to='ordinal_num')
 
 
-def _color_text_as_red(text: str) -> str:
-    return "&push;&main-color=#784784;{}&pop;".format(text)
-
-
 def create_hints(patches: GamePatches,
                  world_list: WorldList,
                  hide_area: bool,
@@ -39,11 +36,7 @@ def create_hints(patches: GamePatches,
     :param hide_area: Should the hint include only the world?
     :return:
     """
-    index_to_node = {
-        node.pickup_index: node
-        for node in world_list.all_nodes
-        if isinstance(node, PickupNode)
-    }
+    hint_name_creator = HintNameCreator(world_list, hide_area)
     sky_temple_key_hints = {}
 
     for pickup_index, pickup in patches.pickup_assignment.items():
@@ -59,18 +52,10 @@ def create_hints(patches: GamePatches,
                 continue
 
             assert resource.index not in sky_temple_key_hints
-            pickup_node = index_to_node[pickup_index]
 
             sky_temple_key_hints[resource.index] = "The {} Sky Temple Key is located in {}".format(
                 _sky_temple_key_name(key_number),
-                _color_text_as_red(
-                    world_list.nodes_to_world(pickup_node).name
-                    if hide_area else
-                    world_list.area_name(
-                        world_list.nodes_to_area(pickup_node),
-                        " - "
-                    )
-                )
+                hint_name_creator.index_node_name(pickup_index),
             )
 
     for starting_resource, quantity in patches.starting_items.items():

--- a/test/games/prime/test_sky_temple_key_hint.py
+++ b/test/games/prime/test_sky_temple_key_hint.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pytest
 
 from randovania.game_description.resources.pickup_index import PickupIndex
@@ -9,10 +11,22 @@ from randovania.resolver.item_pool import pickup_creator
 def _create_hint_text(hide_area: bool,
                       key_text: str,
                       key_location: str,
-                      ) -> str:
+                      ) -> List[str]:
     if hide_area:
         key_location = key_location.split(" - ")[0]
-    return "The {} Sky Temple Key is located in &push;&main-color=#784784;{}&pop;".format(key_text, key_location)
+
+    message = "The {} Sky Temple Key is located in &push;&main-color=#a84343;{}&pop;".format(key_text, key_location)
+    return [message, "", message]
+
+
+def make_starting_stk_hint(key_text: str) -> List[str]:
+    message = "The {} Sky Temple Key has no need to be located.".format(key_text)
+    return [message, "", message]
+
+
+def make_useless_stk_hint(key_text: str) -> List[str]:
+    message = "The {} Sky Temple Key is lost somewhere in Aether.".format(key_text)
+    return [message, "", message]
 
 
 @pytest.mark.parametrize("hide_area", [False, True])
@@ -25,23 +39,23 @@ def test_create_hints_all_placed(hide_area: bool,
     ])
     expected = [
         {"asset_id": 0xD97685FE,
-         "strings": [_create_hint_text(hide_area, "1st", "Temple Grounds - Profane Path")]},
+         "strings": _create_hint_text(hide_area, "1st", "Temple Grounds - Profane Path")},
         {"asset_id": 0x32413EFD,
-         "strings": [_create_hint_text(hide_area, "2nd", "Temple Grounds - Phazon Grounds")]},
+         "strings": _create_hint_text(hide_area, "2nd", "Temple Grounds - Phazon Grounds")},
         {"asset_id": 0xDD8355C3,
-         "strings": [_create_hint_text(hide_area, "3rd", "Temple Grounds - Ing Reliquary")]},
+         "strings": _create_hint_text(hide_area, "3rd", "Temple Grounds - Ing Reliquary")},
         {"asset_id": 0x3F5F4EBA,
-         "strings": [_create_hint_text(hide_area, "4th", "Great Temple - Transport A Access")]},
+         "strings": _create_hint_text(hide_area, "4th", "Great Temple - Transport A Access")},
         {"asset_id": 0xD09D2584,
-         "strings": [_create_hint_text(hide_area, "5th", "Great Temple - Temple Sanctuary")]},
+         "strings": _create_hint_text(hide_area, "5th", "Great Temple - Temple Sanctuary")},
         {"asset_id": 0x3BAA9E87,
-         "strings": [_create_hint_text(hide_area, "6th", "Great Temple - Transport B Access")]},
+         "strings": _create_hint_text(hide_area, "6th", "Great Temple - Transport B Access")},
         {"asset_id": 0xD468F5B9,
-         "strings": [_create_hint_text(hide_area, "7th", "Great Temple - Main Energy Controller")]},
+         "strings": _create_hint_text(hide_area, "7th", "Great Temple - Main Energy Controller")},
         {"asset_id": 0x2563AE34,
-         "strings": [_create_hint_text(hide_area, "8th", "Great Temple - Main Energy Controller")]},
+         "strings": _create_hint_text(hide_area, "8th", "Great Temple - Main Energy Controller")},
         {"asset_id": 0xCAA1C50A,
-         "strings": [_create_hint_text(hide_area, "9th", "Agon Wastes - Mining Plaza")]},
+         "strings": _create_hint_text(hide_area, "9th", "Agon Wastes - Mining Plaza")},
     ]
 
     # Run
@@ -59,25 +73,26 @@ def test_create_hints_all_starting(hide_area: bool,
         echoes_game_description.resource_database.get_item(echoes_items.SKY_TEMPLE_KEY_ITEMS[key]): 1
         for key in range(9)
     })
+
     expected = [
         {"asset_id": 0xD97685FE,
-         "strings": ["The 1st Sky Temple Key has no need to be located."]},
+         "strings": make_starting_stk_hint("1st")},
         {"asset_id": 0x32413EFD,
-         "strings": ["The 2nd Sky Temple Key has no need to be located."]},
+         "strings": make_starting_stk_hint("2nd")},
         {"asset_id": 0xDD8355C3,
-         "strings": ["The 3rd Sky Temple Key has no need to be located."]},
+         "strings": make_starting_stk_hint("3rd")},
         {"asset_id": 0x3F5F4EBA,
-         "strings": ["The 4th Sky Temple Key has no need to be located."]},
+         "strings": make_starting_stk_hint("4th")},
         {"asset_id": 0xD09D2584,
-         "strings": ["The 5th Sky Temple Key has no need to be located."]},
+         "strings": make_starting_stk_hint("5th")},
         {"asset_id": 0x3BAA9E87,
-         "strings": ["The 6th Sky Temple Key has no need to be located."]},
+         "strings": make_starting_stk_hint("6th")},
         {"asset_id": 0xD468F5B9,
-         "strings": ["The 7th Sky Temple Key has no need to be located."]},
+         "strings": make_starting_stk_hint("7th")},
         {"asset_id": 0x2563AE34,
-         "strings": ["The 8th Sky Temple Key has no need to be located."]},
+         "strings": make_starting_stk_hint("8th")},
         {"asset_id": 0xCAA1C50A,
-         "strings": ["The 9th Sky Temple Key has no need to be located."]},
+         "strings": make_starting_stk_hint("9th")},
     ]
 
     # Run
@@ -91,23 +106,23 @@ def test_hide_hints():
     # Setup
     expected = [
         {"asset_id": 0xD97685FE,
-         "strings": ["The 1st Sky Temple Key is lost somewhere in Aether."]},
+         "strings": make_useless_stk_hint("1st")},
         {"asset_id": 0x32413EFD,
-         "strings": ["The 2nd Sky Temple Key is lost somewhere in Aether."]},
+         "strings": make_useless_stk_hint("2nd")},
         {"asset_id": 0xDD8355C3,
-         "strings": ["The 3rd Sky Temple Key is lost somewhere in Aether."]},
+         "strings": make_useless_stk_hint("3rd")},
         {"asset_id": 0x3F5F4EBA,
-         "strings": ["The 4th Sky Temple Key is lost somewhere in Aether."]},
+         "strings": make_useless_stk_hint("4th")},
         {"asset_id": 0xD09D2584,
-         "strings": ["The 5th Sky Temple Key is lost somewhere in Aether."]},
+         "strings": make_useless_stk_hint("5th")},
         {"asset_id": 0x3BAA9E87,
-         "strings": ["The 6th Sky Temple Key is lost somewhere in Aether."]},
+         "strings": make_useless_stk_hint("6th")},
         {"asset_id": 0xD468F5B9,
-         "strings": ["The 7th Sky Temple Key is lost somewhere in Aether."]},
+         "strings": make_useless_stk_hint("7th")},
         {"asset_id": 0x2563AE34,
-         "strings": ["The 8th Sky Temple Key is lost somewhere in Aether."]},
+         "strings": make_useless_stk_hint("8th")},
         {"asset_id": 0xCAA1C50A,
-         "strings": ["The 9th Sky Temple Key is lost somewhere in Aether."]},
+         "strings": make_useless_stk_hint("9th")},
     ]
 
     # Run


### PR DESCRIPTION
Implements #46 

Not implemented: GUI to disable and control how precise.
Extra future features:
- Randomly include "joke hints".
- Multiple hints for certain things.
- Including hints for only a portion of the items
- Option for how precise
- Option to disable
- Use Luminoth Warrior's body scan for what is included in the matching Ing Cache.
- Include Pirate Lore scans in the pool, but make then more likely for joke hints.
- Different tiers of precise hints: "Screw Attack"/"movement system"/"major item".
