### PR TITLE
Correct some roll jump and underwater dash requirements

### DIFF
--- a/randovania/data/json_data/prime2.json
+++ b/randovania/data/json_data/prime2.json
@@ -46863,45 +46863,7 @@
                                         },
                                         {
                                             "requirement_type": 1,
-                                            "requirement_index": 29,
-                                            "amount": 1,
-                                            "negate": false
-                                        },
-                                        {
-                                            "requirement_type": 1,
                                             "requirement_index": 31,
-                                            "amount": 1,
-                                            "negate": false
-                                        },
-                                        {
-                                            "requirement_type": 6,
-                                            "requirement_index": 0,
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    ],
-                                    [
-                                        {
-                                            "requirement_type": 0,
-                                            "requirement_index": 15,
-                                            "amount": 1,
-                                            "negate": false
-                                        },
-                                        {
-                                            "requirement_type": 0,
-                                            "requirement_index": 18,
-                                            "amount": 1,
-                                            "negate": false
-                                        },
-                                        {
-                                            "requirement_type": 1,
-                                            "requirement_index": 31,
-                                            "amount": 1,
-                                            "negate": false
-                                        },
-                                        {
-                                            "requirement_type": 2,
-                                            "requirement_index": 6,
                                             "amount": 1,
                                             "negate": false
                                         },
@@ -47083,45 +47045,7 @@
                                         },
                                         {
                                             "requirement_type": 1,
-                                            "requirement_index": 29,
-                                            "amount": 1,
-                                            "negate": false
-                                        },
-                                        {
-                                            "requirement_type": 1,
                                             "requirement_index": 30,
-                                            "amount": 1,
-                                            "negate": false
-                                        },
-                                        {
-                                            "requirement_type": 6,
-                                            "requirement_index": 0,
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    ],
-                                    [
-                                        {
-                                            "requirement_type": 0,
-                                            "requirement_index": 15,
-                                            "amount": 1,
-                                            "negate": false
-                                        },
-                                        {
-                                            "requirement_type": 0,
-                                            "requirement_index": 18,
-                                            "amount": 1,
-                                            "negate": false
-                                        },
-                                        {
-                                            "requirement_type": 1,
-                                            "requirement_index": 30,
-                                            "amount": 1,
-                                            "negate": false
-                                        },
-                                        {
-                                            "requirement_type": 2,
-                                            "requirement_index": 6,
                                             "amount": 1,
                                             "negate": false
                                         },

--- a/randovania/data/json_data/prime2.json
+++ b/randovania/data/json_data/prime2.json
@@ -50686,20 +50686,26 @@
                                         },
                                         {
                                             "requirement_type": 0,
-                                            "requirement_index": 27,
+                                            "requirement_index": 24,
                                             "amount": 1,
                                             "negate": false
                                         },
                                         {
                                             "requirement_type": 2,
                                             "requirement_index": 5,
-                                            "amount": 1,
+                                            "amount": 3,
                                             "negate": false
                                         },
                                         {
                                             "requirement_type": 3,
                                             "requirement_index": 2,
                                             "amount": 30,
+                                            "negate": false
+                                        },
+                                        {
+                                            "requirement_type": 6,
+                                            "requirement_index": 0,
+                                            "amount": 3,
                                             "negate": false
                                         }
                                     ],
@@ -50803,20 +50809,26 @@
                                         },
                                         {
                                             "requirement_type": 0,
-                                            "requirement_index": 27,
+                                            "requirement_index": 24,
                                             "amount": 1,
                                             "negate": false
                                         },
                                         {
                                             "requirement_type": 2,
                                             "requirement_index": 5,
-                                            "amount": 1,
+                                            "amount": 3,
                                             "negate": false
                                         },
                                         {
                                             "requirement_type": 3,
                                             "requirement_index": 2,
                                             "amount": 30,
+                                            "negate": false
+                                        },
+                                        {
+                                            "requirement_type": 6,
+                                            "requirement_index": 0,
+                                            "amount": 3,
                                             "negate": false
                                         }
                                     ],


### PR DESCRIPTION
This fixes Trivial showing up as an option for roll jumps and underwater dashes in the trick difficulty sliders.