### PR TITLE
Improved item category names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Changed: Some item categories were given clearer names:
     - Dark Agon Keys, Dark Torvus Keys, and Ing Hive Keys are now referred to as "red Temple Keys" instead of
     "Temple Keys".
+    - Items that aren't keys or expansions are collectively referred to as "major upgades" instead of "major items".
 
 ## [0.28.1] - 2019-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Added: In the data visualizer, the damage requirements now have more descriptive names.
 
+-   Changed: Some item categories were given clearer names:
+    - Dark Agon Keys, Dark Torvus Keys, and Ing Hive Keys are now referred to as "red Temple Keys" instead of
+    "Temple Keys".
+
 ## [0.28.1] - 2019-06-14
 
 -   Fixed: Resetting settings would leave the launchers' configuration in an invalid state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Dark Agon Keys, Dark Torvus Keys, and Ing Hive Keys are now referred to as "red Temple Keys" instead of
     "Temple Keys".
     - Items that aren't keys or expansions are collectively referred to as "major upgades" instead of "major items".
+    - Red Temple Keys and Sky Temple Keys are now collectively referred to as "Dark Temple Keys" instead of "keys".
 
 -   Fixed: "Beam combos" are now called "Charge Combos".
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     "Temple Keys".
     - Items that aren't keys or expansions are collectively referred to as "major upgades" instead of "major items".
 
+-   Fixed: "Beam combos" are now called "Charge Combos".
+
 ## [0.28.1] - 2019-06-14
 
 -   Fixed: Resetting settings would leave the launchers' configuration in an invalid state.

--- a/randovania/data/item_database/configuration/major-items.json
+++ b/randovania/data/item_database/configuration/major-items.json
@@ -197,28 +197,28 @@
 
 
     "Super Missile": {
-        "item_category": "beam_combo",
+        "item_category": "charge_combo",
         "model_index": 5,
         "progression": [4],
         "original_index": 74,
         "probability_offset": 0
     },
     "Sunburst": {
-        "item_category": "beam_combo",
+        "item_category": "charge_combo",
         "model_index": 7,
         "progression": [6],
         "original_index": 7,
         "probability_offset": 0
     },
     "Darkburst": {
-        "item_category": "beam_combo",
+        "item_category": "charge_combo",
         "model_index": 6,
         "progression": [5],
         "original_index": 27,
         "probability_offset": 0
     },
     "Sonic Boom": {
-        "item_category": "beam_combo",
+        "item_category": "charge_combo",
         "model_index": 8,
         "progression": [7],
         "original_index": 59,

--- a/randovania/game_description/item/item_category.py
+++ b/randovania/game_description/item/item_category.py
@@ -11,7 +11,7 @@ class ItemCategory(BitPackEnum, Enum):
     MORPH_BALL = "morph_ball"
     MOVEMENT = "movement"
     MISSILE = "missile"
-    BEAM_COMBO = "beam_combo"
+    CHARGE_COMBO = "charge_combo"
     TRANSLATOR = "translator"
     ENERGY_TANK = "energy_tank"
     TEMPLE_KEY = "temple_key"
@@ -43,7 +43,7 @@ MAJOR_ITEM_CATEGORIES = {
     ItemCategory.MORPH_BALL,
     ItemCategory.MOVEMENT,
     ItemCategory.MISSILE,
-    ItemCategory.BEAM_COMBO,
+    ItemCategory.CHARGE_COMBO,
     ItemCategory.TRANSLATOR,
 }
 
@@ -58,7 +58,7 @@ LONG_NAMES = {
     ItemCategory.MORPH_BALL: "Morph Ball",
     ItemCategory.MOVEMENT: "Movement",
     ItemCategory.MISSILE: "Missile",
-    ItemCategory.BEAM_COMBO: "Beam Combos",
+    ItemCategory.CHARGE_COMBO: "Charge Combos",
     ItemCategory.TRANSLATOR: "Translators",
     ItemCategory.ENERGY_TANK: "Energy Tanks",
     ItemCategory.TEMPLE_KEY: "Temple Keys",
@@ -74,7 +74,7 @@ HINT_DETAILS: Dict[ItemCategory, Tuple[str, str]] = {
     ItemCategory.MORPH_BALL: ("A ", "morph ball system"),
     ItemCategory.MOVEMENT: ("A ", "movement system"),
     ItemCategory.MISSILE: ("A ", "missile system"),
-    ItemCategory.BEAM_COMBO: ("A ", "beam combo"),
+    ItemCategory.CHARGE_COMBO: ("A ", "Charge Combo"),
     ItemCategory.TRANSLATOR: ("A ", "translator"),
     ItemCategory.ENERGY_TANK: ("An ", "Energy Tank"),
     ItemCategory.TEMPLE_KEY: ("A ", "red Temple Key"),

--- a/randovania/game_description/item/item_category.py
+++ b/randovania/game_description/item/item_category.py
@@ -77,7 +77,7 @@ HINT_DETAILS: Dict[ItemCategory, Tuple[str, str]] = {
     ItemCategory.BEAM_COMBO: ("A ", "beam combo"),
     ItemCategory.TRANSLATOR: ("A ", "translator"),
     ItemCategory.ENERGY_TANK: ("An ", "Energy Tank"),
-    ItemCategory.TEMPLE_KEY: ("A ", "Temple Key"),
+    ItemCategory.TEMPLE_KEY: ("A ", "red Temple Key"),
     ItemCategory.SKY_TEMPLE_KEY: ("A ", "Sky Temple Key"),
     ItemCategory.ETM: ("An ", "Energy Transfer Module"),
     ItemCategory.EXPANSION: ("An ", "expansion"),

--- a/randovania/games/prime/patcher_file_lib/item_hints.py
+++ b/randovania/games/prime/patcher_file_lib/item_hints.py
@@ -169,7 +169,7 @@ def _calculate_pickup_hint(precision: HintItemPrecision,
 
     elif precision == HintItemPrecision.GENERAL_CATEGORY:
         if pickup.item_category.is_major_category:
-            return False, "A ", "major item"
+            return False, "A ", "major upgrade"
         elif pickup.item_category.is_key:
             return False, "A ", "key"
         else:

--- a/randovania/games/prime/patcher_file_lib/item_hints.py
+++ b/randovania/games/prime/patcher_file_lib/item_hints.py
@@ -171,7 +171,7 @@ def _calculate_pickup_hint(precision: HintItemPrecision,
         if pickup.item_category.is_major_category:
             return False, "A ", "major upgrade"
         elif pickup.item_category.is_key:
-            return False, "A ", "key"
+            return False, "A ", "Dark Temple Key"
         else:
             return False, "An ", "expansion"
 

--- a/test/games/prime/patcher_file_lib/test_item_hints.py
+++ b/test/games/prime/patcher_file_lib/test_item_hints.py
@@ -69,7 +69,7 @@ def test_create_hints_nothing(empty_patches):
 @pytest.mark.parametrize("item", [
     (HintItemPrecision.DETAILED, "The &push;&main-color=#a84343;Pickup&pop;"),
     (HintItemPrecision.PRECISE_CATEGORY, "A &push;&main-color=#a84343;movement system&pop;"),
-    (HintItemPrecision.GENERAL_CATEGORY, "A &push;&main-color=#a84343;major item&pop;"),
+    (HintItemPrecision.GENERAL_CATEGORY, "A &push;&main-color=#a84343;major upgrade&pop;"),
     (HintItemPrecision.WRONG_GAME, "The &push;&main-color=#45f731;X-Ray Visor (?)&pop;"),
 ])
 @pytest.mark.parametrize("location", [


### PR DESCRIPTION
Changes made:
- "Major item" → "Major upgrade" (to hopefully this prevents confusion when using major/minor randomization)
- "Temple Key" → "red Temple Key" (to clarify that Sky Temple Keys are excluded)
- "beam combo" → "Charge Combo" (to match what they're called in-game)
- "key" → "Dark Temple Key" (to match what they're called in-game)