### PR TITLE
Use cardinal numbers in STK hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Changed: Item scans were slightly edited.
 
+-   Changed: The Sky Temple Key hints no longer use ordinal numbers.
+
 ## [0.28.1] - 2019-06-14
 
 -   Fixed: Resetting settings would leave the launchers' configuration in an invalid state.

--- a/randovania/games/prime/patcher_file_lib/sky_temple_key_hint.py
+++ b/randovania/games/prime/patcher_file_lib/sky_temple_key_hint.py
@@ -1,5 +1,3 @@
-import num2words
-
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources import resource_info
 from randovania.game_description.world_list import WorldList
@@ -21,7 +19,7 @@ _SKY_TEMPLE_KEY_SCAN_ASSETS = [
 
 
 def _sky_temple_key_name(key_number: int) -> str:
-    return num2words.num2words(key_number, lang='en', to='ordinal_num')
+    return color_text(TextColor.ITEM, f"Sky Temple Key {key_number}")
 
 
 def create_hints(patches: GamePatches,
@@ -53,7 +51,7 @@ def create_hints(patches: GamePatches,
 
             assert resource.index not in sky_temple_key_hints
 
-            sky_temple_key_hints[resource.index] = "The {} Sky Temple Key is located in {}.".format(
+            sky_temple_key_hints[resource.index] = "{} is located in {}.".format(
                 _sky_temple_key_name(key_number),
                 color_text(TextColor.LOCATION,
                     location_hint_creator.index_node_name(pickup_index, hide_area),
@@ -69,7 +67,7 @@ def create_hints(patches: GamePatches,
             continue
 
         assert starting_resource.index not in sky_temple_key_hints
-        sky_temple_key_hints[starting_resource.index] = "The {} Sky Temple Key has no need to be located.".format(
+        sky_temple_key_hints[starting_resource.index] = "{} has no need to be located.".format(
             _sky_temple_key_name(key_number),
         )
 
@@ -96,7 +94,7 @@ def hide_hints() -> list:
     return [
         create_simple_logbook_hint(
             _SKY_TEMPLE_KEY_SCAN_ASSETS[key_number],
-            "The {} Sky Temple Key is lost somewhere in Aether.".format(_sky_temple_key_name(key_number + 1)),
+            "{} is lost somewhere in Aether.".format(_sky_temple_key_name(key_number + 1)),
         )
         for key_number in range(9)
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ appdirs==1.4.3
 asyncqt==0.7.0
 requests==2.22.0
 networkx==2.3
-num2words==0.5.10
 bitstruct==7.1.0
 construct==2.9.45
 nod==1.1.1

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         'nod>=1.1',
         'requests',
         'networkx',
-        'num2words',
         'bitstruct',
         'construct',
         'tenacity',

--- a/test/games/prime/patcher_file_lib/test_sky_temple_key_hint.py
+++ b/test/games/prime/patcher_file_lib/test_sky_temple_key_hint.py
@@ -9,23 +9,23 @@ from randovania.generator.item_pool import pickup_creator
 
 
 def _create_hint_text(hide_area: bool,
-                      key_text: str,
+                      key_number: int,
                       key_location: str,
                       ) -> List[str]:
     if hide_area:
         key_location = key_location.split(" - ")[0]
 
-    message = "The {} Sky Temple Key is located in &push;&main-color=#FF3333;{}&pop;.".format(key_text, key_location)
+    message = f"&push;&main-color=#FF6705B3;Sky Temple Key {key_number}&pop; is located in &push;&main-color=#FF3333;{key_location}&pop;."
     return [message, "", message]
 
 
-def make_starting_stk_hint(key_text: str) -> List[str]:
-    message = "The {} Sky Temple Key has no need to be located.".format(key_text)
+def make_starting_stk_hint(key_number: int) -> List[str]:
+    message = f"&push;&main-color=#FF6705B3;Sky Temple Key {key_number}&pop; has no need to be located."
     return [message, "", message]
 
 
-def make_useless_stk_hint(key_text: str) -> List[str]:
-    message = "The {} Sky Temple Key is lost somewhere in Aether.".format(key_text)
+def make_useless_stk_hint(key_number: int) -> List[str]:
+    message = f"&push;&main-color=#FF6705B3;Sky Temple Key {key_number}&pop; is lost somewhere in Aether."
     return [message, "", message]
 
 
@@ -39,23 +39,23 @@ def test_create_hints_all_placed(hide_area: bool,
     ])
     expected = [
         {"asset_id": 0xD97685FE,
-         "strings": _create_hint_text(hide_area, "1st", "Sky Temple Grounds - Profane Path")},
+         "strings": _create_hint_text(hide_area, 1, "Sky Temple Grounds - Profane Path")},
         {"asset_id": 0x32413EFD,
-         "strings": _create_hint_text(hide_area, "2nd", "Sky Temple Grounds - Phazon Grounds")},
+         "strings": _create_hint_text(hide_area, 2, "Sky Temple Grounds - Phazon Grounds")},
         {"asset_id": 0xDD8355C3,
-         "strings": _create_hint_text(hide_area, "3rd", "Sky Temple Grounds - Ing Reliquary")},
+         "strings": _create_hint_text(hide_area, 3, "Sky Temple Grounds - Ing Reliquary")},
         {"asset_id": 0x3F5F4EBA,
-         "strings": _create_hint_text(hide_area, "4th", "Great Temple - Transport A Access")},
+         "strings": _create_hint_text(hide_area, 4, "Great Temple - Transport A Access")},
         {"asset_id": 0xD09D2584,
-         "strings": _create_hint_text(hide_area, "5th", "Great Temple - Temple Sanctuary")},
+         "strings": _create_hint_text(hide_area, 5, "Great Temple - Temple Sanctuary")},
         {"asset_id": 0x3BAA9E87,
-         "strings": _create_hint_text(hide_area, "6th", "Great Temple - Transport B Access")},
+         "strings": _create_hint_text(hide_area, 6, "Great Temple - Transport B Access")},
         {"asset_id": 0xD468F5B9,
-         "strings": _create_hint_text(hide_area, "7th", "Great Temple - Main Energy Controller")},
+         "strings": _create_hint_text(hide_area, 7, "Great Temple - Main Energy Controller")},
         {"asset_id": 0x2563AE34,
-         "strings": _create_hint_text(hide_area, "8th", "Great Temple - Main Energy Controller")},
+         "strings": _create_hint_text(hide_area, 8, "Great Temple - Main Energy Controller")},
         {"asset_id": 0xCAA1C50A,
-         "strings": _create_hint_text(hide_area, "9th", "Agon Wastes - Mining Plaza")},
+         "strings": _create_hint_text(hide_area, 9, "Agon Wastes - Mining Plaza")},
     ]
 
     # Run
@@ -76,23 +76,23 @@ def test_create_hints_all_starting(hide_area: bool,
 
     expected = [
         {"asset_id": 0xD97685FE,
-         "strings": make_starting_stk_hint("1st")},
+         "strings": make_starting_stk_hint(1)},
         {"asset_id": 0x32413EFD,
-         "strings": make_starting_stk_hint("2nd")},
+         "strings": make_starting_stk_hint(2)},
         {"asset_id": 0xDD8355C3,
-         "strings": make_starting_stk_hint("3rd")},
+         "strings": make_starting_stk_hint(3)},
         {"asset_id": 0x3F5F4EBA,
-         "strings": make_starting_stk_hint("4th")},
+         "strings": make_starting_stk_hint(4)},
         {"asset_id": 0xD09D2584,
-         "strings": make_starting_stk_hint("5th")},
+         "strings": make_starting_stk_hint(5)},
         {"asset_id": 0x3BAA9E87,
-         "strings": make_starting_stk_hint("6th")},
+         "strings": make_starting_stk_hint(6)},
         {"asset_id": 0xD468F5B9,
-         "strings": make_starting_stk_hint("7th")},
+         "strings": make_starting_stk_hint(7)},
         {"asset_id": 0x2563AE34,
-         "strings": make_starting_stk_hint("8th")},
+         "strings": make_starting_stk_hint(8)},
         {"asset_id": 0xCAA1C50A,
-         "strings": make_starting_stk_hint("9th")},
+         "strings": make_starting_stk_hint(9)},
     ]
 
     # Run
@@ -106,23 +106,23 @@ def test_hide_hints():
     # Setup
     expected = [
         {"asset_id": 0xD97685FE,
-         "strings": make_useless_stk_hint("1st")},
+         "strings": make_useless_stk_hint(1)},
         {"asset_id": 0x32413EFD,
-         "strings": make_useless_stk_hint("2nd")},
+         "strings": make_useless_stk_hint(2)},
         {"asset_id": 0xDD8355C3,
-         "strings": make_useless_stk_hint("3rd")},
+         "strings": make_useless_stk_hint(3)},
         {"asset_id": 0x3F5F4EBA,
-         "strings": make_useless_stk_hint("4th")},
+         "strings": make_useless_stk_hint(4)},
         {"asset_id": 0xD09D2584,
-         "strings": make_useless_stk_hint("5th")},
+         "strings": make_useless_stk_hint(5)},
         {"asset_id": 0x3BAA9E87,
-         "strings": make_useless_stk_hint("6th")},
+         "strings": make_useless_stk_hint(6)},
         {"asset_id": 0xD468F5B9,
-         "strings": make_useless_stk_hint("7th")},
+         "strings": make_useless_stk_hint(7)},
         {"asset_id": 0x2563AE34,
-         "strings": make_useless_stk_hint("8th")},
+         "strings": make_useless_stk_hint(8)},
         {"asset_id": 0xCAA1C50A,
-         "strings": make_useless_stk_hint("9th")},
+         "strings": make_useless_stk_hint(9)},
     ]
 
     # Run


### PR DESCRIPTION
Cardinals are used everywhere else, so this makes the STK names 100% consistent.

In addition, the `num2words` dependency is no longer needed.