### PR TITLE
Add missing default node indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Changed: Joke hints are now used at most once each when placing hints.
 
+-   Fixed: Added proper default nodes for rooms that were missing one, allowing those rooms to be selected as the
+    starting room.
+
 
 ## [0.28.1] - 2019-06-14
 

--- a/randovania/data/json_data/prime2.json
+++ b/randovania/data/json_data/prime2.json
@@ -4614,7 +4614,7 @@
                     "name": "War Ritual Grounds",
                     "in_dark_aether": true,
                     "asset_id": 2859985581,
-                    "default_node_index": 255,
+                    "default_node_index": 0,
                     "nodes": [
                         {
                             "name": "Door to Shrine Access",
@@ -7918,7 +7918,7 @@
                     "name": "GFMC Compound",
                     "in_dark_aether": false,
                     "asset_id": 1467316949,
-                    "default_node_index": 255,
+                    "default_node_index": 2,
                     "nodes": [
                         {
                             "name": "Door to Windchamber Tunnel",
@@ -8922,7 +8922,7 @@
                     "name": "Sacred Path",
                     "in_dark_aether": false,
                     "asset_id": 3258777533,
-                    "default_node_index": 255,
+                    "default_node_index": 1,
                     "nodes": [
                         {
                             "name": "Portal to Profane Path",
@@ -19298,7 +19298,7 @@
                     "name": "Warrior's Walk",
                     "in_dark_aether": true,
                     "asset_id": 872074261,
-                    "default_node_index": 255,
+                    "default_node_index": 0,
                     "nodes": [
                         {
                             "name": "Door to Judgment Pit",
@@ -23648,7 +23648,7 @@
                     "name": "Security Station B",
                     "in_dark_aether": false,
                     "asset_id": 182082287,
-                    "default_node_index": 255,
+                    "default_node_index": 2,
                     "nodes": [
                         {
                             "name": "Door to Command Center (Second)",
@@ -36336,7 +36336,7 @@
                     "name": "Polluted Mire",
                     "in_dark_aether": true,
                     "asset_id": 2208154870,
-                    "default_node_index": 255,
+                    "default_node_index": 1,
                     "nodes": [
                         {
                             "name": "Door to Dark Falls",
@@ -44894,7 +44894,7 @@
                     "name": "Fortress Transport Access",
                     "in_dark_aether": false,
                     "asset_id": 1662585441,
-                    "default_node_index": 255,
+                    "default_node_index": 0,
                     "nodes": [
                         {
                             "name": "Door to Training Chamber",
@@ -45694,7 +45694,7 @@
                     "name": "Temple Transport Access",
                     "in_dark_aether": false,
                     "asset_id": 1650075282,
-                    "default_node_index": 255,
+                    "default_node_index": 0,
                     "nodes": [
                         {
                             "name": "Door to Transport to Temple Grounds",
@@ -45776,7 +45776,7 @@
                     "name": "Sanctuary Entrance",
                     "in_dark_aether": false,
                     "asset_id": 1193696267,
-                    "default_node_index": 255,
+                    "default_node_index": 1,
                     "nodes": [
                         {
                             "name": "Door to Power Junction",
@@ -47193,7 +47193,7 @@
                     "name": "Transit Station",
                     "in_dark_aether": false,
                     "asset_id": 4148317891,
-                    "default_node_index": 255,
+                    "default_node_index": 0,
                     "nodes": [
                         {
                             "name": "Door to Reactor Core",


### PR DESCRIPTION
Fixes #315. The affected rooms are:
- War Ritual Grounds
- GFMC Compound
- Sacred Path
- Warrior's Walk
- Security Station B
- Polluted Mire
- Fortress Transport Access (Torvus)
- Temple Transport Access (Sanctuary)
- Sanctuary Entrance
- Transit Station (Sanctuary)