### PR TITLE
Rework Sandcanyon requirements

### DIFF
--- a/randovania/data/json_data/prime2.json
+++ b/randovania/data/json_data/prime2.json
@@ -19511,7 +19511,8 @@
                         {
                             "name": "Event - Sandcanyon Denzium",
                             "heal": true,
-                            "node_type": 0,
+                            "node_type": 4,
+                            "event_index": 94,
                             "connections": {
                                 "Center Platform": [
                                     []

--- a/randovania/data/json_data/prime2.json
+++ b/randovania/data/json_data/prime2.json
@@ -19284,13 +19284,26 @@
                             "dock_weakness_index": 0,
                             "connections": {
                                 "Door to Agon Temple": [
-                                    []
-                                ],
-                                "Pickup (Power Bomb)": [
                                     [
                                         {
                                             "requirement_type": 0,
                                             "requirement_index": 15,
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    ]
+                                ],
+                                "Center Platform": [
+                                    [
+                                        {
+                                            "requirement_type": 0,
+                                            "requirement_index": 15,
+                                            "amount": 1,
+                                            "negate": false
+                                        },
+                                        {
+                                            "requirement_type": 0,
+                                            "requirement_index": 16,
                                             "amount": 1,
                                             "negate": false
                                         },
@@ -19301,14 +19314,28 @@
                                             "negate": false
                                         },
                                         {
+                                            "requirement_type": 2,
+                                            "requirement_index": 5,
+                                            "amount": 4,
+                                            "negate": false
+                                        },
+                                        {
+                                            "requirement_type": 6,
+                                            "requirement_index": 0,
+                                            "amount": 4,
+                                            "negate": false
+                                        }
+                                    ],
+                                    [
+                                        {
                                             "requirement_type": 0,
-                                            "requirement_index": 27,
+                                            "requirement_index": 24,
                                             "amount": 1,
                                             "negate": false
                                         },
                                         {
                                             "requirement_type": 0,
-                                            "requirement_index": 43,
+                                            "requirement_index": 27,
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -19327,16 +19354,17 @@
                             "dock_weakness_index": 2,
                             "connections": {
                                 "Door to Ventilation Area A": [
-                                    []
-                                ],
-                                "Pickup (Power Bomb)": [
                                     [
                                         {
                                             "requirement_type": 0,
                                             "requirement_index": 15,
                                             "amount": 1,
                                             "negate": false
-                                        },
+                                        }
+                                    ]
+                                ],
+                                "Center Platform": [
+                                    [
                                         {
                                             "requirement_type": 0,
                                             "requirement_index": 24,
@@ -19346,12 +19374,6 @@
                                         {
                                             "requirement_type": 0,
                                             "requirement_index": 27,
-                                            "amount": 1,
-                                            "negate": false
-                                        },
-                                        {
-                                            "requirement_type": 0,
-                                            "requirement_index": 43,
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -19366,7 +19388,83 @@
                             "pickup_index": 42,
                             "major_location": false,
                             "connections": {
+                                "Center Platform": [
+                                    []
+                                ]
+                            }
+                        },
+                        {
+                            "name": "Center Platform",
+                            "heal": true,
+                            "node_type": 0,
+                            "connections": {
                                 "Door to Ventilation Area A": [
+                                    [
+                                        {
+                                            "requirement_type": 0,
+                                            "requirement_index": 24,
+                                            "amount": 1,
+                                            "negate": false
+                                        },
+                                        {
+                                            "requirement_type": 0,
+                                            "requirement_index": 27,
+                                            "amount": 1,
+                                            "negate": false
+                                        },
+                                        {
+                                            "requirement_type": 3,
+                                            "requirement_index": 1,
+                                            "amount": 10,
+                                            "negate": false
+                                        },
+                                        {
+                                            "requirement_type": 6,
+                                            "requirement_index": 0,
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    ]
+                                ],
+                                "Door to Agon Temple": [
+                                    [
+                                        {
+                                            "requirement_type": 0,
+                                            "requirement_index": 15,
+                                            "amount": 1,
+                                            "negate": false
+                                        },
+                                        {
+                                            "requirement_type": 0,
+                                            "requirement_index": 16,
+                                            "amount": 1,
+                                            "negate": false
+                                        },
+                                        {
+                                            "requirement_type": 0,
+                                            "requirement_index": 24,
+                                            "amount": 1,
+                                            "negate": false
+                                        },
+                                        {
+                                            "requirement_type": 1,
+                                            "requirement_index": 94,
+                                            "amount": 1,
+                                            "negate": true
+                                        },
+                                        {
+                                            "requirement_type": 2,
+                                            "requirement_index": 5,
+                                            "amount": 4,
+                                            "negate": false
+                                        },
+                                        {
+                                            "requirement_type": 6,
+                                            "requirement_index": 0,
+                                            "amount": 4,
+                                            "negate": false
+                                        }
+                                    ],
                                     [
                                         {
                                             "requirement_type": 0,
@@ -19382,21 +19480,41 @@
                                         }
                                     ]
                                 ],
-                                "Door to Agon Temple": [
+                                "Pickup (Power Bomb)": [
+                                    [
+                                        {
+                                            "requirement_type": 1,
+                                            "requirement_index": 94,
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    ]
+                                ],
+                                "Event - Sandcanyon Denzium": [
                                     [
                                         {
                                             "requirement_type": 0,
-                                            "requirement_index": 24,
+                                            "requirement_index": 15,
                                             "amount": 1,
                                             "negate": false
                                         },
                                         {
                                             "requirement_type": 0,
-                                            "requirement_index": 27,
+                                            "requirement_index": 43,
                                             "amount": 1,
                                             "negate": false
                                         }
                                     ]
+                                ]
+                            }
+                        },
+                        {
+                            "name": "Event - Sandcanyon Denzium",
+                            "heal": true,
+                            "node_type": 0,
+                            "connections": {
+                                "Center Platform": [
+                                    []
                                 ]
                             }
                         }

--- a/randovania/data/json_data/prime2.json
+++ b/randovania/data/json_data/prime2.json
@@ -774,6 +774,11 @@
                 "index": 93,
                 "long_name": "Dark Samus 3 and 4",
                 "short_name": "Event93"
+            },
+            {
+                "index": 94,
+                "long_name": "Sandcanyon Denzium",
+                "short_name": "Event94"
             }
         ],
         "tricks": [


### PR DESCRIPTION
Adds missing morph ball requirements to crossing Sandcanyon. Also adds the "boost boost" trick to get the Sandcanyon item without Screw Attack.