### PR TITLE
Many Logic Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Added: In Torvus Plaza, method of getting the item without Boost Ball and/or Spider Ball (Normal and above).
 
--   Added: In Controller Access (Agon, Torvus, Sanctuary), method of reaching the Energy Controller and returning without Bombs (Hypermode).
+-   Added: In all Light/Dark Controller Access rooms (Agon, Torvus, Sanctuary), method of reaching the Energy Controllers and returning to the Temples without Bombs (Hypermode).
 
 -   Added: In Putrid Alcove, damage requirements have been added for getting the item and leaving, with just Space Jump and just Bombs.
+
+-	Added: In Torvus Grove, method of climbing the room without Boost Ball (Hard and above).
+
+-	Added: Method to open Seeker Missile Locks with Screw Attack in various rooms (Phazon Grounds, Shrine Access, Plain of Dark Worship, Poisoned Bog) (Hard and above).
+
+-	Added: Method to open most Bomb Slots without Bombs (Hypermode).
+
+-	Added: Methods to climb Main Hydrochamber and Hydrodynamo Station without Gravity Boost and with Air Underwater (Normal and above), Space Jump, and Screw Attack (Hypermode).
+
+-	Added: Method to climb Transport Center with Space Jump and Slope Jump (Normal and above).
+
+-	Added: Method to climb Doomed Entry with Space Jump and Screw Attack (Trival and above).
+
+-	Added: Method of fighting Quadraxis with Power Bombs instead of Bombs (Trivial and above).
+
+-	Added: Method of leaving Hive Temple without Spider Ball (Hypermode).
 
 ## [1.2.2] - 2020-06-06
 
@@ -67,7 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Changed: The logbook entries that contains hints are now named after the room they're in, with the categories
     being about which kind of hint they are.
-    KNOW ISSUE: While scanning something, the categories that show up are incorrect.
+    KNOWN ISSUE: While scanning something, the categories that show up are incorrect.
 
 -   Added: Open -> Trick Details menu entry, similar to what's available in the
     Trick Level tab when customizing a preset. 
@@ -149,7 +165,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Added: In GFMC Compound, a method of reaching the ship item with Screw Attack (Normal and above).
 
--   Added: In Main Gyro Chamber, a method of reaching the bottom of the gyro area from the middle of the room with Screw Attack (Easy and aboive).
+-   Added: In Main Gyro Chamber, a method of reaching the bottom of the gyro area from the middle of the room with Screw Attack (Easy and above).
 
 -   Changed: In Workers Path, Morph Ball Bomb is no longer required.
 

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -2595,7 +2595,7 @@ Asset id: 1272952761
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -3541,7 +3541,7 @@ Asset id: 3209927104
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -3935,7 +3935,7 @@ Asset id: 2733852625
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -3950,7 +3950,7 @@ Asset id: 2733852625
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -4398,7 +4398,7 @@ Asset id: 2763180926
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -4595,7 +4595,7 @@ Asset id: 4146307738
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -4610,7 +4610,7 @@ Asset id: 4146307738
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -6402,7 +6402,7 @@ Asset id: 720788297
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -6417,7 +6417,7 @@ Asset id: 720788297
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -6470,7 +6470,7 @@ Asset id: 298078827
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -6485,7 +6485,7 @@ Asset id: 298078827
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -9936,7 +9936,7 @@ Asset id: 3902528658
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -9951,7 +9951,7 @@ Asset id: 3902528658
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -10209,6 +10209,8 @@ Asset id: 2838429875
           Echo Visor or Invisible Objects (Easy)
 
 > Event - Prepare Elevator Before Fight; Heals? True
+  > Hive Temple/Before Quad
+      Trivial
 
 > Event - Prepare Elevator After Fight; Heals? True
   > Hive Temple/Pickup (Annihilator Beam)
@@ -10375,7 +10377,7 @@ Asset id: 648838942
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30
@@ -10390,7 +10392,7 @@ Asset id: 648838942
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -4338,7 +4338,7 @@ Asset id: 2763180926
 > Door to Main Reactor; Heals? True
   > Main Reactor/Door to Sand Processing
       Trivial
-  > Sand Processing/Room Center
+  > Sand Processing/Bottom of Halfpipe
       Missile
 
 > Door to Save Station C; Heals? True
@@ -4346,26 +4346,26 @@ Asset id: 2763180926
       Trivial
   > Sand Processing/Event - Main Reactor Reloaded via Sand Processing
       After Dark Samus 1
-  > Sand Processing/Room Center
+  > Sand Processing/Bottom of Halfpipe
       Trivial
 
 > Pickup (Missile); Heals? True
-  > Sand Processing/Room Center
+  > Sand Processing/Bottom of Halfpipe
       Trivial
 
 > Event - Sand Processing Sand Drained; Heals? True
-  > Sand Processing/Room Center
+  > Sand Processing/Tunnel
       All of the following:
-          Morph Ball and Boost Ball
+          Morph Ball
           Any of the following:
               Morph Ball Bomb
-              Wall Boost (Hard) and Difficulty: Hard
+              Boost Ball and Wall Boost (Hard) and Difficulty: Hard
 
 > Event - Main Reactor Reloaded via Sand Processing; Heals? True
   > Sand Processing/Door to Save Station C
       Trivial
 
-> Room Center; Heals? True
+> Bottom of Halfpipe; Heals? True
   > Sand Processing/Door to Main Reactor
       Missile
   > Sand Processing/Door to Save Station C
@@ -4382,22 +4382,29 @@ Asset id: 2763180926
                           Screw Attack and Slope Jump (Easy) and Difficulty: Easy
   > Sand Processing/Pickup (Missile)
       After Sand Processing Sand Drained
+  > Sand Processing/Tunnel
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Boost Ball and Morph Ball Bomb
+              Boost Ball and Wall Boost (Hard) and Difficulty: Hard
+              Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Normal) and Difficulty: Normal
+              Space Jump Boots and Screw Attack and Difficulty: Hard
+
+> Tunnel; Heals? True
   > Sand Processing/Event - Sand Processing Sand Drained
       All of the following:
           Scan Visor and Morph Ball
           Any of the following:
-              Boost Ball
+              Morph Ball Bomb
               All of the following:
-                  Morph Ball
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
                   Any of the following:
-                      Morph Ball Bomb
-                      All of the following:
-                          Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
-                          Any of the following:
-                              Dark Beam and Darkburst and Dark Ammo ≥ 30
-                              Light Beam and Sunburst and Light Ammo ≥ 30
-                              Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
-              Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Normal) and Difficulty: Normal
+                      Dark Beam and Darkburst and Dark Ammo ≥ 30
+                      Light Beam and Sunburst and Light Ammo ≥ 30
+                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+  > Sand Processing/Bottom of Halfpipe
+      Trivial
 
 ----------------
 Storage D

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -3526,7 +3526,7 @@ Asset id: 3209927104
           Any of the following:
               Morph Ball Bomb
               All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
                   Any of the following:
                       Dark Beam and Darkburst and Dark Ammo ≥ 30
                       Light Beam and Sunburst and Light Ammo ≥ 30

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -1018,11 +1018,13 @@ Asset id: 521996255
 
 > Door to Gateway Access; Heals? True
   > Gateway Access/Door to Shrine Access
-      All of the following:
-          Seeker Launcher
-          Any of the following:
-              Missile ≥ 5
-              Space Jump Boots and Screw Attack and Missile ≥ 4 and Difficulty: Easy
+      Any of the following:
+          All of the following:
+              Seeker Launcher
+              Any of the following:
+                  Missile ≥ 5
+                  Space Jump Boots and Screw Attack and Missile ≥ 4 and Difficulty: Easy
+          Space Jump Boots and Screw Attack and Missile and Difficulty: Hard
   > Shrine Access/Door to War Ritual Grounds
       All of the following:
           Morph Ball
@@ -1191,11 +1193,13 @@ Plain of Dark Worship
 Asset id: 67496868
 > Door to Lake Access; Heals? True
   > Lake Access/Door to Plain of Dark Worship
-      All of the following:
-          Seeker Launcher
-          Any of the following:
-              Missile ≥ 5
-              Space Jump Boots and Screw Attack and Missile ≥ 4 and Difficulty: Easy
+      Any of the following:
+          All of the following:
+              Seeker Launcher
+              Any of the following:
+                  Missile ≥ 5
+                  Space Jump Boots and Screw Attack and Missile ≥ 4 and Difficulty: Easy
+          Space Jump Boots and Screw Attack and Missile and Difficulty: Hard
   > Plain of Dark Worship/Portal to Temple Assembly Site
       Trivial
   > Plain of Dark Worship/Pickup (Missile)
@@ -1398,7 +1402,7 @@ Asset id: 2278776548
               Annihilator Beam and Charge Beam and Invisible Objects (Trivial) and Dark World Damage ≥ 1500 and Difficulty: Trivial
               Echo Visor and Charge Beam and Dark World Damage ≥ 1500
               Charge Beam and Invisible Objects (Easy) and Dark World Damage ≥ 800 and Difficulty: Easy
-              Space Jump Boots and Screw Attack and Invisible Objects (Normal) and Dark World Damage ≥ 300 and Difficulty: Normal
+              Space Jump Boots and Screw Attack and Missile ≥ 5 and Invisible Objects (Normal) and Dark World Damage ≥ 300 and Difficulty: Normal
 
 ----------------
 GFMC Compound
@@ -1737,11 +1741,13 @@ Asset id: 1683944003
 
 > Door to Reliquary Access; Heals? False
   > Reliquary Access/Door to Phazon Grounds
-      All of the following:
-          Seeker Launcher
-          Any of the following:
-              Missile ≥ 5
-              Space Jump Boots and Screw Attack and Missile ≥ 4 and Difficulty: Easy
+      Any of the following:
+          All of the following:
+              Seeker Launcher
+              Any of the following:
+                  Missile ≥ 5
+                  Space Jump Boots and Screw Attack and Missile ≥ 4 and Difficulty: Easy
+          Space Jump Boots and Screw Attack and Missile ≥ 2 and Difficulty: Hypermode
   > Phazon Grounds/Door to Phazon Pit
       Any of the following:
           Morph Ball and Morph Ball Bomb and Dark World Damage ≥ 55 and Difficulty: Trivial
@@ -2524,39 +2530,18 @@ Asset id: 1272952761
 > Portal to Crossroads; Heals? True
   > Crossroads/Portal from Transport Center
       Dark Beam or Annihilator Beam
-  > Transport Center/Door to Save Station A
-      After Transport Center Gate
   > Transport Center/Door to Transport to Torvus Bog
       Any of the following:
           Space Jump Boots
-          Morph Ball and Boost Ball
           Screw Attack and Screw Attack without Space Jump (Trivial) and Difficulty: Trivial
           Combat/Scan Dash (Easy) and Difficulty: Easy
-  > Transport Center/Door to Portal Terminal
+  > Transport Center/Bottom of Halfpipe
       Trivial
-  > Transport Center/Pickup (Missile)
-      After Transport Center Gate
-  > Transport Center/Event - Transport Center Gate
-      Morph Ball and Morph Ball Bomb
 
 > Door to Save Station A; Heals? True
   > Save Station A/Door to Transport Center
       Trivial
-  > Transport Center/Portal to Crossroads
-      All of the following:
-          Morph Ball and After Transport Center Gate
-          Any of the following:
-              Boost Ball
-              Morph Ball Bomb and Space Jump Boots and Screw Attack and Slope Jump (Normal) and Bomb Space Jump (Normal) and Difficulty: Normal
-  > Transport Center/Door to Transport to Torvus Bog
-      All of the following:
-          After Transport Center Gate
-          Any of the following:
-              Morph Ball and Boost Ball
-              Space Jump Boots and Screw Attack and Slope Jump (Easy) and Difficulty: Easy
-  > Transport Center/Door to Portal Terminal
-      After Transport Center Gate
-  > Transport Center/Pickup (Missile)
+  > Transport Center/Bottom of Halfpipe
       After Transport Center Gate
 
 > Door to Transport to Torvus Bog; Heals? True
@@ -2572,70 +2557,49 @@ Asset id: 1272952761
           Any of the following:
               Boost Ball
               Morph Ball Bomb and Space Jump Boots and Screw Attack and Bomb Space Jump (Normal) and Difficulty: Normal
-  > Transport Center/Door to Save Station A
-      After Transport Center Gate
-  > Transport Center/Door to Portal Terminal
+  > Transport Center/Bottom of Halfpipe
       Trivial
-  > Transport Center/Pickup (Missile)
-      After Transport Center Gate
-  > Transport Center/Event - Transport Center Gate
-      Morph Ball and Morph Ball Bomb
 
 > Door to Portal Terminal; Heals? True
   > Portal Terminal/Door to Transport Center
       Trivial
-  > Transport Center/Portal to Crossroads
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Boost Ball
-              Morph Ball Bomb and Space Jump Boots and Screw Attack and Slope Jump (Normal) and Bomb Space Jump (Normal) and Difficulty: Normal
-  > Transport Center/Door to Save Station A
-      After Transport Center Gate
-  > Transport Center/Door to Transport to Torvus Bog
-      Any of the following:
-          Morph Ball and Boost Ball
-          Space Jump Boots and Screw Attack and Slope Jump (Easy) and Difficulty: Easy
-  > Transport Center/Pickup (Missile)
-      After Transport Center Gate
-  > Transport Center/Event - Transport Center Gate
-      Morph Ball and Morph Ball Bomb
+  > Transport Center/Bottom of Halfpipe
+      Trivial
 
 > Pickup (Missile); Heals? True
-  > Transport Center/Portal to Crossroads
-      All of the following:
-          Morph Ball and After Transport Center Gate
-          Any of the following:
-              Boost Ball
-              Morph Ball Bomb and Space Jump Boots and Screw Attack and Slope Jump (Normal) and Bomb Space Jump (Normal) and Difficulty: Normal
-  > Transport Center/Door to Save Station A
-      After Transport Center Gate
-  > Transport Center/Door to Transport to Torvus Bog
-      All of the following:
-          After Transport Center Gate
-          Any of the following:
-              Morph Ball and Boost Ball
-              Space Jump Boots and Screw Attack and Slope Jump (Easy) and Difficulty: Easy
-  > Transport Center/Door to Portal Terminal
+  > Transport Center/Bottom of Halfpipe
       After Transport Center Gate
 
 > Event - Transport Center Gate; Heals? True
-  > Transport Center/Portal to Crossroads
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Boost Ball
-              Morph Ball Bomb and Space Jump Boots and Screw Attack and Slope Jump (Normal) and Bomb Space Jump (Normal) and Difficulty: Normal
-  > Transport Center/Door to Save Station A
+  > Transport Center/Bottom of Halfpipe
       Trivial
+
+> Bottom of Halfpipe; Heals? True
+  > Transport Center/Portal to Crossroads
+      Morph Ball and Boost Ball
+  > Transport Center/Door to Save Station A
+      After Transport Center Gate
   > Transport Center/Door to Transport to Torvus Bog
       Any of the following:
+          Space Jump Boots
+          Screw Attack and Slope Jump (Easy) and Difficulty: Easy
+          Slope Jump (Normal) and Difficulty: Normal
           Morph Ball and Boost Ball
-          Space Jump Boots and Screw Attack and Slope Jump (Easy) and Difficulty: Easy
   > Transport Center/Door to Portal Terminal
       Trivial
   > Transport Center/Pickup (Missile)
-      Trivial
+      After Transport Center Gate
+  > Transport Center/Event - Transport Center Gate
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Morph Ball Bomb
+              All of the following:
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Any of the following:
+                      Dark Beam and Darkburst and Dark Ammo ≥ 30
+                      Light Beam and Sunburst and Light Ammo ≥ 30
+                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
 
 ----------------
 Mining Station A
@@ -2926,11 +2890,13 @@ Transport to Torvus Bog
 Asset id: 2806956034
 > Door to Transport Center; Heals? False
   > Transport Center/Door to Transport to Torvus Bog
-      All of the following:
-          Seeker Launcher
-          Any of the following:
-              Missile ≥ 5
-              Space Jump Boots and Screw Attack and Missile ≥ 4 and Difficulty: Easy
+      Any of the following:
+          All of the following:
+              Seeker Launcher
+              Any of the following:
+                  Missile ≥ 5
+                  Space Jump Boots and Screw Attack and Missile ≥ 4 and Difficulty: Easy
+          Space Jump Boots and Screw Attack and Missile ≥ 2 and Difficulty: Hypermode
   > Transport to Torvus Bog/Elevator to Torvus Bog - Transport to Agon Wastes
       Scan Visor
 
@@ -3964,13 +3930,31 @@ Asset id: 2733852625
   > Dark Agon Temple/Door to Dark Controller Access
       Trivial
   > Dark Controller Access/Door to Dark Agon Energy Controller
-      Morph Ball and Morph Ball Bomb
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Morph Ball Bomb
+              All of the following:
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Any of the following:
+                      Dark Beam and Darkburst and Dark Ammo ≥ 30
+                      Light Beam and Sunburst and Light Ammo ≥ 30
+                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
 
 > Door to Dark Agon Energy Controller; Heals? True
   > Dark Agon Energy Controller/Door to Dark Controller Access
       Trivial
   > Dark Controller Access/Door to Dark Agon Temple
-      Morph Ball and Morph Ball Bomb
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Morph Ball Bomb
+              All of the following:
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Any of the following:
+                      Dark Beam and Darkburst and Dark Ammo ≥ 30
+                      Light Beam and Sunburst and Light Ammo ≥ 30
+                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
 
 ----------------
 Command Center
@@ -4283,108 +4267,68 @@ Asset id: 2761919085
 > Door to Double Path (Bottom); Heals? True
   > Double Path/Door to Doomed Entry (Bottom)
       Light Beam
-  > Doomed Entry/Door to Double Path (Top)
-      Any of the following:
-          Dark Beam and Charge Beam and Space Jump Boots and Missile
-          Dark Beam and Space Jump Boots and Missile and Dark Ammo
-          Morph Ball and Morph Ball Bomb and Bomb Space Jump (Hard) and Difficulty: Hard
-          Space Jump Boots and Slope Jump (Easy) and Difficulty: Easy
-  > Doomed Entry/Door to Oasis Access
-      Any of the following:
-          Dark Beam and Charge Beam and Space Jump Boots and Missile
-          Dark Beam and Space Jump Boots and Missile and Dark Ammo
-          Morph Ball and Morph Ball Bomb and Bomb Space Jump (Hard) and Difficulty: Hard
-          Space Jump Boots and Slope Jump (Easy) and Difficulty: Easy
-  > Doomed Entry/Door to Feeding Pit Access
+  > Doomed Entry/Next to Portal
       Trivial
-  > Doomed Entry/Pickup (Dark Agon Key 2)
-      Any of the following:
-          Dark Beam and Charge Beam and Space Jump Boots and Missile
-          Dark Beam and Space Jump Boots and Missile and Dark Ammo
-          Morph Ball and Morph Ball Bomb and Bomb Space Jump (Hard) and Difficulty: Hard
-          Space Jump Boots and Slope Jump (Easy) and Difficulty: Easy
 
 > Portal from Command Center; Heals? True
   > Command Center/Portal to Doomed Entry
       Impossible
-  > Doomed Entry/Door to Double Path (Bottom)
+  > Doomed Entry/Next to Portal
       Trivial
-  > Doomed Entry/Door to Double Path (Top)
-      Any of the following:
-          Dark Beam and Charge Beam and Space Jump Boots and Missile
-          Dark Beam and Space Jump Boots and Missile and Dark Ammo
-          Morph Ball and Morph Ball Bomb and Bomb Space Jump (Hard) and Difficulty: Hard
-          Space Jump Boots and Slope Jump (Easy) and Difficulty: Easy
-  > Doomed Entry/Door to Oasis Access
-      Any of the following:
-          Dark Beam and Charge Beam and Space Jump Boots and Missile
-          Dark Beam and Space Jump Boots and Missile and Dark Ammo
-          Morph Ball and Morph Ball Bomb and Bomb Space Jump (Hard) and Difficulty: Hard
-          Space Jump Boots and Slope Jump (Easy) and Difficulty: Easy
-  > Doomed Entry/Door to Feeding Pit Access
-      Trivial
-  > Doomed Entry/Pickup (Dark Agon Key 2)
-      Any of the following:
-          Dark Beam and Charge Beam and Space Jump Boots and Missile
-          Dark Beam and Space Jump Boots and Missile and Dark Ammo
-          Morph Ball and Morph Ball Bomb and Bomb Space Jump (Hard) and Difficulty: Hard
-          Space Jump Boots and Slope Jump (Easy) and Difficulty: Easy
 
 > Door to Double Path (Top); Heals? True
   > Double Path/Door to Doomed Entry (Top)
       Dark Beam
-  > Doomed Entry/Door to Double Path (Bottom)
-      Trivial
   > Doomed Entry/Door to Oasis Access
       Space Jump Boots or Difficulty: Easy
-  > Doomed Entry/Door to Feeding Pit Access
-      Trivial
   > Doomed Entry/Pickup (Dark Agon Key 2)
+      Trivial
+  > Doomed Entry/Next to Portal
       Trivial
 
 > Door to Oasis Access; Heals? True
   > Oasis Access/Door to Doomed Entry
       Dark Beam
-  > Doomed Entry/Door to Double Path (Bottom)
-      Trivial
   > Doomed Entry/Door to Double Path (Top)
       Space Jump Boots or Difficulty: Easy
-  > Doomed Entry/Door to Feeding Pit Access
-      Trivial
   > Doomed Entry/Pickup (Dark Agon Key 2)
       Space Jump Boots or Difficulty: Easy
+  > Doomed Entry/Next to Portal
+      Trivial
 
 > Door to Feeding Pit Access; Heals? True
   > Feeding Pit Access/Door to Doomed Entry
       Light Beam
-  > Doomed Entry/Door to Double Path (Bottom)
+  > Doomed Entry/Next to Portal
       Trivial
-  > Doomed Entry/Door to Double Path (Top)
-      Any of the following:
-          Dark Beam and Charge Beam and Space Jump Boots and Missile
-          Dark Beam and Space Jump Boots and Missile and Dark Ammo
-          Morph Ball and Morph Ball Bomb and Bomb Space Jump (Hard) and Difficulty: Hard
-          Space Jump Boots and Slope Jump (Easy) and Difficulty: Easy
-  > Doomed Entry/Door to Oasis Access
-      Any of the following:
-          Dark Beam and Charge Beam and Space Jump Boots and Missile
-          Dark Beam and Space Jump Boots and Missile and Dark Ammo
-          Morph Ball and Morph Ball Bomb and Bomb Space Jump (Hard) and Difficulty: Hard
-          Space Jump Boots and Slope Jump (Easy) and Difficulty: Easy
-  > Doomed Entry/Pickup (Dark Agon Key 2)
-      Any of the following:
-          Dark Beam and Charge Beam and Space Jump Boots and Missile
-          Dark Beam and Space Jump Boots and Missile and Dark Ammo
-          Morph Ball and Morph Ball Bomb and Bomb Space Jump (Hard) and Difficulty: Hard
-          Space Jump Boots and Slope Jump (Easy) and Difficulty: Easy
 
 > Pickup (Dark Agon Key 2); Heals? True
-  > Doomed Entry/Door to Double Path (Bottom)
-      Trivial
   > Doomed Entry/Door to Double Path (Top)
       Trivial
   > Doomed Entry/Door to Oasis Access
       Space Jump Boots or Difficulty: Easy
+  > Doomed Entry/Next to Portal
+      Trivial
+
+> Next to Portal; Heals? True
+  > Doomed Entry/Door to Double Path (Bottom)
+      Trivial
+  > Doomed Entry/Portal from Command Center
+      Trivial
+  > Doomed Entry/Door to Double Path (Top)
+      Any of the following:
+          Dark Beam and Charge Beam and Space Jump Boots and Missile
+          Dark Beam and Space Jump Boots and Missile and Dark Ammo
+          Morph Ball and Morph Ball Bomb and Bomb Space Jump (Hard) and Difficulty: Hard
+          Space Jump Boots and Slope Jump (Easy) and Difficulty: Easy
+          Space Jump Boots and Screw Attack and Difficulty: Trivial
+  > Doomed Entry/Door to Oasis Access
+      Any of the following:
+          Dark Beam and Charge Beam and Space Jump Boots and Missile
+          Dark Beam and Space Jump Boots and Missile and Dark Ammo
+          Morph Ball and Morph Ball Bomb and Bomb Space Jump (Hard) and Difficulty: Hard
+          Space Jump Boots and Slope Jump (Easy) and Difficulty: Easy
+          Space Jump Boots and Screw Attack and Difficulty: Trivial
   > Doomed Entry/Door to Feeding Pit Access
       Trivial
 
@@ -4394,75 +4338,66 @@ Asset id: 2763180926
 > Door to Main Reactor; Heals? True
   > Main Reactor/Door to Sand Processing
       Trivial
-  > Sand Processing/Door to Save Station C
-      All of the following:
-          Missile
-          Any of the following:
-              Before Sand Processing Sand Drained
-              All of the following:
-                  Morph Ball
-                  Any of the following:
-                      Boost Ball
-                      Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Normal) and Difficulty: Normal
-  > Sand Processing/Pickup (Missile)
-      Missile and After Sand Processing Sand Drained
-  > Sand Processing/Event - Sand Processing Sand Drained
-      All of the following:
-          Scan Visor and Morph Ball and Morph Ball Bomb and Missile
-          Any of the following:
-              Boost Ball
-              Space Jump Boots and Bomb Space Jump (Normal) and Difficulty: Normal
+  > Sand Processing/Room Center
+      Missile
 
 > Door to Save Station C; Heals? True
   > Save Station C/Door to Sand Processing
       Trivial
-  > Sand Processing/Door to Main Reactor
-      Missile
-  > Sand Processing/Pickup (Missile)
-      After Sand Processing Sand Drained
-  > Sand Processing/Event - Sand Processing Sand Drained
-      All of the following:
-          Scan Visor and Morph Ball and Morph Ball Bomb
-          Any of the following:
-              Boost Ball
-              Space Jump Boots and Bomb Space Jump (Normal) and Difficulty: Normal
   > Sand Processing/Event - Main Reactor Reloaded via Sand Processing
       After Dark Samus 1
+  > Sand Processing/Room Center
+      Trivial
 
 > Pickup (Missile); Heals? True
-  > Sand Processing/Door to Main Reactor
-      Missile and After Sand Processing Sand Drained
-  > Sand Processing/Door to Save Station C
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Boost Ball
-              Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Normal) and Difficulty: Normal
+  > Sand Processing/Room Center
+      Trivial
 
 > Event - Sand Processing Sand Drained; Heals? True
-  > Sand Processing/Door to Main Reactor
+  > Sand Processing/Room Center
       All of the following:
-          Morph Ball and Missile
+          Morph Ball and Boost Ball
           Any of the following:
               Morph Ball Bomb
-              Boost Ball and Wall Boost (Hard) and Difficulty: Hard
-  > Sand Processing/Door to Save Station C
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Boost Ball and Morph Ball Bomb
-              Boost Ball and Wall Boost (Hard) and Difficulty: Hard
-              Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Normal) and Difficulty: Normal
-  > Sand Processing/Pickup (Missile)
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              Boost Ball and Wall Boost (Hard) and Difficulty: Hard
+              Wall Boost (Hard) and Difficulty: Hard
 
 > Event - Main Reactor Reloaded via Sand Processing; Heals? True
   > Sand Processing/Door to Save Station C
       Trivial
+
+> Room Center; Heals? True
+  > Sand Processing/Door to Main Reactor
+      Missile
+  > Sand Processing/Door to Save Station C
+      Any of the following:
+          Before Sand Processing Sand Drained
+          All of the following:
+              Morph Ball
+              Any of the following:
+                  Boost Ball
+                  All of the following:
+                      Space Jump Boots
+                      Any of the following:
+                          Morph Ball Bomb and Bomb Space Jump (Normal) and Difficulty: Normal
+                          Screw Attack and Slope Jump (Easy) and Difficulty: Easy
+  > Sand Processing/Pickup (Missile)
+      After Sand Processing Sand Drained
+  > Sand Processing/Event - Sand Processing Sand Drained
+      All of the following:
+          Scan Visor and Morph Ball
+          Any of the following:
+              Boost Ball
+              All of the following:
+                  Morph Ball
+                  Any of the following:
+                      Morph Ball Bomb
+                      All of the following:
+                          Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                          Any of the following:
+                              Dark Beam and Darkburst and Dark Ammo ≥ 30
+                              Light Beam and Sunburst and Light Ammo ≥ 30
+                              Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+              Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Normal) and Difficulty: Normal
 
 ----------------
 Storage D
@@ -4648,13 +4583,31 @@ Asset id: 4146307738
   > Biostorage Station/Door to Security Station A
       Trivial
   > Security Station A/Door to Bioenergy Production
-      Morph Ball and Morph Ball Bomb
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Morph Ball Bomb
+              All of the following:
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Any of the following:
+                      Dark Beam and Darkburst and Dark Ammo ≥ 30
+                      Light Beam and Sunburst and Light Ammo ≥ 30
+                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
 
 > Door to Bioenergy Production; Heals? False
   > Bioenergy Production/Door to Security Station A
       Trivial
   > Security Station A/Door to Biostorage Station
-      Morph Ball and Morph Ball Bomb
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Morph Ball Bomb
+              All of the following:
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Any of the following:
+                      Dark Beam and Darkburst and Dark Ammo ≥ 30
+                      Light Beam and Sunburst and Light Ammo ≥ 30
+                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
 
 ----------------
 Storage B
@@ -5728,11 +5681,13 @@ Asset id: 350405542
 
 > Door to Cache A; Heals? True
   > Cache A/Door to Poisoned Bog
-      All of the following:
-          Seeker Launcher
-          Any of the following:
-              Missile ≥ 5
-              Space Jump Boots and Screw Attack and Missile ≥ 4 and Difficulty: Easy
+      Any of the following:
+          All of the following:
+              Seeker Launcher
+              Any of the following:
+                  Missile ≥ 5
+                  Space Jump Boots and Screw Attack and Missile ≥ 4 and Difficulty: Easy
+          Space Jump Boots and Screw Attack and Missile and Difficulty: Hard
   > Poisoned Bog/Room Center
       Trivial
 
@@ -6503,13 +6458,31 @@ Asset id: 298078827
   > Dark Torvus Energy Controller/Door to Dark Controller Access
       Trivial
   > Dark Controller Access/Door to Dark Torvus Temple
-      Morph Ball and Morph Ball Bomb
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Morph Ball Bomb
+              All of the following:
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Any of the following:
+                      Dark Beam and Darkburst and Dark Ammo ≥ 30
+                      Light Beam and Sunburst and Light Ammo ≥ 30
+                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
 
 > Door to Dark Torvus Temple; Heals? True
   > Dark Torvus Temple/Door to Dark Controller Access
       Trivial
   > Dark Controller Access/Door to Dark Torvus Energy Controller
-      Morph Ball and Morph Ball Bomb
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Morph Ball Bomb
+              All of the following:
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Any of the following:
+                      Dark Beam and Darkburst and Dark Ammo ≥ 30
+                      Light Beam and Sunburst and Light Ammo ≥ 30
+                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
 
 ----------------
 Hydrodynamo Station
@@ -6570,7 +6543,11 @@ Asset id: 3585454182
   > Hydrodynamo Shaft/Door to Hydrodynamo Station
       Trivial
   > Hydrodynamo Station/Room Bottom
-      Gravity Boost and After Hydrodynamo Station Lock (below Seeker Door) and After Hydrodynamo Station Lock (by Dark Door) and After Hydrodynamo Station Lock (by Light Door)
+      All of the following:
+          After Hydrodynamo Station Lock (below Seeker Door) and After Hydrodynamo Station Lock (by Dark Door) and After Hydrodynamo Station Lock (by Light Door)
+          Any of the following:
+              Gravity Boost
+              Space Jump Boots and Screw Attack and Air Underwater (Normal) and Difficulty: Hypermode
 
 > Door to Catacombs Access; Heals? True
   > Catacombs Access/Door to Hydrodynamo Station
@@ -7375,12 +7352,14 @@ Asset id: 3468345533
               Spider Ball and Before Hydrochamber Storage Item
               Morph Ball Bomb and Space Jump Boots and Gravity Boost and Bomb Space Jump (Easy) and Difficulty: Easy
   > Main Hydrochamber/Door to Hydrodynamo Shaft
-      All of the following:
-          Gravity Boost
-          Any of the following:
-              Morph Ball and After Hydrochamber Storage Item and Roll Jump (Hard) and Difficulty: Hard
-              Space Jump Boots and After Hydrochamber Storage Item
-              Before Hydrochamber Storage Item and Difficulty: Easy
+      Any of the following:
+          Morph Ball and Morph Ball Bomb and Space Jump Boots and Screw Attack and Bomb Space Jump (Hypermode) and Air Underwater (Normal) and Difficulty: Hypermode
+          All of the following:
+              Gravity Boost
+              Any of the following:
+                  Morph Ball and After Hydrochamber Storage Item and Roll Jump (Hard) and Difficulty: Hard
+                  Space Jump Boots and After Hydrochamber Storage Item
+                  Before Hydrochamber Storage Item and Difficulty: Easy
 
 > Portal to Undertemple; Heals? True
   > Undertemple/Portal to Main Hydrochamber
@@ -10134,65 +10113,107 @@ Asset id: 2838429875
 > Door to Hive Temple Access; Heals? False
   > Hive Temple Access/Door to Hive Temple
       Trivial
-  > Hive Temple/Event - Quadraxis
+  > Hive Temple/Post-Fight Pillar
       All of the following:
-          Morph Ball and Morph Ball Bomb
+          Screw Attack and After Quadraxis and Dark World Damage ≥ 40
           Any of the following:
-              Light Beam and Boost Ball and Spider Ball and Dark World Damage ≥ 250 and Difficulty: Easy
-              Light Beam and Space Jump Boots and Dark World Damage ≥ 250 and Difficulty: Hard
-              Echo Visor and Boost Ball and Spider Ball and Dark World Damage ≥ 1500
-              Boost Ball and Spider Ball and Dark World Damage ≥ 600 and Difficulty: Easy
-              Space Jump Boots and Dark World Damage ≥ 600 and Difficulty: Hard
+              Space Jump Boots
+              Screw Attack without Space Jump (Trivial) and Difficulty: Trivial
+  > Hive Temple/Before Quad
+      Trivial
+  > Hive Temple/Event - Prepare Elevator Before Fight
+      Trivial
 
 > Door to Hive Controller Access; Heals? False
   > Hive Controller Access/Door to Hive Temple
       Annihilator Beam
-  > Hive Temple/Event - Quadraxis
+  > Hive Temple/Post-Fight Pillar
       All of the following:
-          Morph Ball and Morph Ball Bomb
+          Screw Attack and After Quadraxis and Dark World Damage ≥ 40
           Any of the following:
-              Light Beam and Boost Ball and Spider Ball and Dark World Damage ≥ 250 and Difficulty: Easy
-              Light Beam and Space Jump Boots and Dark World Damage ≥ 250 and Difficulty: Hard
-              Echo Visor and Boost Ball and Spider Ball and Dark World Damage ≥ 1500
-              Boost Ball and Spider Ball and Dark World Damage ≥ 600 and Difficulty: Easy
-              Space Jump Boots and Dark World Damage ≥ 600 and Difficulty: Hard
+              Space Jump Boots
+              Screw Attack without Space Jump (Trivial) and Difficulty: Trivial
+  > Hive Temple/Before Quad
+      Trivial
 
 > Door to Temple Security Access; Heals? False
   > Temple Security Access/Door to Hive Temple
       Annihilator Beam
-  > Hive Temple/Event - Quadraxis
+  > Hive Temple/Post-Fight Pillar
       All of the following:
-          Morph Ball and Morph Ball Bomb
+          Screw Attack and After Quadraxis and Dark World Damage ≥ 40
           Any of the following:
-              Light Beam and Boost Ball and Spider Ball and Dark World Damage ≥ 250 and Difficulty: Easy
-              Light Beam and Space Jump Boots and Dark World Damage ≥ 250 and Difficulty: Hard
-              Echo Visor and Boost Ball and Spider Ball and Dark World Damage ≥ 1500
-              Boost Ball and Spider Ball and Dark World Damage ≥ 600 and Difficulty: Easy
-              Space Jump Boots and Dark World Damage ≥ 600 and Difficulty: Hard
+              Space Jump Boots
+              Screw Attack without Space Jump (Trivial) and Difficulty: Trivial
+  > Hive Temple/Before Quad
+      Trivial
 
 > Pickup (Annihilator Beam); Heals? True
   > Hive Temple/Door to Hive Temple Access
-      All of the following:
-          Morph Ball and Spider Ball
-          Any of the following:
-              Space Jump Boots and Combat/Scan Dash (Hard) and Dark World Damage ≥ 100 and Difficulty: Hypermode
-              Screw Attack and Screw Attack without Space Jump (Trivial) and Dark World Damage ≥ 70 and Difficulty: Trivial
-  > Hive Temple/Door to Hive Controller Access
-      All of the following:
-          Morph Ball and Spider Ball and Screw Attack and Dark World Damage ≥ 70
-          Any of the following:
-              Space Jump Boots
-              Screw Attack without Space Jump (Trivial) and Difficulty: Trivial
-  > Hive Temple/Door to Temple Security Access
-      All of the following:
-          Morph Ball and Spider Ball and Screw Attack and Dark World Damage ≥ 70
-          Any of the following:
-              Space Jump Boots
-              Screw Attack without Space Jump (Trivial) and Difficulty: Trivial
+      After Quadraxis Elevator Prepared and Difficulty: Hypermode
+  > Hive Temple/Post-Fight Pillar
+      Morph Ball and Spider Ball and Dark World Damage ≥ 40
 
 > Event - Quadraxis; Heals? True
   > Hive Temple/Pickup (Annihilator Beam)
       Trivial
+  > Hive Temple/Event - Prepare Elevator After Fight
+      Space Jump Boots and Screw Attack and Dark World Damage ≥ 100 and Difficulty: Hypermode
+
+> Post-Fight Pillar; Heals? True
+  > Hive Temple/Door to Hive Temple Access
+      All of the following:
+          Screw Attack and After Quadraxis and Dark World Damage ≥ 40
+          Any of the following:
+              Space Jump Boots
+              Screw Attack without Space Jump (Trivial) and Difficulty: Trivial
+  > Hive Temple/Door to Hive Controller Access
+      All of the following:
+          Screw Attack and After Quadraxis and Dark World Damage ≥ 40
+          Any of the following:
+              Space Jump Boots
+              Screw Attack without Space Jump (Trivial) and Difficulty: Trivial
+  > Hive Temple/Door to Temple Security Access
+      Any of the following:
+          Space Jump Boots and After Quadraxis and Combat/Scan Dash (Hard) and Dark World Damage ≥ 70 and Difficulty: Hypermode
+          All of the following:
+              Screw Attack and Dark World Damage ≥ 40
+              Any of the following:
+                  Space Jump Boots
+                  Screw Attack without Space Jump (Trivial) and Difficulty: Trivial
+
+> Before Quad; Heals? True
+  > Hive Temple/Event - Quadraxis
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Morph Ball Bomb
+              Power Bomb ≥ 2 and Difficulty: Trivial
+          Any of the following:
+              Boost Ball and Spider Ball
+              Space Jump Boots and Difficulty: Hard
+          Any of the following:
+              Dark World Damage ≥ 1500
+              All of the following:
+                  Difficulty: Easy
+                  Any of the following:
+                      Dark World Damage ≥ 600
+                      Light Beam and Light Ammo ≥ 50 and Dark World Damage ≥ 250
+          Echo Visor or Invisible Objects (Easy)
+
+> Event - Quadraxis Elevator Prepared; Heals? True
+  > Hive Temple/Pickup (Annihilator Beam)
+      Trivial
+
+> Event - Prepare Elevator Before Fight; Heals? True
+  > Hive Temple/Event - Quadraxis Elevator Prepared
+      Trivial
+
+> Event - Prepare Elevator After Fight; Heals? True
+  > Hive Temple/Pickup (Annihilator Beam)
+      Trivial
+  > Hive Temple/Event - Quadraxis Elevator Prepared
+      Morph Ball and Boost Ball and Space Jump Boots and Screw Attack and Dark World Damage ≥ 75 and Difficulty: Hypermode
 
 ----------------
 Aerie Transport Station
@@ -10348,13 +10369,31 @@ Asset id: 648838942
   > Hive Temple/Door to Hive Controller Access
       Annihilator Beam
   > Hive Controller Access/Door to Hive Energy Controller
-      Morph Ball and Morph Ball Bomb
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Morph Ball Bomb
+              All of the following:
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Any of the following:
+                      Dark Beam and Darkburst and Dark Ammo ≥ 30
+                      Light Beam and Sunburst and Light Ammo ≥ 30
+                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
 
 > Door to Hive Energy Controller; Heals? True
   > Hive Energy Controller/Door to Hive Controller Access
       Trivial
   > Hive Controller Access/Door to Hive Temple
-      Morph Ball and Morph Ball Bomb
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Morph Ball Bomb
+              All of the following:
+                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Difficulty: Hypermode
+                  Any of the following:
+                      Dark Beam and Darkburst and Dark Ammo ≥ 30
+                      Light Beam and Sunburst and Light Ammo ≥ 30
+                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
 
 ----------------
 Aerie Access

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -10208,18 +10208,12 @@ Asset id: 2838429875
                       Light Beam and Light Ammo ≥ 50 and Dark World Damage ≥ 250
           Echo Visor or Invisible Objects (Easy)
 
-> Event - Quadraxis Elevator Prepared; Heals? True
-  > Hive Temple/Pickup (Annihilator Beam)
-      Trivial
-
 > Event - Prepare Elevator Before Fight; Heals? True
-  > Hive Temple/Event - Quadraxis Elevator Prepared
-      Trivial
 
 > Event - Prepare Elevator After Fight; Heals? True
   > Hive Temple/Pickup (Annihilator Beam)
       Trivial
-  > Hive Temple/Event - Quadraxis Elevator Prepared
+  > Hive Temple/Before Quad
       Morph Ball and Boost Ball and Space Jump Boots and Screw Attack and Dark World Damage ≥ 75 and Difficulty: Hypermode
 
 ----------------


### PR DESCRIPTION
Logic changes for:
- Torvus Grove climb without Boost Ball
- Seeker Locks with Screw Attack
- Bombless Bomb Slots (some haven't been added yet)
- Lower Torvus Escape without Gravity Boost
- Transport Center Climb with Space Jump + simplifying nodes (Closes https://github.com/randovania/randovania/issues/804) (Contributes to https://github.com/randovania/randovania/issues/103)
- Doomed Entry climb with Space Jump and Screw Attack + simplifying nodes (Closes https://github.com/randovania/randovania/issues/796) (Contributes to https://github.com/randovania/randovania/issues/103)
- Quadraxis with PBs
- Hive Temple escape without Spider Ball (New nodes and updated damage requirements accordingly) (Contributes to https://github.com/randovania/randovania/issues/333) (Contributes to https://github.com/randovania/randovania/issues/103)