### PR TITLE
Minor Logic Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -	Fixed: Trooper Security Station Event now requires Scan Visor coming from Communication Area.
 
+-	Added: Method of reaching Ing Cache 1 door with Space Jump and Screw Attack (No Tricks and above).
+
 ## [1.2.2] - 2020-06-06
 
 -   Changed: Re-organized the tabs in the preset customization window

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,13 +52,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -	Added: Method of leaving Hive Temple without Spider Ball (Hypermode).
 
+-	Fixed: Sand Processing item now requires Scan Visor.
+
 -	Added: Methods of crossing Grand Abyss with Boost Jump and Extended Dash (Veteran and above).
 
 -	Fixed: Entrance to Agon Map Station now requires Bombs, Power Bombs, or Boost Ball if coming from either direction, or Screw Attack as well if coming from Mining Plaza.
 
 -	Fixed: Added Charge Beam and Beam Ammo Requirements to Profane Path and Sentinel's Path.
 
--	Fixed: Added Inivisible Objects and Dark Visor Requirements for Screw Attack without Space Jump in Unseen Way.
+-	Fixed: Added Invisible Objects and Dark Visor Requirements for Screw Attack without Space Jump in Unseen Way.
+
+-	Fixed: Trooper Security Station Event now requires Scan Visor coming from Communication Area.
 
 ## [1.2.2] - 2020-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,11 +60,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -	Fixed: Added Charge Beam and Beam Ammo Requirements to Profane Path and Sentinel's Path.
 
--	Fixed: Added Invisible Objects and Dark Visor Requirements for Screw Attack without Space Jump in Unseen Way.
+-	Fixed: Added Invisible Objects and Dark Visor Requirements for Screw Attack without Space Jump in Unseen Way (Normal and above).
 
 -	Fixed: Trooper Security Station Event now requires Scan Visor coming from Communication Area.
 
 -	Added: Method of reaching Ing Cache 1 door with Space Jump and Screw Attack (No Tricks and above).
+
+-	Fixed: Added Invisible Objects and Dark Visor Requirements for Screw Attack without Space Jump in Phazon Grounds (Hard and above).
 
 ## [1.2.2] - 2020-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -	Fixed: Entrance to Agon Map Station now requires Bombs, Power Bombs, or Boost Ball if coming from either direction, or Screw Attack as well if coming from Mining Plaza.
 
+-	Fixed: Added Charge Beam and Beam Ammo Requirements to Profane Path and Sentinel's Path.
+
+-	Fixed: Added Inivisible Objects and Dark Visor Requirements for Screw Attack without Space Jump in Unseen Way.
+
 ## [1.2.2] - 2020-06-06
 
 -   Changed: Re-organized the tabs in the preset customization window

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -8656,7 +8656,9 @@ Asset id: 3590320811
           Dark Visor and Space Jump Boots
           Space Jump Boots and Screw Attack
           Space Jump Boots and Invisible Objects (Normal) and Difficulty: Normal
-          Screw Attack and Screw Attack without Space Jump (Trivial) and Difficulty: Normal
+          All of the following:
+              Screw Attack and Screw Attack without Space Jump (Normal) and Difficulty: Normal
+              Dark Visor or Invisible Objects (Normal)
 
 > Door to Culling Chamber; Heals? True
   > Culling Chamber/Door to Unseen Way
@@ -8666,7 +8668,9 @@ Asset id: 3590320811
           Dark Visor and Space Jump Boots
           Space Jump Boots and Screw Attack
           Space Jump Boots and Invisible Objects (Normal) and Difficulty: Normal
-          Screw Attack and Screw Attack without Space Jump (Normal) and Difficulty: Normal
+          All of the following:
+              Screw Attack and Screw Attack without Space Jump (Normal) and Difficulty: Normal
+              Dark Visor or Invisible Objects (Normal)
 
 ----------------
 Watch Station

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -4667,6 +4667,7 @@ Asset id: 123369195
           Dark Beam and Morph Ball and Morph Ball Bomb and Difficult Bomb Jump (Veteran) and Difficulty: Veteran
           Dark Beam and Space Jump Boots
           Space Jump Boots and Slope Jump (Normal) and Difficulty: Normal
+          Use Screw Attack
   > Feeding Pit/Pickup (Power Bomb)
       Light Suit
 

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -1716,6 +1716,9 @@ Asset id: 1692811478
       All of the following:
           Annihilator Beam and Echo Visor
           Space Jump Boots or Difficulty: Normal
+          Any of the following:
+              Charge Beam
+              Dark Ammo ≥ 4 and Light Ammo ≥ 4
 
 > Portal to Sacred Path; Heals? True
   > Sacred Path/Portal to Profane Path
@@ -1723,7 +1726,11 @@ Asset id: 1692811478
   > Profane Path/Door to Phazon Pit
       Trivial
   > Profane Path/Pickup (Dark Ammo)
-      Annihilator Beam and Echo Visor
+      All of the following:
+          Annihilator Beam and Echo Visor
+          Any of the following:
+              Charge Beam
+              Dark Ammo ≥ 4 and Light Ammo ≥ 4
 
 > Pickup (Dark Ammo); Heals? True
   > Profane Path/Door to Phazon Pit
@@ -8945,7 +8952,11 @@ Asset id: 2765624647
   > Sentinel's Path/Door to Sanctuary Temple
       Trivial
   > Sentinel's Path/Pickup (Missile)
-      Annihilator Beam and Echo Visor
+      All of the following:
+          Annihilator Beam and Echo Visor
+          Any of the following:
+              Charge Beam
+              Dark Ammo ≥ 4 and Light Ammo ≥ 4
 
 > Door to Sanctuary Temple; Heals? True
   > Sanctuary Temple/Door to Sentinel's Path

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -1774,7 +1774,9 @@ Asset id: 1683944003
           Dark Visor and Space Jump Boots and Dark World Damage ≥ 90
           Space Jump Boots and Screw Attack and Dark World Damage ≥ 30
           Space Jump Boots and Invisible Objects (Normal) and Dark World Damage ≥ 90 and Difficulty: Normal
-          Screw Attack and Screw Attack without Space Jump (Hard) and Dark World Damage ≥ 120 and Difficulty: Hard
+          All of the following:
+              Screw Attack and Screw Attack without Space Jump (Hard) and Dark World Damage ≥ 120 and Difficulty: Hard
+              Dark Visor or Invisible Objects (Hard)
           Invisible Objects (Hypermode) and Dark World Damage ≥ 200 and Difficulty: Hypermode
 
 > Door to Reliquary Access; Heals? False
@@ -1796,7 +1798,9 @@ Asset id: 1683944003
           Dark Visor and Space Jump Boots and Dark World Damage ≥ 100
           Space Jump Boots and Screw Attack and Dark World Damage ≥ 50
           Space Jump Boots and Invisible Objects (Normal) and Dark World Damage ≥ 100 and Difficulty: Normal
-          Screw Attack and Screw Attack without Space Jump (Hard) and Dark World Damage ≥ 120 and Difficulty: Hard
+          All of the following:
+              Screw Attack and Screw Attack without Space Jump (Hard) and Dark World Damage ≥ 120 and Difficulty: Hard
+              Dark Visor or Invisible Objects (Hard)
           Invisible Objects (Hypermode) and Dark World Damage ≥ 200 and Difficulty: Hypermode
 
 > Pickup (Missile); Heals? False
@@ -1805,14 +1809,18 @@ Asset id: 1683944003
           Dark Visor and Space Jump Boots and Dark World Damage ≥ 90
           Space Jump Boots and Screw Attack and Dark World Damage ≥ 50
           Space Jump Boots and Invisible Objects (Normal) and Dark World Damage ≥ 90 and Difficulty: Normal
-          Screw Attack and Screw Attack without Space Jump (Hard) and Dark World Damage ≥ 110 and Difficulty: Hard
+          All of the following:
+              Screw Attack and Screw Attack without Space Jump (Hard) and Dark World Damage ≥ 110 and Difficulty: Hard
+              Dark Visor or Invisible Objects (Hard)
           Invisible Objects (Hypermode) and Dark World Damage ≥ 110 and Difficulty: Hypermode
   > Phazon Grounds/Door to Reliquary Access
       Any of the following:
           Dark Visor and Space Jump Boots and Dark World Damage ≥ 140
           Space Jump Boots and Screw Attack and Dark World Damage ≥ 80
           Space Jump Boots and Invisible Objects (Normal) and Dark World Damage ≥ 140 and Difficulty: Normal
-          Screw Attack and Screw Attack without Space Jump (Hard) and Dark World Damage ≥ 150 and Difficulty: Hard
+          All of the following:
+              Screw Attack and Screw Attack without Space Jump (Hard) and Dark World Damage ≥ 150 and Difficulty: Hard
+              Dark Visor or Invisible Objects (Hard)
           Invisible Objects (Hypermode) and Dark World Damage ≥ 150 and Difficulty: Hypermode
 
 ----------------

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -1555,7 +1555,7 @@ Asset id: 1441689027
               Morph Ball and Power Bomb
               Space Jump Boots and Screw Attack and Difficulty: Trivial
   > Trooper Security Station/Event - Trooper Security Station Gate
-      Morph Ball and Before Trooper Security Station Gate
+      Scan Visor and Morph Ball and Before Trooper Security Station Gate
 
 > Event - Trooper Security Station Gate; Heals? False
   > Trooper Security Station/Door to GFMC Compound

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -13,6 +13,22 @@ Templates
 * Shoot Sonic Boom:
       Annihilator Beam and Sonic Boom and Charge Beam and Missile ≥ 5 and Dark Ammo ≥ 30 and Light Ammo ≥ 30
 
+* Bomb Slot without Bombs (Space Jump):
+      All of the following:
+          Morph Ball and Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
+          Any of the following:
+              Dark Beam and Darkburst and Dark Ammo ≥ 30
+              Light Beam and Sunburst and Light Ammo ≥ 30
+              Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+
+* Bomb Slot without Bombs (No Space Jump):
+      All of the following:
+          Morph Ball and Charge Beam and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
+          Any of the following:
+              Dark Beam and Darkburst and Dark Ammo ≥ 30
+              Light Beam and Sunburst and Light Ammo ≥ 30
+              Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+
 ====================
 Temple Grounds
 ----------------
@@ -2609,16 +2625,9 @@ Asset id: 1272952761
   > Transport Center/Pickup (Missile)
       After Transport Center Gate
   > Transport Center/Event - Transport Center Gate
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 ----------------
 Mining Station A
@@ -3540,31 +3549,17 @@ Asset id: 3209927104
   > Agon Energy Controller/Door to Controller Access
       Trivial
   > Controller Access/Door to Agon Temple
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 > Door to Agon Temple; Heals? False
   > Agon Temple/Door to Controller Access
       Trivial
   > Controller Access/Door to Agon Energy Controller
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 ----------------
 Sandcanyon
@@ -3949,31 +3944,17 @@ Asset id: 2733852625
   > Dark Agon Temple/Door to Dark Controller Access
       Trivial
   > Dark Controller Access/Door to Dark Agon Energy Controller
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 > Door to Dark Agon Energy Controller; Heals? True
   > Dark Agon Energy Controller/Door to Dark Controller Access
       Trivial
   > Dark Controller Access/Door to Dark Agon Temple
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 ----------------
 Command Center
@@ -4421,15 +4402,10 @@ Asset id: 2763180926
 > Tunnel; Heals? True
   > Sand Processing/Event - Sand Processing Sand Drained
       All of the following:
-          Scan Visor and Morph Ball
+          Scan Visor
           Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+              Morph Ball and Morph Ball Bomb
+              Bomb Slot without Bombs (Space Jump)
   > Sand Processing/Bottom of Halfpipe
       Trivial
 
@@ -4617,31 +4593,17 @@ Asset id: 4146307738
   > Biostorage Station/Door to Security Station A
       Trivial
   > Security Station A/Door to Bioenergy Production
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 > Door to Bioenergy Production; Heals? False
   > Bioenergy Production/Door to Security Station A
       Trivial
   > Security Station A/Door to Biostorage Station
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 ----------------
 Storage B
@@ -6424,31 +6386,17 @@ Asset id: 720788297
   > Torvus Temple/Door to Controller Access
       Trivial
   > Controller Access/Door to Torvus Energy Controller
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 > Door to Torvus Energy Controller; Heals? False
   > Torvus Energy Controller/Door to Controller Access
       Trivial
   > Controller Access/Door to Torvus Temple
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 ----------------
 Gloom Vista
@@ -6492,31 +6440,17 @@ Asset id: 298078827
   > Dark Torvus Energy Controller/Door to Dark Controller Access
       Trivial
   > Dark Controller Access/Door to Dark Torvus Temple
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 > Door to Dark Torvus Temple; Heals? True
   > Dark Torvus Temple/Door to Dark Controller Access
       Trivial
   > Dark Controller Access/Door to Dark Torvus Energy Controller
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 ----------------
 Hydrodynamo Station
@@ -9291,16 +9225,13 @@ Asset id: 1932798548
       Missile
   > Main Gyro Chamber/Event - Main Gyro Chamber Puzzle 1
       All of the following:
-          Morph Ball
           Power Beam or Missile ≥ 4
           Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 60
-                      Light Beam and Sunburst and Light Ammo ≥ 60
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 60 and Light Ammo ≥ 60
+              Morph Ball and Morph Ball Bomb
+              Bomb Slot without Bombs (Space Jump)
+          Any of the following:
+              Morph Ball and Morph Ball Bomb
+              Bomb Slot without Bombs (Space Jump)
   > Main Gyro Chamber/Reactor - Save Station Side
       All of the following:
           Morph Ball
@@ -9400,16 +9331,14 @@ Asset id: 1932798548
 > Puzzle 2 Debris; Heals? True
   > Main Gyro Chamber/Event - Main Gyro Chamber Puzzle 2
       All of the following:
-          Morph Ball and After Main Gyro Chamber Puzzle 1
+          After Main Gyro Chamber Puzzle 1
           Power Beam or Missile ≥ 7
           Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 60
-                      Light Beam and Sunburst and Light Ammo ≥ 60
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 60 and Light Ammo ≥ 60
+              Morph Ball and Morph Ball Bomb
+              Bomb Slot without Bombs (Space Jump)
+          Any of the following:
+              Morph Ball and Morph Ball Bomb
+              Bomb Slot without Bombs (Space Jump)
 
 > Reactor - Save Station Side; Heals? True
   > Main Gyro Chamber/Door to Dynamo Access
@@ -9848,15 +9777,10 @@ Asset id: 1378173793
 > Before Bomb Slot; Heals? True
   > Vault/Event - Vault Bomb Slot
       All of the following:
-          Morph Ball and After Vault Puzzle
+          After Vault Puzzle
           Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+              Morph Ball and Morph Ball Bomb
+              Bomb Slot without Bombs (No Space Jump)
 
 ----------------
 Temple Security Access
@@ -9988,31 +9912,17 @@ Asset id: 3902528658
   > Sanctuary Temple/Door to Controller Access
       Trivial
   > Controller Access/Door to Sanctuary Energy Controller
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 > Door to Sanctuary Energy Controller; Heals? False
   > Sanctuary Energy Controller/Door to Controller Access
       Trivial
   > Controller Access/Door to Sanctuary Temple
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 ----------------
 Hive Gyro Chamber
@@ -10429,31 +10339,17 @@ Asset id: 648838942
   > Hive Temple/Door to Hive Controller Access
       Annihilator Beam
   > Hive Controller Access/Door to Hive Energy Controller
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 > Door to Hive Energy Controller; Heals? True
   > Hive Energy Controller/Door to Hive Controller Access
       Trivial
   > Hive Controller Access/Door to Hive Temple
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Morph Ball Bomb
-              All of the following:
-                  Charge Beam and Space Jump Boots and Missile ≥ 5 and Bomb Slot without Bombs (Hypermode) and Difficulty: Hypermode
-                  Any of the following:
-                      Dark Beam and Darkburst and Dark Ammo ≥ 30
-                      Light Beam and Sunburst and Light Ammo ≥ 30
-                      Annihilator Beam and Sonic Boom and Dark Ammo ≥ 30 and Light Ammo ≥ 30
+      Any of the following:
+          Morph Ball and Morph Ball Bomb
+          Bomb Slot without Bombs (Space Jump)
 
 ----------------
 Aerie Access


### PR DESCRIPTION
- Template updates for Bombless Bomb Slots
- Profane Path/Sentinel's Path require Charge if no ammo (Fixes #842, Fixes #843)
- Invisible Objects/Dark Visor updates for Unseen Way and Phazon Grounds (Fixes #833, Fixes #836)
- Trooper Security Station requires Scan Visor for event from the front (Fixes #837)
- SA + SJ to reach Ing Cache 2 Door (Fixes #831)