### PR TITLE
Database improvements for consistency

### DIFF
--- a/randovania/gui/game_session_window.py
+++ b/randovania/gui/game_session_window.py
@@ -101,8 +101,9 @@ class PlayerWidget:
         self.kick.setEnabled(self_player.admin and player.id != self_player.id)
         self.promote.setText(promote_text)
         self.promote.setEnabled(self_player.admin and game_session.num_admins >= num_required)
-        self.move_up.setEnabled(admin_or_you and player.row > 0)
-        self.move_down.setEnabled(admin_or_you and player.row + 1 < game_session.num_rows)
+        if not player.is_observer:
+            self.move_up.setEnabled(admin_or_you and player.row > 0)
+            self.move_down.setEnabled(admin_or_you and player.row + 1 < game_session.num_rows)
         self.abandon.setEnabled(admin_or_you)
         self.switch_observer_action.setText("Include in session" if player.is_observer else "Move to observers")
         self.switch_observer_action.setEnabled(admin_or_you)

--- a/randovania/network_client/game_session.py
+++ b/randovania/network_client/game_session.py
@@ -26,8 +26,7 @@ class GameSessionListEntry:
 class PlayerSessionEntry:
     id: int
     name: str
-    row: int
-    is_observer: bool
+    row: Optional[int]
     admin: bool
 
     @classmethod
@@ -36,9 +35,12 @@ class PlayerSessionEntry:
             id=data["id"],
             name=data["name"],
             row=data["row"],
-            is_observer=data["is_observer"],
             admin=data["admin"],
         )
+
+    @property
+    def is_observer(self):
+        return self.row is None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/test/gui/test_game_session_window.py
+++ b/test/gui/test_game_session_window.py
@@ -24,7 +24,7 @@ async def test_on_game_session_updated(preset_manager, skip_qtbot):
         name="The Session",
         presets=[preset_manager.default_preset, preset_manager.default_preset],
         players={
-            12: PlayerSessionEntry(12, "Player A", 0, False, True),
+            12: PlayerSessionEntry(12, "Player A", 0, True),
         },
         actions=[],
         seed_hash=None,
@@ -38,8 +38,8 @@ async def test_on_game_session_updated(preset_manager, skip_qtbot):
         name="The Session",
         presets=[preset_manager.default_preset],
         players={
-            12: PlayerSessionEntry(12, "Player A", 0, False, True),
-            24: PlayerSessionEntry(24, "Player B", 0, True, False),
+            12: PlayerSessionEntry(12, "Player A", 0, True),
+            24: PlayerSessionEntry(24, "Player B", None, False),
         },
         actions=[
             GameSessionAction("Hello", datetime.datetime(year=2020, month=1, day=5))


### PR DESCRIPTION
GameSessionMembership: Remove is_observer field and make row nullable. Add UNIQUE(session_id, row) constraint.
GameSessionPreset: Add primary key using (session_id, row)

Fixes #1078.