### PR TITLE
Trick Balancing: Slope Jumps and Bomb Space Jumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,6 +324,8 @@ Her contributions to Randovania were invaluable and she'll be missed.
 
 -   Abandoned Base, Bomb Jump to tram is now Advanced (from Intermediate).
 
+-   Central Mining Station, Bomb Space Jump to top door is now Beginner (from Intermediate).
+
 ## [1.2.2] - 2020-06-06
 
 -   Changed: Re-organized the tabs in the preset customization window

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,11 @@ Her contributions to Randovania were invaluable and she'll be missed.
 
 -   Ing Windchamber, method of completing the puzzle with Power Bombs instead of Bombs (Beginner and above).
 
--   Landing Site, method of reaching Service Access door with Bombs and Screw Attack (Intermediate and above).
+-   Landing Site, method of reaching Service Access door:
+    - With Bombs and Screw Attack (Intermediate and above).
+    - With Space Jump and Bomb Space Jump (Beginner and above).
+
+-   Meeting Grounds, method of reaching the tunnel with Space Jump and a Bomb Space Jump (Intermediate and above).
 
 -   Windchamber Gateway, method of reaching the item with a Boost Jump (Advanced and above) and returning with an Extended Dash (Expert and above).
 
@@ -163,9 +167,20 @@ Her contributions to Randovania were invaluable and she'll be missed.
     - Method of reaching Ing Cache 1 door with Space Jump and Screw Attack (No Tricks and above).
     - Method of climbing to Watering Hole door without any items (Expert and above).
 
+-   Mining Station B, method to climb to the Seeker door without Morph Ball and with Space Jump (Beginner and above).
+
 -   Transport Center/Crossroads, method to climb the halfpipe with Space Jump (Advanced and above).
 
--   Abandoned Worksite, method of reaching the item with a Bomb Space Jump without Space Jump (Advanced and above).
+-   Abandoned Worksite:
+    - Method of reaching the item with a Bomb Space Jump without Space Jump (Advanced and above).
+    - Method of reaching the tunnel from Forgotten Bridge with a Slope Jump (Intermediate and above).
+
+-   Catacombs:
+    - Method to reach the Bomb Slot with Air Underwater and Screw Attack (Advanced and above).
+    - Method to reach Transit Tunnel East with a Combat/Scan Dash (Advanced and above).
+    - Method to reach the portal with Screw Attack (Intermediate and above).
+    - Method to reach Transit Tunnel East/South with Morph Ball, Gravity Boost, and Reverse Air Underwater (Advanced and above).
+    - Method to reach Transit Tunnel South with Jump Off Enemy (Advanced and above).
 
 -   Dark/Forgotten Bridge, method to reach Abandoned Worksite/Brooding Ground door from the bridge before rotating and with an Extended Dash (Expert and above).
 
@@ -175,6 +190,7 @@ Her contributions to Randovania were invaluable and she'll be missed.
     - Method to reach the Kinetic Orb Cannon with Gravity Boost and Bombs (Expert and above) or Gravity Boost and Space Jump (Beginner and above).
     - Method to reach Transit Tunnel South from Transit Tunnel West with Morph Ball, Gravity Boost, and Reverse Air Underwater (Advanced and above).
     - Method to reach the Spider Ball tracks with Morph Ball, Gravity Boost, and Reverse Air Underwater (Advanced and above).
+    - Methods to escape the halfpipe after draining the water with Space Jump and Bomb Space Jump or Space Jump and Screw Attack (Advanced and above).
 
 -   Main Hydrochamber/Hydrodynamo Station, methods to climb rooms without Gravity Boost and with Air Underwater (Advanced and above), Space Jump, and Screw Attack (Hypermode).
 
@@ -205,9 +221,13 @@ Her contributions to Randovania were invaluable and she'll be missed.
 
 -   Undertemple Access, method of reaching the item using Screw Attack and Jump Off Enemy (Hypermode).
 
+-   Venomous Pond, method to reach the key from the Save Station with Screw Attack and Standable Terrain (Beginner and above).
+
 -   Aerial Training Site, methods to cross the room from various nodes with Dashes, Roll Jumps, and Extended Dashes (Intermediate/Expert and above).
 
 -   Aerie, method of collecting the item without entering the Dark World (Expert and above).
+
+-   Dynamo Access, method to cross over the Spider Track with Space Jump and Standable Terrain (Beginner and above).
 
 -   Dynamo Works, method of collecting the item with a Roll Jump and Instant Morph (Expert and above).
 
@@ -260,6 +280,10 @@ Her contributions to Randovania were invaluable and she'll be missed.
 
 -   Torvus Temple now requires Morph Ball from Transport to Agon Wastes and Underground Transport to the bottom of the temple.
 
+-   Sand Processing:
+    - Now requires items to climb the room before draining the sand: Space Jump, with a Bomb Jump (Beginner and above) or with Screw Attack (Intermediate and above)
+    - Screw Attacking into the tunnel is now Expert (from Hypermode).
+
 #### Changed
 
 -   Many nodes with missing requirements have been updated/cleaned up.
@@ -279,6 +303,20 @@ Her contributions to Randovania were invaluable and she'll be missed.
 -   Scan Dash to upper level in Central Mining Station from Central Station Access is now Expert (from Advanced).
 
 -   Instant Morph tricks in Hall of Combat Mastery to the item and Central Area Transport East and back are now Advanced (from Intermediate).
+
+-   Agon Temple, Slope Jumps to skip the fight barriers are now Beginner (from Advanced).
+
+-   Mining Station B, reaching Transit Station door from room center with Screw Attack after opening the portal is now Intermediate (from Hypermode).
+
+-   Doomed Entry, Slope Jump to reach the upper level from the portal is now Beginner (from Intermediate).
+
+-   Venomous Pond, reaching the key from the Save Station with Screw Attack is now Beginner (from Intermediate).
+
+-   Dynamo Access, crossing over the Spider Track with a Slope Jump is now Beginner (from Intermediate).
+
+-   Transit Station, reaching the top portal with Screw Attack is now Beginner (from Intermediate).
+
+-   Path of Eyes, Bomb Jumps to get over Light blocks are now Beginner (from Intermediate).
 
 ## [1.2.2] - 2020-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,7 +229,9 @@ Her contributions to Randovania were invaluable and she'll be missed.
 
 -   Dynamo Access, method to cross over the Spider Track with Space Jump and Standable Terrain (Beginner and above).
 
--   Dynamo Works, method of collecting the item with a Roll Jump and Instant Morph (Expert and above).
+-   Dynamo Works:
+    - Method of collecting the item with a Roll Jump and Instant Morph (Expert and above).
+    - Method of reaching the upper door with a Bomb Space Jump (Beginnner and above).
 
 -   Grand Abyss, methods of crossing the gap with Boost Jump (Advanced and above) or Extended Dash (Expert and above).
 
@@ -325,6 +327,8 @@ Her contributions to Randovania were invaluable and she'll be missed.
 -   Abandoned Base, Bomb Jump to tram is now Advanced (from Intermediate).
 
 -   Central Mining Station, Bomb Space Jump to top door is now Beginner (from Intermediate).
+
+-   Hive Dynamo Works, reaching the upper door with a Bomb Space Jump is now Beginner (from Intermediate).
 
 ## [1.2.2] - 2020-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,12 @@ Her contributions to Randovania were invaluable and she'll be missed.
 
 -   Path of Eyes, Bomb Jumps to get over Light blocks are now Beginner (from Intermediate).
 
+-   Great Bridge, Slope Jumps to reach Map Station from Bottom Level and from Map Station to Upper Level are now Beginner and Intermediate (from Intermediate and Advanced, respectively).
+
+-   Torvus Lagoon, reaching Portal Chamber from Temple Transport Access is now Intermediate (from Advanced).
+
+-   Abandoned Base, Bomb Jump to tram is now Advanced (from Intermediate).
+
 ## [1.2.2] - 2020-06-06
 
 -   Changed: Re-organized the tabs in the preset customization window

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,7 +320,9 @@ Her contributions to Randovania were invaluable and she'll be missed.
 
 -   Path of Eyes, Bomb Jumps to get over Light blocks are now Beginner (from Intermediate).
 
--   Great Bridge, Slope Jumps to reach Map Station from Bottom Level and from Map Station to Upper Level are now Beginner and Intermediate (from Intermediate and Advanced, respectively).
+-   Great Bridge:
+    - Slope Jumps to reach Map Station from Bottom Level and from Map Station to Upper Level are now Beginner and Intermediate (from Intermediate and Advanced, respectively).
+    - Bomb Space Jump with Space Jump to reach the Translator Gate is now Advanced (from Expert).
 
 -   Torvus Lagoon, reaching Portal Chamber from Temple Transport Access is now Intermediate (from Advanced).
 
@@ -329,6 +331,8 @@ Her contributions to Randovania were invaluable and she'll be missed.
 -   Central Mining Station, Bomb Space Jump to top door is now Beginner (from Intermediate).
 
 -   Hive Dynamo Works, reaching the upper door with a Bomb Space Jump is now Beginner (from Intermediate).
+
+-   Grand Windchamber, reaching the pickup with Terminal Fall Abuse after solving the Ing Windchamber puzzle is now Beginner (from Intermediate).
 
 ## [1.2.2] - 2020-06-06
 

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -2377,6 +2377,12 @@ Agon Map Station
 Asset id: 2220656039
 > Morph Ball Door to Mining Plaza; Heals? False; Spawn Point
   * Morph Ball Door to Mining Plaza/Morph Ball Door to Agon Map Station
+  > Map Station
+      Morph Ball
+
+> Map Station; Heals? False
+  > Morph Ball Door to Mining Plaza
+      Morph Ball
 
 ----------------
 Transit Station
@@ -3191,7 +3197,7 @@ Asset id: 1803024829
 ----------------
 Agon Temple
 Asset id: 1979488942
-> Door to Mine Shaft; Heals? True
+> Door to Mine Shaft; Heals? False
   * Dark Door to Mine Shaft/Door to Agon Temple
   > Door to Temple Access
       Any of the following:
@@ -3205,22 +3211,23 @@ Asset id: 1979488942
   > Door to Mine Shaft
       Any of the following:
           Morph Ball and Morph Ball Bomb
-          Knowledge (Intermediate) and Use Screw Attack (Space Jump)
+          Movement (Intermediate) and Use Screw Attack (Space Jump)
   > Door to Sandcanyon
       Trivial
   > Event - Bomb Guardian
       Any of the following:
-          Before Bomb Guardian
-          Morph Ball and Morph Ball Bomb
-          Morph Ball and Power Bomb
+          Space Jump Boots or Before Bomb Guardian
+          All of the following:
+              Morph Ball
+              Morph Ball Bomb or Power Bomb
           All of the following:
               Knowledge (Beginner)
               Any of the following:
-                  Space Jump Boots or Use Screw Attack (Space Jump)
+                  Use Screw Attack (Space Jump)
                   Morph Ball and Boost Ball
                   Screw Attack at Z-Axis (Beginner) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
 
-> Door to Controller Access; Heals? True
+> Door to Controller Access; Heals? False
   * Normal Door to Controller Access/Door to Agon Temple
   > Door to Mine Shaft
       Trivial
@@ -3230,13 +3237,14 @@ Asset id: 1979488942
           Movement (Intermediate) and Use Screw Attack (Space Jump)
   > Room Center
       Any of the following:
-          Before Bomb Guardian
-          Morph Ball and Morph Ball Bomb
-          Morph Ball and Power Bomb
+          Space Jump Boots or Before Bomb Guardian
+          All of the following:
+              Morph Ball
+              Morph Ball Bomb or Power Bomb
           All of the following:
               Knowledge (Beginner)
               Any of the following:
-                  Space Jump Boots or Use Screw Attack (Space Jump)
+                  Use Screw Attack (Space Jump)
                   Morph Ball and Boost Ball
                   Screw Attack at Z-Axis (Beginner) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
 
@@ -3270,8 +3278,8 @@ Asset id: 1979488942
               Any of the following:
                   Use Screw Attack (Space Jump)
                   Morph Ball and Boost Ball
-                  Space Jump Boots and Slope Jump (Intermediate)
                   Screw Attack at Z-Axis (Beginner) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
+          Space Jump Boots and Slope Jump (Intermediate)
   > Door to Controller Access
       Any of the following:
           Before Bomb Guardian
@@ -3283,8 +3291,8 @@ Asset id: 1979488942
               Any of the following:
                   Use Screw Attack (Space Jump)
                   Morph Ball and Boost Ball
-                  Space Jump Boots and Slope Jump (Intermediate)
                   Screw Attack at Z-Axis (Beginner) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
+          Space Jump Boots and Slope Jump (Intermediate)
   > Event - Bomb Guardian
       Trivial
 

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -1676,10 +1676,12 @@ Asset id: 3258777533
           All of the following:
               Scan Visor
               Any of the following:
-                  Morph Ball and Missile
+                  After Sacred Path Wall Broken
                   Combat/Scan Dash (Advanced) and Slope Jump (Advanced) and Standable Terrain (Advanced)
           Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner)
           Movement (Intermediate) and Use Screw Attack (No Space Jump)
+  > Event - Sacred Path Wall Broken
+      Morph Ball and Missile
 
 > Door to Temple Transport A; Heals? False
   * Normal Door to Temple Transport A/Door to Sacred Path
@@ -1688,8 +1690,15 @@ Asset id: 3258777533
           Space Jump Boots
           Morph Ball and Morph Ball Bomb and Bomb Jump (Intermediate)
           Movement (Beginner) and Use Screw Attack (No Space Jump)
+          Scan Visor and Morph Ball and After Sacred Path Wall Broken and Combat/Scan Dash (Advanced)
   > Door to Sacred Bridge
       Trivial
+
+> Event - Sacred Path Wall Broken; Heals? False
+  > Door to Sacred Bridge
+      Trivial
+  > Door to Temple Transport A
+      Morph Ball
 
 ----------------
 Temple Transport A

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -880,14 +880,14 @@ Asset id: 3337937090
           All of the following:
               Morph Ball and Morph Ball Bomb
               Any of the following:
-                  Space Jump Boots and Ingclaw Vapor Damage ≥ 1500
+                  Space Jump Boots and Dark World Damage ≥ 40 and Ingclaw Vapor Damage ≥ 1500
                   All of the following:
-                      Bomb Jump (Intermediate) and Movement (Intermediate)
+                      Bomb Jump (Advanced) and Movement (Advanced)
                       Any of the following:
-                          Ingclaw Vapor Damage ≥ 500
-                          Boost Ball and Ingclaw Vapor Damage ≥ 400
-          Space Jump Boots and Slope Jump (Advanced) and Movement (Advanced) and Ingclaw Vapor Damage ≥ 70
-          Standable Terrain (Intermediate) and Dark World Damage ≥ 40 and Use Screw Attack (Space Jump)
+                          Boost Ball and Dark World Damage ≥ 90 and Ingclaw Vapor Damage ≥ 375
+                          Dark World Damage ≥ 200 and Ingclaw Vapor Damage ≥ 525
+          Space Jump Boots and Slope Jump (Advanced) and Ingclaw Vapor Damage ≥ 70
+          Standable Terrain (Intermediate) and Dark World Damage ≥ 50 and Use Screw Attack (Space Jump)
 
 ----------------
 Windchamber Gateway
@@ -1676,7 +1676,7 @@ Asset id: 3258777533
               Scan Visor
               Any of the following:
                   Morph Ball and Missile
-                  Combat/Scan Dash (Advanced) and Slope Jump (Advanced)
+                  Combat/Scan Dash (Advanced) and Slope Jump (Advanced) and Standable Terrain (Advanced)
           Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner)
           Movement (Intermediate) and Use Screw Attack (No Space Jump)
 
@@ -1685,7 +1685,6 @@ Asset id: 3258777533
   > Portal to Profane Path
       Any of the following:
           Space Jump Boots
-          Scan Visor and Morph Ball and Missile and Combat/Scan Dash (Advanced)
           Morph Ball and Morph Ball Bomb and Bomb Jump (Intermediate)
           Movement (Beginner) and Use Screw Attack (No Space Jump)
   > Door to Sacred Bridge
@@ -4194,18 +4193,14 @@ Asset id: 3436835742
       Morph Ball and Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Advanced) and Standable Terrain (Beginner)
   > Before Pickup
       All of the following:
-          Morph Ball and After Dark Samus 1 and After Main Reactor Reloaded after DS1
+          Morph Ball and Spider Ball and After Dark Samus 1 and After Main Reactor Reloaded after DS1
           Any of the following:
+              Boost Ball
               All of the following:
-                  Spider Ball
+                  Morph Ball Bomb
                   Any of the following:
-                      Boost Ball
-                      All of the following:
-                          Morph Ball Bomb
-                          Any of the following:
-                              Bomb Jump (Hypermode)
-                              Space Jump Boots and Bomb Space Jump (Intermediate) and Standable Terrain (Intermediate)
-              Morph Ball Bomb and Bomb Space Jump (Expert) and Standable Terrain (Intermediate) and Use Screw Attack (Space Jump)
+                      Bomb Jump (Hypermode)
+                      Space Jump Boots and Bomb Space Jump (Intermediate) and Standable Terrain (Intermediate)
 
 ----------------
 Dark Agon Energy Controller
@@ -5056,13 +5051,13 @@ Asset id: 2114709145
           After Torvus Lagoon Gates
           Any of the following:
               Space Jump Boots
-              Slope Jump (Advanced) and Standable Terrain (Advanced)
+              Slope Jump (Intermediate) and Standable Terrain (Intermediate)
   > Door to Path of Roots
       Trivial
   > Pickup (Missile)
       Any of the following:
           Gravity Boost
-          Morph Ball and Space Jump Boots and Screw Attack and Air Underwater (Advanced)
+          Air Underwater (Advanced) and Use Screw Attack (Space Jump)
   > Keybearer Corpse (S-Dly)
       Trivial
 
@@ -5349,7 +5344,7 @@ Asset id: 3822429534
 > Door to Torvus Map Station; Heals? False
   * Normal Door to Torvus Map Station/Door to Great Bridge
   > Front of Translator Gate
-      Space Jump Boots and Slope Jump (Advanced)
+      Space Jump Boots and Slope Jump (Intermediate) and Standable Terrain (Beginner)
   > Translator Gate
       Trivial
 
@@ -5398,7 +5393,7 @@ Asset id: 3822429534
 > Door to Temple Access (Bottom); Heals? False
   * Normal Door to Temple Access/Door to Great Bridge (Bottom)
   > Door to Torvus Map Station
-      Space Jump Boots and Combat/Scan Dash (Advanced) and Slope Jump (Advanced)
+      Space Jump Boots and Slope Jump (Advanced)
   > Door to Abandoned Worksite
       Any of the following:
           All of the following:
@@ -5443,7 +5438,7 @@ Asset id: 3822429534
   > Door to Temple Access (Top)
       Any of the following:
           Morph Ball and After Great Bridge Cannon
-          Slope Jump (Advanced) and Use Screw Attack (Space Jump)
+          Slope Jump (Intermediate) and Use Screw Attack (Space Jump)
   > Door to Temple Access (Bottom)
       Trivial
 
@@ -7532,7 +7527,7 @@ Asset id: 3366472600
 > Laser Platform; Heals? False
   > Door to Crypt Tunnel
       Any of the following:
-          Space Jump Boots and Slope Jump (Advanced) and Standable Terrain (Advanced) and Dark World Damage ≥ 25
+          Space Jump Boots and Slope Jump (Intermediate) and Standable Terrain (Intermediate) and Dark World Damage ≥ 25
           All of the following:
               Morph Ball and Morph Ball Bomb
               Any of the following:

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -156,11 +156,13 @@ Asset id: 1655756413
           All of the following:
               Morph Ball and Morph Ball Bomb and Bomb Jump (Intermediate) and Standable Terrain (Intermediate)
               Any of the following:
-                  Slope Jump (Advanced) or Bomb Space Jump (Expert)
+                  Slope Jump (Advanced)
                   Movement (Intermediate) and Use Screw Attack (No Space Jump)
           All of the following:
               Space Jump Boots
-              Slope Jump (Intermediate) or Standable Terrain (Intermediate)
+              Any of the following:
+                  Slope Jump (Intermediate) or Standable Terrain (Intermediate)
+                  Morph Ball and Morph Ball Bomb and Bomb Space Jump (Beginner)
   > Door to Hive Access Tunnel
       After Landing Site Webs
   > Event - Landing Site Webs
@@ -328,12 +330,12 @@ Asset id: 2606692981
 
 > Door to Hall of Eyes; Heals? False
   * Normal Door to Hall of Eyes/Door to Meeting Grounds
-  > Room Center
+  > Bottom of Halfpipe
       Trivial
 
 > Door to Service Access; Heals? False; Spawn Point
   * Super Missile Blast Shield to Service Access/Door to Meeting Grounds
-  > Room Center
+  > Bottom of Halfpipe
       Trivial
 
 > Door to Temple Transport C; Heals? False
@@ -341,7 +343,7 @@ Asset id: 2606692981
   > Translator Gate
       Trivial
 
-> Room Center; Heals? False
+> Bottom of Halfpipe; Heals? False
   > Door to Hall of Eyes
       Trivial
   > Door to Service Access
@@ -351,19 +353,23 @@ Asset id: 2606692981
   > Front of Lore Scan
       Any of the following:
           Morph Ball and Boost Ball
-          Space Jump Boots and Slope Jump (Intermediate)
+          All of the following:
+              Space Jump Boots and Standable Terrain (Intermediate)
+              Any of the following:
+                  Before Torvus Energy Returned and Slope Jump (Intermediate)
+                  Morph Ball and Morph Ball Bomb and Bomb Space Jump (Intermediate)
 
 > Translator Gate; Heals? False
   * Translator Gate (TranslatorGate 1)
   > Door to Temple Transport C
       Trivial
-  > Room Center
+  > Bottom of Halfpipe
       Trivial
 
 > Front of Lore Scan; Heals? False
   > Morph Ball Door to Service Access
       Morph Ball
-  > Room Center
+  > Bottom of Halfpipe
       Trivial
   > Lore Scan
       Trivial
@@ -511,7 +517,7 @@ Asset id: 1655474884
 
 > Door to Collapsed Tunnel; Heals? False
   * Normal Door to Collapsed Tunnel/Door to Industrial Site
-  > Front of Lift Scan
+  > Front of Crate Terminal
       Trivial
 
 > Door to Hive Transport Area; Heals? False; Spawn Point
@@ -519,8 +525,8 @@ Asset id: 1655474884
   > Event - Industrial Site Gate
       All of the following:
           Scan Visor
-          Power Beam or Missile
-  > Front of Lift Scan
+          Power Beam or Missile ≥ 2
+  > Front of Crate Terminal
       Any of the following:
           Space Jump Boots and Instant Morph (Advanced)
           Morph Ball and Morph Ball Bomb and Bomb Jump (Intermediate)
@@ -530,10 +536,10 @@ Asset id: 1655474884
   * Event Industrial Site Gate
   > Door to Hive Transport Area
       Trivial
-  > Front of Lift Scan
+  > Front of Crate Terminal
       Trivial
 
-> Front of Lift Scan; Heals? False
+> Front of Crate Terminal; Heals? False
   > Door to Collapsed Tunnel
       Any of the following:
           Space Jump Boots
@@ -555,6 +561,8 @@ Asset id: 1655474884
 > Front of Translator Gate; Heals? False
   > Door to Collapsed Tunnel
       Power Beam and Scan Visor
+  > Front of Crate Terminal
+      Trivial
   > Translator Gate
       Trivial
 
@@ -649,23 +657,8 @@ Path of Eyes
 Asset id: 3997643454
 > Door to Windchamber Gateway; Heals? False
   * Super Missile Blast Shield to Windchamber Gateway/Door to Path of Eyes
-  > Door to Hall of Eyes
-      All of the following:
-          After Path of Eyes Light Block to Windchamber Gateway
-          Any of the following:
-              Space Jump Boots
-              Movement (Expert) and Shoot Light Beam and Use Screw Attack (No Space Jump)
-              Morph Ball and Morph Ball Bomb and Bomb Jump (Intermediate)
-  > Front of Translator Gate
-      All of the following:
-          After Path of Eyes Light Block to Windchamber Gateway
-          Any of the following:
-              All of the following:
-                  Shoot Light Beam
-                  Any of the following:
-                      Space Jump Boots
-                      Morph Ball and Morph Ball Bomb and Bomb Space Jump (Hypermode)
-              Space Jump Boots and Standable Terrain (Intermediate)
+  > Front of Center Door
+      After Path of Eyes Light Block to Windchamber Gateway
 
 > Portal from Abandoned Base; Heals? False; Spawn Point
   * No Return Portal to Abandoned Base/Portal to Path of Eyes
@@ -674,30 +667,20 @@ Asset id: 3997643454
 
 > Door to Hall of Eyes; Heals? False
   * Super Missile Blast Shield to Hall of Eyes/Door to Path of Eyes
-  > Door to Windchamber Gateway
-      All of the following:
-          After Path of Eyes Light Block to Windchamber Gateway
-          Any of the following:
-              Space Jump Boots
-              All of the following:
-                  Shoot Light Beam
-                  Any of the following:
-                      Slope Jump (Intermediate)
-                      Morph Ball and Morph Ball Bomb and Bomb Jump (Intermediate)
-  > Event - Path of Eyes Light Block to Windchamber Gateway
-      All of the following:
-          Shoot Light Beam
-          Space Jump Boots or Slope Jump (Intermediate)
   > Front of Translator Gate
+      All of the following:
+          Morph Ball
+          Any of the following:
+              After Path of Eyes Light Block In Tunnel
+              Boost Ball and Morph Ball Bomb and Bomb Jump (Advanced) and Movement (Advanced) and NTSC
+  > Front of Center Door
       Any of the following:
+          Space Jump Boots
           All of the following:
               Shoot Light Beam
               Any of the following:
-                  Space Jump Boots
-                  Morph Ball and Morph Ball Bomb and Bomb Space Jump (Hypermode)
-          Morph Ball and Boost Ball and Morph Ball Bomb and Knowledge (Advanced) and NTSC
-          Morph Ball and After Path of Eyes Light Block In Tunnel
-          Space Jump Boots and Standable Terrain (Intermediate)
+                  Slope Jump (Intermediate)
+                  Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner)
 
 > Door to Torvus Transport Access; Heals? False
   * Normal Door to Torvus Transport Access/Door to Path of Eyes
@@ -706,39 +689,33 @@ Asset id: 3997643454
 
 > Event - Path of Eyes Light Block to Windchamber Gateway; Heals? False
   * Event Path of Eyes Light Block to Windchamber Gateway
-  > Door to Windchamber Gateway
+  > Front of Center Door
       Trivial
 
 > Event - Path of Eyes Light Block In Tunnel; Heals? False
   * Event Path of Eyes Light Block In Tunnel
-  > Door to Windchamber Gateway
-      After Path of Eyes Light Block to Windchamber Gateway
   > Door to Hall of Eyes
       Trivial
-  > Event - Path of Eyes Light Block to Windchamber Gateway
-      Shoot Light Beam
   > Front of Translator Gate
-      Trivial
+      Morph Ball
 
 > Front of Translator Gate; Heals? False
-  > Door to Windchamber Gateway
-      After Path of Eyes Light Block to Windchamber Gateway
   > Door to Hall of Eyes
-      Any of the following:
-          Space Jump Boots
-          All of the following:
-              Morph Ball
-              Any of the following:
-                  After Path of Eyes Light Block In Tunnel
-                  Boost Ball and Morph Ball Bomb and Bomb Jump (Intermediate) and Knowledge (Intermediate) and NTSC
-  > Event - Path of Eyes Light Block to Windchamber Gateway
-      Shoot Light Beam
+      All of the following:
+          Morph Ball
+          Any of the following:
+              After Path of Eyes Light Block In Tunnel
+              Boost Ball and Morph Ball Bomb and Bomb Jump (Intermediate) and Movement (Intermediate) and NTSC
   > Event - Path of Eyes Light Block In Tunnel
       Morph Ball and Shoot Light Beam
   > Translator Gate
       Trivial
   > Lore Scan
       Morph Ball
+  > Front of Center Door
+      Any of the following:
+          Space Jump Boots
+          Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner)
 
 > Translator Gate; Heals? False
   * Translator Gate (TranslatorGate 4)
@@ -751,6 +728,24 @@ Asset id: 3997643454
   * Logbook Luminoth Lore (Violet Translator) for 8e9fcfae
   > Front of Translator Gate
       Morph Ball
+
+> Front of Center Door; Heals? False
+  > Door to Windchamber Gateway
+      After Path of Eyes Light Block to Windchamber Gateway
+  > Door to Hall of Eyes
+      Any of the following:
+          Space Jump Boots
+          Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner)
+  > Event - Path of Eyes Light Block to Windchamber Gateway
+      Shoot Light Beam
+  > Front of Translator Gate
+      Any of the following:
+          Space Jump Boots and Standable Terrain (Intermediate)
+          All of the following:
+              Shoot Light Beam
+              Any of the following:
+                  Space Jump Boots
+                  Morph Ball and Morph Ball Bomb and Bomb Jump (Hypermode)
 
 ----------------
 Agon Transport Access
@@ -1951,7 +1946,7 @@ Asset id: 3885674414
                   Morph Ball and Boost Ball
                   Power Beam and Super Missile and Charge Beam and Missile ≥ 5
 
-> Door to Temple Sanctuary; Heals? True
+> Door to Temple Sanctuary; Heals? False
   * Normal Door to Temple Sanctuary/Door to Transport A Access
   > Save Station
       Morph Ball
@@ -1962,12 +1957,12 @@ Asset id: 3885674414
           Slope Jump (Intermediate) and Movement (Intermediate) and Use Screw Attack (No Space Jump)
           Morph Ball and Boost Ball and Wall Boost (Advanced)
 
-> Door to Temple Transport A; Heals? True
+> Door to Temple Transport A; Heals? False
   * Normal Door to Temple Transport A/Door to Transport A Access
   > Door to Temple Sanctuary
       Trivial
 
-> Pickup (Missile); Heals? True
+> Pickup (Missile); Heals? False
   * Pickup 20; Major Location? False
   > Save Station
       Trivial
@@ -1975,12 +1970,12 @@ Asset id: 3885674414
 ----------------
 Temple Sanctuary
 Asset id: 2731245106
-> Door to Transport B Access; Heals? True
+> Door to Transport B Access; Heals? False
   * Normal Door to Transport B Access/Door to Temple Sanctuary
   > Transport B Translator Gate
       Trivial
 
-> Door to Transport A Access; Heals? True; Spawn Point
+> Door to Transport A Access; Heals? False; Spawn Point
   * Normal Door to Transport A Access/Door to Temple Sanctuary
   > Room Center
       Any of the following:
@@ -1991,27 +1986,27 @@ Asset id: 2731245106
   > Event - Transport A Gate Removal
       Disabled Room Randomizer and Disabled Vanilla Great Temple Emerald Translator Gate
 
-> Door to Controller Transport; Heals? True
+> Door to Controller Transport; Heals? False
   * Normal Door to Controller Transport/Door to Temple Sanctuary
   > Room Center
       Trivial
 
-> Door to Transport C Access; Heals? True
+> Door to Transport C Access; Heals? False
   * Normal Door to Transport C Access/Door to Temple Sanctuary
   > Transport C Translator Gate
       Trivial
 
-> Pickup (Energy Transfer Module); Heals? True
+> Pickup (Energy Transfer Module); Heals? False
   * Pickup 21; Major Location? True
   > Room Center
       Trivial
 
-> Event - Alpha Splinter; Heals? True
+> Event - Alpha Splinter; Heals? False
   * Event Alpha Splinter
   > Pickup (Energy Transfer Module)
       Trivial
 
-> Room Center; Heals? True
+> Room Center; Heals? False
   > Door to Controller Transport
       After Alpha Splinter
   > Event - Alpha Splinter
@@ -2023,28 +2018,28 @@ Asset id: 2731245106
   > Transport C Translator Gate
       After Alpha Splinter
 
-> Transport A Translator Gate; Heals? True
+> Transport A Translator Gate; Heals? False
   * Translator Gate (TranslatorGate 9)
   > Door to Transport A Access
       Trivial
   > Room Center
       Trivial
 
-> Transport B Translator Gate; Heals? True
+> Transport B Translator Gate; Heals? False
   * Translator Gate (TranslatorGate 7)
   > Door to Transport B Access
       Trivial
   > Room Center
       Trivial
 
-> Transport C Translator Gate; Heals? True
+> Transport C Translator Gate; Heals? False
   * Translator Gate (TranslatorGate 8)
   > Door to Transport C Access
       Trivial
   > Room Center
       Trivial
 
-> Event - Transport A Gate Removal; Heals? True
+> Event - Transport A Gate Removal; Heals? False
   * Event Great Temple Transport A Translator Gone
   > Door to Transport A Access
       Trivial
@@ -2052,19 +2047,19 @@ Asset id: 2731245106
 ----------------
 Transport C Access
 Asset id: 441310400
-> Door to Temple Transport C; Heals? True
+> Door to Temple Transport C; Heals? False
   * Normal Door to Temple Transport C/Door to Transport C Access
   > Door to Temple Sanctuary
       After Transport C Access Light Block
 
-> Door to Temple Sanctuary; Heals? True; Spawn Point
+> Door to Temple Sanctuary; Heals? False; Spawn Point
   * Normal Door to Temple Sanctuary/Door to Transport C Access
   > Door to Temple Transport C
       After Transport C Access Light Block
   > Event - Transport C Access Light Block
       Shoot Light Beam
 
-> Event - Transport C Access Light Block; Heals? True
+> Event - Transport C Access Light Block; Heals? False
   * Event Transport C Access Light Block
   > Door to Temple Transport C
       Trivial
@@ -2087,22 +2082,25 @@ Asset id: 300223430
 ----------------
 Transport B Access
 Asset id: 4273454375
-> Door to Temple Sanctuary; Heals? True; Spawn Point
+> Door to Temple Sanctuary; Heals? False; Spawn Point
   * Normal Door to Temple Sanctuary/Door to Transport B Access
   > Door to Temple Transport B
       Trivial
   > Pickup (Missile)
       Any of the following:
-          Morph Ball and Boost Ball and Wall Boost (Expert)
-          Morph Ball and Morph Ball Bomb
+          All of the following:
+              Morph Ball
+              Any of the following:
+                  Morph Ball Bomb
+                  Boost Ball and Wall Boost (Expert)
           Space Jump Boots and Slope Jump (Intermediate)
 
-> Door to Temple Transport B; Heals? True
+> Door to Temple Transport B; Heals? False
   * Normal Door to Temple Transport B/Door to Transport B Access
   > Door to Temple Sanctuary
       Trivial
 
-> Pickup (Missile); Heals? True
+> Pickup (Missile); Heals? False
   * Pickup 22; Major Location? False
   > Door to Temple Sanctuary
       Trivial
@@ -2123,7 +2121,7 @@ Asset id: 2556480432
 ----------------
 Main Energy Controller
 Asset id: 44045108
-> Door to Controller Transport; Heals? True; Spawn Point
+> Door to Controller Transport; Heals? False; Spawn Point
   * Normal Door to Controller Transport/Door to Main Energy Controller
   > Pickup (Violet Translator)
       Trivial
@@ -2138,37 +2136,37 @@ Asset id: 44045108
   > Lore Scan
       Trivial
 
-> Pickup (Violet Translator); Heals? True
+> Pickup (Violet Translator); Heals? False
   * Pickup 23; Major Location? True
   > Door to Controller Transport
       Trivial
 
-> Pickup (Light Suit); Heals? True
+> Pickup (Light Suit); Heals? False
   * Pickup 24; Major Location? True
   > Door to Controller Transport
       Trivial
 
-> Teleport to Agon Wastes - Agon Energy Controller; Heals? True
+> Teleport to Agon Wastes - Agon Energy Controller; Heals? False
   * Teleporter to Agon Wastes - Agon Energy Controller
   > Door to Controller Transport
       Trivial
 
-> Teleport to Torvus Bog - Torvus Energy Controller; Heals? True
+> Teleport to Torvus Bog - Torvus Energy Controller; Heals? False
   * Teleporter to Torvus Bog - Torvus Energy Controller
   > Door to Controller Transport
       Trivial
 
-> Teleport to Sanctuary Fortress - Sanctuary Energy Controller; Heals? True
+> Teleport to Sanctuary Fortress - Sanctuary Energy Controller; Heals? False
   * Teleporter to Sanctuary Fortress - Sanctuary Energy Controller
   > Door to Controller Transport
       Trivial
 
-> Event - Main Energy Controller Pickup; Heals? True
+> Event - Main Energy Controller Pickup; Heals? False
   * Event Main Energy Controller Pickup
   > Pickup (Light Suit)
       Trivial
 
-> Lore Scan; Heals? True
+> Lore Scan; Heals? False
   * Logbook Luminoth Lore (Violet Translator) for c3576ea5
   > Door to Controller Transport
       Trivial
@@ -2554,12 +2552,14 @@ Asset id: 3682282733
               All of the following:
                   After Mining Station B Portal Opened
                   Any of the following:
-                      Movement (Advanced) and Use Screw Attack (Space Jump)
+                      Movement (Intermediate) and Use Screw Attack (Space Jump)
                       Slope Jump (Intermediate) and Standable Terrain (Intermediate)
   > Door to Mine Shaft
       Any of the following:
           Scan Visor and Morph Ball
-          Space Jump Boots and Slope Jump (Intermediate)
+          All of the following:
+              Space Jump Boots
+              Slope Jump (Intermediate) or Standable Terrain (Beginner)
   > Portal to Trial Grounds
       All of the following:
           After Mining Station B Portal Opened
@@ -3279,7 +3279,7 @@ Asset id: 1979488942
                   Use Screw Attack (Space Jump)
                   Morph Ball and Boost Ball
                   Screw Attack at Z-Axis (Beginner) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
-          Space Jump Boots and Slope Jump (Intermediate)
+          Space Jump Boots and Slope Jump (Beginner)
   > Door to Controller Access
       Any of the following:
           Before Bomb Guardian
@@ -3292,7 +3292,7 @@ Asset id: 1979488942
                   Use Screw Attack (Space Jump)
                   Morph Ball and Boost Ball
                   Screw Attack at Z-Axis (Beginner) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
-          Space Jump Boots and Slope Jump (Intermediate)
+          Space Jump Boots and Slope Jump (Beginner)
   > Event - Bomb Guardian
       Trivial
 
@@ -3405,18 +3405,20 @@ Asset id: 4121352562
 > Door to Central Station Access; Heals? False; Spawn Point
   * Missile Blast Shield to Central Station Access/Door to Central Mining Station
   > Door to Command Center Access (Top)
-      Any of the following:
-          All of the following:
-              Morph Ball
-              Any of the following:
-                  Spider Ball
-                  Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Intermediate)
-          After Central Mining Station Pirates and Standable Terrain (Intermediate) and Use Screw Attack (Space Jump)
-          All of the following:
-              Space Jump Boots
-              Any of the following:
-                  Slope Jump (Expert)
-                  Scan Visor and Combat/Scan Dash (Expert) and Standable Terrain (Beginner)
+      All of the following:
+          After Central Mining Station Pirates
+          Any of the following:
+              All of the following:
+                  Morph Ball
+                  Any of the following:
+                      Spider Ball
+                      Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Intermediate)
+              Standable Terrain (Intermediate) and Use Screw Attack (Space Jump)
+              All of the following:
+                  Space Jump Boots
+                  Any of the following:
+                      Slope Jump (Expert)
+                      Scan Visor and Combat/Scan Dash (Expert) and Standable Terrain (Beginner)
   > Door to Command Center Access (Bottom)
       After Central Mining Station Pirates
   > Event - Central Mining Station Pirates
@@ -3441,8 +3443,11 @@ Asset id: 4121352562
   > Door to Command Center Access (Top)
       Any of the following:
           Morph Ball and Spider Ball
-          Space Jump Boots and Combat/Scan Dash (Advanced)
-          Morph Ball and Roll Jump (Advanced)
+          All of the following:
+              Space Jump Boots
+              Any of the following:
+                  Scan Visor and Combat/Scan Dash (Advanced)
+                  Morph Ball and Roll Jump (Advanced)
   > Door to Central Station Access
       Trivial
   > Door to Command Center Access (Bottom)
@@ -3495,9 +3500,9 @@ Asset id: 872074261
   * Pickup 41; Major Location? False
   > Safe Zone (Battleground Side)
       Any of the following:
-          Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner) and Normal Damage ≥ 55
-          Space Jump Boots and Dark World Damage ≥ 30
-          Slope Jump (Intermediate) and Normal Damage ≥ 35
+          Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner) and Normal Damage ≥ 55 and Dark World Damage ≥ 25
+          Space Jump Boots and Normal Damage ≥ 30 and Dark World Damage ≥ 15
+          Slope Jump (Intermediate) and Normal Damage ≥ 50 and Dark World Damage ≥ 10
 
 > Safe Zone (Judgment Pit Side); Heals? True
   > Door to Judgment Pit
@@ -3512,7 +3517,7 @@ Asset id: 872074261
           Morph Ball and Dark World Damage ≥ 5
   > Pickup (Missile)
       All of the following:
-          Morph Ball and Normal Damage ≥ 30
+          Morph Ball and Normal Damage ≥ 25 and Dark World Damage ≥ 10
           Morph Ball Bomb or Power Bomb
   > Safe Zone (Judgment Pit Side)
       All of the following:
@@ -4291,7 +4296,7 @@ Asset id: 2761919085
               Dark World Damage ≥ 18
               Morph Ball and Dark World Damage ≥ 10
   > Safe Zone (Movable Platform)
-      Space Jump Boots and Slope Jump (Intermediate) and Dark World Damage ≥ 10
+      Space Jump Boots and Slope Jump (Beginner) and Dark World Damage ≥ 10
 
 > Door to Double Path (Top); Heals? True
   * Dark Door to Double Path/Door to Doomed Entry (Top)
@@ -4382,7 +4387,12 @@ Asset id: 2763180926
       Missile
   > Door to Save Station C
       Any of the following:
-          Before Sand Processing Sand Drained
+          All of the following:
+              Before Sand Processing Sand Drained
+              Any of the following:
+                  Space Jump Boots
+                  Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner)
+                  Slope Jump (Intermediate) and Movement (Intermediate) and Use Screw Attack (No Space Jump)
           All of the following:
               Morph Ball
               Any of the following:
@@ -4399,7 +4409,7 @@ Asset id: 2763180926
                   Boost Ball
                   Morph Ball Bomb or Wall Boost (Expert)
               Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Advanced)
-              Screw Attack into Tunnels (Hypermode) and Use Screw Attack (Space Jump)
+              Screw Attack into Tunnels (Expert) and Use Screw Attack (Space Jump)
 
 > Tunnel; Heals? False
   > Event - Sand Processing Sand Drained
@@ -5178,7 +5188,7 @@ Asset id: 1950913308
           Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner)
   > Next to Pickup
       Any of the following:
-          Grapple Beam and Movement (Beginner)
+          Grapple Beam
           Space Jump Boots and Gravity Boost and Slope Jump (Intermediate)
           All of the following:
               Morph Ball
@@ -5522,7 +5532,9 @@ Asset id: 1423634263
           Morph Ball
           Any of the following:
               Morph Ball Bomb or Use Screw Attack (Space Jump)
-              Space Jump Boots and Movement (Advanced) and Standable Terrain (Intermediate)
+              All of the following:
+                  Space Jump Boots and Standable Terrain (Intermediate)
+                  Slope Jump (Intermediate) or Movement (Advanced)
 
 > Pickup (Missile); Heals? False
   * Pickup 67; Major Location? False
@@ -5787,10 +5799,12 @@ Asset id: 2240736467
       Any of the following:
           Grapple Beam and Movement (Intermediate) and Dark World Damage ≥ 60
           All of the following:
-              Space Jump Boots
+              Space Jump Boots and Dark World Damage ≥ 30
               Any of the following:
-                  Standable Terrain (Intermediate) and Dark World Damage ≥ 30 and NTSC
-                  Slope Jump (Intermediate) and Dark World Damage ≥ 25 and Use Screw Attack (Space Jump)
+                  Standable Terrain (Intermediate) and NTSC
+                  All of the following:
+                      Use Screw Attack (Space Jump)
+                      Slope Jump (Beginner) or Standable Terrain (Beginner)
 
 > Door to Brooding Ground; Heals? True; Spawn Point
   * Normal Door to Brooding Ground/Door to Venomous Pond
@@ -6064,7 +6078,7 @@ Asset id: 3706669497
               All of the following:
                   Space Jump Boots
                   Any of the following:
-                      Screw Attack and Slope Jump (Intermediate) and Dark World Damage ≥ 50
+                      Screw Attack and Standable Terrain (Intermediate) and Dark World Damage ≥ 50
                       Morph Ball Bomb and Bomb Space Jump (Advanced) and Dark World Damage ≥ 100
 
 ----------------
@@ -7088,21 +7102,21 @@ Asset id: 889276218
 > Pickup (Missile); Heals? False
   * Pickup 84; Major Location? False
   > Door to Transit Tunnel South
-      Any of the following:
-          Grapple Beam or After Crypt Laser or Use Screw Attack (Space Jump)
-          Space Jump Boots and Before Gathering Hall Water Drained and Shoot Dark Beam
-          Morph Ball and Morph Ball Bomb and Bomb Jump (Advanced)
-          Morph Ball and Before Gathering Hall Water Drained and Roll Jump (Advanced)
-          Scan Visor and Space Jump Boots and Combat/Scan Dash (Advanced)
-  > Door to Gathering Access
+      Morph Ball and Space Jump Boots and Roll Jump (Advanced)
+  > Kinetic Orb Cannon
       Trivial
 
 > Event - Gathering Hall Water Drained; Heals? False
   * Event Gathering Hall Water Drained
   > Room Bottom
       Any of the following:
-          Morph Ball and Boost Ball
+          All of the following:
+              Morph Ball
+              Any of the following:
+                  Boost Ball
+                  Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Advanced)
           Grapple Beam and Space Jump Boots and Slope Jump (Intermediate)
+          Slope Jump (Advanced) and Use Screw Attack (Space Jump)
 
 > Event - Gathering Hall Portal Gate; Heals? False
   * Event Gathering Hall Portal Gate
@@ -7117,7 +7131,7 @@ Asset id: 889276218
               Morph Ball Bomb
               Space Jump Boots and Missile ≥ 10 and Dark Ammo ≥ 60 and Light Ammo ≥ 60 and Instant Morph (Expert) and Bomb Slot without Bombs (Hypermode) and Activate Bomb Slot without Bombs (Instant Morph)
           Any of the following:
-              Space Jump Boots and Combat/Scan Dash (Expert) and Roll Jump (Expert) and Instant Morph (Expert)
+              Scan Visor and Space Jump Boots and Combat/Scan Dash (Expert) and Roll Jump (Expert) and Instant Morph (Expert)
               All of the following:
                   Boost Ball and Spider Ball
                   Any of the following:
@@ -7173,16 +7187,16 @@ Asset id: 889276218
 > Kinetic Orb Cannon; Heals? False
   > Door to Transit Tunnel West
       Any of the following:
-          Grapple Beam
-          All of the following:
-              Space Jump Boots
-              Combat/Scan Dash (Advanced) or Use Screw Attack (Space Jump)
+          Grapple Beam or Use Screw Attack (Space Jump)
+          Scan Visor and Space Jump Boots and Combat/Scan Dash (Advanced)
   > Door to Transit Tunnel South
       Any of the following:
-          Grapple Beam
+          Grapple Beam or After Crypt Laser or Use Screw Attack (Space Jump)
           All of the following:
               Space Jump Boots
-              Combat/Scan Dash (Advanced) or Use Screw Attack (Space Jump)
+              Any of the following:
+                  Scan Visor and Combat/Scan Dash (Advanced)
+                  Morph Ball and Before Gathering Hall Water Drained and Roll Jump (Advanced)
   > Door to Gathering Access
       Morph Ball
 
@@ -7196,12 +7210,6 @@ Training Chamber
 Asset id: 1270197856
 > Door to Transit Tunnel East; Heals? False
   * Dark Door to Transit Tunnel East/Door to Training Chamber
-  > Door to Training Access
-      Morph Ball and Morph Ball Bomb and Space Jump Boots and Screw Attack and Bomb Space Jump (Expert) and Air Underwater (Expert)
-  > Door to Fortress Transport Access
-      Morph Ball and Morph Ball Bomb and Space Jump Boots and Screw Attack and After Training Chamber Statue and Bomb Space Jump (Expert) and Air Underwater (Expert)
-  > Door to Transit Tunnel West
-      Morph Ball and Morph Ball Bomb and Space Jump Boots and Screw Attack and Bomb Space Jump (Expert) and Air Underwater (Expert)
   > Room Center
       Any of the following:
           Gravity Boost
@@ -7212,17 +7220,19 @@ Asset id: 1270197856
 > Door to Training Access; Heals? False; Spawn Point
   * Normal Door to Training Access/Door to Training Chamber
   > Door to Transit Tunnel East
-      Space Jump Boots and Combat/Scan Dash (Intermediate)
+      Scan Visor and Space Jump Boots and Combat/Scan Dash (Intermediate)
   > Door to Fortress Transport Access
-      Space Jump Boots and After Training Chamber Statue and Combat/Scan Dash (Intermediate)
+      Scan Visor and Space Jump Boots and After Training Chamber Statue and Combat/Scan Dash (Intermediate)
   > Door to Transit Tunnel West
-      Space Jump Boots and Combat/Scan Dash (Intermediate)
+      Scan Visor and Space Jump Boots and Combat/Scan Dash (Intermediate)
   > Pickup (Missile)
       After Training Chamber Statue
   > Room Center
       Trivial
   > Top of Statue
-      Movement (Beginner) and Use Screw Attack (Space Jump)
+      Any of the following:
+          Use Screw Attack (Space Jump)
+          Scan Visor and Space Jump Boots and Combat/Scan Dash (Advanced) and Underwater Dash (Advanced) and Standable Terrain (Intermediate)
 
 > Door to Fortress Transport Access; Heals? False
   * Power Bomb Blast Shield to Fortress Transport Access/Door to Training Chamber
@@ -7235,14 +7245,6 @@ Asset id: 1270197856
 
 > Door to Transit Tunnel West; Heals? False
   * Light Door to Transit Tunnel West/Door to Training Chamber
-  > Door to Transit Tunnel East
-      Morph Ball and Morph Ball Bomb and Space Jump Boots and Screw Attack and Bomb Space Jump (Expert) and Air Underwater (Expert)
-  > Door to Training Access
-      Morph Ball and Morph Ball Bomb and Space Jump Boots and Screw Attack and Bomb Space Jump (Expert) and Air Underwater (Expert)
-  > Door to Fortress Transport Access
-      Morph Ball and Morph Ball Bomb and Space Jump Boots and Screw Attack and After Training Chamber Statue and Bomb Space Jump (Expert) and Air Underwater (Expert)
-  > Event - Training Chamber Statue
-      Morph Ball and Morph Ball Bomb and Space Jump Boots and Screw Attack and Bomb Space Jump (Expert) and Air Underwater (Expert)
   > Room Center
       Any of the following:
           Gravity Boost
@@ -7310,7 +7312,6 @@ Asset id: 1270197856
                       Any of the following:
                           Instant Morph (Intermediate)
                           Morph Ball Bomb and Bomb Jump (Intermediate)
-                  Scan Visor and Space Jump Boots and Combat/Scan Dash (Advanced) and Movement (Expert) and Underwater Dash (Advanced) and Standable Terrain (Intermediate)
           Space Jump Boots and Gravity Boost and Slope Jump (Intermediate) and Standable Terrain (Intermediate)
 
 > Top of Statue; Heals? False
@@ -7369,19 +7370,28 @@ Asset id: 4217540043
       Any of the following:
           Space Jump Boots
           Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner)
-          Scan Visor and Combat/Scan Dash (Advanced) and Standable Terrain (Advanced)
+          Combat/Scan Dash (Advanced) and Standable Terrain (Advanced)
           Slope Jump (Intermediate) and Movement (Intermediate) and Use Screw Attack (No Space Jump)
+          Morph Ball and Gravity Boost and Air Underwater (Advanced)
   > Portal to Dungeon
       Any of the following:
           Morph Ball and Gravity Boost and Air Underwater (Advanced)
           Movement (Advanced) and Use Screw Attack (Space Jump)
-          Space Jump Boots and After Catacombs Gate
-          Scan Visor and After Catacombs Gate and Combat/Scan Dash (Intermediate)
+          All of the following:
+              After Catacombs Gate
+              Any of the following:
+                  Space Jump Boots
+                  All of the following:
+                      Standable Terrain (Intermediate)
+                      Any of the following:
+                          Combat/Scan Dash (Intermediate)
+                          Movement (Intermediate) and Use Screw Attack (No Space Jump)
   > Door to Transit Tunnel South
       Any of the following:
           Space Jump Boots
-          Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner)
-          Scan Visor and Combat/Scan Dash (Intermediate) and Standable Terrain (Intermediate)
+          Morph Ball Bomb and Missile Launcher and Bomb Jump (Beginner)
+          Combat/Scan Dash (Intermediate) and Standable Terrain (Intermediate)
+          After Hydrochamber Storage Item and Normal Damage ≥ 10 and Allow Jumping on Dark Water ≥ 3
   > Door to Catacombs Access
       Trivial
   > Event - Catacombs Gate
@@ -8187,7 +8197,7 @@ Asset id: 4148317891
   > Pickup (Power Bomb)
       Any of the following:
           Morph Ball and Spider Ball
-          Movement (Intermediate) and Use Screw Attack (Space Jump)
+          Screw Attack into Tunnels (Intermediate) and Use Screw Attack (Space Jump)
   > Room Center
       Trivial
 
@@ -8216,14 +8226,14 @@ Asset id: 4148317891
 > Room Center; Heals? False
   > Door to Reactor Core
       Trivial
+  > Portal from Hive Portal Chamber (Second)
+      Any of the following:
+          Slope Jump (Beginner) and Use Screw Attack (Space Jump)
+          Morph Ball and Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Advanced)
   > Door to Main Research
       Trivial
   > Portal to Hive Portal Chamber (First)
       Morph Ball and Power Bomb
-  > Pickup (Power Bomb)
-      Any of the following:
-          Slope Jump (Intermediate) and Use Screw Attack (Space Jump)
-          Morph Ball and Spider Ball and Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Advanced)
 
 ----------------
 Sanctuary Map Station
@@ -8894,14 +8904,18 @@ Asset id: 1120426713
   > Door to Main Gyro Chamber
       Any of the following:
           Morph Ball
-          Space Jump Boots and Slope Jump (Intermediate)
+          All of the following:
+              Space Jump Boots
+              Slope Jump (Beginner) or Standable Terrain (Beginner)
 
 > Door to Main Gyro Chamber; Heals? False
   * Dark Door to Main Gyro Chamber/Door to Dynamo Access
   > Door to Dynamo Works
       Any of the following:
           Morph Ball
-          Space Jump Boots and Slope Jump (Intermediate)
+          All of the following:
+              Space Jump Boots
+              Slope Jump (Beginner) or Standable Terrain (Beginner)
 
 ----------------
 Workers Path

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -1695,6 +1695,7 @@ Asset id: 3258777533
       Trivial
 
 > Event - Sacred Path Wall Broken; Heals? False
+  * Event Sacred Path Wall Broken
   > Door to Sacred Bridge
       Trivial
   > Door to Temple Transport A

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -3393,7 +3393,7 @@ Asset id: 4121352562
       Trivial
   > Next to Pickup
       Any of the following:
-          Morph Ball and Morph Ball Bomb and Screw Attack and After Central Mining Station Pirates and Movement (Expert) and Bomb Space Jump (Expert)
+          Morph Ball Bomb and After Central Mining Station Pirates and Movement (Expert) and Bomb Space Jump (Expert) and Use Screw Attack (No Space Jump)
           All of the following:
               Space Jump Boots
               Any of the following:
@@ -3411,7 +3411,7 @@ Asset id: 4121352562
                   Morph Ball
                   Any of the following:
                       Spider Ball
-                      Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Intermediate)
+                      Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Beginner)
               Standable Terrain (Intermediate) and Use Screw Attack (Space Jump)
               All of the following:
                   Space Jump Boots

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -1103,7 +1103,6 @@ Asset id: 2909835645
           Any of the following:
               Scan Visor and Space Jump Boots and After Ing Windchamber Puzzle and Combat/Scan Dash (Advanced)
               Morph Ball Bomb and Bomb Space Jump (Advanced) and Standable Terrain (Advanced) and Use Screw Attack (Space Jump)
-              Grapple Beam and After Ing Windchamber Puzzle
 
 > Portal to Ing Windchamber; Heals? False
   * Dark Portal to Ing Windchamber/Portal to Grand Windchamber
@@ -1121,12 +1120,14 @@ Asset id: 2909835645
       Trivial
   > Pickup (Sunburst)
       All of the following:
-          Morph Ball
+          Morph Ball and After Ing Windchamber Puzzle
           Any of the following:
-              Scan Visor and Space Jump Boots and After Ing Windchamber Puzzle and Combat/Scan Dash (Advanced)
-              Morph Ball Bomb and Bomb Space Jump (Advanced) and Standable Terrain (Advanced) and Use Screw Attack (Space Jump)
-              Grapple Beam and After Ing Windchamber Puzzle
-              Space Jump Boots and After Ing Windchamber Puzzle and Terminal Fall Abuse (Intermediate) and Normal Damage ≥ 10
+              Grapple Beam
+              All of the following:
+                  Space Jump Boots
+                  Any of the following:
+                      Scan Visor and Combat/Scan Dash (Advanced)
+                      Terminal Fall Abuse (Beginner) and Normal Damage ≥ 10
 
 > Pickup (Sunburst); Heals? False
   * Pickup 7; Major Location? True
@@ -2730,7 +2731,11 @@ Asset id: 3820941951
 
 > Front of Lore Scan; Heals? False
   > Door to Central Station Access
-      Space Jump Boots or Combat/Scan Dash (Intermediate)
+      Any of the following:
+          All of the following:
+              After Mining Station A Gate
+              Space Jump Boots or Combat/Scan Dash (Intermediate)
+          Morph Ball and Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Expert)
   > Room Center
       Trivial
   > Event - Mining Station A Gate
@@ -3703,7 +3708,11 @@ Asset id: 1970603146
 > Event - Amorbis; Heals? True
   * Event Amorbis
   > Pickup (Dark Suit)
-      Normal Damage ≥ 20 and Dark World Damage ≥ 15 and Activate Safe Zone
+      All of the following:
+          Activate Safe Zone
+          Any of the following:
+              Normal Damage ≥ 20 and Dark World Damage ≥ 30
+              Combat (Intermediate) and Normal Damage ≥ 10 and Dark World Damage ≥ 20
 
 > Safe Zone (Dark Agon Temple Access Side); Heals? False
   > Door to Dark Agon Temple Access
@@ -5412,7 +5421,7 @@ Asset id: 3822429534
   > Front of Translator Gate
       Any of the following:
           Space Jump Boots
-          Morph Ball and Morph Ball Bomb and Bomb Space Jump (Expert)
+          Morph Ball and Morph Ball Bomb and Bomb Space Jump (Advanced)
 
 > Pickup (Power Bomb); Heals? False
   * Pickup 64; Major Location? False
@@ -7516,7 +7525,7 @@ Asset id: 3366472600
           Dark World Damage ≥ 12
           Morph Ball and Dark World Damage ≥ 7
   > Event - Crypt Barrier
-      Movement (Intermediate) and Knowledge (Beginner) and Dark World Damage ≥ 12 and Use Screw Attack (Space Jump)
+      Knowledge (Intermediate) and Dark World Damage ≥ 12 and Use Screw Attack (Space Jump)
   > Laser Platform
       Any of the following:
           Space Jump Boots and Dark World Damage ≥ 10

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -1772,9 +1772,11 @@ Asset id: 506667008
           All of the following:
               Morph Ball
               Any of the following:
-                  Space Jump Boots
-                  Roll Jump (Intermediate) and Dark World Damage ≥ 50
-                  Morph Ball Bomb and Bomb Space Jump (Intermediate) and Normal Damage ≥ 15 and Dark World Damage ≥ 75
+                  All of the following:
+                      Space Jump Boots
+                      Any of the following:
+                          Roll Jump (Intermediate) and Dark World Damage ≥ 50
+                          Morph Ball Bomb and Bomb Space Jump (Beginner) and Normal Damage ≥ 15 and Dark World Damage ≥ 75
                   Boost Ball and Boost Jump (Expert) and Dark World Damage ≥ 60
 
 > Door to Phazon Grounds; Heals? False; Spawn Point
@@ -7432,7 +7434,7 @@ Asset id: 3468345533
               Morph Ball Bomb and Space Jump Boots and Gravity Boost and Bomb Space Jump (Intermediate)
   > Door to Hydrodynamo Shaft
       Any of the following:
-          Morph Ball and Morph Ball Bomb and Space Jump Boots and Screw Attack and Bomb Space Jump (Hypermode) and Air Underwater (Advanced)
+          Morph Ball Bomb and Bomb Space Jump (Hypermode) and Air Underwater (Advanced) and Use Screw Attack (Space Jump)
           All of the following:
               Gravity Boost
               Any of the following:
@@ -8704,8 +8706,12 @@ Asset id: 3222355176
   > Door to Central Area Transport East
       Any of the following:
           Morph Ball and Spider Ball and After Spider Guardian
-          Morph Ball and Morph Ball Bomb and Screw Attack and Bomb Space Jump (Expert) and Screw Attack at Z-Axis (Expert) and Disabled Room Randomizer
-          Space Jump Boots and Slope Jump (Intermediate)
+          Morph Ball Bomb and Bomb Space Jump (Expert) and Screw Attack at Z-Axis (Expert) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
+          All of the following:
+              Space Jump Boots
+              Any of the following:
+                  Slope Jump (Intermediate)
+                  Morph Ball and Morph Ball Bomb and Bomb Space Jump (Beginner)
   > Door to Dynamo Access
       Trivial
   > Pickup 2 (Missile)
@@ -9034,7 +9040,7 @@ Asset id: 4065261236
               Morph Ball
               Any of the following:
                   Spider Ball and Dark World Damage ≥ 15
-                  Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Intermediate) and Dark World Damage ≥ 35
+                  Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Beginner) and Dark World Damage ≥ 35
           Space Jump Boots and Slope Jump (Intermediate) and Dark World Damage ≥ 20
   > Event - Hive Dynamo Works Portal Barrier
       Dark Visor and Seeker Launcher and Missile ≥ 5 and Open Gates from Behind (Intermediate) and Dark World Damage ≥ 20
@@ -9767,7 +9773,7 @@ Asset id: 1378173793
           Morph Ball and Boost Ball
           Any of the following:
               Use Screw Attack (Space Jump)
-              Space Jump Boots and Combat/Scan Dash (Advanced)
+              Scan Visor and Space Jump Boots and Combat/Scan Dash (Advanced)
               Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
   > Above Bomb Slot
       Before Vault Bridge


### PR DESCRIPTION
- Fixed logic bugs in Phazon Pit, Central Mining Station, and Sand Processing
- New requirements added
- Room adjustments/Simplification
- Slope Jumps and Bomb Space Jumps are slightly more balanced (Beginner has some of both)
- Balanced/Updated some tricks in a few places
- Added wiki link to Boost Jump trick
- Contributes to #860 