### PR TITLE
Completed Basic Metroid Prime 1 Randomizer Logic

### DIFF
--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -13901,6 +13901,33 @@
                                                     }
                                                 }
                                             ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 19,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Heat-Resisting Suit"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -15135,7 +15135,16 @@
                                             "type": "resource",
                                             "data": {
                                                 "type": 2,
-                                                "index": 2,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
                                                 "amount": 1,
                                                 "negate": false
                                             }

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -939,7 +939,7 @@
                     "name": "Crater Tunnel A",
                     "in_dark_aether": false,
                     "asset_id": 1238049635,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -990,7 +990,7 @@
                     "name": "Phazon Core",
                     "in_dark_aether": false,
                     "asset_id": 3180620483,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -1106,7 +1106,7 @@
                     "name": "Crater Missile Station",
                     "in_dark_aether": false,
                     "asset_id": 1296329791,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -1148,7 +1148,7 @@
                     "name": "Crater Tunnel B",
                     "in_dark_aether": false,
                     "asset_id": 852861312,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -1265,7 +1265,7 @@
                     "name": "Phazon Infusion Chamber",
                     "in_dark_aether": false,
                     "asset_id": 1729456653,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -1311,7 +1311,7 @@
                     "name": "Subchamber One",
                     "in_dark_aether": false,
                     "asset_id": 3672049347,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -1371,7 +1371,7 @@
                     "name": "Subchamber Two",
                     "in_dark_aether": false,
                     "asset_id": 122281798,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -1431,7 +1431,7 @@
                     "name": "Subchamber Three",
                     "in_dark_aether": false,
                     "asset_id": 2050677022,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -1491,7 +1491,7 @@
                     "name": "Subchamber Four",
                     "in_dark_aether": false,
                     "asset_id": 2813067419,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -1551,7 +1551,7 @@
                     "name": "Subchamber Five",
                     "in_dark_aether": false,
                     "asset_id": 2003911832,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -1620,7 +1620,7 @@
                     "name": "Metroid Prime Lair",
                     "in_dark_aether": false,
                     "asset_id": 442920021,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -1652,7 +1652,7 @@
                     "name": "Transport to Magmoor Caverns West",
                     "in_dark_aether": false,
                     "asset_id": 3222157185,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -1710,7 +1710,7 @@
                     "name": "Shoreline Entrance",
                     "in_dark_aether": false,
                     "asset_id": 3289414871,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -1799,7 +1799,7 @@
                     "name": "Phendrana Shorelines",
                     "in_dark_aether": false,
                     "asset_id": 4146616697,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -2071,7 +2071,7 @@
                     "name": "Temple Entryway",
                     "in_dark_aether": false,
                     "asset_id": 2245653401,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -2234,7 +2234,7 @@
                     "name": "Save Station B",
                     "in_dark_aether": false,
                     "asset_id": 92367261,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -2276,7 +2276,7 @@
                     "name": "Ruins Entryway",
                     "in_dark_aether": false,
                     "asset_id": 1007903802,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -2327,7 +2327,7 @@
                     "name": "Plaza Walkway",
                     "in_dark_aether": false,
                     "asset_id": 3356578450,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -2378,7 +2378,7 @@
                     "name": "Ice Ruins Access",
                     "in_dark_aether": false,
                     "asset_id": 1317347388,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -2485,7 +2485,7 @@
                     "name": "Chozo Ice Temple",
                     "in_dark_aether": false,
                     "asset_id": 1716909342,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -2682,7 +2682,7 @@
                     "name": "Ice Ruins West",
                     "in_dark_aether": false,
                     "asset_id": 3006924320,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -2833,7 +2833,7 @@
                     "name": "Ice Ruins East",
                     "in_dark_aether": false,
                     "asset_id": 3673997935,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -2959,7 +2959,7 @@
                     "name": "Chapel Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 4016524108,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -3048,7 +3048,7 @@
                     "name": "Courtyard Entryway",
                     "in_dark_aether": false,
                     "asset_id": 3484986321,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -3099,7 +3099,7 @@
                     "name": "Canyon Entryway",
                     "in_dark_aether": false,
                     "asset_id": 55410999,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -3150,7 +3150,7 @@
                     "name": "Chapel of the Elders",
                     "in_dark_aether": false,
                     "asset_id": 1086671081,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -3288,7 +3288,7 @@
                     "name": "Ruined Courtyard",
                     "in_dark_aether": false,
                     "asset_id": 421627757,
-                    "default_node_index": null,
+                    "default_node_index": 3,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -3585,7 +3585,7 @@
                     "name": "Phendrana Canyon",
                     "in_dark_aether": false,
                     "asset_id": 2718594133,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -3667,7 +3667,7 @@
                     "name": "Save Station A",
                     "in_dark_aether": false,
                     "asset_id": 1452580971,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -3709,7 +3709,7 @@
                     "name": "Specimen Storage",
                     "in_dark_aether": false,
                     "asset_id": 3544306395,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -3760,7 +3760,7 @@
                     "name": "Quarantine Access",
                     "in_dark_aether": false,
                     "asset_id": 3937607887,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -3811,7 +3811,7 @@
                     "name": "Research Entrance",
                     "in_dark_aether": false,
                     "asset_id": 3038760489,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -3887,7 +3887,7 @@
                     "name": "North Quarantine Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 98670126,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -3958,7 +3958,7 @@
                     "name": "Map Station",
                     "in_dark_aether": false,
                     "asset_id": 2199198515,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -3983,7 +3983,7 @@
                     "name": "Hydra Lab Entryway",
                     "in_dark_aether": false,
                     "asset_id": 961011783,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -4034,7 +4034,7 @@
                     "name": "Quarantine Cave",
                     "in_dark_aether": false,
                     "asset_id": 1880625556,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -4318,7 +4318,7 @@
                     "name": "Research Lab Hydra",
                     "in_dark_aether": false,
                     "asset_id": 1139067941,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -4448,7 +4448,7 @@
                     "name": "South Quarantine Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 3538349,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -4519,7 +4519,7 @@
                     "name": "Quarantine Monitor",
                     "in_dark_aether": false,
                     "asset_id": 563191901,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -4583,7 +4583,7 @@
                     "name": "Observatory Access",
                     "in_dark_aether": false,
                     "asset_id": 935047996,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -4634,7 +4634,7 @@
                     "name": "Transport to Magmoor Caverns South",
                     "in_dark_aether": false,
                     "asset_id": 3708487481,
-                    "default_node_index": null,
+                    "default_node_index": 2,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -4746,7 +4746,7 @@
                     "name": "Observatory",
                     "in_dark_aether": false,
                     "asset_id": 1068802894,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -5021,7 +5021,7 @@
                     "name": "Transport Access",
                     "in_dark_aether": false,
                     "asset_id": 3600136536,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -5100,7 +5100,7 @@
                     "name": "West Tower Entrance",
                     "in_dark_aether": false,
                     "asset_id": 508080527,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -5151,7 +5151,7 @@
                     "name": "Save Station D",
                     "in_dark_aether": false,
                     "asset_id": 1901867502,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -5193,7 +5193,7 @@
                     "name": "Frozen Pike",
                     "in_dark_aether": false,
                     "asset_id": 3617515525,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -5352,7 +5352,7 @@
                     "name": "West Tower ",
                     "in_dark_aether": false,
                     "asset_id": 3617418143,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -5413,7 +5413,7 @@
                     "name": "Pike Access",
                     "in_dark_aether": false,
                     "asset_id": 1980658458,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -5464,7 +5464,7 @@
                     "name": "Frost Cave Access",
                     "in_dark_aether": false,
                     "asset_id": 969347001,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -5535,7 +5535,7 @@
                     "name": "Hunter Cave Access",
                     "in_dark_aether": false,
                     "asset_id": 552213808,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -5586,7 +5586,7 @@
                     "name": "Control Tower",
                     "in_dark_aether": false,
                     "asset_id": 3015914057,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -5711,7 +5711,7 @@
                     "name": "Research Core",
                     "in_dark_aether": false,
                     "asset_id": 2761631044,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -5896,7 +5896,7 @@
                     "name": "Frost Cave",
                     "in_dark_aether": false,
                     "asset_id": 1282373491,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -6193,7 +6193,7 @@
                     "name": "Hunter Cave",
                     "in_dark_aether": false,
                     "asset_id": 516396314,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -6454,7 +6454,7 @@
                     "name": "East Tower",
                     "in_dark_aether": false,
                     "asset_id": 1359550769,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -6515,7 +6515,7 @@
                     "name": "Research Core Access",
                     "in_dark_aether": false,
                     "asset_id": 3639150045,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -6566,7 +6566,7 @@
                     "name": "Save Station C",
                     "in_dark_aether": false,
                     "asset_id": 3470637624,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -6608,7 +6608,7 @@
                     "name": "Upper Edge Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 624850611,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -6679,7 +6679,7 @@
                     "name": "Lower Edge Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 1400901764,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -6750,7 +6750,7 @@
                     "name": "Chamber Access",
                     "in_dark_aether": false,
                     "asset_id": 3396124754,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -6801,7 +6801,7 @@
                     "name": "Lake Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 2312609958,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -6852,7 +6852,7 @@
                     "name": "Aether Lab Entryway",
                     "in_dark_aether": false,
                     "asset_id": 2564604705,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -6903,7 +6903,7 @@
                     "name": "Research Lab Aether",
                     "in_dark_aether": false,
                     "asset_id": 565493750,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -7052,7 +7052,7 @@
                     "name": "Phendrana's Edge",
                     "in_dark_aether": false,
                     "asset_id": 1423896872,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -7280,7 +7280,7 @@
                     "name": "Gravity Chamber",
                     "in_dark_aether": false,
                     "asset_id": 1226265714,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -7421,7 +7421,7 @@
                     "name": "Storage Cave",
                     "in_dark_aether": false,
                     "asset_id": 4157096768,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -7465,7 +7465,7 @@
                     "name": "Security Cave",
                     "in_dark_aether": false,
                     "asset_id": 1016369381,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -7536,7 +7536,7 @@
                     "name": "Exterior Docking Hangar",
                     "in_dark_aether": false,
                     "asset_id": 3508802073,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -7625,7 +7625,7 @@
                     "name": "Air Lock",
                     "in_dark_aether": false,
                     "asset_id": 123995650,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -7712,7 +7712,7 @@
                     "name": "Deck Alpha Access Hall",
                     "in_dark_aether": false,
                     "asset_id": 1649363258,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -7758,7 +7758,7 @@
                     "name": "Deck Alpha Mech Shaft",
                     "in_dark_aether": false,
                     "asset_id": 3365346969,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -7804,7 +7804,7 @@
                     "name": "Emergency Evacuation Area",
                     "in_dark_aether": false,
                     "asset_id": 551846422,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -7850,7 +7850,7 @@
                     "name": "Connection Elevator to Deck Alpha",
                     "in_dark_aether": false,
                     "asset_id": 2921253053,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -7918,7 +7918,7 @@
                     "name": "Deck Alpha Umbilical Hall",
                     "in_dark_aether": false,
                     "asset_id": 3995189286,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -7997,7 +7997,7 @@
                     "name": "Biotech Research Area 2",
                     "in_dark_aether": false,
                     "asset_id": 3319675910,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8062,7 +8062,7 @@
                     "name": "Map Facility",
                     "in_dark_aether": false,
                     "asset_id": 3454403824,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8108,7 +8108,7 @@
                     "name": "Main Ventilation Shaft Section F",
                     "in_dark_aether": false,
                     "asset_id": 274035036,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8154,7 +8154,7 @@
                     "name": "Connection Elevator to Deck Beta",
                     "in_dark_aether": false,
                     "asset_id": 834947875,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8210,7 +8210,7 @@
                     "name": "Main Ventilation Shaft Section E",
                     "in_dark_aether": false,
                     "asset_id": 690871324,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8256,7 +8256,7 @@
                     "name": "Deck Beta Conduit Hall",
                     "in_dark_aether": false,
                     "asset_id": 2827042742,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8312,7 +8312,7 @@
                     "name": "Main Ventilation Shaft Section D",
                     "in_dark_aether": false,
                     "asset_id": 1040562396,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8358,7 +8358,7 @@
                     "name": "Biotech Research Area 1",
                     "in_dark_aether": false,
                     "asset_id": 2237107796,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8461,7 +8461,7 @@
                     "name": "Main Ventilation Shaft Section C",
                     "in_dark_aether": false,
                     "asset_id": 1541179036,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8507,7 +8507,7 @@
                     "name": "Deck Beta Security Hall",
                     "in_dark_aether": false,
                     "asset_id": 1237686565,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8553,7 +8553,7 @@
                     "name": "Connection Elevator to Deck Beta (2)",
                     "in_dark_aether": false,
                     "asset_id": 1859330843,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8609,7 +8609,7 @@
                     "name": "Subventilation Shaft Section A",
                     "in_dark_aether": false,
                     "asset_id": 154468580,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8655,7 +8655,7 @@
                     "name": "Main Ventilation Shaft Section B",
                     "in_dark_aether": false,
                     "asset_id": 1291117148,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8701,7 +8701,7 @@
                     "name": "Biohazard Containment",
                     "in_dark_aether": false,
                     "asset_id": 3513460432,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8757,7 +8757,7 @@
                     "name": "Deck Gamma Monitor Hall",
                     "in_dark_aether": false,
                     "asset_id": 3865556485,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8803,7 +8803,7 @@
                     "name": "Subventilation Shaft Section B",
                     "in_dark_aether": false,
                     "asset_id": 3233526410,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8849,7 +8849,7 @@
                     "name": "Main Ventilation Shaft Section A",
                     "in_dark_aether": false,
                     "asset_id": 1972129564,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8895,7 +8895,7 @@
                     "name": "Deck Beta Transit Hall",
                     "in_dark_aether": false,
                     "asset_id": 748855907,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -8941,7 +8941,7 @@
                     "name": "Reactor Core",
                     "in_dark_aether": false,
                     "asset_id": 2269457857,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -9000,7 +9000,7 @@
                     "name": "Cargo Freight Lift to Deck Gamma",
                     "in_dark_aether": false,
                     "asset_id": 1878064482,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -9102,7 +9102,7 @@
                     "name": "Reactor Core Entrance",
                     "in_dark_aether": false,
                     "asset_id": 1050775790,
-                    "default_node_index": null,
+                    "default_node_index": 2,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -9248,7 +9248,7 @@
                     "name": "Burning Trail",
                     "in_dark_aether": false,
                     "asset_id": 1833127758,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -9324,7 +9324,7 @@
                     "name": "Lake Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 2037927229,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -9441,7 +9441,7 @@
                     "name": "Save Station Magmoor A",
                     "in_dark_aether": false,
                     "asset_id": 162783260,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -9483,7 +9483,7 @@
                     "name": "Lava Lake",
                     "in_dark_aether": false,
                     "asset_id": 2758909034,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -10109,7 +10109,7 @@
                     "name": "Pit Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 3660499860,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -10310,7 +10310,7 @@
                     "name": "Triclops Pit",
                     "in_dark_aether": false,
                     "asset_id": 3134844351,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -11114,7 +11114,7 @@
                     "name": "Monitor Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 231492556,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -11185,7 +11185,7 @@
                     "name": "Storage Cavern",
                     "in_dark_aether": false,
                     "asset_id": 2918155326,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -11229,7 +11229,7 @@
                     "name": "Monitor Station",
                     "in_dark_aether": false,
                     "asset_id": 207070785,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -12388,7 +12388,7 @@
                     "name": "Transport Tunnel A",
                     "in_dark_aether": false,
                     "asset_id": 1207091335,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -12689,7 +12689,7 @@
                     "name": "Warrior Shrine",
                     "in_dark_aether": false,
                     "asset_id": 2309409677,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -12856,7 +12856,7 @@
                     "name": "Shore Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 2416984287,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -13157,7 +13157,7 @@
                     "name": "Transport to Phendrana Drifts North",
                     "in_dark_aether": false,
                     "asset_id": 3702104715,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -13215,7 +13215,7 @@
                     "name": "Fiery Shores",
                     "in_dark_aether": false,
                     "asset_id": 4126087266,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -13594,7 +13594,7 @@
                     "name": "Transport Tunnel B",
                     "in_dark_aether": false,
                     "asset_id": 860276342,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -13858,7 +13858,7 @@
                     "name": "Twin Fires Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 3835971118,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -13983,7 +13983,7 @@
                     "name": "Twin Fires",
                     "in_dark_aether": false,
                     "asset_id": 1282952170,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -14090,7 +14090,7 @@
                     "name": "North Core Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 2805715168,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -14179,7 +14179,7 @@
                     "name": "Geothermal Core",
                     "in_dark_aether": false,
                     "asset_id": 3226044022,
-                    "default_node_index": null,
+                    "default_node_index": 2,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -14361,7 +14361,7 @@
                     "name": "Plasma Processing",
                     "in_dark_aether": false,
                     "asset_id": 1287753306,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -14405,7 +14405,7 @@
                     "name": "South Core Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 1893290168,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -14456,7 +14456,7 @@
                     "name": "Magmoor Workstation",
                     "in_dark_aether": false,
                     "asset_id": 2327753667,
-                    "default_node_index": null,
+                    "default_node_index": 2,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -14631,7 +14631,7 @@
                     "name": "Workstation Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 74274377,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -14720,7 +14720,7 @@
                     "name": "Transport Tunnel C",
                     "in_dark_aether": false,
                     "asset_id": 3549419025,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -14771,7 +14771,7 @@
                     "name": "Transport to Phazon Mines West",
                     "in_dark_aether": false,
                     "asset_id": 4012840000,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -14829,7 +14829,7 @@
                     "name": "Transport to Phendrana Drifts South",
                     "in_dark_aether": false,
                     "asset_id": 3249312307,
-                    "default_node_index": null,
+                    "default_node_index": 2,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -14912,7 +14912,7 @@
                     "name": "Save Station Magmoor B",
                     "in_dark_aether": false,
                     "asset_id": 2136398113,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -15019,7 +15019,7 @@
                     "name": "Quarry Access",
                     "in_dark_aether": false,
                     "asset_id": 1758230360,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -15070,7 +15070,7 @@
                     "name": "Main Quarry",
                     "in_dark_aether": false,
                     "asset_id": 1681720207,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -15366,7 +15366,7 @@
                     "name": "Waste Disposal",
                     "in_dark_aether": false,
                     "asset_id": 665031095,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -15455,7 +15455,7 @@
                     "name": "Save Station Mines A",
                     "in_dark_aether": false,
                     "asset_id": 907887024,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -15497,7 +15497,7 @@
                     "name": "Security Access A",
                     "in_dark_aether": false,
                     "asset_id": 3345300114,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -15608,7 +15608,7 @@
                     "name": "Ore Processing",
                     "in_dark_aether": false,
                     "asset_id": 2547167990,
-                    "default_node_index": null,
+                    "default_node_index": 3,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -15807,7 +15807,7 @@
                     "name": "Mine Security Station",
                     "in_dark_aether": false,
                     "asset_id": 2507085138,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -15950,7 +15950,7 @@
                     "name": "Research Access",
                     "in_dark_aether": false,
                     "asset_id": 1128703815,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -16020,7 +16020,7 @@
                     "name": "Storage Depot B",
                     "in_dark_aether": false,
                     "asset_id": 3818665003,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -16064,7 +16064,7 @@
                     "name": "Elevator Access A",
                     "in_dark_aether": false,
                     "asset_id": 639736833,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -16134,7 +16134,7 @@
                     "name": "Security Access B",
                     "in_dark_aether": false,
                     "asset_id": 2718040532,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -16185,7 +16185,7 @@
                     "name": "Storage Depot A",
                     "in_dark_aether": false,
                     "asset_id": 902158134,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -16229,7 +16229,7 @@
                     "name": "Elite Research",
                     "in_dark_aether": false,
                     "asset_id": 2325199700,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -16514,7 +16514,7 @@
                     "name": "Elevator A",
                     "in_dark_aether": false,
                     "asset_id": 21425475,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -16575,7 +16575,7 @@
                     "name": "Elite Control Access",
                     "in_dark_aether": false,
                     "asset_id": 2307445195,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -16682,7 +16682,7 @@
                     "name": "Elite Control",
                     "in_dark_aether": false,
                     "asset_id": 3305828730,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -16805,7 +16805,7 @@
                     "name": "Maintenance Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 3975146125,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -16894,7 +16894,7 @@
                     "name": "Ventilation Shaft",
                     "in_dark_aether": false,
                     "asset_id": 2423298732,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -17019,7 +17019,7 @@
                     "name": "Phazon Processing Center",
                     "in_dark_aether": false,
                     "asset_id": 2905505465,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -17330,7 +17330,7 @@
                     "name": "Omega Research",
                     "in_dark_aether": false,
                     "asset_id": 1060593356,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -17463,7 +17463,7 @@
                     "name": "Transport Access",
                     "in_dark_aether": false,
                     "asset_id": 1120185073,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -17552,7 +17552,7 @@
                     "name": "Processing Center Access",
                     "in_dark_aether": false,
                     "asset_id": 3983402811,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -17668,7 +17668,7 @@
                     "name": "Map Station Mines",
                     "in_dark_aether": false,
                     "asset_id": 428864988,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -17693,7 +17693,7 @@
                     "name": "Dynamo Access",
                     "in_dark_aether": false,
                     "asset_id": 4111966698,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -17744,7 +17744,7 @@
                     "name": "Transport to Magmoor Caverns South",
                     "in_dark_aether": false,
                     "asset_id": 3804417848,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -17802,7 +17802,7 @@
                     "name": "Elite Quarters",
                     "in_dark_aether": false,
                     "asset_id": 961790803,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -17945,7 +17945,7 @@
                     "name": "Central Dynamo",
                     "in_dark_aether": false,
                     "asset_id": 4272124642,
-                    "default_node_index": null,
+                    "default_node_index": 3,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -18291,7 +18291,7 @@
                     "name": "Elite Quarters Access",
                     "in_dark_aether": false,
                     "asset_id": 1899248703,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -18389,7 +18389,7 @@
                     "name": "Quarantine Access A",
                     "in_dark_aether": false,
                     "asset_id": 1522461728,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -18450,7 +18450,7 @@
                     "name": "Save Station Mines B",
                     "in_dark_aether": false,
                     "asset_id": 2077614267,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -18492,7 +18492,7 @@
                     "name": "Metroid Quarantine B",
                     "in_dark_aether": false,
                     "asset_id": 3141205070,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -18729,7 +18729,7 @@
                     "name": "Metroid Quarantine A",
                     "in_dark_aether": false,
                     "asset_id": 4211416922,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -19106,7 +19106,7 @@
                     "name": "Quarantine Access B",
                     "in_dark_aether": false,
                     "asset_id": 340985721,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -19177,7 +19177,7 @@
                     "name": "Save Station Mines C",
                     "in_dark_aether": false,
                     "asset_id": 1724960771,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -19219,7 +19219,7 @@
                     "name": "Elevator Access B",
                     "in_dark_aether": false,
                     "asset_id": 1071241062,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -19270,7 +19270,7 @@
                     "name": "Fungal Hall B",
                     "in_dark_aether": false,
                     "asset_id": 3964125762,
-                    "default_node_index": null,
+                    "default_node_index": 2,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -19440,7 +19440,7 @@
                     "name": "Elevator B",
                     "in_dark_aether": false,
                     "asset_id": 3900266464,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -19501,7 +19501,7 @@
                     "name": "Missile Station Mines",
                     "in_dark_aether": false,
                     "asset_id": 2961781534,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -19526,7 +19526,7 @@
                     "name": "Phazon Mining Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 3153742515,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -19707,7 +19707,7 @@
                     "name": "Fungal Hall Access",
                     "in_dark_aether": false,
                     "asset_id": 3734860277,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -19815,7 +19815,7 @@
                     "name": "Fungal Hall A",
                     "in_dark_aether": false,
                     "asset_id": 257062865,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -24266,7 +24266,7 @@
                     "name": "Ruins Entrance",
                     "in_dark_aether": false,
                     "asset_id": 3086062890,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -24317,7 +24317,7 @@
                     "name": "Main Plaza",
                     "in_dark_aether": false,
                     "asset_id": 3587029001,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -24585,7 +24585,7 @@
                     "name": "Ruined Fountain Access",
                     "in_dark_aether": false,
                     "asset_id": 1443741240,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -24656,7 +24656,7 @@
                     "name": "Ruined Shrine Access",
                     "in_dark_aether": false,
                     "asset_id": 3748948704,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -24707,7 +24707,7 @@
                     "name": "Nursery Access",
                     "in_dark_aether": false,
                     "asset_id": 153979389,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -24758,7 +24758,7 @@
                     "name": "Plaza Access",
                     "in_dark_aether": false,
                     "asset_id": 1396020311,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -24809,7 +24809,7 @@
                     "name": "Piston Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 725556462,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -24880,7 +24880,7 @@
                     "name": "Ruined Fountain",
                     "in_dark_aether": false,
                     "asset_id": 375016937,
-                    "default_node_index": null,
+                    "default_node_index": 3,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -25031,7 +25031,7 @@
                     "name": "Ruined Shrine",
                     "in_dark_aether": false,
                     "asset_id": 1014518864,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -25272,7 +25272,7 @@
                     "name": "Eyon Tunnel",
                     "in_dark_aether": false,
                     "asset_id": 3407776267,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -25323,7 +25323,7 @@
                     "name": "Vault",
                     "in_dark_aether": false,
                     "asset_id": 4010184729,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -25416,7 +25416,7 @@
                     "name": "Training Chamber",
                     "in_dark_aether": false,
                     "asset_id": 1057288964,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -25652,7 +25652,7 @@
                     "name": "Arboretum Access",
                     "in_dark_aether": false,
                     "asset_id": 2265646373,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -25703,7 +25703,7 @@
                     "name": "Meditation Fountain",
                     "in_dark_aether": false,
                     "asset_id": 673912500,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -25754,7 +25754,7 @@
                     "name": "Tower of Light Access",
                     "in_dark_aether": false,
                     "asset_id": 1507858510,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -25805,7 +25805,7 @@
                     "name": "Ruined Nursery",
                     "in_dark_aether": false,
                     "asset_id": 3260509773,
-                    "default_node_index": null,
+                    "default_node_index": 2,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -25923,7 +25923,7 @@
                     "name": "Vault Access",
                     "in_dark_aether": false,
                     "asset_id": 2768802193,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -25994,7 +25994,7 @@
                     "name": "Training Chamber Access",
                     "in_dark_aether": false,
                     "asset_id": 416384699,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -26083,7 +26083,7 @@
                     "name": "Arboretum",
                     "in_dark_aether": false,
                     "asset_id": 413884678,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -26320,7 +26320,7 @@
                     "name": "Magma Pool",
                     "in_dark_aether": false,
                     "asset_id": 1226570426,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -26502,7 +26502,7 @@
                     "name": "Tower of Light",
                     "in_dark_aether": false,
                     "asset_id": 225636855,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -26619,7 +26619,7 @@
                     "name": "Save Station 1",
                     "in_dark_aether": false,
                     "asset_id": 492718124,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -26661,7 +26661,7 @@
                     "name": "North Atrium",
                     "in_dark_aether": false,
                     "asset_id": 1177115808,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -26820,7 +26820,7 @@
                     "name": "Sunchamber Lobby",
                     "in_dark_aether": false,
                     "asset_id": 1025740749,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -26871,7 +26871,7 @@
                     "name": "Gathering Hall Access",
                     "in_dark_aether": false,
                     "asset_id": 2515665310,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -26922,7 +26922,7 @@
                     "name": "Tower Chamber",
                     "in_dark_aether": false,
                     "asset_id": 297624503,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -26966,7 +26966,7 @@
                     "name": "Ruined Gallery",
                     "in_dark_aether": false,
                     "asset_id": 3813660971,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -27112,7 +27112,7 @@
                     "name": "Sun Tower",
                     "in_dark_aether": false,
                     "asset_id": 3725988722,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -27308,7 +27308,7 @@
                     "name": "Transport Access North",
                     "in_dark_aether": false,
                     "asset_id": 986845711,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -27411,7 +27411,7 @@
                     "name": "Sunchamber Access",
                     "in_dark_aether": false,
                     "asset_id": 1422133653,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -27462,7 +27462,7 @@
                     "name": "Gathering Hall",
                     "in_dark_aether": false,
                     "asset_id": 1206336453,
-                    "default_node_index": null,
+                    "default_node_index": 2,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -27620,7 +27620,7 @@
                     "name": "Totem Access",
                     "in_dark_aether": false,
                     "asset_id": 3934929011,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -27671,7 +27671,7 @@
                     "name": "Map Station",
                     "in_dark_aether": false,
                     "asset_id": 442183190,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -27713,7 +27713,7 @@
                     "name": "Sun Tower Access",
                     "in_dark_aether": false,
                     "asset_id": 1103925484,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -27764,7 +27764,7 @@
                     "name": "Hive Totem",
                     "in_dark_aether": false,
                     "asset_id": 3358629366,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -27879,7 +27879,7 @@
                     "name": "Sunchamber",
                     "in_dark_aether": false,
                     "asset_id": 2584347627,
-                    "default_node_index": null,
+                    "default_node_index": 4,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -28134,7 +28134,7 @@
                     "name": "Watery Hall Access",
                     "in_dark_aether": false,
                     "asset_id": 4008477565,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -28213,7 +28213,7 @@
                     "name": "Save Station 2",
                     "in_dark_aether": false,
                     "asset_id": 4158166350,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -28255,7 +28255,7 @@
                     "name": "East Atrium",
                     "in_dark_aether": false,
                     "asset_id": 1899364579,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -28306,7 +28306,7 @@
                     "name": "Watery Hall",
                     "in_dark_aether": false,
                     "asset_id": 1227669322,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -28362,16 +28362,16 @@
                             "name": "Dock to Watery Hall Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -15.349824905395508,
-                                "y": -29.425650596618652,
-                                "z": 5.26800000667572
+                                "x": -15.35,
+                                "y": -29.43,
+                                "z": 5.27
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 4008477565,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
+                            "dock_weakness_index": 4,
                             "connections": {
                                 "Dock to Dynamo Access": {
                                     "type": "and",
@@ -28529,7 +28529,7 @@
                     "name": "Energy Core Access",
                     "in_dark_aether": false,
                     "asset_id": 1178406190,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -28580,7 +28580,7 @@
                     "name": "Dynamo Access",
                     "in_dark_aether": false,
                     "asset_id": 255867655,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -28631,7 +28631,7 @@
                     "name": "Energy Core",
                     "in_dark_aether": false,
                     "asset_id": 3386190780,
-                    "default_node_index": null,
+                    "default_node_index": 2,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -28773,7 +28773,7 @@
                     "name": "Dynamo",
                     "in_dark_aether": false,
                     "asset_id": 81183365,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -28869,7 +28869,7 @@
                     "name": "Burn Dome Access",
                     "in_dark_aether": false,
                     "asset_id": 4018058640,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -28954,7 +28954,7 @@
                     "name": "West Furnace Access",
                     "in_dark_aether": false,
                     "asset_id": 3262208600,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -29005,7 +29005,7 @@
                     "name": "Burn Dome",
                     "in_dark_aether": false,
                     "asset_id": 1095301040,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -29115,7 +29115,7 @@
                     "name": "Furnace",
                     "in_dark_aether": false,
                     "asset_id": 774997107,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -29419,7 +29419,7 @@
                     "name": "East Furnace Access",
                     "in_dark_aether": false,
                     "asset_id": 1155868918,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -29470,7 +29470,7 @@
                     "name": "Crossway Access West",
                     "in_dark_aether": false,
                     "asset_id": 3655831216,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -29989,7 +29989,7 @@
                     "name": "Crossway",
                     "in_dark_aether": false,
                     "asset_id": 335540505,
-                    "default_node_index": null,
+                    "default_node_index": 1,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -30189,7 +30189,7 @@
                     "name": "Reflecting Pool Access",
                     "in_dark_aether": false,
                     "asset_id": 2639359389,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -30240,7 +30240,7 @@
                     "name": "Elder Hall Access",
                     "in_dark_aether": false,
                     "asset_id": 3788397521,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -30291,7 +30291,7 @@
                     "name": "Crossway Access South",
                     "in_dark_aether": false,
                     "asset_id": 1733962111,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -30362,7 +30362,7 @@
                     "name": "Elder Chamber",
                     "in_dark_aether": false,
                     "asset_id": 3784843004,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -30406,7 +30406,7 @@
                     "name": "Reflecting Pool",
                     "in_dark_aether": false,
                     "asset_id": 907987628,
-                    "default_node_index": null,
+                    "default_node_index": 2,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -30581,7 +30581,7 @@
                     "name": "Save Station 3",
                     "in_dark_aether": false,
                     "asset_id": 411706287,
-                    "default_node_index": null,
+                    "default_node_index": 2,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -30696,7 +30696,7 @@
                     "name": "Transport Access South",
                     "in_dark_aether": false,
                     "asset_id": 2734230611,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {
@@ -30747,7 +30747,7 @@
                     "name": "Antechamber",
                     "in_dark_aether": false,
                     "asset_id": 2951734903,
-                    "default_node_index": null,
+                    "default_node_index": 0,
                     "valid_starting_location": true,
                     "nodes": [
                         {

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -10444,8 +10444,13 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Shoot Super Missile"
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 10,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         },
@@ -10884,8 +10889,13 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Shoot Super Missile"
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 10,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         },
@@ -10979,7 +10989,7 @@
                                                             "data": {
                                                                 "type": 3,
                                                                 "index": 5,
-                                                                "amount": 1188,
+                                                                "amount": 188,
                                                                 "negate": false
                                                             }
                                                         }
@@ -10994,7 +11004,7 @@
                                                                 "type": 0,
                                                                 "index": 15,
                                                                 "amount": 1,
-                                                                "negate": true
+                                                                "negate": false
                                                             }
                                                         },
                                                         {

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -13877,33 +13877,6 @@
                                             "type": "and",
                                             "data": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Heat-Resisting Suit"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 16,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 18,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "type": "and",
-                                            "data": [
-                                                {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": 0,

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -4350,15 +4350,6 @@
                                         {
                                             "type": "resource",
                                             "data": {
-                                                "type": 1,
-                                                "index": 20,
-                                                "amount": 1,
-                                                "negate": true
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
                                                 "type": 0,
                                                 "index": 5,
                                                 "amount": 1,

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -4176,13 +4176,22 @@
                             "dock_weakness_index": 0,
                             "connections": {
                                 "Dock to South Quarantine Tunnel": {
-                                    "type": "or",
+                                    "type": "and",
                                     "data": [
                                         {
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
                                                 "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -4524,7 +4533,17 @@
                             "connections": {
                                 "Pickup (Missile)": {
                                     "type": "and",
-                                    "data": []
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         },
@@ -4538,7 +4557,17 @@
                             "connections": {
                                 "Dock to Quarantine Cave": {
                                     "type": "and",
-                                    "data": []
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -5574,7 +5603,7 @@
                                     "data": []
                                 },
                                 "Pickup (Artifact of Elder)": {
-                                    "type": "and",
+                                    "type": "or",
                                     "data": [
                                         {
                                             "type": "resource",
@@ -5586,56 +5615,19 @@
                                             }
                                         },
                                         {
-                                            "type": "or",
-                                            "data": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 4,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 0,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 10,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 11,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            ]
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
                                         },
                                         {
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
-                                                "index": 16,
+                                                "index": 4,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -5674,7 +5666,7 @@
                             "major_location": true,
                             "connections": {
                                 "Dock to East Tower": {
-                                    "type": "or",
+                                    "type": "and",
                                     "data": [
                                         {
                                             "type": "resource",
@@ -7159,6 +7151,15 @@
                                                 "amount": 1,
                                                 "negate": false
                                             }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
                                         }
                                     ]
                                 }
@@ -7221,11 +7222,31 @@
                             "connections": {
                                 "Dock to Lower Edge Tunnel": {
                                     "type": "and",
-                                    "data": []
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 },
                                 "Dock to Upper Edge Tunnel": {
                                     "type": "and",
-                                    "data": []
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 },
                                 "Dock to Storage Cave": {
                                     "type": "and",
@@ -7463,7 +7484,17 @@
                             "connections": {
                                 "Pickup (Power Bomb)": {
                                     "type": "and",
-                                    "data": []
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         },
@@ -7477,7 +7508,17 @@
                             "connections": {
                                 "Dock to Phendrana's Edge": {
                                     "type": "and",
-                                    "data": []
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         }

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -1730,7 +1730,7 @@
                                             "data": {
                                                 "type": 0,
                                                 "index": 10,
-                                                "amount": 1,
+                                                "amount": 3,
                                                 "negate": false
                                             }
                                         },
@@ -1770,7 +1770,7 @@
                                             "data": {
                                                 "type": 0,
                                                 "index": 4,
-                                                "amount": 1,
+                                                "amount": 3,
                                                 "negate": false
                                             }
                                         },
@@ -2024,22 +2024,8 @@
                                             }
                                         },
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 4,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 11,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
+                                            "type": "template",
+                                            "data": "Shoot Super Missile"
                                         }
                                     ]
                                 }
@@ -2119,13 +2105,41 @@
                                             }
                                         },
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 10,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 10,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 2,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -2162,19 +2176,47 @@
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
-                                                "index": 10,
+                                                "index": 3,
                                                 "amount": 1,
                                                 "negate": false
                                             }
                                         },
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 3,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 10,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 2,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -2455,73 +2497,14 @@
                             "dock_type": 0,
                             "dock_weakness_index": 0,
                             "connections": {
-                                "Pickup (Artifact of Sun)": {
-                                    "type": "and",
+                                "Front of Bomb Slot": {
+                                    "type": "or",
                                     "data": [
                                         {
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
                                                 "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 6,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 3,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
-                                "Event (Chozo Ice Temple Bomb Slot)": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 6,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -2545,7 +2528,7 @@
                             "dock_type": 0,
                             "dock_weakness_index": 0,
                             "connections": {
-                                "Dock to Temple Entryway": {
+                                "Front of Bomb Slot": {
                                     "type": "or",
                                     "data": [
                                         {
@@ -2553,56 +2536,6 @@
                                             "data": {
                                                 "type": 1,
                                                 "index": 18,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
-                                "Pickup (Artifact of Sun)": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 4,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 6,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 1,
-                                                "index": 18,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 3,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -2619,22 +2552,8 @@
                             "pickup_index": 37,
                             "major_location": true,
                             "connections": {
-                                "Dock to Temple Entryway": {
+                                "Front of Bomb Slot": {
                                     "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
-                                "Dock to Chapel Tunnel": {
-                                    "type": "or",
                                     "data": [
                                         {
                                             "type": "resource",
@@ -2655,13 +2574,99 @@
                             "coordinates": null,
                             "node_type": "generic",
                             "connections": {
+                                "Front of Bomb Slot": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Front of Bomb Slot",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
                                 "Dock to Temple Entryway": {
                                     "type": "and",
                                     "data": []
                                 },
                                 "Dock to Chapel Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Artifact of Sun)": {
                                     "type": "and",
-                                    "data": []
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Chozo Ice Temple Bomb Slot)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -2712,38 +2717,6 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 0,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 10,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 11,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
                                                 }
                                             ]
                                         }
@@ -2782,15 +2755,6 @@
                                                     "data": {
                                                         "type": 0,
                                                         "index": 4,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 11,
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -3206,7 +3170,7 @@
                                             "data": {
                                                 "type": 0,
                                                 "index": 4,
-                                                "amount": 1,
+                                                "amount": 25,
                                                 "negate": false
                                             }
                                         },
@@ -3235,15 +3199,52 @@
                                                             }
                                                         },
                                                         {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 7,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 7,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 2,
+                                                                        "index": 2,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
                                                         }
                                                     ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 17,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 2,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -3356,15 +3357,6 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 4,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
                                         }
                                     ]
                                 }
@@ -3425,13 +3417,8 @@
                                             }
                                         },
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 11,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
+                                            "type": "template",
+                                            "data": "Shoot Super Missile"
                                         },
                                         {
                                             "type": "or",
@@ -3522,15 +3509,6 @@
                                                 "amount": 1,
                                                 "negate": false
                                             }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 4,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
                                         }
                                     ]
                                 }
@@ -3563,15 +3541,6 @@
                                             "data": {
                                                 "type": 0,
                                                 "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 4,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -3629,13 +3598,22 @@
                             "dock_weakness_index": 0,
                             "connections": {
                                 "Pickup (Boost Ball)": {
-                                    "type": "and",
+                                    "type": "or",
                                     "data": [
                                         {
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
                                                 "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -3660,6 +3638,15 @@
                                             "data": {
                                                 "type": 0,
                                                 "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -4177,31 +4164,17 @@
                             "name": "Dock to Quarantine Monitor",
                             "heal": false,
                             "coordinates": {
-                                "x": -24.950436115264893,
+                                "x": -24.95,
                                 "y": 72.0,
-                                "z": 21.973726272583008
+                                "z": 21.97
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 563191901,
                             "connected_dock_index": 0,
-                            "dock_type": 0,
+                            "dock_type": 1,
                             "dock_weakness_index": 0,
                             "connections": {
-                                "Dock to North Quarantine Tunnel": {
-                                    "type": "or",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
                                 "Dock to South Quarantine Tunnel": {
                                     "type": "or",
                                     "data": [
@@ -4209,7 +4182,7 @@
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
-                                                "index": 16,
+                                                "index": 12,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -4429,31 +4402,8 @@
                                     "type": "and",
                                     "data": [
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 0,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 10,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 11,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
+                                            "type": "template",
+                                            "data": "Shoot Super Missile"
                                         }
                                     ]
                                 }
@@ -4578,7 +4528,7 @@
                             "dock_index": 0,
                             "connected_area_asset_id": 1880625556,
                             "connected_dock_index": 2,
-                            "dock_type": 0,
+                            "dock_type": 1,
                             "dock_weakness_index": 0,
                             "connections": {
                                 "Pickup (Missile)": {
@@ -4648,17 +4598,7 @@
                             "connections": {
                                 "Dock to Observatory": {
                                     "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "data": []
                                 }
                             }
                         }
@@ -4699,20 +4639,6 @@
                                             }
                                         }
                                     ]
-                                },
-                                "Elevator - Transport to Phendrana Drifts South": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
                                 }
                             }
                         },
@@ -4748,6 +4674,20 @@
                                             "data": {
                                                 "type": 0,
                                                 "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Elevator - Transport to Phendrana Drifts South": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -4874,15 +4814,6 @@
                                             "data": {
                                                 "type": 1,
                                                 "index": 19,
-                                                "amount": 1,
-                                                "negate": true
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 1,
-                                                "index": 21,
                                                 "amount": 1,
                                                 "negate": true
                                             }
@@ -6039,38 +5970,6 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 10,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 11,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 0,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
                                                 }
                                             ]
                                         }
@@ -6108,38 +6007,6 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 0,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 10,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 11,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
                                                 }
                                             ]
                                         }
@@ -6168,38 +6035,6 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 0,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 10,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 11,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
                                                 }
                                             ]
                                         }
@@ -6278,38 +6113,6 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 0,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 10,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 11,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
                                                 }
                                             ]
                                         }
@@ -6379,38 +6182,6 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 0,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 10,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 11,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
                                                 }
                                             ]
                                         }
@@ -6474,41 +6245,9 @@
                                                             "data": {
                                                                 "type": 0,
                                                                 "index": 4,
-                                                                "amount": 1,
+                                                                "amount": 3,
                                                                 "negate": false
                                                             }
-                                                        },
-                                                        {
-                                                            "type": "and",
-                                                            "data": [
-                                                                {
-                                                                    "type": "resource",
-                                                                    "data": {
-                                                                        "type": 0,
-                                                                        "index": 0,
-                                                                        "amount": 1,
-                                                                        "negate": false
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "type": "resource",
-                                                                    "data": {
-                                                                        "type": 0,
-                                                                        "index": 11,
-                                                                        "amount": 1,
-                                                                        "negate": false
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "type": "resource",
-                                                                    "data": {
-                                                                        "type": 0,
-                                                                        "index": 10,
-                                                                        "amount": 1,
-                                                                        "negate": false
-                                                                    }
-                                                                }
-                                                            ]
                                                         }
                                                     ]
                                                 }
@@ -6566,41 +6305,9 @@
                                                     "data": {
                                                         "type": 0,
                                                         "index": 4,
-                                                        "amount": 1,
+                                                        "amount": 3,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 0,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 10,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 11,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
                                                 }
                                             ]
                                         }
@@ -6635,41 +6342,9 @@
                                                     "data": {
                                                         "type": 0,
                                                         "index": 4,
-                                                        "amount": 1,
+                                                        "amount": 3,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 0,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 10,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 11,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
                                                 }
                                             ]
                                         }
@@ -6709,41 +6384,9 @@
                                                     "data": {
                                                         "type": 0,
                                                         "index": 4,
-                                                        "amount": 1,
+                                                        "amount": 3,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 0,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 11,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 10,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
                                                 }
                                             ]
                                         }
@@ -6894,17 +6537,7 @@
                             "connections": {
                                 "Dock to Research Lab Aether": {
                                     "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "data": []
                                 }
                             }
                         },
@@ -7382,38 +7015,6 @@
                                                     }
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "type": "and",
-                                            "data": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 0,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 10,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 11,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
                                         }
                                     ]
                                 }
@@ -7554,15 +7155,6 @@
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
                                                 "index": 15,
                                                 "amount": 1,
                                                 "negate": false
@@ -7625,44 +7217,24 @@
                             "name": "Dock to Security Cave",
                             "heal": false,
                             "coordinates": {
-                                "x": -1.93695729970932,
-                                "y": -38.264753341674805,
-                                "z": 82.56095504760742
+                                "x": -1.94,
+                                "y": -38.26,
+                                "z": 82.56
                             },
                             "node_type": "dock",
                             "dock_index": 3,
                             "connected_area_asset_id": 1016369381,
                             "connected_dock_index": 0,
-                            "dock_type": 0,
+                            "dock_type": 1,
                             "dock_weakness_index": 0,
                             "connections": {
                                 "Dock to Lower Edge Tunnel": {
-                                    "type": "or",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "type": "and",
+                                    "data": []
                                 },
                                 "Dock to Upper Edge Tunnel": {
-                                    "type": "or",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "type": "and",
+                                    "data": []
                                 },
                                 "Dock to Storage Cave": {
                                     "type": "and",
@@ -7887,15 +7459,15 @@
                             "name": "Dock to Phendrana's Edge",
                             "heal": false,
                             "coordinates": {
-                                "x": -0.9055264815688133,
-                                "y": 27.27096939086914,
-                                "z": 2.219199538230896
+                                "x": -0.91,
+                                "y": 27.27,
+                                "z": 2.22
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1423896872,
                             "connected_dock_index": 3,
-                            "dock_type": 0,
+                            "dock_type": 1,
                             "dock_weakness_index": 0,
                             "connections": {
                                 "Pickup (Power Bomb)": {
@@ -10040,13 +9612,9 @@
                                                             "data": {
                                                                 "type": 0,
                                                                 "index": 4,
-                                                                "amount": 1,
+                                                                "amount": 2,
                                                                 "negate": false
                                                             }
-                                                        },
-                                                        {
-                                                            "type": "template",
-                                                            "data": "Shoot Super Missile"
                                                         }
                                                     ]
                                                 },
@@ -10082,7 +9650,7 @@
                                                     "data": {
                                                         "type": 0,
                                                         "index": 4,
-                                                        "amount": 1,
+                                                        "amount": 2,
                                                         "negate": false
                                                     }
                                                 }
@@ -10292,7 +9860,7 @@
                                                             "data": {
                                                                 "type": 0,
                                                                 "index": 4,
-                                                                "amount": 1,
+                                                                "amount": 2,
                                                                 "negate": false
                                                             }
                                                         },
@@ -10370,33 +9938,6 @@
                                                                 "type": 3,
                                                                 "index": 5,
                                                                 "amount": 479,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "template",
-                                                            "data": "Shoot Super Missile"
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 7,
-                                                                "amount": 2,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 3,
-                                                                "index": 5,
-                                                                "amount": 494,
                                                                 "negate": false
                                                             }
                                                         }
@@ -10545,51 +10086,79 @@
                             "dock_weakness_index": 0,
                             "connections": {
                                 "Dock to Lava Lake": {
-                                    "type": "and",
+                                    "type": "or",
                                     "data": [
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "or",
+                                            "type": "and",
                                             "data": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": 3,
-                                                        "index": 5,
-                                                        "amount": 95,
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "or",
                                                     "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 18,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
                                                         {
                                                             "type": "resource",
                                                             "data": {
                                                                 "type": 3,
                                                                 "index": 5,
-                                                                "amount": 91,
+                                                                "amount": 95,
                                                                 "negate": false
                                                             }
+                                                        },
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 18,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 3,
+                                                                        "index": 5,
+                                                                        "amount": 91,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
                                                         }
                                                     ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 91,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -10613,51 +10182,79 @@
                             "dock_weakness_index": 0,
                             "connections": {
                                 "Dock to Triclops Pit": {
-                                    "type": "and",
+                                    "type": "or",
                                     "data": [
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "or",
+                                            "type": "and",
                                             "data": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": 3,
-                                                        "index": 5,
-                                                        "amount": 86,
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "or",
                                                     "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 18,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
                                                         {
                                                             "type": "resource",
                                                             "data": {
                                                                 "type": 3,
                                                                 "index": 5,
-                                                                "amount": 72,
+                                                                "amount": 86,
                                                                 "negate": false
                                                             }
+                                                        },
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 18,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 3,
+                                                                        "index": 5,
+                                                                        "amount": 72,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
                                                         }
                                                     ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 91,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -16208,15 +15805,6 @@
                                                 "amount": 1,
                                                 "negate": false
                                             }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
                                         }
                                     ]
                                 },
@@ -16596,18 +16184,8 @@
                             "dock_weakness_index": 2,
                             "connections": {
                                 "Dock to Elite Research": {
-                                    "type": "or",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         }
@@ -17164,15 +16742,6 @@
                                 "Dock to Ventilation Shaft": {
                                     "type": "and",
                                     "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
                                         {
                                             "type": "resource",
                                             "data": {
@@ -18102,18 +17671,8 @@
                             "dock_weakness_index": 1,
                             "connections": {
                                 "Dock to Omega Research": {
-                                    "type": "or",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         },

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -8,287 +8,287 @@
                 "long_name": "Power Beam",
                 "short_name": "Power",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 1,
                 "long_name": "Ice Beam",
                 "short_name": "Ice",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 2,
                 "long_name": "Wave Beam",
                 "short_name": "Wave",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 3,
                 "long_name": "Plasma Beam",
                 "short_name": "Plasma",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 4,
                 "long_name": "Missile",
                 "short_name": "Missile",
                 "max_capacity": 255,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 5,
                 "long_name": "Scan Visor",
                 "short_name": "Scan",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 6,
                 "long_name": "Morph Ball Bomb",
                 "short_name": "Bombs",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 7,
                 "long_name": "Power Bomb",
                 "short_name": "PowerBomb",
                 "max_capacity": 8,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 8,
                 "long_name": "Flamethrower",
                 "short_name": "Flamethrower",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 9,
                 "long_name": "Thermal Visor",
                 "short_name": "Thermal",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 10,
                 "long_name": "Charge Beam",
                 "short_name": "Charge",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 11,
                 "long_name": "Super Missile",
                 "short_name": "Supers",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 12,
                 "long_name": "Grapple Beam",
                 "short_name": "Grapple",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 13,
                 "long_name": "X-Ray Visor",
                 "short_name": "X-Ray",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 14,
                 "long_name": "Ice Spreader",
                 "short_name": "IceSpreader",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 15,
                 "long_name": "Space Jump Boots",
                 "short_name": "SpaceJump",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 16,
                 "long_name": "Morph Ball",
                 "short_name": "MorphBall",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 17,
                 "long_name": "Combat Visor",
                 "short_name": "Combat",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 18,
                 "long_name": "Boost Ball",
                 "short_name": "Boost",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 19,
                 "long_name": "Spider Ball",
                 "short_name": "Spider",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 20,
                 "long_name": "Power Suit",
                 "short_name": "PowerSuit",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 21,
                 "long_name": "Gravity Suit",
                 "short_name": "GravitySuit",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 22,
                 "long_name": "Varia Suit",
                 "short_name": "VariaSuit",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 23,
                 "long_name": "Phazon Suit",
                 "short_name": "PhazonSuit",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 24,
                 "long_name": "Energy Tank",
                 "short_name": "EnergyTank",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 25,
                 "long_name": "Unknown Item 1",
                 "short_name": "Unknown1",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 26,
                 "long_name": "Health Refill",
                 "short_name": "HealthRefill",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 27,
                 "long_name": "Unknown Item 2",
                 "short_name": "Unknown2",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 28,
                 "long_name": "Wavebuster",
                 "short_name": "Wavebuster",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 29,
                 "long_name": "Artifact of Truth",
                 "short_name": "Truth",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 30,
                 "long_name": "Artifact of Strength",
                 "short_name": "Strength",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 31,
                 "long_name": "Artifact of Elder",
                 "short_name": "Elder",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 32,
                 "long_name": "Artifact of Wild",
                 "short_name": "Wild",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 33,
                 "long_name": "Artifact of Lifegiver",
                 "short_name": "Lifegiver",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 34,
                 "long_name": "Artifact of Warrior",
                 "short_name": "Warrior",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 35,
                 "long_name": "Artifact of Chozo",
                 "short_name": "Chozo",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 36,
                 "long_name": "Artifact of Nature",
                 "short_name": "Nature",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 37,
                 "long_name": "Artifact of Sun",
                 "short_name": "Sun",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 38,
                 "long_name": "Artifact of World",
                 "short_name": "World",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 39,
                 "long_name": "Artifact of Spirit",
                 "short_name": "Spirit",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             },
             {
                 "index": 40,
                 "long_name": "Artifact of Newborn",
                 "short_name": "Newborn",
                 "max_capacity": 1,
-                "custom_memory_offset": null
+                "extra": null
             }
         ],
         "events": [
@@ -15917,8 +15917,8 @@
                                         {
                                             "type": "resource",
                                             "data": {
-                                                "type": 1,
-                                                "index": 35,
+                                                "type": 0,
+                                                "index": 2,
                                                 "amount": 1,
                                                 "negate": false
                                             }

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -16415,7 +16415,7 @@
                             "node_type": "event",
                             "event_index": 24,
                             "connections": {
-                                "Dock to Research Access": {
+                                "Top Floor": {
                                     "type": "and",
                                     "data": []
                                 }
@@ -16526,13 +16526,27 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 7,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 7,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 1,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
                                                 }
                                             ]
                                         }
@@ -17915,20 +17929,6 @@
                                             }
                                         }
                                     ]
-                                },
-                                "Pickup (Phazon Suit)": {
-                                    "type": "or",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 1,
-                                                "index": 31,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
                                 }
                             }
                         },
@@ -17974,7 +17974,7 @@
                             "node_type": "event",
                             "event_index": 31,
                             "connections": {
-                                "Dock to Elite Quarters Access": {
+                                "Pickup (Phazon Suit)": {
                                     "type": "and",
                                     "data": []
                                 }
@@ -18101,8 +18101,17 @@
                                         {
                                             "type": "resource",
                                             "data": {
-                                                "type": 1,
-                                                "index": 27,
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -18115,8 +18124,17 @@
                                         {
                                             "type": "resource",
                                             "data": {
-                                                "type": 1,
-                                                "index": 27,
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -18149,7 +18167,7 @@
                                                             "type": "resource",
                                                             "data": {
                                                                 "type": 2,
-                                                                "index": 4,
+                                                                "index": 2,
                                                                 "amount": 1,
                                                                 "negate": false
                                                             }
@@ -18158,7 +18176,7 @@
                                                             "type": "resource",
                                                             "data": {
                                                                 "type": 2,
-                                                                "index": 2,
+                                                                "index": 4,
                                                                 "amount": 1,
                                                                 "negate": false
                                                             }
@@ -18166,29 +18184,6 @@
                                                     ]
                                                 }
                                             ]
-                                        }
-                                    ]
-                                },
-                                "Event (Central Dynamo Bendezium Destroyed)": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 7,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
                                         }
                                     ]
                                 }
@@ -18247,8 +18242,17 @@
                                         {
                                             "type": "resource",
                                             "data": {
-                                                "type": 1,
-                                                "index": 27,
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -18305,38 +18309,6 @@
                                             ]
                                         }
                                     ]
-                                },
-                                "Event (Central Dynamo Bendezium Destroyed)": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 7,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 1,
-                                                "index": 25,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
                                 }
                             }
                         },
@@ -18383,29 +18355,6 @@
                                 "Dock to Save Station Mines B": {
                                     "type": "and",
                                     "data": []
-                                }
-                            }
-                        },
-                        {
-                            "name": "Event (Central Dynamo Bendezium Destroyed)",
-                            "heal": false,
-                            "coordinates": null,
-                            "node_type": "event",
-                            "event_index": 27,
-                            "connections": {
-                                "Dock to Save Station Mines B": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 1,
-                                                "index": 25,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
                                 }
                             }
                         }
@@ -18553,18 +18502,8 @@
                             "dock_weakness_index": 2,
                             "connections": {
                                 "Dock to Central Dynamo": {
-                                    "type": "or",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 1,
-                                                "index": 27,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         }
@@ -18634,9 +18573,27 @@
                             "dock_type": 0,
                             "dock_weakness_index": 3,
                             "connections": {
-                                "Dock to Save Station Mines C": {
+                                "Front of Barrier": {
                                     "type": "and",
                                     "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
                                         {
                                             "type": "resource",
                                             "data": {
@@ -18651,83 +18608,6 @@
                                             "data": {
                                                 "type": 0,
                                                 "index": 19,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 12,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 1,
-                                                "index": 29,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
-                                "Event (Metroid Quarantine B Barrier Lowered)": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 19,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 12,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -18772,29 +18652,6 @@
                             "dock_type": 0,
                             "dock_weakness_index": 3,
                             "connections": {
-                                "Dock to Quarantine Access B": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 1,
-                                                "index": 29,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
                                 "Dock to Elite Quarters Access": {
                                     "type": "and",
                                     "data": []
@@ -18805,6 +18662,20 @@
                                         {
                                             "type": "template",
                                             "data": "Shoot Super Missile"
+                                        }
+                                    ]
+                                },
+                                "Front of Barrier": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 29,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
                                         }
                                     ]
                                 }
@@ -18831,6 +18702,18 @@
                             "node_type": "event",
                             "event_index": 29,
                             "connections": {
+                                "Front of Barrier": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Front of Barrier",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
                                 "Dock to Quarantine Access B": {
                                     "type": "or",
                                     "data": [
@@ -18839,6 +18722,34 @@
                                             "data": {
                                                 "type": 0,
                                                 "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Save Station Mines C": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 29,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Metroid Quarantine B Barrier Lowered)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -18871,18 +18782,23 @@
                             "dock_type": 0,
                             "dock_weakness_index": 2,
                             "connections": {
-                                "Dock to Elevator Access B": {
-                                    "type": "and",
+                                "Event (Metroid Quarantine A Barrier Lowered)": {
+                                    "type": "or",
                                     "data": [
                                         {
                                             "type": "resource",
                                             "data": {
-                                                "type": 1,
-                                                "index": 28,
+                                                "type": 0,
+                                                "index": 5,
                                                 "amount": 1,
                                                 "negate": false
                                             }
-                                        },
+                                        }
+                                    ]
+                                },
+                                "Front of Spider Track": {
+                                    "type": "and",
+                                    "data": [
                                         {
                                             "type": "resource",
                                             "data": {
@@ -18895,6 +18811,15 @@
                                         {
                                             "type": "or",
                                             "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 9,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
                                                 {
                                                     "type": "resource",
                                                     "data": {
@@ -18912,23 +18837,164 @@
                                                         "amount": 2,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 9,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
                                                 }
                                             ]
-                                        },
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Dock to Elevator Access B",
+                            "heal": false,
+                            "coordinates": {
+                                "x": 1.58,
+                                "y": 87.41,
+                                "z": 19.67
+                            },
+                            "node_type": "dock",
+                            "dock_index": 1,
+                            "connected_area_asset_id": 1071241062,
+                            "connected_dock_index": 0,
+                            "dock_type": 0,
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Front of Spider Track": {
+                                    "type": "or",
+                                    "data": [
                                         {
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
-                                                "index": 16,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 86,
+                            "major_location": false,
+                            "connections": {
+                                "Front of Spider Track": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 0,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 9,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 13,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 4,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Metroid Quarantine A Barrier Lowered)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 28,
+                            "connections": {
+                                "Dock to Quarantine Access A": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Front of Spider Track",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Quarantine Access A": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 28,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Elevator Access B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -18937,7 +19003,7 @@
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
-                                                "index": 19,
+                                                "index": 16,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -18959,8 +19025,8 @@
                                         {
                                             "type": "resource",
                                             "data": {
-                                                "type": 1,
-                                                "index": 28,
+                                                "type": 0,
+                                                "index": 16,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -18969,8 +19035,8 @@
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
+                                                "index": 7,
+                                                "amount": 2,
                                                 "negate": false
                                             }
                                         },
@@ -18987,7 +19053,7 @@
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
-                                                "index": 7,
+                                                "index": 15,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -18995,6 +19061,15 @@
                                         {
                                             "type": "or",
                                             "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 9,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
                                                 {
                                                     "type": "resource",
                                                     "data": {
@@ -19012,215 +19087,10 @@
                                                         "amount": 2,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 9,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "name": "Dock to Elevator Access B",
-                            "heal": false,
-                            "coordinates": {
-                                "x": 1.58,
-                                "y": 87.41,
-                                "z": 19.67
-                            },
-                            "node_type": "dock",
-                            "dock_index": 1,
-                            "connected_area_asset_id": 1071241062,
-                            "connected_dock_index": 0,
-                            "dock_type": 0,
-                            "dock_weakness_index": 1,
-                            "connections": {
-                                "Dock to Quarantine Access A": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 1,
-                                                "index": 28,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
-                                "Pickup (Missile)": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 7,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 19,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "or",
-                                            "data": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 15,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 6,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "type": "or",
-                                            "data": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 13,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 2,
-                                                        "index": 4,
-                                                        "amount": 2,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 9,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
                                                 }
                                             ]
                                         }
                                     ]
-                                },
-                                "Event (Metroid Quarantine A Barrier Lowered)": {
-                                    "type": "or",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "name": "Pickup (Missile)",
-                            "heal": false,
-                            "coordinates": null,
-                            "node_type": "pickup",
-                            "pickup_index": 86,
-                            "major_location": false,
-                            "connections": {
-                                "Dock to Quarantine Access A": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 1,
-                                                "index": 28,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "name": "Event (Metroid Quarantine A Barrier Lowered)",
-                            "heal": false,
-                            "coordinates": null,
-                            "node_type": "event",
-                            "event_index": 28,
-                            "connections": {
-                                "Dock to Quarantine Access A": {
-                                    "type": "and",
-                                    "data": []
                                 }
                             }
                         }

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -494,6 +494,12 @@
                 "long_name": "Damage Boosting",
                 "short_name": "DBoosting",
                 "description": "Some damage sources give Samus extra velocity, which can be used to give her a small boost."
+            },
+            {
+                "index": 6,
+                "long_name": "Movement",
+                "short_name": "Movement",
+                "description": "A broad category for non-obvious movement which can't easily be classified using other tricks."
             }
         ],
         "damage": [
@@ -15100,8 +15106,41 @@
                                     ]
                                 },
                                 "Dock to Save Station Mines A": {
-                                    "type": "and",
-                                    "data": []
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 19,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 2,
+                                                "index": 2,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 },
                                 "Dock to Security Access A": {
                                     "type": "or",

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -9609,6 +9609,15 @@
                                                                     ]
                                                                 }
                                                             ]
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 1,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
                                                         }
                                                     ]
                                                 }
@@ -9846,6 +9855,15 @@
                                                                             ]
                                                                         }
                                                                     ]
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 2,
+                                                                        "index": 1,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -9915,33 +9933,6 @@
                                                     "type": "and",
                                                     "data": [
                                                         {
-                                                            "type": "template",
-                                                            "data": "Shoot Super Missile"
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 6,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 3,
-                                                                "index": 5,
-                                                                "amount": 430,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
                                                             "type": "resource",
                                                             "data": {
                                                                 "type": 0,
@@ -9965,6 +9956,15 @@
                                                                 "type": 3,
                                                                 "index": 5,
                                                                 "amount": 479,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 1,
+                                                                "amount": 1,
                                                                 "negate": false
                                                             }
                                                         }
@@ -10077,6 +10077,15 @@
                                                                 "type": 3,
                                                                 "index": 5,
                                                                 "amount": 470,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 1,
+                                                                "amount": 1,
                                                                 "negate": false
                                                             }
                                                         }

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -17093,6 +17093,61 @@
                                 "Dock to Processing Center Access": {
                                     "type": "and",
                                     "data": []
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 9,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 13,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
                                 }
                             }
                         },
@@ -18733,6 +18788,15 @@
                                                         "amount": 2,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 9,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         },
@@ -18822,6 +18886,15 @@
                                                         "type": 2,
                                                         "index": 4,
                                                         "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 9,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -18949,6 +19022,15 @@
                                                         "type": 2,
                                                         "index": 4,
                                                         "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 9,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -505,6 +505,18 @@
                 "long_name": "Movement",
                 "short_name": "Movement",
                 "description": "A broad category for non-obvious movement which can't easily be classified using other tricks."
+            },
+            {
+                "index": 7,
+                "long_name": "Slope Jump",
+                "short_name": "SJump",
+                "description": "A technique where Samus can gain extra height by L-Jumping into certain slopes."
+            },
+            {
+                "index": 8,
+                "long_name": "Standable Terrain",
+                "short_name": "Standable",
+                "description": "Samus can maneuver in unexpected ways by standing on small ledges, vines, railings, and other unlikely objects."
             }
         ],
         "damage": [
@@ -24536,6 +24548,29 @@
                                                     }
                                                 }
                                             ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 7,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -25219,6 +25254,29 @@
                                                     "data": {
                                                         "type": 0,
                                                         "index": 19,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 8,
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -26665,6 +26723,29 @@
                                                     }
                                                 }
                                             ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 7,
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     ]
                                 },
@@ -27637,6 +27718,15 @@
                                             "data": {
                                                 "type": 0,
                                                 "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -30005,43 +30095,98 @@
                                     "data": []
                                 },
                                 "Event - Activate bomb slots": {
-                                    "type": "and",
+                                    "type": "or",
                                     "data": [
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 0,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 0,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 19,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         },
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 6,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 19,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 0,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 8,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     ]
                                 }

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -8,287 +8,287 @@
                 "long_name": "Power Beam",
                 "short_name": "Power",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 1,
                 "long_name": "Ice Beam",
                 "short_name": "Ice",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 2,
                 "long_name": "Wave Beam",
                 "short_name": "Wave",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 3,
                 "long_name": "Plasma Beam",
                 "short_name": "Plasma",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 4,
                 "long_name": "Missile",
                 "short_name": "Missile",
                 "max_capacity": 255,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 5,
                 "long_name": "Scan Visor",
                 "short_name": "Scan",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 6,
                 "long_name": "Morph Ball Bomb",
                 "short_name": "Bombs",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 7,
                 "long_name": "Power Bomb",
                 "short_name": "PowerBomb",
                 "max_capacity": 8,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 8,
                 "long_name": "Flamethrower",
                 "short_name": "Flamethrower",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 9,
                 "long_name": "Thermal Visor",
                 "short_name": "Thermal",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 10,
                 "long_name": "Charge Beam",
                 "short_name": "Charge",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 11,
                 "long_name": "Super Missile",
                 "short_name": "Supers",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 12,
                 "long_name": "Grapple Beam",
                 "short_name": "Grapple",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 13,
                 "long_name": "X-Ray Visor",
                 "short_name": "X-Ray",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 14,
                 "long_name": "Ice Spreader",
                 "short_name": "IceSpreader",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 15,
                 "long_name": "Space Jump Boots",
                 "short_name": "SpaceJump",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 16,
                 "long_name": "Morph Ball",
                 "short_name": "MorphBall",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 17,
                 "long_name": "Combat Visor",
                 "short_name": "Combat",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 18,
                 "long_name": "Boost Ball",
                 "short_name": "Boost",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 19,
                 "long_name": "Spider Ball",
                 "short_name": "Spider",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 20,
                 "long_name": "Power Suit",
                 "short_name": "PowerSuit",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 21,
                 "long_name": "Gravity Suit",
                 "short_name": "GravitySuit",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 22,
                 "long_name": "Varia Suit",
                 "short_name": "VariaSuit",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 23,
                 "long_name": "Phazon Suit",
                 "short_name": "PhazonSuit",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 24,
                 "long_name": "Energy Tank",
                 "short_name": "EnergyTank",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 25,
                 "long_name": "Unknown Item 1",
                 "short_name": "Unknown1",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 26,
                 "long_name": "Health Refill",
                 "short_name": "HealthRefill",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 27,
                 "long_name": "Unknown Item 2",
                 "short_name": "Unknown2",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 28,
                 "long_name": "Wavebuster",
                 "short_name": "Wavebuster",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 29,
                 "long_name": "Artifact of Truth",
                 "short_name": "Truth",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 30,
                 "long_name": "Artifact of Strength",
                 "short_name": "Strength",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 31,
                 "long_name": "Artifact of Elder",
                 "short_name": "Elder",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 32,
                 "long_name": "Artifact of Wild",
                 "short_name": "Wild",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 33,
                 "long_name": "Artifact of Lifegiver",
                 "short_name": "Lifegiver",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 34,
                 "long_name": "Artifact of Warrior",
                 "short_name": "Warrior",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 35,
                 "long_name": "Artifact of Chozo",
                 "short_name": "Chozo",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 36,
                 "long_name": "Artifact of Nature",
                 "short_name": "Nature",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 37,
                 "long_name": "Artifact of Sun",
                 "short_name": "Sun",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 38,
                 "long_name": "Artifact of World",
                 "short_name": "World",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 39,
                 "long_name": "Artifact of Spirit",
                 "short_name": "Spirit",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             },
             {
                 "index": 40,
                 "long_name": "Artifact of Newborn",
                 "short_name": "Newborn",
                 "max_capacity": 1,
-                "extra": null
+                "custom_memory_offset": null
             }
         ],
         "events": [
@@ -460,6 +460,11 @@
             {
                 "index": 34,
                 "long_name": "Phazon Mines Save Station A Barrier Opened",
+                "short_name": "Event34"
+            },
+            {
+                "index": 35,
+                "long_name": "Mine Security Station Barrier Opened",
                 "short_name": "Event34"
             }
         ],
@@ -4223,7 +4228,17 @@
                                 },
                                 "Event (Thardus)": {
                                     "type": "and",
-                                    "data": []
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         },
@@ -15602,29 +15617,6 @@
                                                 "amount": 1,
                                                 "negate": false
                                             }
-                                        },
-                                        {
-                                            "type": "or",
-                                            "data": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 13,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 2,
-                                                        "index": 4,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
                                         }
                                     ]
                                 }
@@ -15901,19 +15893,55 @@
                                             }
                                         }
                                     ]
-                                },
-                                "Dock to Storage Depot A": {
+                                }
+                            }
+                        },
+                        {
+                            "name": "Dock to Security Access B",
+                            "heal": false,
+                            "coordinates": {
+                                "x": -5.78,
+                                "y": 57.92,
+                                "z": 14.9
+                            },
+                            "node_type": "dock",
+                            "dock_index": 1,
+                            "connected_area_asset_id": 2718040532,
+                            "connected_dock_index": 1,
+                            "dock_type": 0,
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Security Access A": {
                                     "type": "and",
                                     "data": [
                                         {
                                             "type": "resource",
                                             "data": {
-                                                "type": 0,
-                                                "index": 2,
+                                                "type": 1,
+                                                "index": 35,
                                                 "amount": 1,
                                                 "negate": false
                                             }
-                                        },
+                                        }
+                                    ]
+                                },
+                                "Dock to Storage Depot A": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 35,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Mine Security Station Barrier Opened)": {
+                                    "type": "and",
+                                    "data": [
                                         {
                                             "type": "resource",
                                             "data": {
@@ -15946,37 +15974,6 @@
                             }
                         },
                         {
-                            "name": "Dock to Security Access B",
-                            "heal": false,
-                            "coordinates": {
-                                "x": -5.78,
-                                "y": 57.92,
-                                "z": 14.9
-                            },
-                            "node_type": "dock",
-                            "dock_index": 1,
-                            "connected_area_asset_id": 2718040532,
-                            "connected_dock_index": 1,
-                            "dock_type": 0,
-                            "dock_weakness_index": 2,
-                            "connections": {
-                                "Dock to Security Access A": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 2,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        {
                             "name": "Dock to Storage Depot A",
                             "heal": false,
                             "coordinates": {
@@ -15991,19 +15988,32 @@
                             "dock_type": 0,
                             "dock_weakness_index": 3,
                             "connections": {
-                                "Dock to Security Access A": {
+                                "Dock to Security Access B": {
                                     "type": "or",
                                     "data": [
                                         {
                                             "type": "resource",
                                             "data": {
-                                                "type": 0,
-                                                "index": 2,
+                                                "type": 1,
+                                                "index": 35,
                                                 "amount": 1,
                                                 "negate": false
                                             }
                                         }
                                     ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Mine Security Station Barrier Opened)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 35,
+                            "connections": {
+                                "Dock to Security Access B": {
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         }
@@ -16310,55 +16320,14 @@
                             "dock_type": 0,
                             "dock_weakness_index": 1,
                             "connections": {
-                                "Dock to Security Access B": {
-                                    "type": "and",
+                                "Top Floor": {
+                                    "type": "or",
                                     "data": [
                                         {
                                             "type": "resource",
                                             "data": {
                                                 "type": 1,
                                                 "index": 24,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
-                                "Pickup (Missile)": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 1,
-                                                "index": 24,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 18,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -16382,120 +16351,6 @@
                             "dock_type": 0,
                             "dock_weakness_index": 1,
                             "connections": {
-                                "Dock to Research Access": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 1,
-                                                "index": 24,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
-                                "Event (Rock Wall in Elite Research Destroyed)": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 18,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
-                                "Pickup (Missile)": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 18,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
                                 "Pickup (Artifact of Warrior)": {
                                     "type": "and",
                                     "data": [
@@ -16527,6 +16382,29 @@
                                             }
                                         }
                                     ]
+                                },
+                                "Top Floor": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         },
@@ -16551,9 +16429,19 @@
                             "pickup_index": 78,
                             "major_location": false,
                             "connections": {
-                                "Dock to Security Access B": {
-                                    "type": "and",
-                                    "data": []
+                                "Top Floor": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         },
@@ -16568,6 +16456,151 @@
                                 "Dock to Security Access B": {
                                     "type": "and",
                                     "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Top Floor",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Research Access": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 24,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Security Access B": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Event (Rock Wall in Elite Research Destroyed)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 7,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 7,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -17023,15 +17056,6 @@
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
-                                                "index": 6,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
                                                 "index": 7,
                                                 "amount": 1,
                                                 "negate": false
@@ -17177,38 +17201,6 @@
                                                 "amount": 1,
                                                 "negate": false
                                             }
-                                        },
-                                        {
-                                            "type": "or",
-                                            "data": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 2,
-                                                        "index": 4,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 9,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 13,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
                                         }
                                     ]
                                 }

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -1730,7 +1730,7 @@
                                             "data": {
                                                 "type": 0,
                                                 "index": 10,
-                                                "amount": 3,
+                                                "amount": 1,
                                                 "negate": false
                                             }
                                         },
@@ -1739,7 +1739,7 @@
                                             "data": {
                                                 "type": 0,
                                                 "index": 4,
-                                                "amount": 1,
+                                                "amount": 3,
                                                 "negate": false
                                             }
                                         }

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -456,6 +456,11 @@
                 "index": 33,
                 "long_name": "Parasite Queen Defeated",
                 "short_name": "Event33"
+            },
+            {
+                "index": 34,
+                "long_name": "Phazon Mines Save Station A Barrier Opened",
+                "short_name": "Event34"
             }
         ],
         "tricks": [
@@ -15475,13 +15480,59 @@
                             "connections": {
                                 "Save Station": {
                                     "type": "and",
-                                    "data": []
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 34,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Save Station A Barrier Opened)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         },
                         {
                             "name": "Save Station",
                             "heal": true,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Main Quarry": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 34,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Save Station A Barrier Opened)",
+                            "heal": false,
                             "coordinates": null,
                             "node_type": "generic",
                             "connections": {
@@ -17984,7 +18035,7 @@
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
-                                                "index": 9,
+                                                "index": 13,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -18042,43 +18093,98 @@
                                                 "amount": 1,
                                                 "negate": false
                                             }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 27,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
                                         }
                                     ]
                                 },
                                 "Event (Security Drone Defeated)": {
-                                    "type": "or",
+                                    "type": "and",
                                     "data": [
                                         {
                                             "type": "resource",
                                             "data": {
-                                                "type": 0,
-                                                "index": 9,
+                                                "type": 1,
+                                                "index": 27,
                                                 "amount": 1,
                                                 "negate": false
                                             }
                                         },
                                         {
-                                            "type": "and",
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
                                             "data": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": 2,
-                                                        "index": 2,
+                                                        "type": 0,
+                                                        "index": 13,
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 2,
-                                                        "index": 4,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 4,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 2,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
                                                 }
                                             ]
+                                        }
+                                    ]
+                                },
+                                "Event (Central Dynamo Bendezium Destroyed)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
                                         }
                                     ]
                                 }
@@ -18146,37 +18252,51 @@
                                     ]
                                 },
                                 "Event (Security Drone Defeated)": {
-                                    "type": "or",
+                                    "type": "and",
                                     "data": [
                                         {
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
-                                                "index": 9,
+                                                "index": 15,
                                                 "amount": 1,
                                                 "negate": false
                                             }
                                         },
                                         {
-                                            "type": "and",
+                                            "type": "or",
                                             "data": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": 2,
-                                                        "index": 2,
+                                                        "type": 0,
+                                                        "index": 13,
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 2,
-                                                        "index": 4,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 2,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 4,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
                                                 }
                                             ]
                                         }
@@ -27907,6 +28027,20 @@
                                                 "index": 8,
                                                 "amount": 1,
                                                 "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event - Flaahgra": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": true
                                             }
                                         }
                                     ]

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -5603,7 +5603,7 @@
                                     "data": []
                                 },
                                 "Pickup (Artifact of Elder)": {
-                                    "type": "or",
+                                    "type": "and",
                                     "data": [
                                         {
                                             "type": "resource",
@@ -5628,6 +5628,15 @@
                                             "data": {
                                                 "type": 0,
                                                 "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -15693,10 +15702,6 @@
                             "dock_type": 0,
                             "dock_weakness_index": 1,
                             "connections": {
-                                "Dock to Research Access": {
-                                    "type": "and",
-                                    "data": []
-                                },
                                 "Dock to Storage Depot B": {
                                     "type": "or",
                                     "data": [
@@ -15887,47 +15892,6 @@
                                 "Dock to Security Access A": {
                                     "type": "and",
                                     "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 2,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
-                                "Dock to Storage Depot A": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 7,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
                                         {
                                             "type": "resource",
                                             "data": {
@@ -16503,10 +16467,6 @@
                             "event_index": 24,
                             "connections": {
                                 "Dock to Research Access": {
-                                    "type": "and",
-                                    "data": []
-                                },
-                                "Dock to Security Access B": {
                                     "type": "and",
                                     "data": []
                                 }
@@ -19032,70 +18992,6 @@
                                                 "amount": 1,
                                                 "negate": false
                                             }
-                                        }
-                                    ]
-                                },
-                                "Dock to Elevator Access B": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 6,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 19,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "or",
-                                            "data": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 13,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 2,
-                                                        "index": 4,
-                                                        "amount": 2,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
                                         }
                                     ]
                                 }

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -504,11 +504,11 @@
                 "reductions": [
                     {
                         "index": 21,
-                        "multiplier": 0.8
+                        "multiplier": 0.800000011920929
                     },
                     {
                         "index": 22,
-                        "multiplier": 0.9
+                        "multiplier": 0.8999999761581421
                     },
                     {
                         "index": 23,
@@ -523,11 +523,11 @@
                 "reductions": [
                     {
                         "index": 21,
-                        "multiplier": 0.8
+                        "multiplier": 0.800000011920929
                     },
                     {
                         "index": 22,
-                        "multiplier": 0.9
+                        "multiplier": 0.8999999761581421
                     },
                     {
                         "index": 23,
@@ -542,11 +542,11 @@
                 "reductions": [
                     {
                         "index": 21,
-                        "multiplier": 0.8
+                        "multiplier": 0.800000011920929
                     },
                     {
                         "index": 22,
-                        "multiplier": 0.9
+                        "multiplier": 0.8999999761581421
                     },
                     {
                         "index": 23,
@@ -561,11 +561,11 @@
                 "reductions": [
                     {
                         "index": 21,
-                        "multiplier": 0.8
+                        "multiplier": 0.800000011920929
                     },
                     {
                         "index": 22,
-                        "multiplier": 0.9
+                        "multiplier": 0.8999999761581421
                     },
                     {
                         "index": 23,
@@ -599,11 +599,11 @@
                 "reductions": [
                     {
                         "index": 21,
-                        "multiplier": 0.8
+                        "multiplier": 0.800000011920929
                     },
                     {
                         "index": 22,
-                        "multiplier": 0.9
+                        "multiplier": 0.8999999761581421
                     },
                     {
                         "index": 23,

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -14228,65 +14228,6 @@
                                     "type": "and",
                                     "data": []
                                 },
-                                "Dock to Plasma Processing": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 12,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 18,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 19,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 6,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
                                 "Event (Geothermal Core Opened)": {
                                     "type": "and",
                                     "data": [

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -7220,20 +7220,6 @@
                             "dock_type": 1,
                             "dock_weakness_index": 0,
                             "connections": {
-                                "Dock to Lower Edge Tunnel": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
                                 "Dock to Upper Edge Tunnel": {
                                     "type": "and",
                                     "data": [

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -19283,20 +19283,6 @@
                             "dock_weakness_index": 3,
                             "connections": {
                                 "Dock to Phazon Mining Tunnel": {
-                                    "type": "or",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
-                                "Pickup (Missile)": {
                                     "type": "and",
                                     "data": []
                                 }
@@ -19318,20 +19304,6 @@
                             "dock_weakness_index": 3,
                             "connections": {
                                 "Dock to Phazon Mining Tunnel": {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
-                                "Pickup (Missile)": {
                                     "type": "and",
                                     "data": []
                                 }
@@ -19400,7 +19372,54 @@
                                 },
                                 "Pickup (Missile)": {
                                     "type": "and",
-                                    "data": []
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 7,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 1,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
                                 }
                             }
                         },
@@ -19413,18 +19432,8 @@
                             "major_location": false,
                             "connections": {
                                 "Dock to Phazon Mining Tunnel": {
-                                    "type": "or",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         }
@@ -19560,13 +19569,27 @@
                                             }
                                         },
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 18,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 18,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     ]
                                 },
@@ -19641,13 +19664,27 @@
                                             }
                                         },
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 18,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 18,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -19668,7 +19705,7 @@
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
-                                                "index": 4,
+                                                "index": 16,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -19781,15 +19818,6 @@
                                 "Dock to Elevator B": {
                                     "type": "and",
                                     "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
                                         {
                                             "type": "resource",
                                             "data": {

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -371,15 +371,245 @@
                 "index": 16,
                 "long_name": "Hive Mecha",
                 "short_name": "Event16"
+            },
+            {
+                "index": 17,
+                "long_name": "Thardus",
+                "short_name": "Event17"
+            },
+            {
+                "index": 18,
+                "long_name": "Chozo Ice Temple Bomb Slot",
+                "short_name": "Event18"
+            },
+            {
+                "index": 19,
+                "long_name": "Research Core Power Outage",
+                "short_name": "Event19"
+            },
+            {
+                "index": 20,
+                "long_name": "Research Lab Hydra Barrier Lowered",
+                "short_name": "Event20"
+            },
+            {
+                "index": 21,
+                "long_name": "Observatory Activated",
+                "short_name": "Event21"
+            },
+            {
+                "index": 22,
+                "long_name": "Geothermal Core Opened",
+                "short_name": "Event22"
+            },
+            {
+                "index": 23,
+                "long_name": "Main Quarry Barrier Deactivated",
+                "short_name": "Event23"
+            },
+            {
+                "index": 24,
+                "long_name": "Rock Wall in Elite Research Destroyed",
+                "short_name": "Event24"
+            },
+            {
+                "index": 25,
+                "long_name": "Security Drone Defeated",
+                "short_name": "Event25"
+            },
+            {
+                "index": 26,
+                "long_name": "Elite Control Barriers Lowered",
+                "short_name": "Event26"
+            },
+            {
+                "index": 27,
+                "long_name": "Central Dynamo Bendezium Destroyed",
+                "short_name": "Event27"
+            },
+            {
+                "index": 28,
+                "long_name": "Metroid Quarantine A Barrier Lowered",
+                "short_name": "Event28"
+            },
+            {
+                "index": 29,
+                "long_name": "Metroid Quarantine B Barrier Lowered",
+                "short_name": "Event29"
+            },
+            {
+                "index": 30,
+                "long_name": "Elite Quarters Access Barrier Opened",
+                "short_name": "Event30"
+            },
+            {
+                "index": 31,
+                "long_name": "Omega Pirate Defeated",
+                "short_name": "Event31"
+            },
+            {
+                "index": 32,
+                "long_name": "Processing Center Access Barrier Opened",
+                "short_name": "Event32"
+            },
+            {
+                "index": 33,
+                "long_name": "Parasite Queen Defeated",
+                "short_name": "Event33"
             }
         ],
-        "tricks": [],
+        "tricks": [
+            {
+                "index": 0,
+                "long_name": "Combat/Scan Dash",
+                "short_name": "Dash",
+                "description": "By locking onto an enemy or scan point and strafing left or right, then pressing R immediately after strafing, Samus' momentum can be maintainted. This is useful in crossing gaps.<br /><a href='https://wiki.metroidprime.run/wiki/Dash_Jump_(Prime)'>Check the wiki for more details.</a>"
+            },
+            {
+                "index": 1,
+                "long_name": "Knowledge",
+                "short_name": "Knowledge",
+                "description": "This trick covers breakable objects that one wouldn't expect to be broken with certain items."
+            },
+            {
+                "index": 2,
+                "long_name": "Combat",
+                "short_name": "Combat",
+                "description": "Mainly used for bosses, requiring either fewer items or less health to beat a boss."
+            },
+            {
+                "index": 3,
+                "long_name": "L-Jump",
+                "short_name": "LJump",
+                "description": "This beginner trick allows Samus to jump farther than usual by holding L during the beginning of a jump."
+            },
+            {
+                "index": 4,
+                "long_name": "Invisible Objects",
+                "short_name": "InvisibleObjects",
+                "description": "Objects that normally need visors to be seen or accessed without the required visor, such as Power Conduits without Thermal Visor or Invisible Platforms without X-Ray Visor."
+            },
+            {
+                "index": 5,
+                "long_name": "Damage Boosting",
+                "short_name": "DBoosting",
+                "description": "Some damage sources give Samus extra velocity, which can be used to give her a small boost."
+            }
+        ],
         "damage": [
             {
                 "index": 1,
                 "long_name": "Normal",
                 "short_name": "Damage",
-                "reductions": []
+                "reductions": [
+                    {
+                        "index": 21,
+                        "multiplier": 0.8
+                    },
+                    {
+                        "index": 22,
+                        "multiplier": 0.9
+                    },
+                    {
+                        "index": 23,
+                        "multiplier": 0.5
+                    }
+                ]
+            },
+            {
+                "index": 2,
+                "long_name": "Poisoned Water",
+                "short_name": "RuinsWater",
+                "reductions": [
+                    {
+                        "index": 21,
+                        "multiplier": 0.8
+                    },
+                    {
+                        "index": 22,
+                        "multiplier": 0.9
+                    },
+                    {
+                        "index": 23,
+                        "multiplier": 0.5
+                    }
+                ]
+            },
+            {
+                "index": 3,
+                "long_name": "Phazon",
+                "short_name": "Phazon",
+                "reductions": [
+                    {
+                        "index": 21,
+                        "multiplier": 0.8
+                    },
+                    {
+                        "index": 22,
+                        "multiplier": 0.9
+                    },
+                    {
+                        "index": 23,
+                        "multiplier": 0.0
+                    }
+                ]
+            },
+            {
+                "index": 4,
+                "long_name": "Poison Gas",
+                "short_name": "MinesGas",
+                "reductions": [
+                    {
+                        "index": 21,
+                        "multiplier": 0.8
+                    },
+                    {
+                        "index": 22,
+                        "multiplier": 0.9
+                    },
+                    {
+                        "index": 23,
+                        "multiplier": 0.5
+                    }
+                ]
+            },
+            {
+                "index": 5,
+                "long_name": "Heated Rooms",
+                "short_name": "HeatDamage1",
+                "reductions": [
+                    {
+                        "index": 21,
+                        "multiplier": 0.0
+                    },
+                    {
+                        "index": 22,
+                        "multiplier": 0.0
+                    },
+                    {
+                        "index": 23,
+                        "multiplier": 0.0
+                    }
+                ]
+            },
+            {
+                "index": 6,
+                "long_name": "Lava",
+                "short_name": "HeatDamage2",
+                "reductions": [
+                    {
+                        "index": 21,
+                        "multiplier": 0.8
+                    },
+                    {
+                        "index": 22,
+                        "multiplier": 0.9
+                    },
+                    {
+                        "index": 23,
+                        "multiplier": 0.5
+                    }
+                ]
             }
         ],
         "versions": [
@@ -482,6 +712,38 @@
                         "data": {
                             "type": 0,
                             "index": 3,
+                            "amount": 1,
+                            "negate": false
+                        }
+                    }
+                ]
+            },
+            "Heat-Resisting Suit": {
+                "type": "or",
+                "data": [
+                    {
+                        "type": "resource",
+                        "data": {
+                            "type": 0,
+                            "index": 21,
+                            "amount": 1,
+                            "negate": false
+                        }
+                    },
+                    {
+                        "type": "resource",
+                        "data": {
+                            "type": 0,
+                            "index": 22,
+                            "amount": 1,
+                            "negate": false
+                        }
+                    },
+                    {
+                        "type": "resource",
+                        "data": {
+                            "type": 0,
+                            "index": 23,
                             "amount": 1,
                             "negate": false
                         }
@@ -1401,7 +1663,40 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Elevator - Transport to Phendrana Drifts North": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Elevator - Transport to Phendrana Drifts North",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "teleporter",
+                            "destination_world_asset_id": 1056449404,
+                            "destination_area_asset_id": 3702104715,
+                            "teleporter_instance_id": 45,
+                            "scan_asset_id": 769336033,
+                            "keep_name_when_vanilla": false,
+                            "editable": true,
+                            "connections": {
+                                "Dock to Shoreline Entrance": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -1426,7 +1721,31 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Phendrana Shorelines": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 10,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Phendrana Shorelines",
@@ -1442,7 +1761,31 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Transport to Magmoor Caverns West": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 10,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -1467,7 +1810,63 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Temple Entryway": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Save Station B": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Plaza Walkway": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Ice Ruins Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Temple Entryway",
@@ -1483,7 +1882,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Shoreline Entrance": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Save Station B",
@@ -1499,7 +1903,12 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Shoreline Entrance": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Ruins Entryway",
@@ -1515,7 +1924,16 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Shoreline Entrance": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Plaza Walkway": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Plaza Walkway",
@@ -1531,7 +1949,16 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Shoreline Entrance": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Ruins Entryway": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Ice Ruins Access",
@@ -1547,7 +1974,104 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Shoreline Entrance": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Pickup (Missile Behind Ice)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Spider Track Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 11,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile Behind Ice)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 35,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Ice Ruins Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Spider Track Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 36,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Ice Ruins Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -1572,7 +2096,40 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Phendrana Shorelines": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 10,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Phendrana Shorelines",
@@ -1588,7 +2145,40 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Chozo Ice Temple": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 10,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -1613,7 +2203,24 @@
                             "connected_dock_index": 2,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Save Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Save Station",
+                            "heal": true,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Phendrana Shorelines": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -1638,7 +2245,12 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Phendrana Shorelines": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Phendrana Shorelines",
@@ -1654,7 +2266,12 @@
                             "connected_dock_index": 3,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Ice Ruins West": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -1679,7 +2296,12 @@
                             "connected_dock_index": 4,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Ice Ruins East": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Ice Ruins East",
@@ -1695,7 +2317,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Phendrana Shorelines": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -1720,7 +2347,40 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Phendrana Shorelines": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 10,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Phendrana Shorelines",
@@ -1736,7 +2396,40 @@
                             "connected_dock_index": 5,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Ice Ruins East": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 10,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -1761,7 +2454,81 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Pickup (Artifact of Sun)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Chozo Ice Temple Bomb Slot)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Chapel Tunnel",
@@ -1777,7 +2544,126 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Temple Entryway": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Artifact of Sun)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Artifact of Sun)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 37,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Temple Entryway": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Chapel Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Chozo Ice Temple Bomb Slot)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Temple Entryway": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Chapel Tunnel": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -1802,39 +2688,174 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Courtyard Entryway": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 10,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 11,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Canyon Entryway": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Pickup (Power Bomb)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 11,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Courtyard Entryway",
                             "heal": false,
                             "coordinates": {
-                                "x": 25.740617752075195,
-                                "y": -42.96563911437988,
-                                "z": 12.448527336120605
+                                "x": 25.74,
+                                "y": -42.97,
+                                "z": 12.45
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3484986321,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Ruins Entryway": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Canyon Entryway",
                             "heal": false,
                             "coordinates": {
-                                "x": -41.257694244384766,
-                                "y": -34.953887939453125,
-                                "z": -2.502363590931054
+                                "x": -41.26,
+                                "y": -34.95,
+                                "z": -2.5
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 55410999,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 4,
+                            "connections": {
+                                "Dock to Ruins Entryway": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Power Bomb)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 38,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Ruins Entryway": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -1859,7 +2880,59 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Plaza Walkway": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Spider Track Missile Expansion)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile Expansion Behind Ice)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Plaza Walkway",
@@ -1875,7 +2948,40 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Ice Ruins Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Spider Track Missile Expansion)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 40,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Ice Ruins Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile Expansion Behind Ice)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 39,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Ice Ruins Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -1900,7 +3006,31 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Chozo Ice Temple": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Chozo Ice Temple",
@@ -1916,7 +3046,31 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Chapel of the Elders": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -1941,7 +3095,12 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Ice Ruins West": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Ice Ruins West",
@@ -1957,7 +3116,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Ruined Courtyard": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -1982,23 +3146,33 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Ice Ruins West": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Ice Ruins West",
                             "heal": false,
                             "coordinates": {
-                                "x": 40.963829040527344,
-                                "y": -10.750392436981201,
-                                "z": 2.4999985347442646
+                                "x": 40.96,
+                                "y": -10.75,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3006924320,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 4,
+                            "connections": {
+                                "Dock to Phendrana Canyon": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2013,17 +3187,93 @@
                             "name": "Dock to Chapel Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": 36.301631927490234,
-                                "y": -1.0157042145729065,
-                                "z": 7.690916061401367
+                                "x": 36.3,
+                                "y": -1.02,
+                                "z": 7.69
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 4016524108,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Pickup (Wave Beam)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 6,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 7,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Wave Beam)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 41,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Chapel Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -2048,39 +3298,243 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Save Station A": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 19,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 6,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Save Station A",
                             "heal": false,
                             "coordinates": {
-                                "x": -21.450159072875977,
-                                "y": 33.98010444641113,
-                                "z": 33.68099784851074
+                                "x": -21.45,
+                                "y": 33.98,
+                                "z": 33.68
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1452580971,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 4,
+                            "connections": {
+                                "Dock to Courtyard Entryway": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Specimen Storage": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Quarantine Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 2,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 11,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 9,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Energy Tank)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Specimen Storage",
                             "heal": false,
                             "coordinates": {
-                                "x": -69.26522064208984,
-                                "y": -23.636831283569336,
-                                "z": 33.673301696777344
+                                "x": -69.27,
+                                "y": -23.64,
+                                "z": 33.67
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 3544306395,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Courtyard Entryway": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Save Station A": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Quarantine Access",
@@ -2096,7 +3550,59 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Courtyard Entryway": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Save Station A": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Energy Tank)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 42,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Courtyard Entryway": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -2121,7 +3627,46 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Pickup (Boost Ball)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Boost Ball)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 43,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Canyon Entryway": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -2136,17 +3681,34 @@
                             "name": "Dock to Ruined Courtyard",
                             "heal": false,
                             "coordinates": {
-                                "x": -0.03148007392883301,
-                                "y": 18.183027267456055,
-                                "z": 2.5000029305115277
+                                "x": -0.03,
+                                "y": 18.18,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 421627757,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 4,
+                            "connections": {
+                                "Save Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Save Station",
+                            "heal": true,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Ruined Courtyard": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2161,33 +3723,43 @@
                             "name": "Dock to Research Entrance",
                             "heal": false,
                             "coordinates": {
-                                "x": 0.5024330019950867,
-                                "y": -6.294145584106445,
-                                "z": 2.633129060268402
+                                "x": 0.5,
+                                "y": -6.29,
+                                "z": 2.63
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3038760489,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Ruined Courtyard": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Ruined Courtyard",
                             "heal": false,
                             "coordinates": {
-                                "x": -0.46765589714050293,
-                                "y": 58.03829574584961,
-                                "z": 2.63315200060606
+                                "x": -0.47,
+                                "y": 58.04,
+                                "z": 2.63
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 421627757,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Research Entrance": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2212,7 +3784,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Ruined Courtyard": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Ruined Courtyard",
@@ -2228,7 +3805,12 @@
                             "connected_dock_index": 3,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to North Quarantine Tunnel": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2243,17 +3825,22 @@
                             "name": "Dock to Specimen Storage",
                             "heal": false,
                             "coordinates": {
-                                "x": 2.5000200135800696,
-                                "y": 50.71451187133789,
-                                "z": 5.0000081062316895
+                                "x": 2.5,
+                                "y": 50.71,
+                                "z": 5.0
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3544306395,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Map Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Map Station",
@@ -2269,23 +3856,37 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Specimen Storage": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Hydra Lab Entryway": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Hydra Lab Entryway",
                             "heal": false,
                             "coordinates": {
                                 "x": 2.5,
-                                "y": -46.42365646362305,
-                                "z": 16.999990940093994
+                                "y": -46.42,
+                                "z": 17.0
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 961011783,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Map Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2300,33 +3901,63 @@
                             "name": "Dock to Quarantine Cave",
                             "heal": false,
                             "coordinates": {
-                                "x": 27.310791015625,
-                                "y": -44.92017936706543,
-                                "z": 3.647480010986328
+                                "x": 27.31,
+                                "y": -44.92,
+                                "z": 3.65
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1880625556,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Quarantine Access": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Quarantine Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -1.951034039258957,
-                                "y": 70.28852844238281,
-                                "z": 1.6078248918056488
+                                "x": -1.95,
+                                "y": 70.29,
+                                "z": 1.61
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3937607887,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Quarantine Cave": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -2366,33 +3997,43 @@
                             "name": "Dock to Research Entrance",
                             "heal": false,
                             "coordinates": {
-                                "x": 11.42181396484375,
-                                "y": 40.89152908325195,
-                                "z": 2.5000070762787345
+                                "x": 11.42,
+                                "y": 40.89,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3038760489,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Research Lab Hydra": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Research Lab Hydra",
                             "heal": false,
                             "coordinates": {
-                                "x": -10.75039291381836,
-                                "y": -40.963829040527344,
-                                "z": 2.4999929237212655
+                                "x": -10.75,
+                                "y": -40.96,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1139067941,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Research Entrance": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2407,33 +4048,130 @@
                             "name": "Dock to North Quarantine Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": 0.08071494102478027,
-                                "y": -106.49665832519531,
-                                "z": 18.827259063720703
+                                "x": 0.08,
+                                "y": -106.5,
+                                "z": 18.83
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 98670126,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to South Quarantine Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 17,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Thardus)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to South Quarantine Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": 77.71442413330078,
-                                "y": 12.171336650848389,
-                                "z": 21.18256187438965
+                                "x": 77.71,
+                                "y": 12.17,
+                                "z": 21.18
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3538349,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to North Quarantine Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 17,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Quarantine Monitor": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Thardus)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Quarantine Monitor",
@@ -2449,7 +4187,142 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to North Quarantine Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to South Quarantine Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Thardus)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Thardus)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 17,
+                            "connections": {
+                                "Pickup (Spider Ball)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 2,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 9,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Spider Ball)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 44,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to North Quarantine Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to South Quarantine Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -2464,33 +4337,154 @@
                             "name": "Dock to Hydra Lab Entryway",
                             "heal": false,
                             "coordinates": {
-                                "x": -2.4339990317821503,
-                                "y": 40.56486129760742,
-                                "z": 2.5000070762787345
+                                "x": -2.43,
+                                "y": 40.56,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 961011783,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Observatory Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 20,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Research Lab Hydra Barrier Lowered)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 20,
+                                                "amount": 1,
+                                                "negate": true
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Observatory Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -29.749459266662598,
-                                "y": 17.98340654373169,
-                                "z": 29.884411811828613
+                                "x": -29.75,
+                                "y": 17.98,
+                                "z": 29.88
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 935047996,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Hydra Lab Entryway": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 20,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 0,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 10,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 11,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Research Lab Hydra Barrier Lowered)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 20,
+                            "connections": {
+                                "Dock to Observatory Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 45,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Observatory Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2505,33 +4499,63 @@
                             "name": "Dock to Quarantine Cave",
                             "heal": false,
                             "coordinates": {
-                                "x": 25.467470169067383,
-                                "y": 72.92511749267578,
-                                "z": 3.9665069580078125
+                                "x": 25.47,
+                                "y": 72.93,
+                                "z": 3.97
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1880625556,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Transport to Magmoor Caverns South": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Transport to Magmoor Caverns South",
                             "heal": false,
                             "coordinates": {
-                                "x": -26.53873634338379,
-                                "y": -48.44746398925781,
-                                "z": 3.966485023498535
+                                "x": -26.54,
+                                "y": -48.45,
+                                "z": 3.97
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3708487481,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Quarantine Cave": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -2546,9 +4570,9 @@
                             "name": "Dock to Quarantine Cave",
                             "heal": false,
                             "coordinates": {
-                                "x": -28.98897361755371,
-                                "y": -0.00594601035118103,
-                                "z": 1.4041727483272552
+                                "x": -28.99,
+                                "y": -0.01,
+                                "z": 1.4
                             },
                             "node_type": "dock",
                             "dock_index": 0,
@@ -2556,7 +4580,26 @@
                             "connected_dock_index": 2,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 46,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Quarantine Cave": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2571,33 +4614,53 @@
                             "name": "Dock to Observatory",
                             "heal": false,
                             "coordinates": {
-                                "x": -9.660812139511108,
-                                "y": -38.06995391845703,
-                                "z": 0.5210340023040771
+                                "x": -9.66,
+                                "y": -38.07,
+                                "z": 0.52
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1068802894,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Research Lab Hydra": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Research Lab Hydra",
                             "heal": false,
                             "coordinates": {
-                                "x": 9.764790773391724,
-                                "y": 25.057985305786133,
-                                "z": -2.6934635639190674
+                                "x": 9.76,
+                                "y": 25.06,
+                                "z": -2.69
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1139067941,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Observatory": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -2612,33 +4675,104 @@
                             "name": "Dock to Transport Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -0.01854109764099121,
-                                "y": -32.714508056640625,
-                                "z": 17.49999475479126
+                                "x": -0.02,
+                                "y": -32.71,
+                                "z": 17.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3600136536,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to South Quarantine Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Elevator - Transport to Phendrana Drifts South": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to South Quarantine Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": 0.01854109764099121,
-                                "y": 18.714506149291992,
-                                "z": 2.5000039073486278
+                                "x": 0.02,
+                                "y": 18.71,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3538349,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Transport Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Elevator - Transport to Phendrana Drifts South",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "teleporter",
+                            "destination_world_asset_id": 1056449404,
+                            "destination_area_asset_id": 3249312307,
+                            "teleporter_instance_id": 1900634,
+                            "scan_asset_id": 2570907624,
+                            "keep_name_when_vanilla": false,
+                            "editable": true,
+                            "connections": {
+                                "Dock to Transport Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2653,49 +4787,276 @@
                             "name": "Dock to Observatory Access",
                             "heal": false,
                             "coordinates": {
-                                "x": 0.02261495590209961,
-                                "y": 56.96450233459473,
-                                "z": 12.500009536743164
+                                "x": 0.02,
+                                "y": 56.96,
+                                "z": 12.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 935047996,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Save Station D": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Observatory Activated)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": true
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": true
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to West Tower Entrance",
                             "heal": false,
                             "coordinates": {
-                                "x": 0.02261495590209961,
-                                "y": 46.96449851989746,
-                                "z": 37.50000762939453
+                                "x": 0.02,
+                                "y": 46.96,
+                                "z": 37.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 508080527,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Observatory Access": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Save Station D": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Super Missile)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Save Station D",
                             "heal": false,
                             "coordinates": {
-                                "x": -0.02261805534362793,
-                                "y": -46.96450996398926,
-                                "z": 37.49999237060547
+                                "x": -0.02,
+                                "y": -46.96,
+                                "z": 37.5
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 1901867502,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 4,
+                            "connections": {
+                                "Dock to Observatory Access": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to West Tower Entrance": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Super Missile)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Observatory Activated)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 21,
+                            "connections": {
+                                "Dock to Observatory Access": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Save Station D": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Super Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 47,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Observatory Access": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to West Tower Entrance": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Save Station D": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -2710,33 +5071,71 @@
                             "name": "Dock to Transport to Magmoor Caverns South",
                             "heal": false,
                             "coordinates": {
-                                "x": 0.10027408599853516,
-                                "y": 52.363075256347656,
-                                "z": 3.8603044152259827
+                                "x": 0.1,
+                                "y": 52.36,
+                                "z": 3.86
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3708487481,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Frozen Pike": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Frozen Pike",
                             "heal": false,
                             "coordinates": {
-                                "x": 0.10027408599853516,
-                                "y": -18.998326301574707,
-                                "z": 3.860292971134186
+                                "x": 0.1,
+                                "y": -19.0,
+                                "z": 3.86
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3617515525,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Transport to Magmoor Caverns South": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Pickup (Energy Tank)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Energy Tank)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 48,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Frozen Pike": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2751,33 +5150,43 @@
                             "name": "Dock to West Tower ",
                             "heal": false,
                             "coordinates": {
-                                "x": 11.432268142700195,
-                                "y": 14.307278156280518,
-                                "z": 2.500001953674314
+                                "x": 11.43,
+                                "y": 14.31,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3617418143,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 4,
+                            "connections": {
+                                "Dock to Observatory": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Observatory",
                             "heal": false,
                             "coordinates": {
-                                "x": -10.761533737182617,
-                                "y": -29.313274383544922,
-                                "z": 2.499995115814272
+                                "x": -10.76,
+                                "y": -29.31,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1068802894,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to West Tower ": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2802,7 +5211,24 @@
                             "connected_dock_index": 2,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Save Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Save Station",
+                            "heal": true,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Observatory": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2817,8 +5243,8 @@
                             "name": "Dock to Pike Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -32.762733459472656,
-                                "y": -0.3065764904022217,
+                                "x": -32.76,
+                                "y": -0.31,
                                 "z": 57.5
                             },
                             "node_type": "dock",
@@ -2826,56 +5252,142 @@
                             "connected_area_asset_id": 1980658458,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Transport Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Frost Cave Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Transport Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -0.7258550524711609,
-                                "y": 39.83653259277344,
-                                "z": 87.49999237060547
+                                "x": -0.73,
+                                "y": 39.84,
+                                "z": 87.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3600136536,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Pike Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Frost Cave Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -0.06914710998535156,
-                                "y": -30.133618354797363,
-                                "z": 39.4373779296875
+                                "x": -0.07,
+                                "y": -30.13,
+                                "z": 39.44
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 969347001,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Pike Access": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Hunter Cave Access": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Hunter Cave Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -2.098558947443962,
-                                "y": -30.1276912689209,
-                                "z": 8.502821922302246
+                                "x": -2.1,
+                                "y": -30.13,
+                                "z": 8.5
                             },
                             "node_type": "dock",
                             "dock_index": 3,
                             "connected_area_asset_id": 552213808,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Frost Cave Access": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -2890,33 +5402,53 @@
                             "name": "Dock to West Tower Entrance",
                             "heal": false,
                             "coordinates": {
-                                "x": -4.76837158203125e-07,
-                                "y": -22.714508056640625,
-                                "z": 2.4999960926513722
+                                "x": -0.0,
+                                "y": -22.71,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 508080527,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 4,
+                            "connections": {
+                                "Dock to Control Tower": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Control Tower",
                             "heal": false,
                             "coordinates": {
-                                "x": 18.03266716003418,
-                                "y": -0.08397746086120605,
-                                "z": 39.500064849853516
+                                "x": 18.03,
+                                "y": -0.08,
+                                "z": 39.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3015914057,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to West Tower Entrance": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2931,33 +5463,43 @@
                             "name": "Dock to Frozen Pike",
                             "heal": false,
                             "coordinates": {
-                                "x": 26.83206558227539,
-                                "y": -2.4647855376824737,
-                                "z": 3.5307745337486267
+                                "x": 26.83,
+                                "y": -2.46,
+                                "z": 3.53
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3617515525,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Research Core": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Research Core",
                             "heal": false,
                             "coordinates": {
-                                "x": -34.7027702331543,
-                                "y": -5.457466542720795,
-                                "z": 3.5307735800743103
+                                "x": -34.7,
+                                "y": -5.46,
+                                "z": 3.53
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 2761631044,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Frozen Pike": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -2973,32 +5515,62 @@
                             "heal": false,
                             "coordinates": {
                                 "x": 0.0,
-                                "y": 74.12281799316406,
-                                "z": 2.4946384830400348
+                                "y": 74.12,
+                                "z": 2.49
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3617515525,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Frost Cave": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Frost Cave",
                             "heal": false,
                             "coordinates": {
                                 "x": -30.0,
-                                "y": -92.26781845092773,
-                                "z": 22.494613647460938
+                                "y": -92.27,
+                                "z": 22.49
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1282373491,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Frozen Pike": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -3013,33 +5585,43 @@
                             "name": "Dock to Frozen Pike",
                             "heal": false,
                             "coordinates": {
-                                "x": 21.391111373901367,
-                                "y": -92.22008514404297,
-                                "z": 2.499987562698152
+                                "x": 21.39,
+                                "y": -92.22,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3617515525,
                             "connected_dock_index": 3,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Hunter Cave": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Hunter Cave",
                             "heal": false,
                             "coordinates": {
-                                "x": -13.491754531860352,
-                                "y": 74.1228141784668,
-                                "z": 22.500011444091797
+                                "x": -13.49,
+                                "y": 74.12,
+                                "z": 22.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 516396314,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Frozen Pike": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -3054,33 +5636,145 @@
                             "name": "Dock to East Tower",
                             "heal": false,
                             "coordinates": {
-                                "x": 24.72031593322754,
-                                "y": 0.10060501098632812,
-                                "z": 2.4934815680608153
+                                "x": 24.72,
+                                "y": 0.1,
+                                "z": 2.49
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1359550769,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to West Tower ": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Pickup (Artifact of Elder)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 10,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 11,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to West Tower ",
                             "heal": false,
                             "coordinates": {
-                                "x": -24.551124572753906,
-                                "y": -0.0845637321472168,
-                                "z": 2.547433437779546
+                                "x": -24.55,
+                                "y": -0.08,
+                                "z": 2.55
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3617418143,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to East Tower": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Artifact of Elder)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 49,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to East Tower": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -3095,33 +5789,177 @@
                             "name": "Dock to Pike Access",
                             "heal": false,
                             "coordinates": {
-                                "x": 34.14543533325195,
-                                "y": 0.13142549991607666,
-                                "z": 2.498574497643858
+                                "x": 34.15,
+                                "y": 0.13,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1980658458,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Research Core Access": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 1,
+                                                        "index": 19,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 2,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 9,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 4,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": true
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Thermal Visor)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Research Core Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -0.13143301010131836,
-                                "y": 34.145408630371094,
-                                "z": 47.500003814697266
+                                "x": -0.13,
+                                "y": 34.15,
+                                "z": 47.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3639150045,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Pike Access": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Pickup (Thermal Visor)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Thermal Visor)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 50,
+                            "major_location": true,
+                            "connections": {
+                                "Event (Research Core Power Outage)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Research Core Power Outage)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 19,
+                            "connections": {
+                                "Dock to Pike Access": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Research Core Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 2,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -3136,49 +5974,449 @@
                             "name": "Dock to Save Station C",
                             "heal": false,
                             "coordinates": {
-                                "x": -50.74738693237305,
-                                "y": 6.9214476346969604,
-                                "z": 28.956936836242676
+                                "x": -50.75,
+                                "y": 6.92,
+                                "z": 28.96
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3470637624,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Frost Cave Access": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Frost Cave Access",
                             "heal": false,
                             "coordinates": {
-                                "x": 13.740457534790039,
-                                "y": 49.32008171081543,
-                                "z": 35.13916778564453
+                                "x": 13.74,
+                                "y": 49.32,
+                                "z": 35.14
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 969347001,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Save Station C": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 10,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 11,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Upper Edge Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 12,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 10,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 11,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 10,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 11,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Upper Edge Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": -2.97643606364727,
-                                "y": -45.66440963745117,
-                                "z": 23.287379264831543
+                                "x": -2.98,
+                                "y": -45.66,
+                                "z": 23.29
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 624850611,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Frost Cave Access": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 51,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Save Station C": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 10,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 11,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Frost Cave Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Upper Edge Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 12,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 10,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 11,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -3193,65 +6431,381 @@
                             "name": "Dock to Hunter Cave Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -11.399953365325928,
-                                "y": 37.03974533081055,
-                                "z": 30.020258903503418
+                                "x": -11.4,
+                                "y": 37.04,
+                                "z": 30.02
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 552213808,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Lower Edge Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 12,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 4,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 0,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 11,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 10,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Chamber Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Lower Edge Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": -18.629304885864258,
-                                "y": -42.79967498779297,
-                                "z": 18.900144577026367
+                                "x": -18.63,
+                                "y": -42.8,
+                                "z": 18.9
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1400901764,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Hunter Cave Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 10,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 11,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Chamber Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 10,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 11,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Lake Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 21,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 11,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 10,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Chamber Access",
                             "heal": false,
                             "coordinates": {
-                                "x": 42.80681228637695,
-                                "y": 15.513291120529175,
-                                "z": 30.02025556564331
+                                "x": 42.81,
+                                "y": 15.51,
+                                "z": 30.02
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 3396124754,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Hunter Cave Access": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Lake Tunnel": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Lake Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": 47.61391830444336,
-                                "y": -2.745901294052601,
-                                "z": 17.484049081802368
+                                "x": 47.61,
+                                "y": -2.75,
+                                "z": 17.48
                             },
                             "node_type": "dock",
                             "dock_index": 3,
                             "connected_area_asset_id": 2312609958,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Lower Edge Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -3267,32 +6821,52 @@
                             "heal": false,
                             "coordinates": {
                                 "x": 0.0,
-                                "y": -22.714506149291992,
-                                "z": 2.4999960926513722
+                                "y": -22.71,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2564604705,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Control Tower": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Control Tower",
                             "heal": false,
                             "coordinates": {
-                                "x": -18.03266143798828,
-                                "y": 0.08570146560668945,
-                                "z": 39.50006103515625
+                                "x": -18.03,
+                                "y": 0.09,
+                                "z": 39.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3015914057,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Aether Lab Entryway": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -3307,33 +6881,53 @@
                             "name": "Dock to Research Core",
                             "heal": false,
                             "coordinates": {
-                                "x": 6.212490558624268,
-                                "y": -23.943927764892578,
-                                "z": 2.4999960926513722
+                                "x": 6.21,
+                                "y": -23.94,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2761631044,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Research Lab Aether": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Research Lab Aether",
                             "heal": false,
                             "coordinates": {
-                                "x": -6.207448959350586,
-                                "y": 16.701655387878418,
-                                "z": 5.854422569274902
+                                "x": -6.21,
+                                "y": 16.7,
+                                "z": 5.85
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 565493750,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Research Core": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -3348,17 +6942,34 @@
                             "name": "Dock to Frost Cave",
                             "heal": false,
                             "coordinates": {
-                                "x": 18.183027267456055,
-                                "y": 0.031479477882385254,
-                                "z": 2.5000002499999994
+                                "x": 18.18,
+                                "y": 0.03,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1282373491,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Save Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Save Station",
+                            "heal": true,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Frost Cave": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -3374,32 +6985,62 @@
                             "heal": false,
                             "coordinates": {
                                 "x": -0.25,
-                                "y": -40.71450424194336,
-                                "z": 2.4999929237212655
+                                "y": -40.71,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1423896872,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Frost Cave": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Frost Cave",
                             "heal": false,
                             "coordinates": {
                                 "x": -29.75,
-                                "y": 40.71450424194336,
-                                "z": 2.5000070762787345
+                                "y": 40.71,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1282373491,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Phendrana's Edge": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -3414,33 +7055,63 @@
                             "name": "Dock to Phendrana's Edge",
                             "heal": false,
                             "coordinates": {
-                                "x": -29.171337127685547,
-                                "y": -42.66279983520508,
-                                "z": -0.3063650131225586
+                                "x": -29.17,
+                                "y": -42.66,
+                                "z": -0.31
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1423896872,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Hunter Cave": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Hunter Cave",
                             "heal": false,
                             "coordinates": {
-                                "x": 14.710057973861694,
-                                "y": 53.964290618896484,
-                                "z": -2.6172599904239178
+                                "x": 14.71,
+                                "y": 53.96,
+                                "z": -2.62
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 516396314,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Phendrana's Edge": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -3455,33 +7126,43 @@
                             "name": "Dock to Hunter Cave",
                             "heal": false,
                             "coordinates": {
-                                "x": -30.714506149291992,
-                                "y": -2.500001715255735,
-                                "z": 12.499999523162842
+                                "x": -30.71,
+                                "y": -2.5,
+                                "z": 12.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 516396314,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Gravity Chamber": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Gravity Chamber",
                             "heal": false,
                             "coordinates": {
-                                "x": 30.714506149291992,
-                                "y": 19.999999046325684,
-                                "z": 7.500003337860107
+                                "x": 30.71,
+                                "y": 20.0,
+                                "z": 7.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1226265714,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Hunter Cave": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -3496,33 +7177,43 @@
                             "name": "Dock to Hunter Cave",
                             "heal": false,
                             "coordinates": {
-                                "x": -47.4452018737793,
-                                "y": -2.745901294052601,
-                                "z": 17.484049081802368
+                                "x": -47.45,
+                                "y": -2.75,
+                                "z": 17.48
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 516396314,
                             "connected_dock_index": 3,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Gravity Chamber": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Gravity Chamber",
                             "heal": false,
                             "coordinates": {
-                                "x": 17.176700592041016,
-                                "y": -2.9867005199193954,
-                                "z": 8.020254611968994
+                                "x": 17.18,
+                                "y": -2.99,
+                                "z": 8.02
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1226265714,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Hunter Cave": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -3537,33 +7228,43 @@
                             "name": "Dock to East Tower",
                             "heal": false,
                             "coordinates": {
-                                "x": -11.432268142700195,
-                                "y": 14.307278156280518,
-                                "z": 2.500001953674314
+                                "x": -11.43,
+                                "y": 14.31,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1359550769,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Research Lab Aether": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Research Lab Aether",
                             "heal": false,
                             "coordinates": {
-                                "x": 10.761533737182617,
-                                "y": -29.313274383544922,
-                                "z": 2.499995115814272
+                                "x": 10.76,
+                                "y": -29.31,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 565493750,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to East Tower": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -3578,33 +7279,173 @@
                             "name": "Dock to Aether Lab Entryway",
                             "heal": false,
                             "coordinates": {
-                                "x": 15.67152214050293,
-                                "y": 27.08530330657959,
-                                "z": 29.792510986328125
+                                "x": 15.67,
+                                "y": 27.09,
+                                "z": 29.79
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2564604705,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Research Core Access": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Research Core Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -3.4487129151821136,
-                                "y": -45.3761100769043,
-                                "z": 2.437931537628174
+                                "x": -3.45,
+                                "y": -45.38,
+                                "z": 2.44
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3639150045,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Aether Lab Entryway": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Energy Tank)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 7,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 0,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 10,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 11,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Energy Tank)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 52,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Research Core Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 53,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Research Core Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -3619,49 +7460,166 @@
                             "name": "Dock to Lower Edge Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": -1.6802630126476288,
-                                "y": 29.720075607299805,
-                                "z": 11.44979190826416
+                                "x": -1.68,
+                                "y": 29.72,
+                                "z": 11.45
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1400901764,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Upper Edge Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Upper Edge Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": -0.6248140335083008,
-                                "y": 29.71951961517334,
-                                "z": 39.34176254272461
+                                "x": -0.62,
+                                "y": 29.72,
+                                "z": 39.34
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 624850611,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Lower Edge Tunnel": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Storage Cave": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Security Cave": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Storage Cave",
                             "heal": false,
                             "coordinates": {
-                                "x": 31.815397262573242,
-                                "y": -4.114669919013977,
-                                "z": 74.14421081542969
+                                "x": 31.82,
+                                "y": -4.11,
+                                "z": 74.14
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 4157096768,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Upper Edge Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Security Cave",
@@ -3677,7 +7635,59 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Lower Edge Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Upper Edge Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Storage Cave": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -3692,33 +7702,133 @@
                             "name": "Dock to Lake Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": -25.714508056640625,
-                                "y": -34.98818588256836,
-                                "z": 17.49999189376831
+                                "x": -25.71,
+                                "y": -34.99,
+                                "z": 17.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2312609958,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Pickup (Gravity Suit)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Chamber Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -33.714500427246094,
-                                "y": 6.011805534362793,
-                                "z": 34.499995708465576
+                                "x": -33.71,
+                                "y": 6.01,
+                                "z": 34.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3396124754,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Pickup (Gravity Suit)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Gravity Suit)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 54,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Chamber Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 55,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Chamber Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -3733,17 +7843,36 @@
                             "name": "Dock to Phendrana's Edge",
                             "heal": false,
                             "coordinates": {
-                                "x": -18.183027267456055,
-                                "y": -0.03148055076599121,
-                                "z": 2.5000002499999994
+                                "x": -18.18,
+                                "y": -0.03,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1423896872,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Pickup (Artifact of Spirit)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Artifact of Spirit)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 56,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Phendrana's Edge": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -3768,7 +7897,26 @@
                             "connected_dock_index": 3,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Pickup (Power Bomb)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Power Bomb)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 57,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Phendrana's Edge": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 }
@@ -3800,6 +7948,70 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
+                            "connections": {
+                                "Ship Save": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 33,
+                                                "amount": 1,
+                                                "negate": true
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Teleport to Landing Site": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 33,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Ship Save",
+                            "heal": true,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Air Lock": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Teleport to Landing Site",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "teleporter",
+                            "destination_world_asset_id": 972217896,
+                            "destination_area_asset_id": 2993688902,
+                            "teleporter_instance_id": 134218592,
+                            "scan_asset_id": null,
+                            "keep_name_when_vanilla": false,
+                            "editable": false,
                             "connections": {}
                         }
                     ]
@@ -3841,7 +8053,22 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Deck Alpha Access Hall": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Deck Alpha Mech Shaft",
@@ -3857,7 +8084,22 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Exterior Docking Hangar": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 33,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -3882,7 +8124,12 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Emergency Evacuation Area": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Emergency Evacuation Area",
@@ -3923,7 +8170,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Air Lock": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Air Lock",
@@ -3980,7 +8232,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Deck Alpha Umbilical Hall": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -4005,7 +8262,22 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Event (Item Loss) UNIMPLEMENTED": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Deck Alpha Mech Shaft",
@@ -4022,6 +8294,18 @@
                             "dock_type": 0,
                             "dock_weakness_index": 0,
                             "connections": {}
+                        },
+                        {
+                            "name": "Event (Item Loss) UNIMPLEMENTED",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Deck Alpha Mech Shaft": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -4046,7 +8330,45 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Map Facility": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 10,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 0,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 1,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Map Facility",
@@ -4087,7 +8409,31 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Connection Elevator to Deck Alpha": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Connection Elevator to Deck Alpha",
@@ -4128,7 +8474,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Connection Elevator to Deck Beta": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Connection Elevator to Deck Beta",
@@ -4185,7 +8536,12 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Biotech Research Area 2": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -4210,7 +8566,22 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Deck Beta Conduit Hall": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Deck Beta Conduit Hall",
@@ -4267,7 +8638,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Main Ventilation Shaft Section F": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -4308,7 +8684,22 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Biotech Research Area 1": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -4333,7 +8724,12 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Main Ventilation Shaft Section E": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Main Ventilation Shaft Section E",
@@ -4390,7 +8786,22 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Deck Beta Security Hall": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 33,
+                                                "amount": 1,
+                                                "negate": true
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Connection Elevator to Deck Beta",
@@ -4406,7 +8817,22 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Subventilation Shaft Section A": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 33,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Subventilation Shaft Section A",
@@ -4463,7 +8889,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Main Ventilation Shaft Section D": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -4504,12 +8935,17 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Biohazard Containment": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
                 {
-                    "name": "Connection Elevator to Deck Beta",
+                    "name": "Connection Elevator to Deck Beta (2)",
                     "in_dark_aether": false,
                     "asset_id": 1859330843,
                     "default_node_index": null,
@@ -4545,7 +8981,22 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Biotech Research Area 1": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -4570,7 +9021,12 @@
                             "connected_dock_index": 3,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Subventilation Shaft Section B": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Subventilation Shaft Section B",
@@ -4611,7 +9067,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Main Ventilation Shaft Section C": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Main Ventilation Shaft Section C",
@@ -4668,7 +9129,22 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Deck Beta Transit Hall": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -4693,7 +9169,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Connection Elevator to Deck Beta": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Connection Elevator to Deck Beta",
@@ -4750,7 +9231,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Cargo Freight Lift to Deck Gamma": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -4775,7 +9261,12 @@
                             "connected_dock_index": 2,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Main Ventilation Shaft Section B": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Main Ventilation Shaft Section B",
@@ -4832,7 +9323,12 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Cargo Freight Lift to Deck Gamma": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -4857,7 +9353,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Event (Parasite Queen Defeated)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Deck Gamma Monitor Hall",
@@ -4874,6 +9375,19 @@
                             "dock_type": 0,
                             "dock_weakness_index": 0,
                             "connections": {}
+                        },
+                        {
+                            "name": "Event (Parasite Queen Defeated)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 33,
+                            "connections": {
+                                "Dock to Deck Gamma Monitor Hall": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -4898,7 +9412,31 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Reactor Core Entrance": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Subventilation Shaft Section B",
@@ -4914,7 +9452,12 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Main Ventilation Shaft Section A": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Main Ventilation Shaft Section A",
@@ -4971,7 +9514,35 @@
                             "connected_dock_index": 3,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Reactor Core": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Save Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Reactor Core",
@@ -4988,6 +9559,18 @@
                             "dock_type": 0,
                             "dock_weakness_index": 0,
                             "connections": {}
+                        },
+                        {
+                            "name": "Save Station",
+                            "heal": true,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Cargo Freight Lift to Deck Gamma": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 }
@@ -5077,7 +9660,12 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Save Station Magmoor A": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Transport to Chozo Ruins North",
@@ -5093,23 +9681,37 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Save Station Magmoor A": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Save Station Magmoor A",
                             "heal": false,
                             "coordinates": {
-                                "x": -4.190483033657074,
-                                "y": 22.65715789794922,
-                                "z": 3.212377518415451
+                                "x": -4.19,
+                                "y": 22.66,
+                                "z": 3.21
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 162783260,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 4,
+                            "connections": {
+                                "Dock to Lake Tunnel": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Transport to Chozo Ruins North": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -5134,7 +9736,45 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Burning Trail": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 100,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 91,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Burning Trail",
@@ -5150,7 +9790,45 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Lava Lake": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 87,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 78,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5165,17 +9843,34 @@
                             "name": "Dock to Burning Trail",
                             "heal": false,
                             "coordinates": {
-                                "x": -7.822096824645996,
-                                "y": -59.98817443847656,
-                                "z": 2.5752505511045456
+                                "x": -7.82,
+                                "y": -59.99,
+                                "z": 2.58
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1833127758,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 4,
+                            "connections": {
+                                "Save Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Save Station",
+                            "heal": true,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Burning Trail": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -5200,7 +9895,229 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Pit Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 6,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "or",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 3,
+                                                                        "index": 5,
+                                                                        "amount": 514,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "and",
+                                                                    "data": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": 0,
+                                                                                "index": 15,
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": 3,
+                                                                                "index": 5,
+                                                                                "amount": 458,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 7,
+                                                                "amount": 2,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "or",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 3,
+                                                                        "index": 5,
+                                                                        "amount": 586,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "and",
+                                                                    "data": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": 3,
+                                                                                "index": 5,
+                                                                                "amount": 539,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": 0,
+                                                                                "index": 15,
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Artifact of Nature)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 12,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 4,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "template",
+                                                            "data": "Shoot Super Missile"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Heat-Resisting Suit"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 161,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 145,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Super Missile"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Pit Tunnel",
@@ -5216,7 +10133,392 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Lake Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 6,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "or",
+                                                                    "data": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": 3,
+                                                                                "index": 5,
+                                                                                "amount": 507,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": [
+                                                                                {
+                                                                                    "type": "resource",
+                                                                                    "data": {
+                                                                                        "type": 3,
+                                                                                        "index": 5,
+                                                                                        "amount": 458,
+                                                                                        "negate": false
+                                                                                    }
+                                                                                },
+                                                                                {
+                                                                                    "type": "resource",
+                                                                                    "data": {
+                                                                                        "type": 0,
+                                                                                        "index": 15,
+                                                                                        "amount": 1,
+                                                                                        "negate": false
+                                                                                    }
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 7,
+                                                                        "amount": 2,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "or",
+                                                                    "data": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": 3,
+                                                                                "index": 5,
+                                                                                "amount": 565,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": [
+                                                                                {
+                                                                                    "type": "resource",
+                                                                                    "data": {
+                                                                                        "type": 3,
+                                                                                        "index": 5,
+                                                                                        "amount": 548,
+                                                                                        "negate": false
+                                                                                    }
+                                                                                },
+                                                                                {
+                                                                                    "type": "resource",
+                                                                                    "data": {
+                                                                                        "type": 0,
+                                                                                        "index": 15,
+                                                                                        "amount": 1,
+                                                                                        "negate": false
+                                                                                    }
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Artifact of Nature)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 4,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 6,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 404,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "template",
+                                                            "data": "Shoot Super Missile"
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 6,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 430,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 4,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 7,
+                                                                "amount": 2,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 479,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "template",
+                                                            "data": "Shoot Super Missile"
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 7,
+                                                                "amount": 2,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 494,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Artifact of Nature)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 90,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Lake Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 165,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 156,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Pit Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 6,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 389,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 7,
+                                                                "amount": 2,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 470,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5241,7 +10543,59 @@
                             "connected_dock_index": 2,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Lava Lake": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 95,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 91,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Lava Lake",
@@ -5257,7 +10611,59 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Triclops Pit": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 86,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 72,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5282,7 +10688,160 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Storage Cavern": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 275,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 222,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Pit Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 163,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 143,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile Expansion)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 201,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Super Missile"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 13,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Storage Cavern",
@@ -5298,7 +10857,220 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Monitor Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 299,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 286,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 15,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 263,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 15,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 257,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Pit Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 267,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 239,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 242,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 15,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 234,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 15,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Pit Tunnel",
@@ -5314,7 +11086,378 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Monitor Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 170,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 155,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 18,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 3,
+                                                                        "index": 5,
+                                                                        "amount": 152,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Storage Cavern": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 252,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 211,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile Expansion)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 13,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Super Missile"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 157,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile Expansion)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 91,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Monitor Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 176,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 114,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Storage Cavern": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 1188,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 15,
+                                                                "amount": 1,
+                                                                "negate": true
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 207,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 15,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 177,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 216,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Pit Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 131,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 120,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5339,7 +11482,22 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Triclops Pit": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 113,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Triclops Pit",
@@ -5355,7 +11513,22 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Monitor Station": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 110,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5380,7 +11553,26 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 92,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Triclops Pit": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -5405,7 +11597,393 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Transport Tunnel A": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 582,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 480,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "template",
+                                                                    "data": "Shoot Super Missile"
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 3,
+                                                                        "index": 5,
+                                                                        "amount": 357,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 1,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 3,
+                                                                        "index": 5,
+                                                                        "amount": 345,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 10,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 3,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 3,
+                                                                        "index": 5,
+                                                                        "amount": 386,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 4,
+                                                                        "amount": 15,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "template",
+                                                                    "data": "Shoot Super Missile"
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 3,
+                                                                        "index": 5,
+                                                                        "amount": 388,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 8,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 402,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 1,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 412,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 3,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 10,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 386,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 15,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Super Missile"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 380,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Warrior Shrine": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 670,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 4,
+                                                                "amount": 8,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 536,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 1,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 496,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 3,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 10,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 569,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Shore Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 100,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Transport Tunnel A",
@@ -5421,7 +11999,123 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Monitor Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 142,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 119,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Warrior Shrine": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 233,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Shore Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 204,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 182,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Warrior Shrine",
@@ -5437,7 +12131,174 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Monitor Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 244,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 183,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 3,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 10,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 203,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 1,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 247,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 109,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Transport Tunnel A": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 139,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 96,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Shore Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 79,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Shore Tunnel",
@@ -5453,7 +12314,424 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Monitor Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 90,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Transport Tunnel A": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 496,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 8,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 254,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 1,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 283,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 3,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 10,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 293,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 10,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Super Missile"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 277,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 330,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 8,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 395,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 1,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 350,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 3,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 10,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 383,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 10,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Super Missile"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 335,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Dock to Warrior Shrine": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 555,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 4,
+                                                                "amount": 6,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 475,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 1,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 451,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 4,
+                                                                "amount": 10,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "template",
+                                                            "data": "Shoot Super Missile"
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 469,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5478,7 +12756,100 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Monitor Station": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 107,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 102,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Energy Tank)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 289,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Monitor Station",
@@ -5494,7 +12865,174 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Transport to Phendrana Drifts North": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 102,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 5,
+                                                                "amount": 95,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Energy Tank)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 182,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Energy Tank)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 93,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Transport to Phendrana Drifts North": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 78,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Monitor Station": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 73,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5519,23 +13057,149 @@
                             "connected_dock_index": 2,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Fiery Shores": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 96,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Artifact of Strength)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 64,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 48,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Fiery Shores",
                             "heal": false,
                             "coordinates": {
-                                "x": -31.67426872253418,
-                                "y": 32.33364772796631,
-                                "z": 4.233016014099121
+                                "x": -31.67,
+                                "y": 32.33,
+                                "z": 4.23
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 4126087266,
                             "connected_dock_index": 2,
-                            "dock_type": 0,
+                            "dock_type": 1,
                             "dock_weakness_index": 0,
                             "connections": {}
+                        },
+                        {
+                            "name": "Pickup (Artifact of Strength)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 94,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Monitor Station": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 89,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Fiery Shores": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 56,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5560,7 +13224,109 @@
                             "connected_dock_index": 3,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Fiery Shores": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 113,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 101,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 18,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 95,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Ice Spreader)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 84,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Fiery Shores",
@@ -5576,7 +13342,165 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Monitor Station": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 114,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 96,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 18,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 92,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Ice Spreader)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 84,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Ice Spreader)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 95,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Monitor Station": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 62,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Fiery Shores": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 82,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5601,7 +13525,40 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Elevator - Transport to Magmoor Caverns West": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Elevator - Transport to Magmoor Caverns West",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "teleporter",
+                            "destination_world_asset_id": 2831049361,
+                            "destination_area_asset_id": 3222157185,
+                            "teleporter_instance_id": 852002,
+                            "scan_asset_id": 3500678745,
+                            "keep_name_when_vanilla": false,
+                            "editable": true,
+                            "connections": {
+                                "Dock to Transport Tunnel A": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -5626,7 +13583,100 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Transport Tunnel B": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 319,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 277,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 358,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Transport Tunnel B",
@@ -5642,23 +13692,252 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Shore Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 324,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 284,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 246,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Warrior Shrine",
                             "heal": false,
                             "coordinates": {
-                                "x": -50.80683708190918,
-                                "y": 69.01950454711914,
-                                "z": 26.292661666870117
+                                "x": -50.81,
+                                "y": 69.02,
+                                "z": 26.29
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 2309409677,
                             "connected_dock_index": 1,
-                            "dock_type": 0,
+                            "dock_type": 1,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Pickup (Power Bomb)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 40,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Power Bomb)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 97,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Shore Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 98,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Transport Tunnel B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 357,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 411,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 96,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Shore Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 208,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Transport Tunnel B": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 280,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5683,7 +13962,77 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Fiery Shores": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 151,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 95,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 18,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 87,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Fiery Shores",
@@ -5699,7 +14048,77 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Transport to Tallon Overworld West": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 5,
+                                                "amount": 163,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 107,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 18,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 97,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5752,7 +14171,17 @@
                                 },
                                 "Elevator to Tallon Overworld - Transport to Magmoor Caverns East": {
                                     "type": "and",
-                                    "data": []
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         },
@@ -5797,7 +14226,63 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Transport to Tallon Overworld West": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Heat-Resisting Suit"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 18,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 5,
+                                                        "amount": 165,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Transport to Tallon Overworld West",
@@ -5813,7 +14298,35 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Twin Fires": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "template",
+                                            "data": "Heat-Resisting Suit"
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5828,17 +14341,50 @@
                             "name": "Dock to North Core Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": -119.56726837158203,
-                                "y": -40.91443634033203,
-                                "z": 7.925799131393433
+                                "x": -119.57,
+                                "y": -40.91,
+                                "z": 7.93
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2805715168,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Twin Fires Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Twin Fires Tunnel",
@@ -5854,7 +14400,40 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to North Core Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5869,33 +14448,81 @@
                             "name": "Dock to Twin Fires",
                             "heal": false,
                             "coordinates": {
-                                "x": -31.1513032913208,
-                                "y": 44.987552642822266,
-                                "z": -3.372948080301285
+                                "x": -31.15,
+                                "y": 44.99,
+                                "z": -3.37
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1282952170,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Geothermal Core": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Geothermal Core",
                             "heal": false,
                             "coordinates": {
-                                "x": 28.626956939697266,
-                                "y": -14.622861623764038,
-                                "z": -3.3729564994573593
+                                "x": 28.63,
+                                "y": -14.62,
+                                "z": -3.37
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3226044022,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Twin Fires": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 21,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5910,9 +14537,9 @@
                             "name": "Dock to North Core Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": -42.77541732788086,
-                                "y": 0.7592625319957733,
-                                "z": -27.052345275878906
+                                "x": -42.78,
+                                "y": 0.76,
+                                "z": -27.05
                             },
                             "node_type": "dock",
                             "dock_index": 0,
@@ -5920,23 +14547,43 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to South Core Tunnel": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Plasma Processing",
                             "heal": false,
                             "coordinates": {
-                                "x": -1.8821969628334045,
-                                "y": 41.39183044433594,
-                                "z": 30.99088764190674
+                                "x": -1.88,
+                                "y": 41.39,
+                                "z": 30.99
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1287753306,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to North Core Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 22,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to South Core Tunnel",
@@ -5952,7 +14599,171 @@
                             "connected_dock_index": 0,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to North Core Tunnel": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Plasma Processing": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Geothermal Core Opened)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Geothermal Core Opened)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 22,
+                            "connections": {
+                                "Dock to Plasma Processing": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -5968,7 +14779,7 @@
                             "heal": false,
                             "coordinates": {
                                 "x": 0.0,
-                                "y": -0.7145074903964996,
+                                "y": -0.71,
                                 "z": 2.5
                             },
                             "node_type": "dock",
@@ -5976,8 +14787,27 @@
                             "connected_area_asset_id": 3226044022,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Pickup (Plasma Beam)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Plasma Beam)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 98,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Geothermal Core": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -5992,33 +14822,43 @@
                             "name": "Dock to Geothermal Core",
                             "heal": false,
                             "coordinates": {
-                                "x": 25.235980987548828,
-                                "y": -27.147716522216797,
-                                "z": 2.491143601713702
+                                "x": 25.24,
+                                "y": -27.15,
+                                "z": 2.49
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3226044022,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Magmoor Workstation": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Magmoor Workstation",
                             "heal": false,
                             "coordinates": {
-                                "x": -0.5974400043487549,
-                                "y": 46.5748176574707,
-                                "z": 2.491155073978007
+                                "x": -0.6,
+                                "y": 46.57,
+                                "z": 2.49
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 2327753667,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Geothermal Core": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6043,7 +14883,91 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Workstation Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Transport Tunnel C": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Energy Tank)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 2,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 9,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Workstation Tunnel",
@@ -6059,23 +14983,57 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to South Core Tunnel": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Transport Tunnel C",
                             "heal": false,
                             "coordinates": {
-                                "x": -47.16240692138672,
-                                "y": -3.285429999232292,
-                                "z": 14.112992525100708
+                                "x": -47.16,
+                                "y": -3.29,
+                                "z": 14.11
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 3549419025,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to South Core Tunnel": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Energy Tank)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 99,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to South Core Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -6090,17 +15048,41 @@
                             "name": "Dock to Transport to Phazon Mines West",
                             "heal": false,
                             "coordinates": {
-                                "x": 25.714506149291992,
+                                "x": 25.71,
                                 "y": -37.5,
-                                "z": 2.4999936621397865
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 4012840000,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Magmoor Workstation": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Magmoor Workstation",
@@ -6116,7 +15098,31 @@
                             "connected_dock_index": 1,
                             "dock_type": 0,
                             "dock_weakness_index": 0,
-                            "connections": {}
+                            "connections": {
+                                "Dock to Transport to Phazon Mines West": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -6131,33 +15137,43 @@
                             "name": "Dock to Transport to Phendrana Drifts South",
                             "heal": false,
                             "coordinates": {
-                                "x": -22.250595092773438,
-                                "y": 2.4999995115814215,
-                                "z": 2.5000004884185785
+                                "x": -22.25,
+                                "y": 2.5,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3249312307,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Magmoor Workstation": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Magmoor Workstation",
                             "heal": false,
                             "coordinates": {
-                                "x": 21.369956970214844,
-                                "y": -19.693801879882812,
-                                "z": 2.4999968310698932
+                                "x": 21.37,
+                                "y": -19.69,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 2327753667,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Transport to Phendrana Drifts South": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6172,17 +15188,50 @@
                             "name": "Dock to Workstation Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": -19.77329444885254,
-                                "y": 31.26821517944336,
-                                "z": -1.688426986336708
+                                "x": -19.77,
+                                "y": 31.27,
+                                "z": -1.69
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 74274377,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Elevator - Transport to Magmoor Caverns South": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Elevator - Transport to Magmoor Caverns South",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "teleporter",
+                            "destination_world_asset_id": 2980859237,
+                            "destination_area_asset_id": 3804417848,
+                            "teleporter_instance_id": 1703972,
+                            "scan_asset_id": 800030426,
+                            "keep_name_when_vanilla": false,
+                            "editable": true,
+                            "connections": {
+                                "Dock to Workstation Tunnel": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6197,33 +15246,75 @@
                             "name": "Dock to Save Station Magmoor B",
                             "heal": false,
                             "coordinates": {
-                                "x": -18.23522186279297,
-                                "y": 0.018859505653381348,
-                                "z": -41.90966033935547
+                                "x": -18.24,
+                                "y": 0.02,
+                                "z": -41.91
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2136398113,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 4,
+                            "connections": {
+                                "Dock to Transport Tunnel C": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Elevator - Transport to Magmoor Caverns South": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Transport Tunnel C",
                             "heal": false,
                             "coordinates": {
-                                "x": 24.572690963745117,
-                                "y": 0.018859505653381348,
-                                "z": -41.90966033935547
+                                "x": 24.57,
+                                "y": 0.02,
+                                "z": -41.91
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3549419025,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Save Station Magmoor B": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Elevator - Transport to Magmoor Caverns South",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "teleporter",
+                            "destination_world_asset_id": 2831049361,
+                            "destination_area_asset_id": 3708487481,
+                            "teleporter_instance_id": 1769512,
+                            "scan_asset_id": 1865475028,
+                            "keep_name_when_vanilla": false,
+                            "editable": true,
+                            "connections": {
+                                "Dock to Save Station Magmoor B": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6238,17 +15329,34 @@
                             "name": "Dock to Transport to Phendrana Drifts South",
                             "heal": false,
                             "coordinates": {
-                                "x": 12.541706085205078,
-                                "y": 1.1769375503063202,
-                                "z": -3.508232057094574
+                                "x": 12.54,
+                                "y": 1.18,
+                                "z": -3.51
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3249312307,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 4,
+                            "connections": {
+                                "Save Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Save Station",
+                            "heal": true,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Transport to Phendrana Drifts South": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 }
@@ -6328,33 +15436,43 @@
                             "name": "Dock to Main Quarry",
                             "heal": false,
                             "coordinates": {
-                                "x": -29.503087997436523,
-                                "y": -10.20680856704712,
-                                "z": -2.4999912200469225
+                                "x": -29.5,
+                                "y": -10.21,
+                                "z": -2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1681720207,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Transport to Tallon Overworld South": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Transport to Tallon Overworld South",
                             "heal": false,
                             "coordinates": {
-                                "x": 29.64620018005371,
-                                "y": 10.290167331695557,
-                                "z": 2.5000012268371563
+                                "x": 29.65,
+                                "y": 10.29,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1125030300,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Main Quarry": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6369,65 +15487,246 @@
                             "name": "Dock to Waste Disposal",
                             "heal": false,
                             "coordinates": {
-                                "x": -19.87315559387207,
-                                "y": 28.502294540405273,
-                                "z": 37.475128173828125
+                                "x": -19.87,
+                                "y": 28.5,
+                                "z": 37.48
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 665031095,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Quarry Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Quarry Access",
                             "heal": false,
                             "coordinates": {
-                                "x": 69.95883178710938,
-                                "y": 8.68190884590149,
-                                "z": 22.499990463256836
+                                "x": 69.96,
+                                "y": 8.68,
+                                "z": 22.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1758230360,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Waste Disposal": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Save Station Mines A": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Security Access A": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 23,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 2,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 9,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Event (Main Quarry Barrier Deactivated)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Save Station Mines A",
                             "heal": false,
                             "coordinates": {
-                                "x": 4.768674969673157,
-                                "y": -64.99998092651367,
-                                "z": 21.108945846557617
+                                "x": 4.77,
+                                "y": -65.0,
+                                "z": 21.11
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 907887024,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Quarry Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Security Access A",
                             "heal": false,
                             "coordinates": {
-                                "x": -49.03507614135742,
-                                "y": -65.94475555419922,
-                                "z": 7.4999940395355225
+                                "x": -49.04,
+                                "y": -65.94,
+                                "z": 7.5
                             },
                             "node_type": "dock",
                             "dock_index": 3,
                             "connected_area_asset_id": 3345300114,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Quarry Access": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 23,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 73,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Quarry Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Main Quarry Barrier Deactivated)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 23,
+                            "connections": {
+                                "Dock to Quarry Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6442,33 +15741,81 @@
                             "name": "Dock to Main Quarry",
                             "heal": false,
                             "coordinates": {
-                                "x": -0.12585210800170898,
-                                "y": -13.96434211730957,
-                                "z": 6.120857119560242
+                                "x": -0.13,
+                                "y": -13.96,
+                                "z": 6.12
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1681720207,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Ore Processing": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Ore Processing",
                             "heal": false,
                             "coordinates": {
-                                "x": -10.150739908218384,
-                                "y": 19.09503746032715,
-                                "z": 33.54609298706055
+                                "x": -10.15,
+                                "y": 19.1,
+                                "z": 33.55
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 2547167990,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Main Quarry": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -6481,19 +15828,36 @@
                     "nodes": [
                         {
                             "name": "Dock to Main Quarry",
-                            "heal": false,
+                            "heal": true,
                             "coordinates": {
-                                "x": -0.20240497589111328,
-                                "y": 17.657129287719727,
-                                "z": 2.5000029305115277
+                                "x": -0.2,
+                                "y": 17.66,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1681720207,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Save Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Save Station",
+                            "heal": true,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Main Quarry": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6508,33 +15872,103 @@
                             "name": "Dock to Main Quarry",
                             "heal": false,
                             "coordinates": {
-                                "x": 21.40460968017578,
-                                "y": 13.98636531829834,
-                                "z": 0.32008790969848633
+                                "x": 21.4,
+                                "y": 13.99,
+                                "z": 0.32
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1681720207,
                             "connected_dock_index": 3,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Mine Security Station": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 13,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Mine Security Station",
                             "heal": false,
                             "coordinates": {
-                                "x": -35.17102813720703,
-                                "y": -1.4342097640037537,
-                                "z": 1.863025352358818
+                                "x": -35.17,
+                                "y": -1.43,
+                                "z": 1.86
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 2507085138,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Main Quarry": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 74,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Main Quarry": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6549,65 +15983,195 @@
                             "name": "Dock to Research Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -34.14543533325195,
-                                "y": 0.13142871856689453,
-                                "z": 2.4946265110047534
+                                "x": -34.15,
+                                "y": 0.13,
+                                "z": 2.49
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1128703815,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Elevator Access A": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Storage Depot B",
                             "heal": false,
                             "coordinates": {
-                                "x": 0.13143205642700195,
-                                "y": 34.14540481567383,
-                                "z": 47.502685546875
+                                "x": 0.13,
+                                "y": 34.15,
+                                "z": 47.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3818665003,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Waste Disposal": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Elevator Access A": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Waste Disposal",
                             "heal": false,
                             "coordinates": {
-                                "x": 0.0839700698852539,
-                                "y": -33.70220184326172,
-                                "z": 47.50267791748047
+                                "x": 0.08,
+                                "y": -33.7,
+                                "z": 47.5
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 665031095,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Research Access": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Storage Depot B": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Elevator Access A": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Elevator Access A",
                             "heal": false,
                             "coordinates": {
-                                "x": -34.14542007446289,
-                                "y": 0.2604222297668457,
-                                "z": 32.49580669403076
+                                "x": -34.15,
+                                "y": 0.26,
+                                "z": 32.5
                             },
                             "node_type": "dock",
                             "dock_index": 3,
                             "connected_area_asset_id": 639736833,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Research Access": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Storage Depot B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -6622,49 +16186,185 @@
                             "name": "Dock to Security Access A",
                             "heal": false,
                             "coordinates": {
-                                "x": 25.62916374206543,
-                                "y": -9.34390139579773,
-                                "z": 3.3836665004491806
+                                "x": 25.63,
+                                "y": -9.34,
+                                "z": 3.38
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3345300114,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Security Access B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 2,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Storage Depot A": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 2,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Security Access B",
                             "heal": false,
                             "coordinates": {
-                                "x": -5.777001738548279,
-                                "y": 57.92091369628906,
-                                "z": 14.89921522140503
+                                "x": -5.78,
+                                "y": 57.92,
+                                "z": 14.9
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 2718040532,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Security Access A": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 2,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Storage Depot A": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 2,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Storage Depot A",
                             "heal": false,
                             "coordinates": {
-                                "x": -5.587048292160034,
-                                "y": 66.50636291503906,
-                                "z": 0.9141109585762024
+                                "x": -5.59,
+                                "y": 66.51,
+                                "z": 0.91
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 902158134,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Security Access A": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 2,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -6679,33 +16379,62 @@
                             "name": "Dock to Ore Processing",
                             "heal": false,
                             "coordinates": {
-                                "x": 22.96479034423828,
-                                "y": 2.2825604267418385,
-                                "z": -27.17374610900879
+                                "x": 22.96,
+                                "y": 2.28,
+                                "z": -27.17
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2547167990,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Elite Research": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Elite Research",
                             "heal": false,
                             "coordinates": {
-                                "x": -23.01547622680664,
-                                "y": 1.1374147534370422,
-                                "z": 12.826265335083008
+                                "x": -23.02,
+                                "y": 1.14,
+                                "z": 12.83
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 2325199700,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Ore Processing": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6721,16 +16450,35 @@
                             "heal": false,
                             "coordinates": {
                                 "x": 0.0,
-                                "y": -23.214506149291992,
-                                "z": 2.4999960926513722
+                                "y": -23.21,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2547167990,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Pickup (Grapple Beam)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Grapple Beam)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 75,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Ore Processing": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6745,33 +16493,62 @@
                             "name": "Dock to Ore Processing",
                             "heal": false,
                             "coordinates": {
-                                "x": 8.570911407470703,
-                                "y": -18.876493453979492,
-                                "z": 2.8262485712766647
+                                "x": 8.57,
+                                "y": -18.88,
+                                "z": 2.83
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2547167990,
                             "connected_dock_index": 3,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Elevator A": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Elevator A",
                             "heal": false,
                             "coordinates": {
-                                "x": -17.86063003540039,
-                                "y": 14.277541399002075,
-                                "z": -27.17374038696289
+                                "x": -17.86,
+                                "y": 14.28,
+                                "z": -27.17
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 21425475,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Ore Processing": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -6786,33 +16563,53 @@
                             "name": "Dock to Elite Research",
                             "heal": false,
                             "coordinates": {
-                                "x": -9.110214710235596,
-                                "y": 33.45608139038086,
-                                "z": 5.714512348175049
+                                "x": -9.11,
+                                "y": 33.46,
+                                "z": 5.71
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2325199700,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Mine Security Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Mine Security Station",
                             "heal": false,
                             "coordinates": {
-                                "x": 11.386771202087402,
-                                "y": -39.26418685913086,
-                                "z": -0.714513510465622
+                                "x": 11.39,
+                                "y": -39.26,
+                                "z": -0.71
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 2507085138,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Elite Research": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -6828,16 +16625,35 @@
                             "heal": false,
                             "coordinates": {
                                 "x": 0.0,
-                                "y": -23.214506149291992,
-                                "z": 2.4999960926513722
+                                "y": -23.21,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2507085138,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Pickup (Flamethrower)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Flamethrower)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 76,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Mine Security Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6852,33 +16668,281 @@
                             "name": "Dock to Research Access",
                             "heal": false,
                             "coordinates": {
-                                "x": 37.03289794921875,
-                                "y": -30.144466400146484,
-                                "z": 20.219799995422363
+                                "x": 37.03,
+                                "y": -30.14,
+                                "z": 20.22
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1128703815,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Security Access B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 24,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 24,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Security Access B",
                             "heal": false,
                             "coordinates": {
-                                "x": -10.37375521659851,
-                                "y": -65.86322593688965,
-                                "z": -12.685014247894287
+                                "x": -10.37,
+                                "y": -65.86,
+                                "z": -12.69
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 2718040532,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Research Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 24,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Rock Wall in Elite Research Destroyed)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Artifact of Warrior)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 25,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Rock Wall in Elite Research Destroyed)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 24,
+                            "connections": {
+                                "Dock to Research Access": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Security Access B": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 78,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Security Access B": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Artifact of Warrior)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 77,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Security Access B": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6893,33 +16957,53 @@
                             "name": "Dock to Elevator Access A",
                             "heal": false,
                             "coordinates": {
-                                "x": 22.71450424194336,
-                                "y": -1.0481319725513458,
-                                "z": 37.49832534790039
+                                "x": 22.71,
+                                "y": -1.05,
+                                "z": 37.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 639736833,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Elite Control Access": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Elite Control Access",
                             "heal": false,
                             "coordinates": {
-                                "x": 22.71452522277832,
-                                "y": -1.131392478942871,
-                                "z": -37.500919342041016
+                                "x": 22.71,
+                                "y": -1.13,
+                                "z": -37.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 2307445195,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Elevator Access A": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6934,33 +17018,99 @@
                             "name": "Dock to Elevator A",
                             "heal": false,
                             "coordinates": {
-                                "x": -28.61044692993164,
-                                "y": 6.154462218284607,
-                                "z": 3.5000095069408417
+                                "x": -28.61,
+                                "y": 6.15,
+                                "z": 3.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 21425475,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Elite Control": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Elite Control",
                             "heal": false,
                             "coordinates": {
-                                "x": 14.1297607421875,
-                                "y": -36.51436233520508,
-                                "z": -6.517991065979004
+                                "x": 14.13,
+                                "y": -36.51,
+                                "z": -6.52
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3305828730,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Elevator A": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 79,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Elite Control": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -6975,49 +17125,124 @@
                             "name": "Dock to Maintenance Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": -44.28844451904297,
-                                "y": 5.327189683914185,
-                                "z": -15.29471468925476
+                                "x": -44.29,
+                                "y": 5.33,
+                                "z": -15.29
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3975146125,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Elite Control Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Elite Control Access",
                             "heal": false,
                             "coordinates": {
-                                "x": 37.317283630371094,
-                                "y": 41.00149154663086,
-                                "z": -15.294927597045898
+                                "x": 37.32,
+                                "y": 41.0,
+                                "z": -15.29
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 2307445195,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Maintenance Tunnel": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Dock to Ventilation Shaft": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 26,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Elite Control Barriers Lowered)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Ventilation Shaft",
                             "heal": false,
                             "coordinates": {
-                                "x": -20.85631561279297,
-                                "y": -22.562203407287598,
-                                "z": 12.222489833831787
+                                "x": -20.86,
+                                "y": -22.56,
+                                "z": 12.22
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 2423298732,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Elite Control Access": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 26,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Elite Control Barriers Lowered)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 26,
+                            "connections": {
+                                "Dock to Elite Control Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -7032,33 +17257,81 @@
                             "name": "Dock to Elite Control",
                             "heal": false,
                             "coordinates": {
-                                "x": 36.22657775878906,
-                                "y": 25.612056732177734,
-                                "z": -0.49999356269836426
+                                "x": 36.23,
+                                "y": 25.61,
+                                "z": -0.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3305828730,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Phazon Processing Center": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Phazon Processing Center",
                             "heal": false,
                             "coordinates": {
-                                "x": -34.44357681274414,
-                                "y": -7.988855361938477,
-                                "z": 1.999998539686203
+                                "x": -34.44,
+                                "y": -7.99,
+                                "z": 2.0
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 2905505465,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Elite Control": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -7073,33 +17346,117 @@
                             "name": "Dock to Omega Research",
                             "heal": false,
                             "coordinates": {
-                                "x": 14.999994277954102,
-                                "y": -34.16853713989258,
-                                "z": 2.500005384185897
+                                "x": 15.0,
+                                "y": -34.17,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1060593356,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Elite Control": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Energy Tank)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Elite Control",
                             "heal": false,
                             "coordinates": {
-                                "x": -9.99999713897705,
-                                "y": 26.677058219909668,
-                                "z": 13.120506763458252
+                                "x": -10.0,
+                                "y": 26.68,
+                                "z": 13.12
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3305828730,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Omega Research": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Energy Tank)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 80,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Omega Research": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -7114,24 +17471,29 @@
                             "name": "Dock to Transport Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -21.714506149291992,
-                                "y": -60.23887252807617,
-                                "z": 92.99967193603516
+                                "x": -21.71,
+                                "y": -60.24,
+                                "z": 93.0
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1120185073,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Maintenance Tunnel": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Maintenance Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": 20.71450424194336,
-                                "y": -5.000008583068848,
+                                "x": 20.71,
+                                "y": -5.0,
                                 "z": 42.5
                             },
                             "node_type": "dock",
@@ -7139,24 +17501,218 @@
                             "connected_area_asset_id": 3975146125,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Transport Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Processing Center Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Processing Center Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -9.761001825332642,
-                                "y": -55.99647903442383,
-                                "z": 2.4999960926513722
+                                "x": -9.76,
+                                "y": -56.0,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 3983402811,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Maintenance Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 16,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 6,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 19,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 13,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 9,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 13,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 9,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 81,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Processing Center Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -7171,49 +17727,125 @@
                             "name": "Dock to Map Station Mines",
                             "heal": false,
                             "coordinates": {
-                                "x": 8.666543006896973,
-                                "y": -53.82004928588867,
-                                "z": 6.26404881477356
+                                "x": 8.67,
+                                "y": -53.82,
+                                "z": 6.26
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 428864988,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Ventilation Shaft": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Ventilation Shaft",
                             "heal": false,
                             "coordinates": {
-                                "x": 29.71066665649414,
-                                "y": 29.257716178894043,
-                                "z": 6.36540162563324
+                                "x": 29.71,
+                                "y": 29.26,
+                                "z": 6.37
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 2423298732,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Map Station Mines": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Dynamo Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Dynamo Access",
                             "heal": false,
                             "coordinates": {
-                                "x": 47.49181365966797,
-                                "y": -43.85544967651367,
-                                "z": -17.284343719482422
+                                "x": 47.49,
+                                "y": -43.86,
+                                "z": -17.28
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 4111966698,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Ventilation Shaft": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -7228,33 +17860,81 @@
                             "name": "Dock to Phazon Processing Center",
                             "heal": false,
                             "coordinates": {
-                                "x": -1.9073486328125e-06,
-                                "y": -26.001426696777344,
-                                "z": 2.49998608586111
+                                "x": -0.0,
+                                "y": -26.0,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2905505465,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Transport to Magmoor Caverns South": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Transport to Magmoor Caverns South",
                             "heal": false,
                             "coordinates": {
-                                "x": 0.4218275547027588,
-                                "y": 35.998897552490234,
-                                "z": 2.499994400558535
+                                "x": 0.42,
+                                "y": 36.0,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3804417848,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Phazon Processing Center": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -7269,33 +17949,108 @@
                             "name": "Dock to Phazon Processing Center",
                             "heal": false,
                             "coordinates": {
-                                "x": 19.061878204345703,
-                                "y": 22.13248920440674,
-                                "z": -6.499995589256287
+                                "x": 19.06,
+                                "y": 22.13,
+                                "z": -6.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2905505465,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Elite Quarters": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 32,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Elite Quarters",
                             "heal": false,
                             "coordinates": {
-                                "x": -13.60658884048462,
-                                "y": -25.56556797027588,
-                                "z": -6.500003814697266
+                                "x": -13.61,
+                                "y": -25.57,
+                                "z": -6.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 961790803,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Phazon Processing Center": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 32,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Processing Center Access Barrier Opened)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Energy Tank)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Processing Center Access Barrier Opened)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 32,
+                            "connections": {
+                                "Dock to Elite Quarters": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Energy Tank)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 82,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Elite Quarters": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -7310,16 +18065,16 @@
                             "name": "Dock to Omega Research",
                             "heal": false,
                             "coordinates": {
-                                "x": 15.714506149291992,
-                                "y": -0.004677534103393555,
-                                "z": 2.5000002499999994
+                                "x": 15.71,
+                                "y": -0.0,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1060593356,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
+                            "dock_weakness_index": 1,
                             "connections": {}
                         }
                     ]
@@ -7335,33 +18090,53 @@
                             "name": "Dock to Central Dynamo",
                             "heal": false,
                             "coordinates": {
-                                "x": 34.2894287109375,
-                                "y": 14.9246346950531,
-                                "z": 2.5000014652557354
+                                "x": 34.29,
+                                "y": 14.92,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 4272124642,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Omega Research": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Omega Research",
                             "heal": false,
                             "coordinates": {
-                                "x": -26.79795265197754,
-                                "y": -10.576765060424805,
-                                "z": 5.578413963317871
+                                "x": -26.8,
+                                "y": -10.58,
+                                "z": 5.58
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1060593356,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Central Dynamo": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -7376,17 +18151,50 @@
                             "name": "Dock to Transport Access",
                             "heal": false,
                             "coordinates": {
-                                "x": 24.57270050048828,
-                                "y": 0.017116546630859375,
-                                "z": 2.499995854232793
+                                "x": 24.57,
+                                "y": 0.02,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1120185073,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Elevator - Transport to Phazon Mines West": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Elevator - Transport to Phazon Mines West",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "teleporter",
+                            "destination_world_asset_id": 1056449404,
+                            "destination_area_asset_id": 4012840000,
+                            "teleporter_instance_id": 1638417,
+                            "scan_asset_id": 495694188,
+                            "keep_name_when_vanilla": false,
+                            "editable": true,
+                            "connections": {
+                                "Dock to Transport Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -7401,33 +18209,135 @@
                             "name": "Dock to Elite Quarters Access",
                             "heal": false,
                             "coordinates": {
-                                "x": 0.4112589359283447,
-                                "y": -37.49916076660156,
-                                "z": 2.3721819445490837
+                                "x": 0.41,
+                                "y": -37.5,
+                                "z": 2.37
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1899248703,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Processing Center Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 31,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Omega Pirate Defeated)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "template",
+                                            "data": "Have all Beams"
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 13,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Phazon Suit)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 31,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Processing Center Access",
                             "heal": false,
                             "coordinates": {
-                                "x": 0.4112379550933838,
-                                "y": 90.44281005859375,
-                                "z": 32.3533935546875
+                                "x": 0.41,
+                                "y": 90.44,
+                                "z": 32.35
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3983402811,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Event (Omega Pirate Defeated)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "template",
+                                            "data": "Have all Beams"
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 13,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Omega Pirate Defeated)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 31,
+                            "connections": {
+                                "Dock to Elite Quarters Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Phazon Suit)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 83,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Elite Quarters Access": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -7442,49 +18352,338 @@
                             "name": "Dock to Dynamo Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -35.63698959350586,
-                                "y": -34.90064239501953,
-                                "z": 18.61671257019043
+                                "x": -35.64,
+                                "y": -34.9,
+                                "z": 18.62
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 4111966698,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Save Station Mines B": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 25,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Security Drone Defeated)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 9,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 2,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Quarantine Access A",
                             "heal": false,
                             "coordinates": {
-                                "x": -0.050148963928222656,
-                                "y": 64.4590072631836,
-                                "z": 9.70635461807251
+                                "x": -0.05,
+                                "y": 64.46,
+                                "z": 9.71
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1522461728,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Save Station Mines B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 25,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Security Drone Defeated)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 9,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 2,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Save Station Mines B",
                             "heal": false,
                             "coordinates": {
-                                "x": 2.181094080209732,
-                                "y": -39.7519416809082,
-                                "z": 5.514097571372986
+                                "x": 2.18,
+                                "y": -39.75,
+                                "z": 5.51
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 2077614267,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Dynamo Access": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 25,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Quarantine Access A": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 25,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 27,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Security Drone Defeated)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 9,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 2,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Event (Central Dynamo Bendezium Destroyed)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 25,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Security Drone Defeated)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 25,
+                            "connections": {
+                                "Pickup (Main Power Bombs)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Main Power Bombs)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 84,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Save Station Mines B": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Central Dynamo Bendezium Destroyed)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 27,
+                            "connections": {
+                                "Dock to Save Station Mines B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 25,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -7499,33 +18698,90 @@
                             "name": "Dock to Metroid Quarantine B",
                             "heal": false,
                             "coordinates": {
-                                "x": 38.233551025390625,
-                                "y": -5.305819511413574,
-                                "z": 2.4999995115814215
+                                "x": 38.23,
+                                "y": -5.31,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3141205070,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Elite Quarters": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 30,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Elite Quarters Access Barrier Opened)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 3,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Elite Quarters",
                             "heal": false,
                             "coordinates": {
-                                "x": -8.857912540435791,
-                                "y": 26.75605583190918,
-                                "z": 2.500004884185728
+                                "x": -8.86,
+                                "y": 26.76,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 961790803,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Metroid Quarantine B": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 30,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Elite Quarters Access Barrier Opened)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 30,
+                            "connections": {
+                                "Dock to Metroid Quarantine B": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -7540,33 +18796,53 @@
                             "name": "Dock to Central Dynamo",
                             "heal": false,
                             "coordinates": {
-                                "x": 12.012839317321777,
-                                "y": -30.496397018432617,
-                                "z": 2.500004384185786
+                                "x": 12.01,
+                                "y": -30.5,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 4272124642,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Metroid Quarantine A": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Metroid Quarantine A",
                             "heal": false,
                             "coordinates": {
-                                "x": -12.422174453735352,
-                                "y": 30.495290756225586,
-                                "z": 2.5000144141386045
+                                "x": -12.42,
+                                "y": 30.5,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 4211416922,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Central Dynamo": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 27,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -7581,17 +18857,34 @@
                             "name": "Dock to Central Dynamo",
                             "heal": false,
                             "coordinates": {
-                                "x": -0.20240497589111328,
-                                "y": 17.657129287719727,
-                                "z": 2.5000029305115277
+                                "x": -0.2,
+                                "y": 17.66,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 4272124642,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Save Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Save Station",
+                            "heal": true,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Central Dynamo": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -7606,49 +18899,229 @@
                             "name": "Dock to Quarantine Access B",
                             "heal": false,
                             "coordinates": {
-                                "x": 90.16883087158203,
-                                "y": 23.345199584960938,
-                                "z": -9.01063060760498
+                                "x": 90.17,
+                                "y": 23.35,
+                                "z": -9.01
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 340985721,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Save Station Mines C": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 29,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Event (Metroid Quarantine B Barrier Lowered)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Elite Quarters Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -86.28419494628906,
-                                "y": 8.423248767852783,
-                                "z": 1.2198694944381714
+                                "x": -86.28,
+                                "y": 8.42,
+                                "z": 1.22
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1899248703,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Save Station Mines C": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Save Station Mines C",
                             "heal": false,
                             "coordinates": {
-                                "x": -55.3802490234375,
-                                "y": -57.72956657409668,
-                                "z": -13.780115127563477
+                                "x": -55.38,
+                                "y": -57.73,
+                                "z": -13.78
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 1724960771,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Quarantine Access B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 29,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Elite Quarters Access": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "template",
+                                            "data": "Shoot Super Missile"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 85,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Save Station Mines C": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Metroid Quarantine B Barrier Lowered)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 29,
+                            "connections": {
+                                "Dock to Quarantine Access B": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -7663,33 +19136,406 @@
                             "name": "Dock to Quarantine Access A",
                             "heal": false,
                             "coordinates": {
-                                "x": -42.340511322021484,
-                                "y": -89.04336547851562,
-                                "z": 0.16934609413146973
+                                "x": -42.34,
+                                "y": -89.04,
+                                "z": 0.17
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1522461728,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 2,
+                            "connections": {
+                                "Dock to Elevator Access B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 28,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 13,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 28,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 13,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Elevator Access B",
                             "heal": false,
                             "coordinates": {
-                                "x": 1.5814270377159119,
-                                "y": 87.41142272949219,
-                                "z": 19.66937255859375
+                                "x": 1.58,
+                                "y": 87.41,
+                                "z": 19.67
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 1071241062,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Quarantine Access A": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 28,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 15,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 13,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "Event (Metroid Quarantine A Barrier Lowered)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 86,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Quarantine Access A": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 28,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Elevator Access B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 19,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 13,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 4,
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Event (Metroid Quarantine A Barrier Lowered)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "event",
+                            "event_index": 28,
+                            "connections": {
+                                "Dock to Quarantine Access A": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -7704,33 +19550,63 @@
                             "name": "Dock to Metroid Quarantine B",
                             "heal": false,
                             "coordinates": {
-                                "x": -23.719335556030273,
-                                "y": -12.718968868255615,
-                                "z": 0.9999964535236359
+                                "x": -23.72,
+                                "y": -12.72,
+                                "z": 1.0
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3141205070,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Fungal Hall B": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Fungal Hall B",
                             "heal": false,
                             "coordinates": {
-                                "x": 17.743006229400635,
-                                "y": 18.865697860717773,
-                                "z": 1.0000119805335999
+                                "x": 17.74,
+                                "y": 18.87,
+                                "z": 1.0
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3964125762,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Metroid Quarantine B": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -7746,16 +19622,33 @@
                             "heal": false,
                             "coordinates": {
                                 "x": 0.0,
-                                "y": 23.214506149291992,
-                                "z": 2.5000039073486278
+                                "y": 23.21,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3141205070,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Save Station": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Save Station",
+                            "heal": true,
+                            "coordinates": null,
+                            "node_type": "generic",
+                            "connections": {
+                                "Dock to Metroid Quarantine B": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -7770,33 +19663,43 @@
                             "name": "Dock to Metroid Quarantine A",
                             "heal": false,
                             "coordinates": {
-                                "x": 13.764360427856445,
-                                "y": -29.573772430419922,
-                                "z": -9.17699670791626
+                                "x": 13.76,
+                                "y": -29.57,
+                                "z": -9.18
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 4211416922,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Elevator B": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Elevator B",
                             "heal": false,
                             "coordinates": {
-                                "x": -6.732637643814087,
-                                "y": 29.575197219848633,
-                                "z": -11.176984786987305
+                                "x": -6.73,
+                                "y": 29.58,
+                                "z": -11.18
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3900266464,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Metroid Quarantine A": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -7811,49 +19714,162 @@
                             "name": "Dock to Missile Station Mines",
                             "heal": false,
                             "coordinates": {
-                                "x": 42.01609420776367,
-                                "y": -36.67749786376953,
-                                "z": 8.70495319366455
+                                "x": 42.02,
+                                "y": -36.68,
+                                "z": 8.7
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 2961781534,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Phazon Mining Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Quarantine Access B",
                             "heal": false,
                             "coordinates": {
-                                "x": -31.52579975128174,
-                                "y": -84.66736602783203,
-                                "z": -1.2537489533424377
+                                "x": -31.53,
+                                "y": -84.67,
+                                "z": -1.25
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 340985721,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Phazon Mining Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Phazon Mining Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": 9.11983585357666,
-                                "y": 89.98545837402344,
-                                "z": -7.373335838317871
+                                "x": 9.12,
+                                "y": 89.99,
+                                "z": -7.37
                             },
                             "node_type": "dock",
                             "dock_index": 2,
                             "connected_area_asset_id": 3153742515,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Missile Station Mines": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Dock to Quarantine Access B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 87,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Phazon Mining Tunnel": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -7868,33 +19884,53 @@
                             "name": "Dock to Elevator Access B",
                             "heal": false,
                             "coordinates": {
-                                "x": -3.0481034219264984,
-                                "y": -26.71454620361328,
-                                "z": 37.50189971923828
+                                "x": -3.05,
+                                "y": -26.71,
+                                "z": 37.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 1071241062,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Fungal Hall Access": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Fungal Hall Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -3.0038839280605316,
-                                "y": -26.71455192565918,
-                                "z": -37.499507904052734
+                                "x": -3.0,
+                                "y": -26.71,
+                                "z": -37.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3734860277,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Elevator Access B": {
+                                    "type": "and",
+                                    "data": []
+                                }
+                            }
                         }
                     ]
                 },
@@ -7909,16 +19945,16 @@
                             "name": "Dock to Fungal Hall B",
                             "heal": false,
                             "coordinates": {
-                                "x": -30.714506149291992,
-                                "y": -4.76837158203125e-07,
-                                "z": 2.5000002499999994
+                                "x": -30.71,
+                                "y": -0.0,
+                                "z": 2.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3964125762,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
+                            "dock_weakness_index": 3,
                             "connections": {}
                         }
                     ]
@@ -7934,33 +19970,173 @@
                             "name": "Dock to Fungal Hall B",
                             "heal": false,
                             "coordinates": {
-                                "x": 23.376882553100586,
-                                "y": -11.448168277740479,
-                                "z": 16.499996662139893
+                                "x": 23.38,
+                                "y": -11.45,
+                                "z": 16.5
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3964125762,
                             "connected_dock_index": 2,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Fungal Hall A": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                "Pickup (Artifact of Newborn)": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 23,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Fungal Hall A",
                             "heal": false,
                             "coordinates": {
-                                "x": -24.376869201660156,
-                                "y": 17.414027214050293,
-                                "z": 29.50000286102295
+                                "x": -24.38,
+                                "y": 17.41,
+                                "z": 29.5
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 257062865,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Fungal Hall B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 7,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Artifact of Newborn)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 88,
+                            "major_location": true,
+                            "connections": {
+                                "Dock to Fungal Hall B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 4,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 23,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -7975,33 +20151,100 @@
                             "name": "Dock to Fungal Hall A",
                             "heal": false,
                             "coordinates": {
-                                "x": -10.959269523620605,
-                                "y": -26.47145175933838,
-                                "z": -7.119049072265625
+                                "x": -10.96,
+                                "y": -26.47,
+                                "z": -7.12
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 257062865,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Elevator B": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Elevator B",
                             "heal": false,
                             "coordinates": {
-                                "x": 5.768691062927246,
-                                "y": 26.47568988800049,
-                                "z": 7.880958318710327
+                                "x": 5.77,
+                                "y": 26.48,
+                                "z": 7.88
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3900266464,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 3,
+                            "connections": {
+                                "Dock to Fungal Hall A": {
+                                    "type": "and",
+                                    "data": []
+                                },
+                                "Pickup (Missile)": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "Pickup (Missile)",
+                            "heal": false,
+                            "coordinates": null,
+                            "node_type": "pickup",
+                            "pickup_index": 89,
+                            "major_location": false,
+                            "connections": {
+                                "Dock to Elevator B": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 },
@@ -8016,33 +20259,72 @@
                             "name": "Dock to Phazon Mining Tunnel",
                             "heal": false,
                             "coordinates": {
-                                "x": -50.57845687866211,
-                                "y": -61.77936935424805,
-                                "z": 26.880176544189453
+                                "x": -50.58,
+                                "y": -61.78,
+                                "z": 26.88
                             },
                             "node_type": "dock",
                             "dock_index": 0,
                             "connected_area_asset_id": 3153742515,
                             "connected_dock_index": 1,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Fungal Hall Access": {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         },
                         {
                             "name": "Dock to Fungal Hall Access",
                             "heal": false,
                             "coordinates": {
-                                "x": -9.009514808654785,
-                                "y": 105.6949462890625,
-                                "z": 6.417659878730774
+                                "x": -9.01,
+                                "y": 105.69,
+                                "z": 6.42
                             },
                             "node_type": "dock",
                             "dock_index": 1,
                             "connected_area_asset_id": 3734860277,
                             "connected_dock_index": 0,
                             "dock_type": 0,
-                            "dock_weakness_index": 0,
-                            "connections": {}
+                            "dock_weakness_index": 1,
+                            "connections": {
+                                "Dock to Phazon Mining Tunnel": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     ]
                 }
@@ -16153,25 +28435,99 @@
                             "event_index": 7,
                             "connections": {
                                 "Pickup (Varia Suit)": {
-                                    "type": "and",
+                                    "type": "or",
                                     "data": [
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 16,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 6,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 2,
+                                                                        "index": 2,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 7,
+                                                                        "amount": 4,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
                                         },
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 6,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 2,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 28,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 4,
+                                                        "amount": 230,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 2,
+                                                        "amount": 5,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     ]
                                 }

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -2388,7 +2388,7 @@ Asset id: 1681720207
       Grapple Beam and Space Jump Boots
   > Dock to Save Station Mines A
       Any of the following:
-          Combat (Beginner)
+          Space Jump Boots or Movement (Beginner)
           Morph Ball and Spider Ball
   > Dock to Security Access A
       After Main Quarry Barrier Deactivated

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -2725,6 +2725,10 @@ Asset id: 2905505465
       Space Jump Boots and Morph Ball and Spider Ball
   > Dock to Processing Center Access
       Trivial
+  > Pickup (Missile)
+      All of the following:
+          Power Bomb and Morph Ball
+          Thermal Visor or X-Ray Visor or Invisible Objects (Beginner)
 
 > Dock to Processing Center Access; Heals? False
   * Plasma Door to Processing Center Access/Dock to Phazon Processing Center
@@ -2999,11 +3003,11 @@ Asset id: 4211416922
   > Dock to Elevator Access B
       All of the following:
           Morph Ball Bomb and Space Jump Boots and Morph Ball and Spider Ball and After Metroid Quarantine A Barrier Lowered
-          X-Ray Visor or Invisible Objects (Intermediate)
+          Thermal Visor or X-Ray Visor or Invisible Objects (Intermediate)
   > Pickup (Missile)
       All of the following:
           Power Bomb and Space Jump Boots and Morph Ball and Spider Ball and After Metroid Quarantine A Barrier Lowered
-          X-Ray Visor or Invisible Objects (Intermediate)
+          Thermal Visor or X-Ray Visor or Invisible Objects (Intermediate)
 
 > Dock to Elevator Access B; Heals? False
   * Ice Door to Elevator Access B/Dock to Metroid Quarantine A
@@ -3013,7 +3017,7 @@ Asset id: 4211416922
       All of the following:
           Power Bomb and Morph Ball and Spider Ball
           Morph Ball Bomb or Space Jump Boots
-          X-Ray Visor or Invisible Objects (Intermediate)
+          Thermal Visor or X-Ray Visor or Invisible Objects (Intermediate)
   > Event (Metroid Quarantine A Barrier Lowered)
       Scan Visor
 

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -2610,7 +2610,7 @@ Asset id: 2325199700
 
 > Event (Rock Wall in Elite Research Destroyed); Heals? False
   * Event Rock Wall in Elite Research Destroyed
-  > Dock to Research Access
+  > Top Floor
       Trivial
 
 > Pickup (Missile); Heals? False
@@ -2631,7 +2631,9 @@ Asset id: 2325199700
   > Event (Rock Wall in Elite Research Destroyed)
       All of the following:
           Scan Visor and Morph Ball and Boost Ball
-          Morph Ball Bomb or Power Bomb
+          Any of the following:
+              Morph Ball Bomb
+              Power Bomb and Knowledge (Beginner)
   > Pickup (Missile)
       All of the following:
           Scan Visor and Space Jump Boots and Morph Ball and Boost Ball
@@ -2866,8 +2868,6 @@ Asset id: 961790803
       Scan Visor and After Omega Pirate Defeated
   > Event (Omega Pirate Defeated)
       X-Ray Visor and Have all Beams
-  > Pickup (Phazon Suit)
-      After Omega Pirate Defeated
 
 > Dock to Processing Center Access; Heals? False
   * Plasma Door to Processing Center Access/Dock to Elite Quarters
@@ -2876,7 +2876,7 @@ Asset id: 961790803
 
 > Event (Omega Pirate Defeated); Heals? False
   * Event Omega Pirate Defeated
-  > Dock to Elite Quarters Access
+  > Pickup (Phazon Suit)
       Trivial
 
 > Pickup (Phazon Suit); Heals? False
@@ -2899,30 +2899,26 @@ Asset id: 4272124642
 > Dock to Quarantine Access A; Heals? False
   * Ice Door to Quarantine Access A/Dock to Central Dynamo
   > Dock to Save Station Mines B
-      After Security Drone Defeated and After Central Dynamo Bendezium Destroyed
+      Power Bomb and Morph Ball and After Security Drone Defeated
   > Event (Security Drone Defeated)
       All of the following:
-          Space Jump Boots and After Central Dynamo Bendezium Destroyed
+          Power Bomb and Space Jump Boots and Morph Ball
           Any of the following:
               X-Ray Visor
               Combat (Beginner) and Invisible Objects (Beginner)
-  > Event (Central Dynamo Bendezium Destroyed)
-      Power Bomb and Morph Ball
 
 > Dock to Save Station Mines B; Heals? False
   * Ice Door to Save Station Mines B/Dock to Central Dynamo
   > Dock to Dynamo Access
       Space Jump Boots and After Security Drone Defeated
   > Dock to Quarantine Access A
-      After Security Drone Defeated and After Central Dynamo Bendezium Destroyed
+      Power Bomb and Morph Ball and After Security Drone Defeated
   > Event (Security Drone Defeated)
       All of the following:
           Space Jump Boots
           Any of the following:
               X-Ray Visor
               Combat (Beginner) and Invisible Objects (Beginner)
-  > Event (Central Dynamo Bendezium Destroyed)
-      Power Bomb and Morph Ball and After Security Drone Defeated
 
 > Event (Security Drone Defeated); Heals? False; Spawn Point
   * Event Security Drone Defeated
@@ -2933,11 +2929,6 @@ Asset id: 4272124642
   * Pickup 84; Major Location? True
   > Dock to Save Station Mines B
       Trivial
-
-> Event (Central Dynamo Bendezium Destroyed); Heals? False
-  * Event Central Dynamo Bendezium Destroyed
-  > Dock to Save Station Mines B
-      After Security Drone Defeated
 
 ----------------
 Elite Quarters Access
@@ -2970,7 +2961,7 @@ Asset id: 1522461728
 > Dock to Metroid Quarantine A; Heals? False
   * Wave Door to Metroid Quarantine A/Dock to Quarantine Access A
   > Dock to Central Dynamo
-      After Central Dynamo Bendezium Destroyed
+      Trivial
 
 ----------------
 Save Station Mines B
@@ -2989,10 +2980,8 @@ Metroid Quarantine B
 Asset id: 3141205070
 > Dock to Quarantine Access B; Heals? False; Spawn Point
   * Plasma Door to Quarantine Access B/Dock to Metroid Quarantine B
-  > Dock to Save Station Mines C
-      Grapple Beam and Space Jump Boots and Morph Ball and Spider Ball and After Metroid Quarantine B Barrier Lowered
-  > Event (Metroid Quarantine B Barrier Lowered)
-      Scan Visor and Grapple Beam and Space Jump Boots and Morph Ball and Spider Ball
+  > Front of Barrier
+      Grapple Beam and Space Jump Boots and Morph Ball and Spider Ball
 
 > Dock to Elite Quarters Access; Heals? False
   * Plasma Door to Elite Quarters Access/Dock to Metroid Quarantine B
@@ -3001,12 +2990,12 @@ Asset id: 3141205070
 
 > Dock to Save Station Mines C; Heals? False
   * Plasma Door to Save Station Mines C/Dock to Metroid Quarantine B
-  > Dock to Quarantine Access B
-      Space Jump Boots and After Metroid Quarantine B Barrier Lowered
   > Dock to Elite Quarters Access
       Trivial
   > Pickup (Missile)
       Shoot Super Missile
+  > Front of Barrier
+      After Metroid Quarantine B Barrier Lowered
 
 > Pickup (Missile); Heals? False
   * Pickup 85; Major Location? False
@@ -3015,44 +3004,55 @@ Asset id: 3141205070
 
 > Event (Metroid Quarantine B Barrier Lowered); Heals? False
   * Event Metroid Quarantine B Barrier Lowered
+  > Front of Barrier
+      Trivial
+
+> Front of Barrier; Heals? False
   > Dock to Quarantine Access B
       Space Jump Boots
+  > Dock to Save Station Mines C
+      After Metroid Quarantine B Barrier Lowered
+  > Event (Metroid Quarantine B Barrier Lowered)
+      Scan Visor
 
 ----------------
 Metroid Quarantine A
 Asset id: 4211416922
 > Dock to Quarantine Access A; Heals? False; Spawn Point
   * Wave Door to Quarantine Access A/Dock to Metroid Quarantine A
-  > Dock to Elevator Access B
+  > Event (Metroid Quarantine A Barrier Lowered)
+      Scan Visor
+  > Front of Spider Track
       All of the following:
-          Morph Ball Bomb and Space Jump Boots and Morph Ball and Spider Ball and After Metroid Quarantine A Barrier Lowered
-          Thermal Visor or X-Ray Visor or Invisible Objects (Intermediate)
-  > Pickup (Missile)
-      All of the following:
-          Power Bomb and Space Jump Boots and Morph Ball and Spider Ball and After Metroid Quarantine A Barrier Lowered
+          Space Jump Boots
           Thermal Visor or X-Ray Visor or Invisible Objects (Intermediate)
 
 > Dock to Elevator Access B; Heals? False
   * Ice Door to Elevator Access B/Dock to Metroid Quarantine A
-  > Dock to Quarantine Access A
-      Space Jump Boots and After Metroid Quarantine A Barrier Lowered
-  > Pickup (Missile)
-      All of the following:
-          Power Bomb and Morph Ball and Spider Ball
-          Morph Ball Bomb or Space Jump Boots
-          Thermal Visor or X-Ray Visor or Invisible Objects (Intermediate)
-  > Event (Metroid Quarantine A Barrier Lowered)
-      Scan Visor
+  > Front of Spider Track
+      Space Jump Boots
 
 > Pickup (Missile); Heals? False
   * Pickup 86; Major Location? False
-  > Dock to Quarantine Access A
-      Space Jump Boots and After Metroid Quarantine A Barrier Lowered
+  > Front of Spider Track
+      All of the following:
+          Space Jump Boots
+          Power Beam or Thermal Visor or X-Ray Visor or Invisible Objects (Beginner)
 
 > Event (Metroid Quarantine A Barrier Lowered); Heals? False
   * Event Metroid Quarantine A Barrier Lowered
   > Dock to Quarantine Access A
       Trivial
+
+> Front of Spider Track; Heals? False
+  > Dock to Quarantine Access A
+      Space Jump Boots and After Metroid Quarantine A Barrier Lowered
+  > Dock to Elevator Access B
+      Morph Ball Bomb and Morph Ball and Spider Ball
+  > Pickup (Missile)
+      All of the following:
+          Power Bomb ≥ 2 and Space Jump Boots and Morph Ball and Spider Ball
+          Thermal Visor or X-Ray Visor or Invisible Objects (Intermediate)
 
 ----------------
 Quarantine Access B

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -2387,7 +2387,9 @@ Asset id: 1681720207
   > Dock to Waste Disposal
       Grapple Beam and Space Jump Boots
   > Dock to Save Station Mines A
-      Trivial
+      Any of the following:
+          Combat (Beginner)
+          Morph Ball and Spider Ball
   > Dock to Security Access A
       After Main Quarry Barrier Deactivated
   > Pickup (Missile)

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -1792,7 +1792,7 @@ Asset id: 3134844351
   > Pickup (Missile Expansion)
       All of the following:
           Space Jump Boots and Heated Rooms Damage ≥ 201
-          Missile or Shoot Super Missile
+          Missile or Charge Beam
           X-Ray Visor or Invisible Objects (Intermediate)
 
 > Dock to Storage Cavern; Heals? False
@@ -1834,7 +1834,7 @@ Asset id: 3134844351
       All of the following:
           Space Jump Boots and Heated Rooms Damage ≥ 157
           X-Ray Visor or Invisible Objects (Intermediate)
-          Missile or Shoot Super Missile
+          Missile or Charge Beam
 
 > Pickup (Missile Expansion); Heals? False
   * Pickup 91; Major Location? False
@@ -1847,8 +1847,8 @@ Asset id: 3134844351
           Morph Ball
           Any of the following:
               Heated Rooms Damage ≥ 216
-              Boost Ball and Heated Rooms Damage ≥ 1188
-              No Space Jump Boots and Heated Rooms Damage ≥ 207
+              Boost Ball and Heated Rooms Damage ≥ 188
+              Space Jump Boots and Heated Rooms Damage ≥ 207
               Space Jump Boots and Boost Ball and Heated Rooms Damage ≥ 177
   > Dock to Pit Tunnel
       Any of the following:

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -4012,7 +4012,9 @@ Asset id: 3587029001
   > Dock to Nursery Access
       Trivial
   > Pickup (Missile Expansion)
-      Morph Ball and Boost Ball
+      Any of the following:
+          Morph Ball and Boost Ball
+          Space Jump Boots and Slope Jump (Beginner)
 
 > Dock to Ruined Shrine Access; Heals? False
   * Missile Blast Shield to Ruined Shrine Access/Dock to Main Plaza
@@ -4161,7 +4163,9 @@ Asset id: 1014518864
 > Dock to Ruined Shrine Access; Heals? False; Spawn Point
   * Normal Door to Ruined Shrine Access/Dock to Ruined Shrine
   > Dock to Tower of Light Access
-      Morph Ball and Boost Ball and Spider Ball
+      Any of the following:
+          Morph Ball and Boost Ball and Spider Ball
+          Space Jump Boots and Standable Terrain (Beginner)
   > Pickup (Missile Expansion)
       Morph Ball and Boost Ball
   > Pit
@@ -4418,7 +4422,9 @@ Asset id: 225636855
 > Dock to Tower of Light Access; Heals? False; Spawn Point
   * Wave Door to Tower of Light Access/Dock to Tower of Light
   > Dock to Tower Chamber
-      Space Jump Boots and Gravity Suit
+      All of the following:
+          Space Jump Boots
+          Gravity Suit or Slope Jump (Intermediate)
   > Pickup (Wavebuster)
       Missile ≥ 36 and Space Jump Boots
 
@@ -4636,7 +4642,7 @@ Asset id: 1206336453
   > Dock to Save Station 2
       Trivial
   > Dock to East Atrium
-      Morph Ball
+      Space Jump Boots or Morph Ball
 
 > Dock to Save Station 2; Heals? False; Spawn Point
   * Missile Blast Shield to Save Station 2/Dock to Gathering Hall
@@ -5068,7 +5074,11 @@ Asset id: 4216627403
   > Dock to East Furnace Access
       Trivial
   > Event - Activate bomb slots
-      Power Beam and Morph Ball Bomb and Morph Ball and Spider Ball
+      All of the following:
+          Power Beam and Morph Ball Bomb and Morph Ball
+          Any of the following:
+              Spider Ball
+              Space Jump Boots and Standable Terrain (Beginner)
 
 > Dock to Elder Chamber; Heals? False
   * Ice Door to Elder Chamber/Dock to Hall of the Elders

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -2215,8 +2215,6 @@ Asset id: 3226044022
   * Normal Door to South Core Tunnel/Dock to Geothermal Core
   > Dock to North Core Tunnel
       Trivial
-  > Dock to Plasma Processing
-      Morph Ball Bomb and Grapple Beam and Space Jump Boots and Morph Ball and Boost Ball and Spider Ball
   > Event (Geothermal Core Opened)
       Morph Ball Bomb and Grapple Beam and Space Jump Boots and Morph Ball and Boost Ball and Spider Ball
 

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -7,6 +7,9 @@ Templates
 * Have all Beams:
       Power Beam and Ice Beam and Wave Beam and Plasma Beam
 
+* Heat-Resisting Suit:
+      Gravity Suit or Varia Suit or Phazon Suit
+
 ====================
 Dock Weaknesses
 
@@ -196,207 +199,421 @@ Transport to Magmoor Caverns West
 Asset id: 3222157185
 > Dock to Shoreline Entrance; Heals? False
   * Normal Door to Shoreline Entrance/Dock to Transport to Magmoor Caverns West
+  > Elevator - Transport to Phendrana Drifts North
+      Scan Visor
+
+> Elevator - Transport to Phendrana Drifts North; Heals? False
+  * Teleporter to Magmoor Caverns - Transport to Phendrana Drifts North
+  > Dock to Shoreline Entrance
+      Trivial
 
 ----------------
 Shoreline Entrance
 Asset id: 3289414871
 > Dock to Transport to Magmoor Caverns West; Heals? False
   * Normal Door to Transport to Magmoor Caverns West/Dock to Shoreline Entrance
+  > Dock to Phendrana Shorelines
+      Missile or Charge Beam
 
 > Dock to Phendrana Shorelines; Heals? False
   * Normal Door to Phendrana Shorelines/Dock to Shoreline Entrance
+  > Dock to Transport to Magmoor Caverns West
+      Missile or Charge Beam
 
 ----------------
 Phendrana Shorelines
 Asset id: 4146616697
 > Dock to Shoreline Entrance; Heals? False
   * Normal Door to Shoreline Entrance/Dock to Phendrana Shorelines
+  > Dock to Temple Entryway
+      Space Jump Boots
+  > Dock to Save Station B
+      Trivial
+  > Dock to Plaza Walkway
+      Space Jump Boots
+  > Dock to Ice Ruins Access
+      Missile and Scan Visor
 
 > Dock to Temple Entryway; Heals? False
   * Normal Door to Temple Entryway/Dock to Phendrana Shorelines
+  > Dock to Shoreline Entrance
+      Trivial
 
 > Dock to Save Station B; Heals? False
   * Normal Door to Save Station B/Dock to Phendrana Shorelines
+  > Dock to Shoreline Entrance
+      Trivial
 
 > Dock to Ruins Entryway; Heals? False
   * Normal Door to Ruins Entryway/Dock to Phendrana Shorelines
+  > Dock to Shoreline Entrance
+      Trivial
+  > Dock to Plaza Walkway
+      Trivial
 
 > Dock to Plaza Walkway; Heals? False
   * Normal Door to Plaza Walkway/Dock to Phendrana Shorelines
+  > Dock to Shoreline Entrance
+      Trivial
+  > Dock to Ruins Entryway
+      Trivial
 
 > Dock to Ice Ruins Access; Heals? False
   * Normal Door to Ice Ruins Access/Dock to Phendrana Shorelines
+  > Dock to Shoreline Entrance
+      Trivial
+  > Pickup (Missile Behind Ice)
+      Plasma Beam
+  > Pickup (Spider Track Missile)
+      Missile and Scan Visor and Super Missile and Morph Ball and Spider Ball
+
+> Pickup (Missile Behind Ice); Heals? False
+  * Pickup 35; Major Location? False
+  > Dock to Ice Ruins Access
+      Trivial
+
+> Pickup (Spider Track Missile); Heals? False
+  * Pickup 36; Major Location? False
+  > Dock to Ice Ruins Access
+      Trivial
 
 ----------------
 Temple Entryway
 Asset id: 2245653401
 > Dock to Chozo Ice Temple; Heals? False
   * Normal Door to Chozo Ice Temple/Dock to Temple Entryway
+  > Dock to Phendrana Shorelines
+      Plasma Beam or Missile or Charge Beam
 
 > Dock to Phendrana Shorelines; Heals? False
   * Normal Door to Phendrana Shorelines/Dock to Temple Entryway
+  > Dock to Chozo Ice Temple
+      Plasma Beam or Missile or Charge Beam
 
 ----------------
 Save Station B
 Asset id: 92367261
 > Dock to Phendrana Shorelines; Heals? False
   * Normal Door to Phendrana Shorelines/Dock to Save Station B
+  > Save Station
+      Trivial
+
+> Save Station; Heals? True
+  > Dock to Phendrana Shorelines
+      Trivial
 
 ----------------
 Ruins Entryway
 Asset id: 1007903802
 > Dock to Ice Ruins West; Heals? False
   * Normal Door to Ice Ruins West/Dock to Ruins Entryway
+  > Dock to Phendrana Shorelines
+      Trivial
 
 > Dock to Phendrana Shorelines; Heals? False
   * Normal Door to Phendrana Shorelines/Dock to Ruins Entryway
+  > Dock to Ice Ruins West
+      Trivial
 
 ----------------
 Plaza Walkway
 Asset id: 3356578450
 > Dock to Phendrana Shorelines; Heals? False
   * Normal Door to Phendrana Shorelines/Dock to Plaza Walkway
+  > Dock to Ice Ruins East
+      Trivial
 
 > Dock to Ice Ruins East; Heals? False
   * Normal Door to Ice Ruins East/Dock to Plaza Walkway
+  > Dock to Phendrana Shorelines
+      Trivial
 
 ----------------
 Ice Ruins Access
 Asset id: 1317347388
 > Dock to Ice Ruins East; Heals? False
   * Normal Door to Ice Ruins East/Dock to Ice Ruins Access
+  > Dock to Phendrana Shorelines
+      Plasma Beam or Missile or Charge Beam
 
 > Dock to Phendrana Shorelines; Heals? False
   * Normal Door to Phendrana Shorelines/Dock to Ice Ruins Access
+  > Dock to Ice Ruins East
+      Plasma Beam or Missile or Charge Beam
 
 ----------------
 Chozo Ice Temple
 Asset id: 1716909342
 > Dock to Temple Entryway; Heals? False
   * Normal Door to Temple Entryway/Dock to Chozo Ice Temple
+  > Pickup (Artifact of Sun)
+      Plasma Beam and Morph Ball Bomb and Space Jump Boots and Morph Ball
+  > Event (Chozo Ice Temple Bomb Slot)
+      Morph Ball Bomb and Space Jump Boots and Morph Ball
 
 > Dock to Chapel Tunnel; Heals? False
   * Normal Door to Chapel Tunnel/Dock to Chozo Ice Temple
+  > Dock to Temple Entryway
+      After Chozo Ice Temple Bomb Slot
+  > Pickup (Artifact of Sun)
+      Plasma Beam and Missile and Morph Ball Bomb and Morph Ball and After Chozo Ice Temple Bomb Slot
+
+> Pickup (Artifact of Sun); Heals? False
+  * Pickup 37; Major Location? True
+  > Dock to Temple Entryway
+      Morph Ball
+  > Dock to Chapel Tunnel
+      Morph Ball
+
+> Event (Chozo Ice Temple Bomb Slot); Heals? False
+  > Dock to Temple Entryway
+      Trivial
+  > Dock to Chapel Tunnel
+      Trivial
 
 ----------------
 Ice Ruins West
 Asset id: 3006924320
 > Dock to Ruins Entryway; Heals? False
   * Normal Door to Ruins Entryway/Dock to Ice Ruins West
+  > Dock to Courtyard Entryway
+      All of the following:
+          Space Jump Boots
+          Any of the following:
+              Missile
+              Power Beam and Charge Beam and Super Missile
+  > Dock to Canyon Entryway
+      Trivial
+  > Pickup (Power Bomb)
+      All of the following:
+          Plasma Beam and Space Jump Boots
+          Missile or Super Missile
 
 > Dock to Courtyard Entryway; Heals? False
-  * Normal Door to Courtyard Entryway/Dock to Ice Ruins West
+  * Wave Door to Courtyard Entryway/Dock to Ice Ruins West
+  > Dock to Ruins Entryway
+      Trivial
 
 > Dock to Canyon Entryway; Heals? False
-  * Normal Door to Canyon Entryway/Dock to Ice Ruins West
+  * Missile Blast Shield to Canyon Entryway/Dock to Ice Ruins West
+  > Dock to Ruins Entryway
+      Trivial
+
+> Pickup (Power Bomb); Heals? False
+  * Pickup 38; Major Location? False
+  > Dock to Ruins Entryway
+      Trivial
 
 ----------------
 Ice Ruins East
 Asset id: 3673997935
 > Dock to Ice Ruins Access; Heals? False
   * Normal Door to Ice Ruins Access/Dock to Ice Ruins East
+  > Dock to Plaza Walkway
+      Space Jump Boots
+  > Pickup (Spider Track Missile Expansion)
+      Morph Ball and Spider Ball
+  > Pickup (Missile Expansion Behind Ice)
+      Plasma Beam
 
 > Dock to Plaza Walkway; Heals? False
   * Normal Door to Plaza Walkway/Dock to Ice Ruins East
+  > Dock to Ice Ruins Access
+      Trivial
+
+> Pickup (Spider Track Missile Expansion); Heals? False
+  * Pickup 40; Major Location? False
+  > Dock to Ice Ruins Access
+      Trivial
+
+> Pickup (Missile Expansion Behind Ice); Heals? False
+  * Pickup 39; Major Location? False
+  > Dock to Ice Ruins Access
+      Trivial
 
 ----------------
 Chapel Tunnel
 Asset id: 4016524108
 > Dock to Chapel of the Elders; Heals? False
   * Normal Door to Chapel of the Elders/Dock to Chapel Tunnel
+  > Dock to Chozo Ice Temple
+      Morph Ball Bomb and Morph Ball
 
 > Dock to Chozo Ice Temple; Heals? False
   * Normal Door to Chozo Ice Temple/Dock to Chapel Tunnel
+  > Dock to Chapel of the Elders
+      Morph Ball Bomb and Morph Ball
 
 ----------------
 Courtyard Entryway
 Asset id: 3484986321
 > Dock to Ruined Courtyard; Heals? False
   * Normal Door to Ruined Courtyard/Dock to Courtyard Entryway
+  > Dock to Ice Ruins West
+      Trivial
 
 > Dock to Ice Ruins West; Heals? False
   * Normal Door to Ice Ruins West/Dock to Courtyard Entryway
+  > Dock to Ruined Courtyard
+      Trivial
 
 ----------------
 Canyon Entryway
 Asset id: 55410999
 > Dock to Phendrana Canyon; Heals? False
   * Normal Door to Phendrana Canyon/Dock to Canyon Entryway
+  > Dock to Ice Ruins West
+      Trivial
 
 > Dock to Ice Ruins West; Heals? False
-  * Normal Door to Ice Ruins West/Dock to Canyon Entryway
+  * Missile Blast Shield to Ice Ruins West/Dock to Canyon Entryway
+  > Dock to Phendrana Canyon
+      Trivial
 
 ----------------
 Chapel of the Elders
 Asset id: 1086671081
 > Dock to Chapel Tunnel; Heals? False
-  * Normal Door to Chapel Tunnel/Dock to Chapel of the Elders
+  * Wave Door to Chapel Tunnel/Dock to Chapel of the Elders
+  > Pickup (Wave Beam)
+      Any of the following:
+          Missile
+          All of the following:
+              Morph Ball
+              Morph Ball Bomb or Power Bomb
+
+> Pickup (Wave Beam); Heals? False
+  * Pickup 41; Major Location? True
+  > Dock to Chapel Tunnel
+      Space Jump Boots
 
 ----------------
 Ruined Courtyard
 Asset id: 421627757
 > Dock to Courtyard Entryway; Heals? False
   * Normal Door to Courtyard Entryway/Dock to Ruined Courtyard
+  > Dock to Save Station A
+      All of the following:
+          Missile and Space Jump Boots and Morph Ball
+          Any of the following:
+              Spider Ball
+              Morph Ball Bomb and Boost Ball
 
 > Dock to Save Station A; Heals? False
-  * Normal Door to Save Station A/Dock to Ruined Courtyard
+  * Missile Blast Shield to Save Station A/Dock to Ruined Courtyard
+  > Dock to Courtyard Entryway
+      Trivial
+  > Dock to Specimen Storage
+      Space Jump Boots
+  > Dock to Quarantine Access
+      All of the following:
+          Wave Beam and Super Missile and Space Jump Boots
+          Thermal Visor or Invisible Objects (Beginner)
+  > Pickup (Energy Tank)
+      Morph Ball Bomb and Space Jump Boots and Morph Ball
 
 > Dock to Specimen Storage; Heals? False
-  * Normal Door to Specimen Storage/Dock to Ruined Courtyard
+  * Wave Door to Specimen Storage/Dock to Ruined Courtyard
+  > Dock to Courtyard Entryway
+      Trivial
+  > Dock to Save Station A
+      Missile and Space Jump Boots
 
 > Dock to Quarantine Access; Heals? False
   * Normal Door to Quarantine Access/Dock to Ruined Courtyard
+  > Dock to Courtyard Entryway
+      Trivial
+  > Dock to Save Station A
+      Missile and Space Jump Boots
+
+> Pickup (Energy Tank); Heals? False
+  * Pickup 42; Major Location? False
+  > Dock to Courtyard Entryway
+      Morph Ball
 
 ----------------
 Phendrana Canyon
 Asset id: 2718594133
 > Dock to Canyon Entryway; Heals? False
   * Normal Door to Canyon Entryway/Dock to Phendrana Canyon
+  > Pickup (Boost Ball)
+      Space Jump Boots
+
+> Pickup (Boost Ball); Heals? False
+  * Pickup 43; Major Location? True
+  > Dock to Canyon Entryway
+      Boost Ball
 
 ----------------
 Save Station A
 Asset id: 1452580971
 > Dock to Ruined Courtyard; Heals? False
-  * Normal Door to Ruined Courtyard/Dock to Save Station A
+  * Missile Blast Shield to Ruined Courtyard/Dock to Save Station A
+  > Save Station
+      Trivial
+
+> Save Station; Heals? True
+  > Dock to Ruined Courtyard
+      Trivial
 
 ----------------
 Specimen Storage
 Asset id: 3544306395
 > Dock to Research Entrance; Heals? False
-  * Normal Door to Research Entrance/Dock to Specimen Storage
+  * Wave Door to Research Entrance/Dock to Specimen Storage
+  > Dock to Ruined Courtyard
+      Trivial
 
 > Dock to Ruined Courtyard; Heals? False
-  * Normal Door to Ruined Courtyard/Dock to Specimen Storage
+  * Wave Door to Ruined Courtyard/Dock to Specimen Storage
+  > Dock to Research Entrance
+      Trivial
 
 ----------------
 Quarantine Access
 Asset id: 3937607887
 > Dock to North Quarantine Tunnel; Heals? False
   * Normal Door to North Quarantine Tunnel/Dock to Quarantine Access
+  > Dock to Ruined Courtyard
+      Trivial
 
 > Dock to Ruined Courtyard; Heals? False
   * Normal Door to Ruined Courtyard/Dock to Quarantine Access
+  > Dock to North Quarantine Tunnel
+      Trivial
 
 ----------------
 Research Entrance
 Asset id: 3038760489
 > Dock to Specimen Storage; Heals? False
-  * Normal Door to Specimen Storage/Dock to Research Entrance
+  * Wave Door to Specimen Storage/Dock to Research Entrance
+  > Dock to Map Station
+      Trivial
 
 > Dock to Map Station; Heals? False
   * Normal Door to Map Station/Dock to Research Entrance
+  > Dock to Specimen Storage
+      Trivial
+  > Dock to Hydra Lab Entryway
+      Trivial
 
 > Dock to Hydra Lab Entryway; Heals? False
-  * Normal Door to Hydra Lab Entryway/Dock to Research Entrance
+  * Wave Door to Hydra Lab Entryway/Dock to Research Entrance
+  > Dock to Map Station
+      Trivial
 
 ----------------
 North Quarantine Tunnel
 Asset id: 98670126
 > Dock to Quarantine Cave; Heals? False
-  * Normal Door to Quarantine Cave/Dock to North Quarantine Tunnel
+  * Wave Door to Quarantine Cave/Dock to North Quarantine Tunnel
+  > Dock to Quarantine Access
+      Morph Ball
 
 > Dock to Quarantine Access; Heals? False
-  * Normal Door to Quarantine Access/Dock to North Quarantine Tunnel
+  * Wave Door to Quarantine Access/Dock to North Quarantine Tunnel
+  > Dock to Quarantine Cave
+      Morph Ball
 
 ----------------
 Map Station
@@ -408,310 +625,681 @@ Asset id: 2199198515
 Hydra Lab Entryway
 Asset id: 961011783
 > Dock to Research Entrance; Heals? False
-  * Normal Door to Research Entrance/Dock to Hydra Lab Entryway
+  * Wave Door to Research Entrance/Dock to Hydra Lab Entryway
+  > Dock to Research Lab Hydra
+      Trivial
 
 > Dock to Research Lab Hydra; Heals? False
-  * Normal Door to Research Lab Hydra/Dock to Hydra Lab Entryway
+  * Wave Door to Research Lab Hydra/Dock to Hydra Lab Entryway
+  > Dock to Research Entrance
+      Trivial
 
 ----------------
 Quarantine Cave
 Asset id: 1880625556
 > Dock to North Quarantine Tunnel; Heals? False
-  * Normal Door to North Quarantine Tunnel/Dock to Quarantine Cave
+  * Wave Door to North Quarantine Tunnel/Dock to Quarantine Cave
+  > Dock to South Quarantine Tunnel
+      Morph Ball and Spider Ball and After Thardus
+  > Event (Thardus)
+      Trivial
 
 > Dock to South Quarantine Tunnel; Heals? False
-  * Normal Door to South Quarantine Tunnel/Dock to Quarantine Cave
+  * Wave Door to South Quarantine Tunnel/Dock to Quarantine Cave
+  > Dock to North Quarantine Tunnel
+      Morph Ball and Spider Ball and After Thardus
+  > Dock to Quarantine Monitor
+      Grapple Beam and Morph Ball
+  > Event (Thardus)
+      Trivial
 
 > Dock to Quarantine Monitor; Heals? False
   * Normal Door to Quarantine Monitor/Dock to Quarantine Cave
+  > Dock to North Quarantine Tunnel
+      Morph Ball
+  > Dock to South Quarantine Tunnel
+      Morph Ball
+  > Event (Thardus)
+      Trivial
+
+> Event (Thardus); Heals? False
+  * Event Thardus
+  > Pickup (Spider Ball)
+      Any of the following:
+          Thermal Visor
+          Combat (Beginner) and Invisible Objects (Beginner)
+
+> Pickup (Spider Ball); Heals? False
+  * Pickup 44; Major Location? True
+  > Dock to North Quarantine Tunnel
+      Morph Ball and Spider Ball
+  > Dock to South Quarantine Tunnel
+      Morph Ball and Spider Ball
 
 ----------------
 Research Lab Hydra
 Asset id: 1139067941
 > Dock to Hydra Lab Entryway; Heals? False
-  * Normal Door to Hydra Lab Entryway/Dock to Research Lab Hydra
+  * Wave Door to Hydra Lab Entryway/Dock to Research Lab Hydra
+  > Dock to Observatory Access
+      Scan Visor and After Research Lab Hydra Barrier Lowered
+  > Event (Research Lab Hydra Barrier Lowered)
+      Scan Visor and Before Research Lab Hydra Barrier Lowered
 
 > Dock to Observatory Access; Heals? False
-  * Normal Door to Observatory Access/Dock to Research Lab Hydra
+  * Wave Door to Observatory Access/Dock to Research Lab Hydra
+  > Dock to Hydra Lab Entryway
+      After Research Lab Hydra Barrier Lowered
+  > Pickup (Missile)
+      Power Beam and Charge Beam and Super Missile
+
+> Event (Research Lab Hydra Barrier Lowered); Heals? False
+  * Event Research Lab Hydra Barrier Lowered
+  > Dock to Observatory Access
+      Trivial
+
+> Pickup (Missile); Heals? False
+  * Pickup 45; Major Location? False
+  > Dock to Observatory Access
+      Trivial
 
 ----------------
 South Quarantine Tunnel
 Asset id: 3538349
 > Dock to Quarantine Cave; Heals? False
-  * Normal Door to Quarantine Cave/Dock to South Quarantine Tunnel
+  * Wave Door to Quarantine Cave/Dock to South Quarantine Tunnel
+  > Dock to Transport to Magmoor Caverns South
+      Morph Ball
 
 > Dock to Transport to Magmoor Caverns South; Heals? False
-  * Normal Door to Transport to Magmoor Caverns South/Dock to South Quarantine Tunnel
+  * Wave Door to Transport to Magmoor Caverns South/Dock to South Quarantine Tunnel
+  > Dock to Quarantine Cave
+      Morph Ball
 
 ----------------
 Quarantine Monitor
 Asset id: 563191901
 > Dock to Quarantine Cave; Heals? False
   * Normal Door to Quarantine Cave/Dock to Quarantine Monitor
+  > Pickup (Missile)
+      Trivial
+
+> Pickup (Missile); Heals? False
+  * Pickup 46; Major Location? False
+  > Dock to Quarantine Cave
+      Trivial
 
 ----------------
 Observatory Access
 Asset id: 935047996
 > Dock to Observatory; Heals? False
-  * Normal Door to Observatory/Dock to Observatory Access
+  * Wave Door to Observatory/Dock to Observatory Access
+  > Dock to Research Lab Hydra
+      Trivial
 
 > Dock to Research Lab Hydra; Heals? False
-  * Normal Door to Research Lab Hydra/Dock to Observatory Access
+  * Wave Door to Research Lab Hydra/Dock to Observatory Access
+  > Dock to Observatory
+      Space Jump Boots
 
 ----------------
 Transport to Magmoor Caverns South
 Asset id: 3708487481
 > Dock to Transport Access; Heals? False
-  * Normal Door to Transport Access/Dock to Transport to Magmoor Caverns South
+  * Ice Door to Transport Access/Dock to Transport to Magmoor Caverns South
+  > Dock to South Quarantine Tunnel
+      Morph Ball
+  > Elevator - Transport to Phendrana Drifts South
+      Scan Visor
 
 > Dock to South Quarantine Tunnel; Heals? False
-  * Normal Door to South Quarantine Tunnel/Dock to Transport to Magmoor Caverns South
+  * Wave Door to South Quarantine Tunnel/Dock to Transport to Magmoor Caverns South
+  > Dock to Transport Access
+      Morph Ball and Spider Ball
+
+> Elevator - Transport to Phendrana Drifts South; Heals? False
+  * Teleporter to Magmoor Caverns - Transport to Phendrana Drifts South
+  > Dock to Transport Access
+      Trivial
 
 ----------------
 Observatory
 Asset id: 1068802894
 > Dock to Observatory Access; Heals? False
-  * Normal Door to Observatory Access/Dock to Observatory
+  * Wave Door to Observatory Access/Dock to Observatory
+  > Dock to Save Station D
+      Space Jump Boots and After Observatory Activated
+  > Event (Observatory Activated)
+      Scan Visor and Morph Ball Bomb and Space Jump Boots and Morph Ball and Boost Ball and Before Research Core Power Outage and Before Observatory Activated
 
 > Dock to West Tower Entrance; Heals? False
-  * Normal Door to West Tower Entrance/Dock to Observatory
+  * Wave Door to West Tower Entrance/Dock to Observatory
+  > Dock to Observatory Access
+      Trivial
+  > Dock to Save Station D
+      Space Jump Boots
+  > Pickup (Super Missile)
+      After Observatory Activated
 
 > Dock to Save Station D; Heals? False
-  * Normal Door to Save Station D/Dock to Observatory
+  * Missile Blast Shield to Save Station D/Dock to Observatory
+  > Dock to Observatory Access
+      Trivial
+  > Dock to West Tower Entrance
+      After Observatory Activated
+  > Pickup (Super Missile)
+      After Observatory Activated
+
+> Event (Observatory Activated); Heals? False
+  * Event Observatory Activated
+  > Dock to Observatory Access
+      Trivial
+  > Dock to Save Station D
+      Space Jump Boots
+
+> Pickup (Super Missile); Heals? False
+  * Pickup 47; Major Location? True
+  > Dock to Observatory Access
+      Trivial
+  > Dock to West Tower Entrance
+      After Observatory Activated
+  > Dock to Save Station D
+      After Observatory Activated
 
 ----------------
 Transport Access
 Asset id: 3600136536
 > Dock to Transport to Magmoor Caverns South; Heals? False
-  * Normal Door to Transport to Magmoor Caverns South/Dock to Transport Access
+  * Ice Door to Transport to Magmoor Caverns South/Dock to Transport Access
+  > Dock to Frozen Pike
+      Trivial
 
 > Dock to Frozen Pike; Heals? False
-  * Normal Door to Frozen Pike/Dock to Transport Access
+  * Wave Door to Frozen Pike/Dock to Transport Access
+  > Dock to Transport to Magmoor Caverns South
+      Trivial
+  > Pickup (Energy Tank)
+      Plasma Beam
+
+> Pickup (Energy Tank); Heals? False
+  * Pickup 48; Major Location? False
+  > Dock to Frozen Pike
+      Trivial
 
 ----------------
 West Tower Entrance
 Asset id: 508080527
 > Dock to West Tower ; Heals? False
-  * Normal Door to West Tower /Dock to West Tower Entrance
+  * Missile Blast Shield to West Tower /Dock to West Tower Entrance
+  > Dock to Observatory
+      Trivial
 
 > Dock to Observatory; Heals? False
-  * Normal Door to Observatory/Dock to West Tower Entrance
+  * Wave Door to Observatory/Dock to West Tower Entrance
+  > Dock to West Tower 
+      Trivial
 
 ----------------
 Save Station D
 Asset id: 1901867502
 > Dock to Observatory; Heals? False
   * Normal Door to Observatory/Dock to Save Station D
+  > Save Station
+      Trivial
+
+> Save Station; Heals? True
+  > Dock to Observatory
+      Trivial
 
 ----------------
 Frozen Pike
 Asset id: 3617515525
 > Dock to Pike Access; Heals? False
-  * Normal Door to Pike Access/Dock to Frozen Pike
+  * Wave Door to Pike Access/Dock to Frozen Pike
+  > Dock to Transport Access
+      Morph Ball Bomb and Space Jump Boots and Morph Ball
+  > Dock to Frost Cave Access
+      Trivial
 
 > Dock to Transport Access; Heals? False
-  * Normal Door to Transport Access/Dock to Frozen Pike
+  * Wave Door to Transport Access/Dock to Frozen Pike
+  > Dock to Pike Access
+      Trivial
 
 > Dock to Frost Cave Access; Heals? False
-  * Normal Door to Frost Cave Access/Dock to Frozen Pike
+  * Wave Door to Frost Cave Access/Dock to Frozen Pike
+  > Dock to Pike Access
+      Space Jump Boots
+  > Dock to Hunter Cave Access
+      Gravity Suit
 
 > Dock to Hunter Cave Access; Heals? False
-  * Normal Door to Hunter Cave Access/Dock to Frozen Pike
+  * Wave Door to Hunter Cave Access/Dock to Frozen Pike
+  > Dock to Frost Cave Access
+      Space Jump Boots
 
 ----------------
 West Tower 
 Asset id: 3617418143
 > Dock to West Tower Entrance; Heals? False
-  * Normal Door to West Tower Entrance/Dock to West Tower 
+  * Missile Blast Shield to West Tower Entrance/Dock to West Tower 
+  > Dock to Control Tower
+      Scan Visor
 
 > Dock to Control Tower; Heals? False
-  * Normal Door to Control Tower/Dock to West Tower 
+  * Wave Door to Control Tower/Dock to West Tower 
+  > Dock to West Tower Entrance
+      Trivial
 
 ----------------
 Pike Access
 Asset id: 1980658458
 > Dock to Frozen Pike; Heals? False
-  * Normal Door to Frozen Pike/Dock to Pike Access
+  * Wave Door to Frozen Pike/Dock to Pike Access
+  > Dock to Research Core
+      Trivial
 
 > Dock to Research Core; Heals? False
-  * Normal Door to Research Core/Dock to Pike Access
+  * Ice Door to Research Core/Dock to Pike Access
+  > Dock to Frozen Pike
+      Trivial
 
 ----------------
 Frost Cave Access
 Asset id: 969347001
 > Dock to Frozen Pike; Heals? False
-  * Normal Door to Frozen Pike/Dock to Frost Cave Access
+  * Wave Door to Frozen Pike/Dock to Frost Cave Access
+  > Dock to Frost Cave
+      Morph Ball
 
 > Dock to Frost Cave; Heals? False
-  * Normal Door to Frost Cave/Dock to Frost Cave Access
+  * Wave Door to Frost Cave/Dock to Frost Cave Access
+  > Dock to Frozen Pike
+      Morph Ball
 
 ----------------
 Hunter Cave Access
 Asset id: 552213808
 > Dock to Frozen Pike; Heals? False
-  * Normal Door to Frozen Pike/Dock to Hunter Cave Access
+  * Wave Door to Frozen Pike/Dock to Hunter Cave Access
+  > Dock to Hunter Cave
+      Trivial
 
 > Dock to Hunter Cave; Heals? False
-  * Normal Door to Hunter Cave/Dock to Hunter Cave Access
+  * Wave Door to Hunter Cave/Dock to Hunter Cave Access
+  > Dock to Frozen Pike
+      Trivial
 
 ----------------
 Control Tower
 Asset id: 3015914057
 > Dock to East Tower; Heals? False
-  * Normal Door to East Tower/Dock to Control Tower
+  * Wave Door to East Tower/Dock to Control Tower
+  > Dock to West Tower 
+      Trivial
+  > Pickup (Artifact of Elder)
+      All of the following:
+          Space Jump Boots and Morph Ball
+          Any of the following:
+              Missile
+              Power Beam and Charge Beam and Super Missile
 
 > Dock to West Tower ; Heals? False
-  * Normal Door to West Tower /Dock to Control Tower
+  * Wave Door to West Tower /Dock to Control Tower
+  > Dock to East Tower
+      Trivial
+
+> Pickup (Artifact of Elder); Heals? False
+  * Pickup 49; Major Location? True
+  > Dock to East Tower
+      Morph Ball Bomb or Morph Ball
 
 ----------------
 Research Core
 Asset id: 2761631044
 > Dock to Pike Access; Heals? False
-  * Normal Door to Pike Access/Dock to Research Core
+  * Ice Door to Pike Access/Dock to Research Core
+  > Dock to Research Core Access
+      Any of the following:
+          Before Research Core Power Outage
+          All of the following:
+              Wave Beam and After Research Core Power Outage
+              Thermal Visor or Invisible Objects (Beginner)
+  > Pickup (Thermal Visor)
+      Scan Visor
 
 > Dock to Research Core Access; Heals? False
-  * Normal Door to Research Core Access/Dock to Research Core
+  * Wave Door to Research Core Access/Dock to Research Core
+  > Dock to Pike Access
+      Trivial
+  > Pickup (Thermal Visor)
+      Scan Visor
+
+> Pickup (Thermal Visor); Heals? False
+  * Pickup 50; Major Location? True
+  > Event (Research Core Power Outage)
+      Trivial
+
+> Event (Research Core Power Outage); Heals? False
+  * Event Research Core Power Outage
+  > Dock to Pike Access
+      Trivial
+  > Dock to Research Core Access
+      Wave Beam and After Research Core Power Outage
 
 ----------------
 Frost Cave
 Asset id: 1282373491
 > Dock to Save Station C; Heals? False
-  * Normal Door to Save Station C/Dock to Frost Cave
+  * Wave Door to Save Station C/Dock to Frost Cave
+  > Dock to Frost Cave Access
+      Space Jump Boots
 
 > Dock to Frost Cave Access; Heals? False
-  * Normal Door to Frost Cave Access/Dock to Frost Cave
+  * Wave Door to Frost Cave Access/Dock to Frost Cave
+  > Dock to Save Station C
+      All of the following:
+          Space Jump Boots
+          Any of the following:
+              Missile
+              Power Beam and Charge Beam and Super Missile
+  > Dock to Upper Edge Tunnel
+      All of the following:
+          Space Jump Boots
+          Any of the following:
+              Missile or Grapple Beam
+              Power Beam and Charge Beam and Super Missile
+  > Pickup (Missile)
+      All of the following:
+          Grapple Beam
+          Any of the following:
+              Missile
+              Power Beam and Charge Beam and Super Missile
 
 > Dock to Upper Edge Tunnel; Heals? False
-  * Normal Door to Upper Edge Tunnel/Dock to Frost Cave
+  * Wave Door to Upper Edge Tunnel/Dock to Frost Cave
+  > Dock to Frost Cave Access
+      Space Jump Boots
+
+> Pickup (Missile); Heals? False
+  * Pickup 51; Major Location? False
+  > Dock to Save Station C
+      All of the following:
+          Space Jump Boots and Gravity Suit
+          Any of the following:
+              Missile
+              Power Beam and Charge Beam and Super Missile
+  > Dock to Frost Cave Access
+      Space Jump Boots and Gravity Suit
+  > Dock to Upper Edge Tunnel
+      All of the following:
+          Space Jump Boots and Gravity Suit
+          Any of the following:
+              Missile or Grapple Beam
+              Power Beam and Charge Beam and Super Missile
 
 ----------------
 Hunter Cave
 Asset id: 516396314
 > Dock to Hunter Cave Access; Heals? False
-  * Normal Door to Hunter Cave Access/Dock to Hunter Cave
+  * Wave Door to Hunter Cave Access/Dock to Hunter Cave
+  > Dock to Lower Edge Tunnel
+      Any of the following:
+          Space Jump Boots
+          All of the following:
+              Grapple Beam
+              Any of the following:
+                  Missile
+                  Power Beam and Charge Beam and Super Missile
+  > Dock to Chamber Access
+      Trivial
 
 > Dock to Lower Edge Tunnel; Heals? False
-  * Normal Door to Lower Edge Tunnel/Dock to Hunter Cave
+  * Wave Door to Lower Edge Tunnel/Dock to Hunter Cave
+  > Dock to Hunter Cave Access
+      All of the following:
+          Grapple Beam and Space Jump Boots
+          Any of the following:
+              Missile
+              Power Beam and Charge Beam and Super Missile
+  > Dock to Chamber Access
+      All of the following:
+          Grapple Beam and Space Jump Boots
+          Any of the following:
+              Missile
+              Power Beam and Charge Beam and Super Missile
+  > Dock to Lake Tunnel
+      Any of the following:
+          Missile
+          Space Jump Boots and Gravity Suit
+          Power Beam and Charge Beam and Super Missile
 
 > Dock to Chamber Access; Heals? False
-  * Normal Door to Chamber Access/Dock to Hunter Cave
+  * Wave Door to Chamber Access/Dock to Hunter Cave
+  > Dock to Hunter Cave Access
+      Trivial
+  > Dock to Lake Tunnel
+      Trivial
 
 > Dock to Lake Tunnel; Heals? False
-  * Normal Door to Lake Tunnel/Dock to Hunter Cave
+  * Wave Door to Lake Tunnel/Dock to Hunter Cave
+  > Dock to Lower Edge Tunnel
+      Space Jump Boots
 
 ----------------
 East Tower
 Asset id: 1359550769
 > Dock to Aether Lab Entryway; Heals? False
-  * Normal Door to Aether Lab Entryway/Dock to East Tower
+  * Wave Door to Aether Lab Entryway/Dock to East Tower
+  > Dock to Control Tower
+      Trivial
 
 > Dock to Control Tower; Heals? False
-  * Normal Door to Control Tower/Dock to East Tower
+  * Wave Door to Control Tower/Dock to East Tower
+  > Dock to Aether Lab Entryway
+      Scan Visor
 
 ----------------
 Research Core Access
 Asset id: 3639150045
 > Dock to Research Core; Heals? False
-  * Normal Door to Research Core/Dock to Research Core Access
+  * Wave Door to Research Core/Dock to Research Core Access
+  > Dock to Research Lab Aether
+      Space Jump Boots
 
 > Dock to Research Lab Aether; Heals? False
-  * Normal Door to Research Lab Aether/Dock to Research Core Access
+  * Wave Door to Research Lab Aether/Dock to Research Core Access
+  > Dock to Research Core
+      Trivial
 
 ----------------
 Save Station C
 Asset id: 3470637624
 > Dock to Frost Cave; Heals? False
-  * Normal Door to Frost Cave/Dock to Save Station C
+  * Wave Door to Frost Cave/Dock to Save Station C
+  > Save Station
+      Trivial
+
+> Save Station; Heals? True
+  > Dock to Frost Cave
+      Trivial
 
 ----------------
 Upper Edge Tunnel
 Asset id: 624850611
 > Dock to Phendrana's Edge; Heals? False
-  * Normal Door to Phendrana's Edge/Dock to Upper Edge Tunnel
+  * Wave Door to Phendrana's Edge/Dock to Upper Edge Tunnel
+  > Dock to Frost Cave
+      Morph Ball
 
 > Dock to Frost Cave; Heals? False
-  * Normal Door to Frost Cave/Dock to Upper Edge Tunnel
+  * Wave Door to Frost Cave/Dock to Upper Edge Tunnel
+  > Dock to Phendrana's Edge
+      Morph Ball
 
 ----------------
 Lower Edge Tunnel
 Asset id: 1400901764
 > Dock to Phendrana's Edge; Heals? False
-  * Normal Door to Phendrana's Edge/Dock to Lower Edge Tunnel
+  * Wave Door to Phendrana's Edge/Dock to Lower Edge Tunnel
+  > Dock to Hunter Cave
+      Morph Ball
 
 > Dock to Hunter Cave; Heals? False
-  * Normal Door to Hunter Cave/Dock to Lower Edge Tunnel
+  * Wave Door to Hunter Cave/Dock to Lower Edge Tunnel
+  > Dock to Phendrana's Edge
+      Morph Ball
 
 ----------------
 Chamber Access
 Asset id: 3396124754
 > Dock to Hunter Cave; Heals? False
-  * Normal Door to Hunter Cave/Dock to Chamber Access
+  * Wave Door to Hunter Cave/Dock to Chamber Access
+  > Dock to Gravity Chamber
+      Trivial
 
 > Dock to Gravity Chamber; Heals? False
-  * Normal Door to Gravity Chamber/Dock to Chamber Access
+  * Wave Door to Gravity Chamber/Dock to Chamber Access
+  > Dock to Hunter Cave
+      Trivial
 
 ----------------
 Lake Tunnel
 Asset id: 2312609958
 > Dock to Hunter Cave; Heals? False
-  * Normal Door to Hunter Cave/Dock to Lake Tunnel
+  * Wave Door to Hunter Cave/Dock to Lake Tunnel
+  > Dock to Gravity Chamber
+      Trivial
 
 > Dock to Gravity Chamber; Heals? False
-  * Normal Door to Gravity Chamber/Dock to Lake Tunnel
+  * Wave Door to Gravity Chamber/Dock to Lake Tunnel
+  > Dock to Hunter Cave
+      Trivial
 
 ----------------
 Aether Lab Entryway
 Asset id: 2564604705
 > Dock to East Tower; Heals? False
-  * Normal Door to East Tower/Dock to Aether Lab Entryway
+  * Wave Door to East Tower/Dock to Aether Lab Entryway
+  > Dock to Research Lab Aether
+      Trivial
 
 > Dock to Research Lab Aether; Heals? False
-  * Normal Door to Research Lab Aether/Dock to Aether Lab Entryway
+  * Wave Door to Research Lab Aether/Dock to Aether Lab Entryway
+  > Dock to East Tower
+      Trivial
 
 ----------------
 Research Lab Aether
 Asset id: 565493750
 > Dock to Aether Lab Entryway; Heals? False
-  * Normal Door to Aether Lab Entryway/Dock to Research Lab Aether
+  * Wave Door to Aether Lab Entryway/Dock to Research Lab Aether
+  > Dock to Research Core Access
+      Trivial
+  > Pickup (Missile)
+      Space Jump Boots and Morph Ball
 
 > Dock to Research Core Access; Heals? False
-  * Normal Door to Research Core Access/Dock to Research Lab Aether
+  * Wave Door to Research Core Access/Dock to Research Lab Aether
+  > Dock to Aether Lab Entryway
+      Scan Visor
+  > Pickup (Energy Tank)
+      Any of the following:
+          Missile
+          Power Bomb and Morph Ball
+          Power Beam and Charge Beam and Super Missile
+
+> Pickup (Energy Tank); Heals? False
+  * Pickup 52; Major Location? False
+  > Dock to Research Core Access
+      Trivial
+
+> Pickup (Missile); Heals? False
+  * Pickup 53; Major Location? False
+  > Dock to Research Core Access
+      Trivial
 
 ----------------
 Phendrana's Edge
 Asset id: 1423896872
 > Dock to Lower Edge Tunnel; Heals? False
-  * Normal Door to Lower Edge Tunnel/Dock to Phendrana's Edge
+  * Wave Door to Lower Edge Tunnel/Dock to Phendrana's Edge
+  > Dock to Upper Edge Tunnel
+      Space Jump Boots
 
 > Dock to Upper Edge Tunnel; Heals? False
-  * Normal Door to Upper Edge Tunnel/Dock to Phendrana's Edge
+  * Wave Door to Upper Edge Tunnel/Dock to Phendrana's Edge
+  > Dock to Lower Edge Tunnel
+      Trivial
+  > Dock to Storage Cave
+      Power Bomb and Grapple Beam and Space Jump Boots and Morph Ball
+  > Dock to Security Cave
+      Grapple Beam and Space Jump Boots and Morph Ball
 
 > Dock to Storage Cave; Heals? False
-  * Normal Door to Storage Cave/Dock to Phendrana's Edge
+  * Plasma Door to Storage Cave/Dock to Phendrana's Edge
+  > Dock to Upper Edge Tunnel
+      Power Bomb and Morph Ball
 
 > Dock to Security Cave; Heals? False
   * Normal Door to Security Cave/Dock to Phendrana's Edge
+  > Dock to Lower Edge Tunnel
+      Morph Ball
+  > Dock to Upper Edge Tunnel
+      Morph Ball
+  > Dock to Storage Cave
+      Power Bomb and Morph Ball
 
 ----------------
 Gravity Chamber
 Asset id: 1226265714
 > Dock to Lake Tunnel; Heals? False
-  * Normal Door to Lake Tunnel/Dock to Gravity Chamber
+  * Wave Door to Lake Tunnel/Dock to Gravity Chamber
+  > Pickup (Gravity Suit)
+      Space Jump Boots
 
 > Dock to Chamber Access; Heals? False
-  * Normal Door to Chamber Access/Dock to Gravity Chamber
+  * Wave Door to Chamber Access/Dock to Gravity Chamber
+  > Pickup (Gravity Suit)
+      Space Jump Boots
+  > Pickup (Missile)
+      Plasma Beam and Grapple Beam
+
+> Pickup (Gravity Suit); Heals? False
+  * Pickup 54; Major Location? True
+  > Dock to Chamber Access
+      Space Jump Boots and Gravity Suit
+
+> Pickup (Missile); Heals? False
+  * Pickup 55; Major Location? False
+  > Dock to Chamber Access
+      Trivial
 
 ----------------
 Storage Cave
 Asset id: 4157096768
 > Dock to Phendrana's Edge; Heals? False
-  * Normal Door to Phendrana's Edge/Dock to Storage Cave
+  * Plasma Door to Phendrana's Edge/Dock to Storage Cave
+  > Pickup (Artifact of Spirit)
+      Trivial
+
+> Pickup (Artifact of Spirit); Heals? False
+  * Pickup 56; Major Location? True
+  > Dock to Phendrana's Edge
+      Trivial
 
 ----------------
 Security Cave
 Asset id: 1016369381
 > Dock to Phendrana's Edge; Heals? False
   * Normal Door to Phendrana's Edge/Dock to Security Cave
+  > Pickup (Power Bomb)
+      Trivial
+
+> Pickup (Power Bomb); Heals? False
+  * Pickup 57; Major Location? False
+  > Dock to Phendrana's Edge
+      Trivial
 
 ====================
 Space Pirate Frigate
@@ -720,6 +1308,17 @@ Exterior Docking Hangar
 Asset id: 3508802073
 > Dock to Air Lock; Heals? False
   * Normal Door to Air Lock/Dock to Exterior Docking Hangar
+  > Ship Save
+      Before Parasite Queen Defeated
+  > Teleport to Landing Site
+      After Parasite Queen Defeated
+
+> Ship Save; Heals? True
+  > Dock to Air Lock
+      Scan Visor
+
+> Teleport to Landing Site; Heals? False
+  * Teleporter to Tallon Overworld - Landing Site
 
 ----------------
 Air Lock
@@ -729,15 +1328,21 @@ Asset id: 123995650
 
 > Dock to Exterior Docking Hangar; Heals? False
   * Normal Door to Exterior Docking Hangar/Dock to Air Lock
+  > Dock to Deck Alpha Access Hall
+      Scan Visor
 
 > Dock to Deck Alpha Mech Shaft; Heals? False
   * Normal Door to Deck Alpha Mech Shaft/Dock to Air Lock
+  > Dock to Exterior Docking Hangar
+      After Parasite Queen Defeated
 
 ----------------
 Deck Alpha Access Hall
 Asset id: 1649363258
 > Dock to Air Lock; Heals? False
   * Normal Door to Air Lock/Dock to Deck Alpha Access Hall
+  > Dock to Emergency Evacuation Area
+      Trivial
 
 > Dock to Emergency Evacuation Area; Heals? False
   * Normal Door to Emergency Evacuation Area/Dock to Deck Alpha Access Hall
@@ -747,6 +1352,8 @@ Deck Alpha Mech Shaft
 Asset id: 3365346969
 > Dock to Connection Elevator to Deck Alpha; Heals? False
   * Normal Door to Connection Elevator to Deck Alpha/Dock to Deck Alpha Mech Shaft
+  > Dock to Air Lock
+      Trivial
 
 > Dock to Air Lock; Heals? False
   * Normal Door to Air Lock/Dock to Deck Alpha Mech Shaft
@@ -759,21 +1366,33 @@ Asset id: 551846422
 
 > Dock to Deck Alpha Access Hall; Heals? False
   * Normal Door to Deck Alpha Access Hall/Dock to Emergency Evacuation Area
+  > Dock to Deck Alpha Umbilical Hall
+      Trivial
 
 ----------------
 Connection Elevator to Deck Alpha
 Asset id: 2921253053
 > Dock to Biotech Research Area 2; Heals? False
   * Normal Door to Biotech Research Area 2/Dock to Connection Elevator to Deck Alpha
+  > Event (Item Loss) UNIMPLEMENTED
+      Scan Visor
 
 > Dock to Deck Alpha Mech Shaft; Heals? False
   * Normal Door to Deck Alpha Mech Shaft/Dock to Connection Elevator to Deck Alpha
+
+> Event (Item Loss) UNIMPLEMENTED; Heals? False
+  > Dock to Deck Alpha Mech Shaft
+      Trivial
 
 ----------------
 Deck Alpha Umbilical Hall
 Asset id: 3995189286
 > Dock to Emergency Evacuation Area; Heals? False
   * Normal Door to Emergency Evacuation Area/Dock to Deck Alpha Umbilical Hall
+  > Dock to Map Facility
+      All of the following:
+          Charge Beam
+          Power Beam or Ice Beam
 
 > Dock to Map Facility; Heals? False
   * Normal Door to Map Facility/Dock to Deck Alpha Umbilical Hall
@@ -783,6 +1402,8 @@ Biotech Research Area 2
 Asset id: 3319675910
 > Dock to Main Ventilation Shaft Section F; Heals? False
   * Normal Door to Main Ventilation Shaft Section F/Dock to Biotech Research Area 2
+  > Dock to Connection Elevator to Deck Alpha
+      Grapple Beam or Space Jump Boots
 
 > Dock to Connection Elevator to Deck Alpha; Heals? False
   * Normal Door to Connection Elevator to Deck Alpha/Dock to Biotech Research Area 2
@@ -792,6 +1413,8 @@ Map Facility
 Asset id: 3454403824
 > Dock to Deck Alpha Umbilical Hall; Heals? False
   * Normal Door to Deck Alpha Umbilical Hall/Dock to Map Facility
+  > Dock to Connection Elevator to Deck Beta
+      Trivial
 
 > Dock to Connection Elevator to Deck Beta; Heals? False
   * Normal Door to Connection Elevator to Deck Beta/Dock to Map Facility
@@ -804,12 +1427,16 @@ Asset id: 274035036
 
 > Dock to Main Ventilation Shaft Section E; Heals? False
   * Normal Door to Main Ventilation Shaft Section E/Dock to Main Ventilation Shaft Section F
+  > Dock to Biotech Research Area 2
+      Trivial
 
 ----------------
 Connection Elevator to Deck Beta
 Asset id: 834947875
 > Dock to Map Facility; Heals? False
   * Normal Door to Map Facility/Dock to Connection Elevator to Deck Beta
+  > Dock to Deck Beta Conduit Hall
+      Scan Visor
 
 > Dock to Deck Beta Conduit Hall; Heals? False
   * Normal Door to Deck Beta Conduit Hall/Dock to Connection Elevator to Deck Beta
@@ -822,6 +1449,8 @@ Asset id: 690871324
 
 > Dock to Main Ventilation Shaft Section D; Heals? False
   * Normal Door to Main Ventilation Shaft Section D/Dock to Main Ventilation Shaft Section E
+  > Dock to Main Ventilation Shaft Section F
+      Trivial
 
 ----------------
 Deck Beta Conduit Hall
@@ -831,12 +1460,16 @@ Asset id: 2827042742
 
 > Dock to Connection Elevator to Deck Beta; Heals? False
   * Normal Door to Connection Elevator to Deck Beta/Dock to Deck Beta Conduit Hall
+  > Dock to Biotech Research Area 1
+      Morph Ball
 
 ----------------
 Main Ventilation Shaft Section D
 Asset id: 1040562396
 > Dock to Main Ventilation Shaft Section C; Heals? False
   * Normal Door to Main Ventilation Shaft Section C/Dock to Main Ventilation Shaft Section D
+  > Dock to Main Ventilation Shaft Section E
+      Trivial
 
 > Dock to Main Ventilation Shaft Section E; Heals? False
   * Normal Door to Main Ventilation Shaft Section E/Dock to Main Ventilation Shaft Section D
@@ -849,9 +1482,13 @@ Asset id: 2237107796
 
 > Dock to Deck Beta Conduit Hall; Heals? False
   * Normal Door to Deck Beta Conduit Hall/Dock to Biotech Research Area 1
+  > Dock to Deck Beta Security Hall
+      Before Parasite Queen Defeated
 
 > Dock to Connection Elevator to Deck Beta; Heals? False
-  * Normal Door to Connection Elevator to Deck Beta/Dock to Biotech Research Area 1
+  * Normal Door to Connection Elevator to Deck Beta (2)/Dock to Biotech Research Area 1
+  > Dock to Subventilation Shaft Section A
+      After Parasite Queen Defeated
 
 > Dock to Subventilation Shaft Section A; Heals? False
   * Normal Door to Subventilation Shaft Section A/Dock to Biotech Research Area 1
@@ -864,6 +1501,8 @@ Asset id: 1541179036
 
 > Dock to Main Ventilation Shaft Section B; Heals? False
   * Normal Door to Main Ventilation Shaft Section B/Dock to Main Ventilation Shaft Section C
+  > Dock to Main Ventilation Shaft Section D
+      Trivial
 
 ----------------
 Deck Beta Security Hall
@@ -873,21 +1512,27 @@ Asset id: 1237686565
 
 > Dock to Biotech Research Area 1; Heals? False
   * Normal Door to Biotech Research Area 1/Dock to Deck Beta Security Hall
+  > Dock to Biohazard Containment
+      Trivial
 
 ----------------
-Connection Elevator to Deck Beta
+Connection Elevator to Deck Beta (2)
 Asset id: 1859330843
 > Dock to Biotech Research Area 1; Heals? False
   * Normal Door to Biotech Research Area 1/Dock to Connection Elevator to Deck Beta
 
 > Dock to Deck Gamma Monitor Hall; Heals? False
   * Normal Door to Deck Gamma Monitor Hall/Dock to Connection Elevator to Deck Beta
+  > Dock to Biotech Research Area 1
+      Scan Visor
 
 ----------------
 Subventilation Shaft Section A
 Asset id: 154468580
 > Dock to Biotech Research Area 1; Heals? False
   * Normal Door to Biotech Research Area 1/Dock to Subventilation Shaft Section A
+  > Dock to Subventilation Shaft Section B
+      Trivial
 
 > Dock to Subventilation Shaft Section B; Heals? False
   * Normal Door to Subventilation Shaft Section B/Dock to Subventilation Shaft Section A
@@ -897,6 +1542,8 @@ Main Ventilation Shaft Section B
 Asset id: 1291117148
 > Dock to Main Ventilation Shaft Section A; Heals? False
   * Normal Door to Main Ventilation Shaft Section A/Dock to Main Ventilation Shaft Section B
+  > Dock to Main Ventilation Shaft Section C
+      Trivial
 
 > Dock to Main Ventilation Shaft Section C; Heals? False
   * Normal Door to Main Ventilation Shaft Section C/Dock to Main Ventilation Shaft Section B
@@ -909,15 +1556,19 @@ Asset id: 3513460432
 
 > Dock to Deck Beta Security Hall; Heals? False
   * Normal Door to Deck Beta Security Hall/Dock to Biohazard Containment
+  > Dock to Deck Beta Transit Hall
+      Scan Visor
 
 ----------------
 Deck Gamma Monitor Hall
 Asset id: 3865556485
 > Dock to Reactor Core; Heals? False
   * Normal Door to Reactor Core/Dock to Deck Gamma Monitor Hall
+  > Dock to Connection Elevator to Deck Beta
+      Trivial
 
 > Dock to Connection Elevator to Deck Beta; Heals? False
-  * Normal Door to Connection Elevator to Deck Beta/Dock to Deck Gamma Monitor Hall
+  * Normal Door to Connection Elevator to Deck Beta (2)/Dock to Deck Gamma Monitor Hall
 
 ----------------
 Subventilation Shaft Section B
@@ -927,12 +1578,16 @@ Asset id: 3233526410
 
 > Dock to Subventilation Shaft Section A; Heals? False
   * Normal Door to Subventilation Shaft Section A/Dock to Subventilation Shaft Section B
+  > Dock to Cargo Freight Lift to Deck Gamma
+      Trivial
 
 ----------------
 Main Ventilation Shaft Section A
 Asset id: 1972129564
 > Dock to Cargo Freight Lift to Deck Gamma; Heals? False
   * Normal Door to Cargo Freight Lift to Deck Gamma/Dock to Main Ventilation Shaft Section A
+  > Dock to Main Ventilation Shaft Section B
+      Trivial
 
 > Dock to Main Ventilation Shaft Section B; Heals? False
   * Normal Door to Main Ventilation Shaft Section B/Dock to Main Ventilation Shaft Section A
@@ -945,24 +1600,37 @@ Asset id: 748855907
 
 > Dock to Biohazard Containment; Heals? False
   * Normal Door to Biohazard Containment/Dock to Deck Beta Transit Hall
+  > Dock to Cargo Freight Lift to Deck Gamma
+      Trivial
 
 ----------------
 Reactor Core
 Asset id: 2269457857
 > Dock to Reactor Core Entrance; Heals? False
   * Normal Door to Reactor Core Entrance/Dock to Reactor Core
+  > Event (Parasite Queen Defeated)
+      Trivial
 
 > Dock to Deck Gamma Monitor Hall; Heals? False
   * Normal Door to Deck Gamma Monitor Hall/Dock to Reactor Core
+
+> Event (Parasite Queen Defeated); Heals? False
+  * Event Parasite Queen Defeated
+  > Dock to Deck Gamma Monitor Hall
+      Trivial
 
 ----------------
 Cargo Freight Lift to Deck Gamma
 Asset id: 1878064482
 > Dock to Deck Beta Transit Hall; Heals? False
   * Normal Door to Deck Beta Transit Hall/Dock to Cargo Freight Lift to Deck Gamma
+  > Dock to Reactor Core Entrance
+      Scan Visor and Morph Ball
 
 > Dock to Subventilation Shaft Section B; Heals? False
   * Normal Door to Subventilation Shaft Section B/Dock to Cargo Freight Lift to Deck Gamma
+  > Dock to Main Ventilation Shaft Section A
+      Trivial
 
 > Dock to Main Ventilation Shaft Section A; Heals? False
   * Normal Door to Main Ventilation Shaft Section A/Dock to Cargo Freight Lift to Deck Gamma
@@ -975,9 +1643,17 @@ Reactor Core Entrance
 Asset id: 1050775790
 > Dock to Cargo Freight Lift to Deck Gamma; Heals? False
   * Normal Door to Cargo Freight Lift to Deck Gamma/Dock to Reactor Core Entrance
+  > Dock to Reactor Core
+      Scan Visor and Morph Ball
+  > Save Station
+      Trivial
 
 > Dock to Reactor Core; Heals? False
   * Normal Door to Reactor Core/Dock to Reactor Core Entrance
+
+> Save Station; Heals? True
+  > Dock to Cargo Freight Lift to Deck Gamma
+      Trivial
 
 ====================
 Magmoor Caverns
@@ -999,141 +1675,497 @@ Burning Trail
 Asset id: 1833127758
 > Dock to Lake Tunnel; Heals? False
   * Normal Door to Lake Tunnel/Dock to Burning Trail
+  > Dock to Save Station Magmoor A
+      Trivial
 
 > Dock to Transport to Chozo Ruins North; Heals? False
   * Normal Door to Transport to Chozo Ruins North/Dock to Burning Trail
+  > Dock to Save Station Magmoor A
+      Trivial
 
 > Dock to Save Station Magmoor A; Heals? False
-  * Normal Door to Save Station Magmoor A/Dock to Burning Trail
+  * Missile Blast Shield to Save Station Magmoor A/Dock to Burning Trail
+  > Dock to Lake Tunnel
+      Trivial
+  > Dock to Transport to Chozo Ruins North
+      Trivial
 
 ----------------
 Lake Tunnel
 Asset id: 2037927229
 > Dock to Lava Lake; Heals? False
   * Normal Door to Lava Lake/Dock to Lake Tunnel
+  > Dock to Burning Trail
+      Any of the following:
+          Heated Rooms Damage ≥ 100
+          Space Jump Boots and Heated Rooms Damage ≥ 91
 
 > Dock to Burning Trail; Heals? False
   * Normal Door to Burning Trail/Dock to Lake Tunnel
+  > Dock to Lava Lake
+      Any of the following:
+          Heated Rooms Damage ≥ 87
+          Space Jump Boots and Heated Rooms Damage ≥ 78
 
 ----------------
 Save Station Magmoor A
 Asset id: 162783260
 > Dock to Burning Trail; Heals? False
-  * Normal Door to Burning Trail/Dock to Save Station Magmoor A
+  * Missile Blast Shield to Burning Trail/Dock to Save Station Magmoor A
+  > Save Station
+      Trivial
+
+> Save Station; Heals? True
+  > Dock to Burning Trail
+      Trivial
 
 ----------------
 Lava Lake
 Asset id: 2758909034
 > Dock to Lake Tunnel; Heals? False
   * Normal Door to Lake Tunnel/Dock to Lava Lake
+  > Dock to Pit Tunnel
+      All of the following:
+          Morph Ball
+          Any of the following:
+              All of the following:
+                  Morph Ball Bomb
+                  Any of the following:
+                      Heated Rooms Damage ≥ 514
+                      Space Jump Boots and Heated Rooms Damage ≥ 458
+              All of the following:
+                  Power Bomb ≥ 2
+                  Any of the following:
+                      Heated Rooms Damage ≥ 586
+                      Space Jump Boots and Heated Rooms Damage ≥ 539
+  > Pickup (Artifact of Nature)
+      Any of the following:
+          All of the following:
+              Grapple Beam and Heat-Resisting Suit
+              Missile or Shoot Super Missile
+          Missile and Space Jump Boots and Heated Rooms Damage ≥ 161
+          Space Jump Boots and Heated Rooms Damage ≥ 145 and Shoot Super Missile
 
 > Dock to Pit Tunnel; Heals? False
   * Normal Door to Pit Tunnel/Dock to Lava Lake
+  > Dock to Lake Tunnel
+      All of the following:
+          Morph Ball
+          Any of the following:
+              All of the following:
+                  Morph Ball Bomb
+                  Any of the following:
+                      Heated Rooms Damage ≥ 507
+                      Space Jump Boots and Heated Rooms Damage ≥ 458
+              All of the following:
+                  Power Bomb ≥ 2
+                  Any of the following:
+                      Heated Rooms Damage ≥ 565
+                      Space Jump Boots and Heated Rooms Damage ≥ 548
+  > Pickup (Artifact of Nature)
+      All of the following:
+          Space Jump Boots and Morph Ball
+          Any of the following:
+              Missile and Morph Ball Bomb and Heated Rooms Damage ≥ 404
+              Morph Ball Bomb and Heated Rooms Damage ≥ 430 and Shoot Super Missile
+              Missile and Power Bomb ≥ 2 and Heated Rooms Damage ≥ 479
+              Power Bomb ≥ 2 and Heated Rooms Damage ≥ 494 and Shoot Super Missile
+
+> Pickup (Artifact of Nature); Heals? False
+  * Pickup 90; Major Location? True
+  > Dock to Lake Tunnel
+      Any of the following:
+          Heated Rooms Damage ≥ 165
+          Space Jump Boots and Heated Rooms Damage ≥ 156
+  > Dock to Pit Tunnel
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Morph Ball Bomb and Heated Rooms Damage ≥ 389
+              Power Bomb ≥ 2 and Heated Rooms Damage ≥ 470
 
 ----------------
 Pit Tunnel
 Asset id: 3660499860
 > Dock to Triclops Pit; Heals? False
   * Normal Door to Triclops Pit/Dock to Pit Tunnel
+  > Dock to Lava Lake
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Heated Rooms Damage ≥ 95
+              Boost Ball and Heated Rooms Damage ≥ 91
 
 > Dock to Lava Lake; Heals? False
   * Normal Door to Lava Lake/Dock to Pit Tunnel
+  > Dock to Triclops Pit
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Heated Rooms Damage ≥ 86
+              Boost Ball and Heated Rooms Damage ≥ 72
 
 ----------------
 Triclops Pit
 Asset id: 3134844351
 > Dock to Monitor Tunnel; Heals? False
   * Normal Door to Monitor Tunnel/Dock to Triclops Pit
+  > Dock to Storage Cavern
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Heated Rooms Damage ≥ 275
+              Boost Ball and Heated Rooms Damage ≥ 222
+  > Dock to Pit Tunnel
+      Any of the following:
+          Heated Rooms Damage ≥ 163
+          Space Jump Boots and Heated Rooms Damage ≥ 143
+  > Pickup (Missile Expansion)
+      All of the following:
+          Space Jump Boots and Heated Rooms Damage ≥ 201
+          Missile or Shoot Super Missile
+          X-Ray Visor or Invisible Objects (Intermediate)
 
 > Dock to Storage Cavern; Heals? False
   * Normal Door to Storage Cavern/Dock to Triclops Pit
+  > Dock to Monitor Tunnel
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Heated Rooms Damage ≥ 299
+              Boost Ball and Heated Rooms Damage ≥ 286
+              Space Jump Boots and Heated Rooms Damage ≥ 263
+              Space Jump Boots and Boost Ball and Heated Rooms Damage ≥ 257
+  > Dock to Pit Tunnel
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Heated Rooms Damage ≥ 267
+              Boost Ball and Heated Rooms Damage ≥ 239
+              Space Jump Boots and Heated Rooms Damage ≥ 242
+              Space Jump Boots and Boost Ball and Heated Rooms Damage ≥ 234
 
 > Dock to Pit Tunnel; Heals? False
   * Normal Door to Pit Tunnel/Dock to Triclops Pit
+  > Dock to Monitor Tunnel
+      Any of the following:
+          Heated Rooms Damage ≥ 170
+          All of the following:
+              Morph Ball
+              Any of the following:
+                  Heated Rooms Damage ≥ 155
+                  Boost Ball and Heated Rooms Damage ≥ 152
+  > Dock to Storage Cavern
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Heated Rooms Damage ≥ 252
+              Boost Ball and Heated Rooms Damage ≥ 211
+  > Pickup (Missile Expansion)
+      All of the following:
+          Space Jump Boots and Heated Rooms Damage ≥ 157
+          X-Ray Visor or Invisible Objects (Intermediate)
+          Missile or Shoot Super Missile
+
+> Pickup (Missile Expansion); Heals? False
+  * Pickup 91; Major Location? False
+  > Dock to Monitor Tunnel
+      Any of the following:
+          Heated Rooms Damage ≥ 176
+          Space Jump Boots and Heated Rooms Damage ≥ 114
+  > Dock to Storage Cavern
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Heated Rooms Damage ≥ 216
+              Boost Ball and Heated Rooms Damage ≥ 1188
+              No Space Jump Boots and Heated Rooms Damage ≥ 207
+              Space Jump Boots and Boost Ball and Heated Rooms Damage ≥ 177
+  > Dock to Pit Tunnel
+      Any of the following:
+          Heated Rooms Damage ≥ 131
+          Space Jump Boots and Heated Rooms Damage ≥ 120
 
 ----------------
 Monitor Tunnel
 Asset id: 231492556
 > Dock to Monitor Station; Heals? False
   * Normal Door to Monitor Station/Dock to Monitor Tunnel
+  > Dock to Triclops Pit
+      Heated Rooms Damage ≥ 113
 
 > Dock to Triclops Pit; Heals? False
   * Normal Door to Triclops Pit/Dock to Monitor Tunnel
+  > Dock to Monitor Station
+      Heated Rooms Damage ≥ 110
 
 ----------------
 Storage Cavern
 Asset id: 2918155326
 > Dock to Triclops Pit; Heals? False
   * Normal Door to Triclops Pit/Dock to Storage Cavern
+  > Pickup (Missile)
+      Trivial
+
+> Pickup (Missile); Heals? False
+  * Pickup 92; Major Location? False
+  > Dock to Triclops Pit
+      Trivial
 
 ----------------
 Monitor Station
 Asset id: 207070785
 > Dock to Monitor Tunnel; Heals? False
   * Normal Door to Monitor Tunnel/Dock to Monitor Station
+  > Dock to Transport Tunnel A
+      Any of the following:
+          Heated Rooms Damage ≥ 582
+          All of the following:
+              Space Jump Boots
+              Any of the following:
+                  Heated Rooms Damage ≥ 480
+                  Heated Rooms Damage ≥ 357 and Shoot Super Missile
+                  Ice Beam and Heated Rooms Damage ≥ 345
+                  Plasma Beam and Charge Beam and Heated Rooms Damage ≥ 386
+                  Missile ≥ 15 and Heated Rooms Damage ≥ 388 and Shoot Super Missile
+          Missile ≥ 8 and Heated Rooms Damage ≥ 402
+          Ice Beam and Heated Rooms Damage ≥ 412
+          Plasma Beam and Charge Beam and Heated Rooms Damage ≥ 386
+          Missile ≥ 15 and Heated Rooms Damage ≥ 380 and Shoot Super Missile
+  > Dock to Warrior Shrine
+      All of the following:
+          Space Jump Boots and Morph Ball and Boost Ball
+          Any of the following:
+              Heated Rooms Damage ≥ 670
+              Missile ≥ 8 and Heated Rooms Damage ≥ 536
+              Ice Beam and Heated Rooms Damage ≥ 496
+              Plasma Beam and Charge Beam and Heated Rooms Damage ≥ 569
+  > Dock to Shore Tunnel
+      Heated Rooms Damage ≥ 100
 
 > Dock to Transport Tunnel A; Heals? False
   * Normal Door to Transport Tunnel A/Dock to Monitor Station
+  > Dock to Monitor Tunnel
+      Any of the following:
+          Heated Rooms Damage ≥ 142
+          Space Jump Boots and Heated Rooms Damage ≥ 119
+  > Dock to Warrior Shrine
+      Space Jump Boots and Morph Ball and Boost Ball and Heated Rooms Damage ≥ 233
+  > Dock to Shore Tunnel
+      Any of the following:
+          Heated Rooms Damage ≥ 204
+          Space Jump Boots and Heated Rooms Damage ≥ 182
 
 > Dock to Warrior Shrine; Heals? False
   * Normal Door to Warrior Shrine/Dock to Monitor Station
+  > Dock to Monitor Tunnel
+      Any of the following:
+          Heated Rooms Damage ≥ 244
+          Missile ≥ 2 and Heated Rooms Damage ≥ 183
+          Plasma Beam and Charge Beam and Heated Rooms Damage ≥ 203
+          Ice Beam and Heated Rooms Damage ≥ 247
+          Space Jump Boots and Heated Rooms Damage ≥ 109
+  > Dock to Transport Tunnel A
+      Any of the following:
+          Heated Rooms Damage ≥ 139
+          Space Jump Boots and Heated Rooms Damage ≥ 96
+  > Dock to Shore Tunnel
+      Heated Rooms Damage ≥ 79
 
 > Dock to Shore Tunnel; Heals? False
   * Normal Door to Shore Tunnel/Dock to Monitor Station
+  > Dock to Monitor Tunnel
+      Heated Rooms Damage ≥ 90
+  > Dock to Transport Tunnel A
+      Any of the following:
+          Heated Rooms Damage ≥ 496
+          Missile ≥ 8 and Space Jump Boots and Heated Rooms Damage ≥ 254
+          Ice Beam and Space Jump Boots and Heated Rooms Damage ≥ 283
+          Plasma Beam and Charge Beam and Space Jump Boots and Heated Rooms Damage ≥ 293
+          Missile ≥ 10 and Space Jump Boots and Heated Rooms Damage ≥ 277 and Shoot Super Missile
+          Space Jump Boots and Heated Rooms Damage ≥ 330
+          Missile ≥ 8 and Heated Rooms Damage ≥ 395
+          Ice Beam and Heated Rooms Damage ≥ 350
+          Plasma Beam and Charge Beam and Heated Rooms Damage ≥ 383
+          Missile ≥ 10 and Heated Rooms Damage ≥ 335 and Shoot Super Missile
+  > Dock to Warrior Shrine
+      All of the following:
+          Space Jump Boots and Morph Ball and Boost Ball
+          Any of the following:
+              Heated Rooms Damage ≥ 555
+              Missile ≥ 6 and Heated Rooms Damage ≥ 475
+              Ice Beam and Heated Rooms Damage ≥ 451
+              Missile ≥ 10 and Heated Rooms Damage ≥ 469 and Shoot Super Missile
 
 ----------------
 Transport Tunnel A
 Asset id: 1207091335
 > Dock to Transport to Phendrana Drifts North; Heals? False
   * Normal Door to Transport to Phendrana Drifts North/Dock to Transport Tunnel A
+  > Dock to Monitor Station
+      All of the following:
+          Morph Ball Bomb and Morph Ball
+          Any of the following:
+              Heated Rooms Damage ≥ 107
+              Boost Ball and Heated Rooms Damage ≥ 102
+  > Pickup (Energy Tank)
+      Morph Ball Bomb and Morph Ball and Heated Rooms Damage ≥ 289
 
 > Dock to Monitor Station; Heals? False
   * Normal Door to Monitor Station/Dock to Transport Tunnel A
+  > Dock to Transport to Phendrana Drifts North
+      All of the following:
+          Morph Ball Bomb and Morph Ball
+          Any of the following:
+              Heated Rooms Damage ≥ 102
+              Boost Ball and Heated Rooms Damage ≥ 95
+  > Pickup (Energy Tank)
+      Morph Ball Bomb and Morph Ball and Heated Rooms Damage ≥ 182
+
+> Pickup (Energy Tank); Heals? False
+  * Pickup 93; Major Location? False
+  > Dock to Transport to Phendrana Drifts North
+      Morph Ball Bomb and Morph Ball and Heated Rooms Damage ≥ 78
+  > Dock to Monitor Station
+      Morph Ball Bomb and Morph Ball and Heated Rooms Damage ≥ 73
 
 ----------------
 Warrior Shrine
 Asset id: 2309409677
 > Dock to Monitor Station; Heals? False
   * Normal Door to Monitor Station/Dock to Warrior Shrine
+  > Dock to Fiery Shores
+      Power Bomb and Morph Ball and Heated Rooms Damage ≥ 96
+  > Pickup (Artifact of Strength)
+      Any of the following:
+          Heated Rooms Damage ≥ 64
+          Space Jump Boots and Heated Rooms Damage ≥ 48
 
 > Dock to Fiery Shores; Heals? False
-  * Normal Door to Fiery Shores/Dock to Warrior Shrine
+  * Morph Ball Door to Fiery Shores/Dock to Warrior Shrine
+
+> Pickup (Artifact of Strength); Heals? False
+  * Pickup 94; Major Location? True
+  > Dock to Monitor Station
+      Heated Rooms Damage ≥ 89
+  > Dock to Fiery Shores
+      Power Bomb and Morph Ball and Heated Rooms Damage ≥ 56
 
 ----------------
 Shore Tunnel
 Asset id: 2416984287
 > Dock to Monitor Station; Heals? False
   * Normal Door to Monitor Station/Dock to Shore Tunnel
+  > Dock to Fiery Shores
+      Any of the following:
+          Heated Rooms Damage ≥ 113
+          All of the following:
+              Morph Ball
+              Any of the following:
+                  Heated Rooms Damage ≥ 101
+                  Boost Ball and Heated Rooms Damage ≥ 95
+  > Pickup (Ice Spreader)
+      Power Bomb and Morph Ball and Heated Rooms Damage ≥ 84
 
 > Dock to Fiery Shores; Heals? False
   * Normal Door to Fiery Shores/Dock to Shore Tunnel
+  > Dock to Monitor Station
+      Any of the following:
+          Heated Rooms Damage ≥ 114
+          All of the following:
+              Morph Ball
+              Any of the following:
+                  Heated Rooms Damage ≥ 96
+                  Boost Ball and Heated Rooms Damage ≥ 92
+  > Pickup (Ice Spreader)
+      Power Bomb and Morph Ball and Heated Rooms Damage ≥ 84
+
+> Pickup (Ice Spreader); Heals? False
+  * Pickup 95; Major Location? True
+  > Dock to Monitor Station
+      Space Jump Boots and Heated Rooms Damage ≥ 62
+  > Dock to Fiery Shores
+      Space Jump Boots and Heated Rooms Damage ≥ 82
 
 ----------------
 Transport to Phendrana Drifts North
 Asset id: 3702104715
 > Dock to Transport Tunnel A; Heals? False
   * Normal Door to Transport Tunnel A/Dock to Transport to Phendrana Drifts North
+  > Elevator - Transport to Magmoor Caverns West
+      Scan Visor
+
+> Elevator - Transport to Magmoor Caverns West; Heals? False
+  * Teleporter to Phendrana Drifts - Transport to Magmoor Caverns West
+  > Dock to Transport Tunnel A
+      Trivial
 
 ----------------
 Fiery Shores
 Asset id: 4126087266
 > Dock to Shore Tunnel; Heals? False
   * Normal Door to Shore Tunnel/Dock to Fiery Shores
+  > Dock to Transport Tunnel B
+      Any of the following:
+          Morph Ball Bomb and Morph Ball and Heated Rooms Damage ≥ 319
+          Space Jump Boots and Heated Rooms Damage ≥ 277
+  > Pickup (Missile)
+      Morph Ball Bomb and Morph Ball and Heated Rooms Damage ≥ 358
 
 > Dock to Transport Tunnel B; Heals? False
   * Normal Door to Transport Tunnel B/Dock to Fiery Shores
+  > Dock to Shore Tunnel
+      Any of the following:
+          Heated Rooms Damage ≥ 324
+          Space Jump Boots and Heated Rooms Damage ≥ 284
+  > Pickup (Missile)
+      Morph Ball Bomb and Morph Ball and Heated Rooms Damage ≥ 246
 
 > Dock to Warrior Shrine; Heals? False
-  * Normal Door to Warrior Shrine/Dock to Fiery Shores
+  * Morph Ball Door to Warrior Shrine/Dock to Fiery Shores
+  > Pickup (Power Bomb)
+      Heated Rooms Damage ≥ 40
+
+> Pickup (Power Bomb); Heals? False
+  * Pickup 97; Major Location? False
+  > Dock to Shore Tunnel
+      Morph Ball Bomb and Morph Ball and Heated Rooms Damage ≥ 98
+  > Dock to Transport Tunnel B
+      Morph Ball Bomb and Morph Ball and Heated Rooms Damage ≥ 357
+  > Pickup (Missile)
+      Morph Ball Bomb and Morph Ball and Heated Rooms Damage ≥ 411
+
+> Pickup (Missile); Heals? False
+  * Pickup 96; Major Location? False
+  > Dock to Shore Tunnel
+      Heated Rooms Damage ≥ 208
+  > Dock to Transport Tunnel B
+      Heated Rooms Damage ≥ 280
 
 ----------------
 Transport Tunnel B
 Asset id: 860276342
 > Dock to Transport to Tallon Overworld West; Heals? False
   * Normal Door to Transport to Tallon Overworld West/Dock to Transport Tunnel B
+  > Dock to Fiery Shores
+      Any of the following:
+          Heated Rooms Damage ≥ 151
+          All of the following:
+              Morph Ball
+              Any of the following:
+                  Heated Rooms Damage ≥ 95
+                  Boost Ball and Heated Rooms Damage ≥ 87
 
 > Dock to Fiery Shores; Heals? False
   * Normal Door to Fiery Shores/Dock to Transport Tunnel B
+  > Dock to Transport to Tallon Overworld West
+      Any of the following:
+          Heated Rooms Damage ≥ 163
+          All of the following:
+              Morph Ball
+              Any of the following:
+                  Heated Rooms Damage ≥ 107
+                  Boost Ball and Heated Rooms Damage ≥ 97
 
 ----------------
 Transport to Tallon Overworld West
@@ -1148,7 +2180,7 @@ Asset id: 1279075404
   > Dock to Twin Fires Tunnel
       Trivial
   > Elevator to Tallon Overworld - Transport to Magmoor Caverns East
-      Trivial
+      Scan Visor
 
 > Elevator to Tallon Overworld - Transport to Magmoor Caverns East; Heals? False; Spawn Point
   * Teleporter to Tallon Overworld - Transport to Magmoor Caverns East
@@ -1160,105 +2192,194 @@ Twin Fires Tunnel
 Asset id: 3835971118
 > Dock to Twin Fires; Heals? False
   * Normal Door to Twin Fires/Dock to Twin Fires Tunnel
+  > Dock to Transport to Tallon Overworld West
+      Any of the following:
+          Morph Ball and Boost Ball and Heat-Resisting Suit
+          Space Jump Boots and Heated Rooms Damage ≥ 165
 
 > Dock to Transport to Tallon Overworld West; Heals? False
   * Normal Door to Transport to Tallon Overworld West/Dock to Twin Fires Tunnel
+  > Dock to Twin Fires
+      Morph Ball and Spider Ball and Heat-Resisting Suit
 
 ----------------
 Twin Fires
 Asset id: 1282952170
 > Dock to North Core Tunnel; Heals? False
-  * Normal Door to North Core Tunnel/Dock to Twin Fires
+  * Wave Door to North Core Tunnel/Dock to Twin Fires
+  > Dock to Twin Fires Tunnel
+      Grapple Beam or Space Jump Boots or Gravity Suit
 
 > Dock to Twin Fires Tunnel; Heals? False
   * Normal Door to Twin Fires Tunnel/Dock to Twin Fires
+  > Dock to North Core Tunnel
+      Grapple Beam or Space Jump Boots or Gravity Suit
 
 ----------------
 North Core Tunnel
 Asset id: 2805715168
 > Dock to Twin Fires; Heals? False
-  * Normal Door to Twin Fires/Dock to North Core Tunnel
+  * Wave Door to Twin Fires/Dock to North Core Tunnel
+  > Dock to Geothermal Core
+      Space Jump Boots or Gravity Suit
 
 > Dock to Geothermal Core; Heals? False
-  * Normal Door to Geothermal Core/Dock to North Core Tunnel
+  * Wave Door to Geothermal Core/Dock to North Core Tunnel
+  > Dock to Twin Fires
+      Space Jump Boots or Gravity Suit
 
 ----------------
 Geothermal Core
 Asset id: 3226044022
 > Dock to North Core Tunnel; Heals? False
   * Normal Door to North Core Tunnel/Dock to Geothermal Core
+  > Dock to South Core Tunnel
+      Trivial
 
 > Dock to Plasma Processing; Heals? False
-  * Normal Door to Plasma Processing/Dock to Geothermal Core
+  * Ice Door to Plasma Processing/Dock to Geothermal Core
+  > Dock to North Core Tunnel
+      After Geothermal Core Opened
 
 > Dock to South Core Tunnel; Heals? False
   * Normal Door to South Core Tunnel/Dock to Geothermal Core
+  > Dock to North Core Tunnel
+      Trivial
+  > Dock to Plasma Processing
+      Morph Ball Bomb and Grapple Beam and Space Jump Boots and Morph Ball and Boost Ball and Spider Ball
+  > Event (Geothermal Core Opened)
+      Morph Ball Bomb and Grapple Beam and Space Jump Boots and Morph Ball and Boost Ball and Spider Ball
+
+> Event (Geothermal Core Opened); Heals? False
+  * Event Geothermal Core Opened
+  > Dock to Plasma Processing
+      Morph Ball Bomb and Morph Ball and Spider Ball
 
 ----------------
 Plasma Processing
 Asset id: 1287753306
 > Dock to Geothermal Core; Heals? False
-  * Normal Door to Geothermal Core/Dock to Plasma Processing
+  * Plasma Door to Geothermal Core/Dock to Plasma Processing
+  > Pickup (Plasma Beam)
+      Trivial
+
+> Pickup (Plasma Beam); Heals? False
+  * Pickup 98; Major Location? True
+  > Dock to Geothermal Core
+      Trivial
 
 ----------------
 South Core Tunnel
 Asset id: 1893290168
 > Dock to Geothermal Core; Heals? False
-  * Normal Door to Geothermal Core/Dock to South Core Tunnel
+  * Wave Door to Geothermal Core/Dock to South Core Tunnel
+  > Dock to Magmoor Workstation
+      Trivial
 
 > Dock to Magmoor Workstation; Heals? False
-  * Normal Door to Magmoor Workstation/Dock to South Core Tunnel
+  * Wave Door to Magmoor Workstation/Dock to South Core Tunnel
+  > Dock to Geothermal Core
+      Trivial
 
 ----------------
 Magmoor Workstation
 Asset id: 2327753667
 > Dock to South Core Tunnel; Heals? False
   * Normal Door to South Core Tunnel/Dock to Magmoor Workstation
+  > Dock to Workstation Tunnel
+      Space Jump Boots
+  > Dock to Transport Tunnel C
+      Space Jump Boots
+  > Pickup (Energy Tank)
+      All of the following:
+          Wave Beam and Scan Visor and Morph Ball
+          Thermal Visor or Invisible Objects (Beginner)
 
 > Dock to Workstation Tunnel; Heals? False
   * Normal Door to Workstation Tunnel/Dock to Magmoor Workstation
+  > Dock to South Core Tunnel
+      Trivial
 
 > Dock to Transport Tunnel C; Heals? False
-  * Normal Door to Transport Tunnel C/Dock to Magmoor Workstation
+  * Wave Door to Transport Tunnel C/Dock to Magmoor Workstation
+  > Dock to South Core Tunnel
+      Trivial
+
+> Pickup (Energy Tank); Heals? False
+  * Pickup 99; Major Location? False
+  > Dock to South Core Tunnel
+      Morph Ball
 
 ----------------
 Workstation Tunnel
 Asset id: 74274377
 > Dock to Transport to Phazon Mines West; Heals? False
-  * Normal Door to Transport to Phazon Mines West/Dock to Workstation Tunnel
+  * Ice Door to Transport to Phazon Mines West/Dock to Workstation Tunnel
+  > Dock to Magmoor Workstation
+      Power Bomb and Morph Ball
 
 > Dock to Magmoor Workstation; Heals? False
   * Normal Door to Magmoor Workstation/Dock to Workstation Tunnel
+  > Dock to Transport to Phazon Mines West
+      Power Bomb and Morph Ball
 
 ----------------
 Transport Tunnel C
 Asset id: 3549419025
 > Dock to Transport to Phendrana Drifts South; Heals? False
-  * Normal Door to Transport to Phendrana Drifts South/Dock to Transport Tunnel C
+  * Wave Door to Transport to Phendrana Drifts South/Dock to Transport Tunnel C
+  > Dock to Magmoor Workstation
+      Trivial
 
 > Dock to Magmoor Workstation; Heals? False
-  * Normal Door to Magmoor Workstation/Dock to Transport Tunnel C
+  * Wave Door to Magmoor Workstation/Dock to Transport Tunnel C
+  > Dock to Transport to Phendrana Drifts South
+      Trivial
 
 ----------------
 Transport to Phazon Mines West
 Asset id: 4012840000
 > Dock to Workstation Tunnel; Heals? False
-  * Normal Door to Workstation Tunnel/Dock to Transport to Phazon Mines West
+  * Ice Door to Workstation Tunnel/Dock to Transport to Phazon Mines West
+  > Elevator - Transport to Magmoor Caverns South
+      Scan Visor
+
+> Elevator - Transport to Magmoor Caverns South; Heals? False
+  * Teleporter to Phazon Mines - Transport to Magmoor Caverns South
+  > Dock to Workstation Tunnel
+      Trivial
 
 ----------------
 Transport to Phendrana Drifts South
 Asset id: 3249312307
 > Dock to Save Station Magmoor B; Heals? False
-  * Normal Door to Save Station Magmoor B/Dock to Transport to Phendrana Drifts South
+  * Missile Blast Shield to Save Station Magmoor B/Dock to Transport to Phendrana Drifts South
+  > Dock to Transport Tunnel C
+      Trivial
+  > Elevator - Transport to Magmoor Caverns South
+      Scan Visor
 
 > Dock to Transport Tunnel C; Heals? False
-  * Normal Door to Transport Tunnel C/Dock to Transport to Phendrana Drifts South
+  * Wave Door to Transport Tunnel C/Dock to Transport to Phendrana Drifts South
+  > Dock to Save Station Magmoor B
+      Trivial
+
+> Elevator - Transport to Magmoor Caverns South; Heals? False
+  * Teleporter to Phendrana Drifts - Transport to Magmoor Caverns South
+  > Dock to Save Station Magmoor B
+      Trivial
 
 ----------------
 Save Station Magmoor B
 Asset id: 2136398113
 > Dock to Transport to Phendrana Drifts South; Heals? False
-  * Normal Door to Transport to Phendrana Drifts South/Dock to Save Station Magmoor B
+  * Missile Blast Shield to Transport to Phendrana Drifts South/Dock to Save Station Magmoor B
+  > Save Station
+      Trivial
+
+> Save Station; Heals? True
+  > Dock to Transport to Phendrana Drifts South
+      Trivial
 
 ====================
 Phazon Mines
@@ -1279,379 +2400,814 @@ Asset id: 1125030300
 Quarry Access
 Asset id: 1758230360
 > Dock to Main Quarry; Heals? False
-  * Normal Door to Main Quarry/Dock to Quarry Access
+  * Wave Door to Main Quarry/Dock to Quarry Access
+  > Dock to Transport to Tallon Overworld South
+      Trivial
 
 > Dock to Transport to Tallon Overworld South; Heals? False
-  * Normal Door to Transport to Tallon Overworld South/Dock to Quarry Access
+  * Wave Door to Transport to Tallon Overworld South/Dock to Quarry Access
+  > Dock to Main Quarry
+      Trivial
 
 ----------------
 Main Quarry
 Asset id: 1681720207
 > Dock to Waste Disposal; Heals? False
-  * Normal Door to Waste Disposal/Dock to Main Quarry
+  * Ice Door to Waste Disposal/Dock to Main Quarry
+  > Dock to Quarry Access
+      Trivial
 
 > Dock to Quarry Access; Heals? False
-  * Normal Door to Quarry Access/Dock to Main Quarry
+  * Wave Door to Quarry Access/Dock to Main Quarry
+  > Dock to Waste Disposal
+      Grapple Beam and Space Jump Boots
+  > Dock to Save Station Mines A
+      Trivial
+  > Dock to Security Access A
+      After Main Quarry Barrier Deactivated
+  > Pickup (Missile)
+      All of the following:
+          Wave Beam and Scan Visor and Space Jump Boots and Morph Ball and Spider Ball
+          Thermal Visor or Invisible Objects (Beginner)
+  > Event (Main Quarry Barrier Deactivated)
+      Scan Visor
 
 > Dock to Save Station Mines A; Heals? False
-  * Normal Door to Save Station Mines A/Dock to Main Quarry
+  * Wave Door to Save Station Mines A/Dock to Main Quarry
+  > Dock to Quarry Access
+      Trivial
 
 > Dock to Security Access A; Heals? False
-  * Normal Door to Security Access A/Dock to Main Quarry
+  * Ice Door to Security Access A/Dock to Main Quarry
+  > Dock to Quarry Access
+      After Main Quarry Barrier Deactivated
+
+> Pickup (Missile); Heals? False
+  * Pickup 73; Major Location? False
+  > Dock to Quarry Access
+      Trivial
+
+> Event (Main Quarry Barrier Deactivated); Heals? False
+  * Event Main Quarry Barrier Deactivated
+  > Dock to Quarry Access
+      Trivial
 
 ----------------
 Waste Disposal
 Asset id: 665031095
 > Dock to Main Quarry; Heals? False
-  * Normal Door to Main Quarry/Dock to Waste Disposal
+  * Ice Door to Main Quarry/Dock to Waste Disposal
+  > Dock to Ore Processing
+      Morph Ball Bomb and Morph Ball
 
 > Dock to Ore Processing; Heals? False
-  * Normal Door to Ore Processing/Dock to Waste Disposal
+  * Ice Door to Ore Processing/Dock to Waste Disposal
+  > Dock to Main Quarry
+      Morph Ball Bomb and Morph Ball
 
 ----------------
 Save Station Mines A
 Asset id: 907887024
-> Dock to Main Quarry; Heals? False
-  * Normal Door to Main Quarry/Dock to Save Station Mines A
+> Dock to Main Quarry; Heals? True
+  * Wave Door to Main Quarry/Dock to Save Station Mines A
+  > Save Station
+      Trivial
+
+> Save Station; Heals? True
+  > Dock to Main Quarry
+      Trivial
 
 ----------------
 Security Access A
 Asset id: 3345300114
 > Dock to Main Quarry; Heals? False
-  * Normal Door to Main Quarry/Dock to Security Access A
+  * Ice Door to Main Quarry/Dock to Security Access A
+  > Dock to Mine Security Station
+      Trivial
+  > Pickup (Missile)
+      All of the following:
+          Power Bomb and Morph Ball
+          X-Ray Visor or Invisible Objects (Beginner)
 
 > Dock to Mine Security Station; Heals? False
-  * Normal Door to Mine Security Station/Dock to Security Access A
+  * Ice Door to Mine Security Station/Dock to Security Access A
+  > Dock to Main Quarry
+      Trivial
+
+> Pickup (Missile); Heals? False
+  * Pickup 74; Major Location? False
+  > Dock to Main Quarry
+      Trivial
 
 ----------------
 Ore Processing
 Asset id: 2547167990
 > Dock to Research Access; Heals? False
-  * Normal Door to Research Access/Dock to Ore Processing
+  * Ice Door to Research Access/Dock to Ore Processing
+  > Dock to Elevator Access A
+      Morph Ball Bomb and Morph Ball and Spider Ball
 
 > Dock to Storage Depot B; Heals? False
-  * Normal Door to Storage Depot B/Dock to Ore Processing
+  * Ice Door to Storage Depot B/Dock to Ore Processing
+  > Dock to Waste Disposal
+      Grapple Beam
+  > Dock to Elevator Access A
+      Trivial
 
 > Dock to Waste Disposal; Heals? False
-  * Normal Door to Waste Disposal/Dock to Ore Processing
+  * Ice Door to Waste Disposal/Dock to Ore Processing
+  > Dock to Research Access
+      Trivial
+  > Dock to Storage Depot B
+      Grapple Beam
+  > Dock to Elevator Access A
+      Trivial
 
 > Dock to Elevator Access A; Heals? False
-  * Normal Door to Elevator Access A/Dock to Ore Processing
+  * Ice Door to Elevator Access A/Dock to Ore Processing
+  > Dock to Research Access
+      Trivial
+  > Dock to Storage Depot B
+      Morph Ball Bomb and Power Bomb and Space Jump Boots and Morph Ball and Spider Ball
 
 ----------------
 Mine Security Station
 Asset id: 2507085138
 > Dock to Security Access A; Heals? False
-  * Normal Door to Security Access A/Dock to Mine Security Station
+  * Ice Door to Security Access A/Dock to Mine Security Station
+  > Dock to Security Access B
+      Wave Beam and Space Jump Boots
+  > Dock to Storage Depot A
+      Wave Beam and Scan Visor and Power Bomb and Morph Ball
 
 > Dock to Security Access B; Heals? False
-  * Normal Door to Security Access B/Dock to Mine Security Station
+  * Wave Door to Security Access B/Dock to Mine Security Station
+  > Dock to Security Access A
+      Wave Beam
+  > Dock to Storage Depot A
+      Wave Beam and Scan Visor and Power Bomb and Morph Ball
 
 > Dock to Storage Depot A; Heals? False
-  * Normal Door to Storage Depot A/Dock to Mine Security Station
+  * Plasma Door to Storage Depot A/Dock to Mine Security Station
+  > Dock to Security Access A
+      Wave Beam
 
 ----------------
 Research Access
 Asset id: 1128703815
 > Dock to Ore Processing; Heals? False
-  * Normal Door to Ore Processing/Dock to Research Access
+  * Ice Door to Ore Processing/Dock to Research Access
+  > Dock to Elite Research
+      Morph Ball and Spider Ball
 
 > Dock to Elite Research; Heals? False
-  * Normal Door to Elite Research/Dock to Research Access
+  * Ice Door to Elite Research/Dock to Research Access
+  > Dock to Ore Processing
+      Trivial
 
 ----------------
 Storage Depot B
 Asset id: 3818665003
 > Dock to Ore Processing; Heals? False
-  * Normal Door to Ore Processing/Dock to Storage Depot B
+  * Ice Door to Ore Processing/Dock to Storage Depot B
+  > Pickup (Grapple Beam)
+      Trivial
+
+> Pickup (Grapple Beam); Heals? False
+  * Pickup 75; Major Location? True
+  > Dock to Ore Processing
+      Trivial
 
 ----------------
 Elevator Access A
 Asset id: 639736833
 > Dock to Ore Processing; Heals? False
-  * Normal Door to Ore Processing/Dock to Elevator Access A
+  * Ice Door to Ore Processing/Dock to Elevator Access A
+  > Dock to Elevator A
+      Trivial
 
 > Dock to Elevator A; Heals? False
-  * Normal Door to Elevator A/Dock to Elevator Access A
+  * Ice Door to Elevator A/Dock to Elevator Access A
+  > Dock to Ore Processing
+      Morph Ball and Spider Ball
 
 ----------------
 Security Access B
 Asset id: 2718040532
 > Dock to Elite Research; Heals? False
-  * Normal Door to Elite Research/Dock to Security Access B
+  * Ice Door to Elite Research/Dock to Security Access B
+  > Dock to Mine Security Station
+      Trivial
 
 > Dock to Mine Security Station; Heals? False
-  * Normal Door to Mine Security Station/Dock to Security Access B
+  * Wave Door to Mine Security Station/Dock to Security Access B
+  > Dock to Elite Research
+      Space Jump Boots
 
 ----------------
 Storage Depot A
 Asset id: 902158134
 > Dock to Mine Security Station; Heals? False
-  * Normal Door to Mine Security Station/Dock to Storage Depot A
+  * Plasma Door to Mine Security Station/Dock to Storage Depot A
+  > Pickup (Flamethrower)
+      Trivial
+
+> Pickup (Flamethrower); Heals? False
+  * Pickup 76; Major Location? True
+  > Dock to Mine Security Station
+      Trivial
 
 ----------------
 Elite Research
 Asset id: 2325199700
 > Dock to Research Access; Heals? False
-  * Normal Door to Research Access/Dock to Elite Research
+  * Ice Door to Research Access/Dock to Elite Research
+  > Dock to Security Access B
+      After Rock Wall in Elite Research Destroyed
+  > Pickup (Missile)
+      Scan Visor and Morph Ball and Boost Ball and After Rock Wall in Elite Research Destroyed
 
 > Dock to Security Access B; Heals? False
-  * Normal Door to Security Access B/Dock to Elite Research
+  * Ice Door to Security Access B/Dock to Elite Research
+  > Dock to Research Access
+      Scan Visor and Space Jump Boots and After Rock Wall in Elite Research Destroyed
+  > Event (Rock Wall in Elite Research Destroyed)
+      Scan Visor and Space Jump Boots and Morph Ball and Boost Ball
+  > Pickup (Missile)
+      Scan Visor and Space Jump Boots and Morph Ball and Boost Ball
+  > Pickup (Artifact of Warrior)
+      Power Bomb and Morph Ball and After Security Drone Defeated
+
+> Event (Rock Wall in Elite Research Destroyed); Heals? False
+  * Event Rock Wall in Elite Research Destroyed
+  > Dock to Research Access
+      Trivial
+  > Dock to Security Access B
+      Trivial
+
+> Pickup (Missile); Heals? False
+  * Pickup 78; Major Location? False
+  > Dock to Security Access B
+      Trivial
+
+> Pickup (Artifact of Warrior); Heals? False
+  * Pickup 77; Major Location? True
+  > Dock to Security Access B
+      Trivial
 
 ----------------
 Elevator A
 Asset id: 21425475
 > Dock to Elevator Access A; Heals? False
-  * Normal Door to Elevator Access A/Dock to Elevator A
+  * Ice Door to Elevator Access A/Dock to Elevator A
+  > Dock to Elite Control Access
+      Scan Visor
 
 > Dock to Elite Control Access; Heals? False
-  * Normal Door to Elite Control Access/Dock to Elevator A
+  * Ice Door to Elite Control Access/Dock to Elevator A
+  > Dock to Elevator Access A
+      Trivial
 
 ----------------
 Elite Control Access
 Asset id: 2307445195
 > Dock to Elevator A; Heals? False
-  * Normal Door to Elevator A/Dock to Elite Control Access
+  * Ice Door to Elevator A/Dock to Elite Control Access
+  > Dock to Elite Control
+      Trivial
+  > Pickup (Missile)
+      Morph Ball Bomb and Space Jump Boots and Morph Ball
 
 > Dock to Elite Control; Heals? False
-  * Normal Door to Elite Control/Dock to Elite Control Access
+  * Wave Door to Elite Control/Dock to Elite Control Access
+  > Dock to Elevator A
+      Space Jump Boots
+
+> Pickup (Missile); Heals? False
+  * Pickup 79; Major Location? False
+  > Dock to Elite Control
+      Trivial
 
 ----------------
 Elite Control
 Asset id: 3305828730
 > Dock to Maintenance Tunnel; Heals? False
-  * Normal Door to Maintenance Tunnel/Dock to Elite Control
+  * Ice Door to Maintenance Tunnel/Dock to Elite Control
+  > Dock to Elite Control Access
+      Trivial
 
 > Dock to Elite Control Access; Heals? False
-  * Normal Door to Elite Control Access/Dock to Elite Control
+  * Wave Door to Elite Control Access/Dock to Elite Control
+  > Dock to Maintenance Tunnel
+      Trivial
+  > Dock to Ventilation Shaft
+      Space Jump Boots and After Elite Control Barriers Lowered
+  > Event (Elite Control Barriers Lowered)
+      Scan Visor
 
 > Dock to Ventilation Shaft; Heals? False
-  * Normal Door to Ventilation Shaft/Dock to Elite Control
+  * Ice Door to Ventilation Shaft/Dock to Elite Control
+  > Dock to Elite Control Access
+      After Elite Control Barriers Lowered
+
+> Event (Elite Control Barriers Lowered); Heals? False
+  * Event Elite Control Barriers Lowered
+  > Dock to Elite Control Access
+      Trivial
 
 ----------------
 Maintenance Tunnel
 Asset id: 3975146125
 > Dock to Elite Control; Heals? False
-  * Normal Door to Elite Control/Dock to Maintenance Tunnel
+  * Ice Door to Elite Control/Dock to Maintenance Tunnel
+  > Dock to Phazon Processing Center
+      Power Bomb and Morph Ball
 
 > Dock to Phazon Processing Center; Heals? False
-  * Normal Door to Phazon Processing Center/Dock to Maintenance Tunnel
+  * Ice Door to Phazon Processing Center/Dock to Maintenance Tunnel
+  > Dock to Elite Control
+      Power Bomb and Morph Ball
 
 ----------------
 Ventilation Shaft
 Asset id: 2423298732
 > Dock to Omega Research; Heals? False
-  * Normal Door to Omega Research/Dock to Ventilation Shaft
+  * Ice Door to Omega Research/Dock to Ventilation Shaft
+  > Dock to Elite Control
+      Morph Ball and Boost Ball
+  > Pickup (Energy Tank)
+      Scan Visor and Morph Ball Bomb and Power Bomb and Morph Ball
 
 > Dock to Elite Control; Heals? False
-  * Normal Door to Elite Control/Dock to Ventilation Shaft
+  * Ice Door to Elite Control/Dock to Ventilation Shaft
+  > Dock to Omega Research
+      Trivial
+
+> Pickup (Energy Tank); Heals? False
+  * Pickup 80; Major Location? False
+  > Dock to Omega Research
+      Trivial
 
 ----------------
 Phazon Processing Center
 Asset id: 2905505465
 > Dock to Transport Access; Heals? False
-  * Normal Door to Transport Access/Dock to Phazon Processing Center
+  * Ice Door to Transport Access/Dock to Phazon Processing Center
+  > Dock to Maintenance Tunnel
+      Trivial
 
 > Dock to Maintenance Tunnel; Heals? False
-  * Normal Door to Maintenance Tunnel/Dock to Phazon Processing Center
+  * Ice Door to Maintenance Tunnel/Dock to Phazon Processing Center
+  > Dock to Transport Access
+      Space Jump Boots and Morph Ball and Spider Ball
+  > Dock to Processing Center Access
+      Trivial
 
 > Dock to Processing Center Access; Heals? False
-  * Normal Door to Processing Center Access/Dock to Phazon Processing Center
+  * Plasma Door to Processing Center Access/Dock to Phazon Processing Center
+  > Dock to Maintenance Tunnel
+      All of the following:
+          Space Jump Boots
+          Any of the following:
+              Thermal Visor or X-Ray Visor or Invisible Objects (Beginner)
+              Morph Ball Bomb and Morph Ball and Spider Ball
+  > Pickup (Missile)
+      All of the following:
+          Power Bomb and Space Jump Boots and Morph Ball
+          Thermal Visor or X-Ray Visor or Invisible Objects (Beginner)
+
+> Pickup (Missile); Heals? False
+  * Pickup 81; Major Location? False
+  > Dock to Processing Center Access
+      Trivial
 
 ----------------
 Omega Research
 Asset id: 1060593356
 > Dock to Map Station Mines; Heals? False
-  * Normal Door to Map Station Mines/Dock to Omega Research
+  * Ice Door to Map Station Mines/Dock to Omega Research
+  > Dock to Ventilation Shaft
+      Power Bomb and Morph Ball
 
 > Dock to Ventilation Shaft; Heals? False
-  * Normal Door to Ventilation Shaft/Dock to Omega Research
+  * Ice Door to Ventilation Shaft/Dock to Omega Research
+  > Dock to Map Station Mines
+      Power Bomb and Morph Ball
+  > Dock to Dynamo Access
+      Trivial
 
 > Dock to Dynamo Access; Heals? False
-  * Normal Door to Dynamo Access/Dock to Omega Research
+  * Ice Door to Dynamo Access/Dock to Omega Research
+  > Dock to Ventilation Shaft
+      Scan Visor and Space Jump Boots
 
 ----------------
 Transport Access
 Asset id: 1120185073
 > Dock to Phazon Processing Center; Heals? False
-  * Normal Door to Phazon Processing Center/Dock to Transport Access
+  * Ice Door to Phazon Processing Center/Dock to Transport Access
+  > Dock to Transport to Magmoor Caverns South
+      Grapple Beam or Space Jump Boots
 
 > Dock to Transport to Magmoor Caverns South; Heals? False
-  * Normal Door to Transport to Magmoor Caverns South/Dock to Transport Access
+  * Ice Door to Transport to Magmoor Caverns South/Dock to Transport Access
+  > Dock to Phazon Processing Center
+      Grapple Beam or Space Jump Boots
 
 ----------------
 Processing Center Access
 Asset id: 3983402811
 > Dock to Phazon Processing Center; Heals? False
-  * Normal Door to Phazon Processing Center/Dock to Processing Center Access
+  * Plasma Door to Phazon Processing Center/Dock to Processing Center Access
+  > Dock to Elite Quarters
+      After Processing Center Access Barrier Opened
 
 > Dock to Elite Quarters; Heals? False
-  * Normal Door to Elite Quarters/Dock to Processing Center Access
+  * Plasma Door to Elite Quarters/Dock to Processing Center Access
+  > Dock to Phazon Processing Center
+      After Processing Center Access Barrier Opened
+  > Event (Processing Center Access Barrier Opened)
+      Scan Visor
+  > Pickup (Energy Tank)
+      Trivial
+
+> Event (Processing Center Access Barrier Opened); Heals? False
+  * Event Processing Center Access Barrier Opened
+  > Dock to Elite Quarters
+      Trivial
+
+> Pickup (Energy Tank); Heals? False
+  * Pickup 82; Major Location? False
+  > Dock to Elite Quarters
+      Trivial
 
 ----------------
 Map Station Mines
 Asset id: 428864988
 > Dock to Omega Research; Heals? False
-  * Normal Door to Omega Research/Dock to Map Station Mines
+  * Ice Door to Omega Research/Dock to Map Station Mines
 
 ----------------
 Dynamo Access
 Asset id: 4111966698
 > Dock to Central Dynamo; Heals? False
-  * Normal Door to Central Dynamo/Dock to Dynamo Access
+  * Ice Door to Central Dynamo/Dock to Dynamo Access
+  > Dock to Omega Research
+      Space Jump Boots
 
 > Dock to Omega Research; Heals? False
-  * Normal Door to Omega Research/Dock to Dynamo Access
+  * Ice Door to Omega Research/Dock to Dynamo Access
+  > Dock to Central Dynamo
+      Trivial
 
 ----------------
 Transport to Magmoor Caverns South
 Asset id: 3804417848
 > Dock to Transport Access; Heals? False
-  * Normal Door to Transport Access/Dock to Transport to Magmoor Caverns South
+  * Ice Door to Transport Access/Dock to Transport to Magmoor Caverns South
+  > Elevator - Transport to Phazon Mines West
+      Scan Visor
+
+> Elevator - Transport to Phazon Mines West; Heals? False
+  * Teleporter to Magmoor Caverns - Transport to Phazon Mines West
+  > Dock to Transport Access
+      Trivial
 
 ----------------
 Elite Quarters
 Asset id: 961790803
 > Dock to Elite Quarters Access; Heals? False
-  * Normal Door to Elite Quarters Access/Dock to Elite Quarters
+  * Plasma Door to Elite Quarters Access/Dock to Elite Quarters
+  > Dock to Processing Center Access
+      Scan Visor and After Omega Pirate Defeated
+  > Event (Omega Pirate Defeated)
+      X-Ray Visor and Have all Beams
+  > Pickup (Phazon Suit)
+      After Omega Pirate Defeated
 
 > Dock to Processing Center Access; Heals? False
-  * Normal Door to Processing Center Access/Dock to Elite Quarters
+  * Plasma Door to Processing Center Access/Dock to Elite Quarters
+  > Event (Omega Pirate Defeated)
+      X-Ray Visor and Have all Beams
+
+> Event (Omega Pirate Defeated); Heals? False
+  * Event Omega Pirate Defeated
+  > Dock to Elite Quarters Access
+      Trivial
+
+> Pickup (Phazon Suit); Heals? False
+  * Pickup 83; Major Location? True
+  > Dock to Elite Quarters Access
+      Trivial
 
 ----------------
 Central Dynamo
 Asset id: 4272124642
 > Dock to Dynamo Access; Heals? False
-  * Normal Door to Dynamo Access/Dock to Central Dynamo
+  * Ice Door to Dynamo Access/Dock to Central Dynamo
+  > Dock to Save Station Mines B
+      After Security Drone Defeated
+  > Event (Security Drone Defeated)
+      Any of the following:
+          Thermal Visor
+          Combat (Beginner) and Invisible Objects (Beginner)
 
 > Dock to Quarantine Access A; Heals? False
-  * Normal Door to Quarantine Access A/Dock to Central Dynamo
+  * Ice Door to Quarantine Access A/Dock to Central Dynamo
+  > Dock to Save Station Mines B
+      After Security Drone Defeated
+  > Event (Security Drone Defeated)
+      Any of the following:
+          Thermal Visor
+          Combat (Beginner) and Invisible Objects (Beginner)
 
 > Dock to Save Station Mines B; Heals? False
-  * Normal Door to Save Station Mines B/Dock to Central Dynamo
+  * Ice Door to Save Station Mines B/Dock to Central Dynamo
+  > Dock to Dynamo Access
+      Space Jump Boots and After Security Drone Defeated
+  > Dock to Quarantine Access A
+      After Security Drone Defeated and After Central Dynamo Bendezium Destroyed
+  > Event (Security Drone Defeated)
+      Any of the following:
+          Thermal Visor
+          Combat (Beginner) and Invisible Objects (Beginner)
+  > Event (Central Dynamo Bendezium Destroyed)
+      Power Bomb and Morph Ball and After Security Drone Defeated
+
+> Event (Security Drone Defeated); Heals? False
+  * Event Security Drone Defeated
+  > Pickup (Main Power Bombs)
+      Morph Ball Bomb and Morph Ball
+
+> Pickup (Main Power Bombs); Heals? False
+  * Pickup 84; Major Location? True
+  > Dock to Save Station Mines B
+      Trivial
+
+> Event (Central Dynamo Bendezium Destroyed); Heals? False
+  * Event Central Dynamo Bendezium Destroyed
+  > Dock to Save Station Mines B
+      After Security Drone Defeated
 
 ----------------
 Elite Quarters Access
 Asset id: 1899248703
 > Dock to Metroid Quarantine B; Heals? False
-  * Normal Door to Metroid Quarantine B/Dock to Elite Quarters Access
+  * Plasma Door to Metroid Quarantine B/Dock to Elite Quarters Access
+  > Dock to Elite Quarters
+      After Elite Quarters Access Barrier Opened
+  > Event (Elite Quarters Access Barrier Opened)
+      Plasma Beam
 
 > Dock to Elite Quarters; Heals? False
-  * Normal Door to Elite Quarters/Dock to Elite Quarters Access
+  * Plasma Door to Elite Quarters/Dock to Elite Quarters Access
+  > Dock to Metroid Quarantine B
+      After Elite Quarters Access Barrier Opened
+
+> Event (Elite Quarters Access Barrier Opened); Heals? False
+  * Event Elite Quarters Access Barrier Opened
+  > Dock to Metroid Quarantine B
+      Trivial
 
 ----------------
 Quarantine Access A
 Asset id: 1522461728
 > Dock to Central Dynamo; Heals? False
-  * Normal Door to Central Dynamo/Dock to Quarantine Access A
+  * Ice Door to Central Dynamo/Dock to Quarantine Access A
+  > Dock to Metroid Quarantine A
+      Trivial
 
 > Dock to Metroid Quarantine A; Heals? False
-  * Normal Door to Metroid Quarantine A/Dock to Quarantine Access A
+  * Wave Door to Metroid Quarantine A/Dock to Quarantine Access A
+  > Dock to Central Dynamo
+      After Central Dynamo Bendezium Destroyed
 
 ----------------
 Save Station Mines B
 Asset id: 2077614267
 > Dock to Central Dynamo; Heals? False
-  * Normal Door to Central Dynamo/Dock to Save Station Mines B
+  * Ice Door to Central Dynamo/Dock to Save Station Mines B
+  > Save Station
+      Trivial
+
+> Save Station; Heals? True
+  > Dock to Central Dynamo
+      Trivial
 
 ----------------
 Metroid Quarantine B
 Asset id: 3141205070
 > Dock to Quarantine Access B; Heals? False
-  * Normal Door to Quarantine Access B/Dock to Metroid Quarantine B
+  * Plasma Door to Quarantine Access B/Dock to Metroid Quarantine B
+  > Dock to Save Station Mines C
+      Grapple Beam and Space Jump Boots and Morph Ball and Spider Ball and After Metroid Quarantine B Barrier Lowered
+  > Event (Metroid Quarantine B Barrier Lowered)
+      Scan Visor and Grapple Beam and Space Jump Boots and Morph Ball and Spider Ball
 
 > Dock to Elite Quarters Access; Heals? False
-  * Normal Door to Elite Quarters Access/Dock to Metroid Quarantine B
+  * Plasma Door to Elite Quarters Access/Dock to Metroid Quarantine B
+  > Dock to Save Station Mines C
+      Trivial
 
 > Dock to Save Station Mines C; Heals? False
-  * Normal Door to Save Station Mines C/Dock to Metroid Quarantine B
+  * Plasma Door to Save Station Mines C/Dock to Metroid Quarantine B
+  > Dock to Quarantine Access B
+      Space Jump Boots and After Metroid Quarantine B Barrier Lowered
+  > Dock to Elite Quarters Access
+      Trivial
+  > Pickup (Missile)
+      Shoot Super Missile
+
+> Pickup (Missile); Heals? False
+  * Pickup 85; Major Location? False
+  > Dock to Save Station Mines C
+      Trivial
+
+> Event (Metroid Quarantine B Barrier Lowered); Heals? False
+  * Event Metroid Quarantine B Barrier Lowered
+  > Dock to Quarantine Access B
+      Space Jump Boots
 
 ----------------
 Metroid Quarantine A
 Asset id: 4211416922
 > Dock to Quarantine Access A; Heals? False
-  * Normal Door to Quarantine Access A/Dock to Metroid Quarantine A
+  * Wave Door to Quarantine Access A/Dock to Metroid Quarantine A
+  > Dock to Elevator Access B
+      All of the following:
+          Morph Ball Bomb and Space Jump Boots and Morph Ball and Spider Ball and After Metroid Quarantine A Barrier Lowered
+          X-Ray Visor or Invisible Objects (Intermediate)
+  > Pickup (Missile)
+      All of the following:
+          Power Bomb and Space Jump Boots and Morph Ball and Spider Ball and After Metroid Quarantine A Barrier Lowered
+          X-Ray Visor or Invisible Objects (Intermediate)
 
 > Dock to Elevator Access B; Heals? False
-  * Normal Door to Elevator Access B/Dock to Metroid Quarantine A
+  * Ice Door to Elevator Access B/Dock to Metroid Quarantine A
+  > Dock to Quarantine Access A
+      Space Jump Boots and After Metroid Quarantine A Barrier Lowered
+  > Pickup (Missile)
+      All of the following:
+          Power Bomb and Morph Ball and Spider Ball
+          Morph Ball Bomb or Space Jump Boots
+          X-Ray Visor or Invisible Objects (Intermediate)
+  > Event (Metroid Quarantine A Barrier Lowered)
+      Scan Visor
+
+> Pickup (Missile); Heals? False
+  * Pickup 86; Major Location? False
+  > Dock to Quarantine Access A
+      Space Jump Boots and After Metroid Quarantine A Barrier Lowered
+  > Dock to Elevator Access B
+      All of the following:
+          Morph Ball Bomb and Space Jump Boots and Morph Ball and Spider Ball
+          X-Ray Visor or Invisible Objects (Intermediate)
+
+> Event (Metroid Quarantine A Barrier Lowered); Heals? False
+  * Event Metroid Quarantine A Barrier Lowered
+  > Dock to Quarantine Access A
+      Trivial
 
 ----------------
 Quarantine Access B
 Asset id: 340985721
 > Dock to Metroid Quarantine B; Heals? False
-  * Normal Door to Metroid Quarantine B/Dock to Quarantine Access B
+  * Plasma Door to Metroid Quarantine B/Dock to Quarantine Access B
+  > Dock to Fungal Hall B
+      Space Jump Boots
 
 > Dock to Fungal Hall B; Heals? False
-  * Normal Door to Fungal Hall B/Dock to Quarantine Access B
+  * Plasma Door to Fungal Hall B/Dock to Quarantine Access B
+  > Dock to Metroid Quarantine B
+      Space Jump Boots
 
 ----------------
 Save Station Mines C
 Asset id: 1724960771
 > Dock to Metroid Quarantine B; Heals? False
-  * Normal Door to Metroid Quarantine B/Dock to Save Station Mines C
+  * Plasma Door to Metroid Quarantine B/Dock to Save Station Mines C
+  > Save Station
+      Trivial
+
+> Save Station; Heals? True
+  > Dock to Metroid Quarantine B
+      Trivial
 
 ----------------
 Elevator Access B
 Asset id: 1071241062
 > Dock to Metroid Quarantine A; Heals? False
-  * Normal Door to Metroid Quarantine A/Dock to Elevator Access B
+  * Ice Door to Metroid Quarantine A/Dock to Elevator Access B
+  > Dock to Elevator B
+      Trivial
 
 > Dock to Elevator B; Heals? False
-  * Normal Door to Elevator B/Dock to Elevator Access B
+  * Plasma Door to Elevator B/Dock to Elevator Access B
+  > Dock to Metroid Quarantine A
+      Trivial
 
 ----------------
 Fungal Hall B
 Asset id: 3964125762
 > Dock to Missile Station Mines; Heals? False
-  * Normal Door to Missile Station Mines/Dock to Fungal Hall B
+  * Plasma Door to Missile Station Mines/Dock to Fungal Hall B
+  > Dock to Phazon Mining Tunnel
+      Space Jump Boots
+  > Pickup (Missile)
+      Trivial
 
 > Dock to Quarantine Access B; Heals? False
-  * Normal Door to Quarantine Access B/Dock to Fungal Hall B
+  * Plasma Door to Quarantine Access B/Dock to Fungal Hall B
+  > Dock to Phazon Mining Tunnel
+      Space Jump Boots
+  > Pickup (Missile)
+      Trivial
 
 > Dock to Phazon Mining Tunnel; Heals? False
-  * Normal Door to Phazon Mining Tunnel/Dock to Fungal Hall B
+  * Plasma Door to Phazon Mining Tunnel/Dock to Fungal Hall B
+  > Dock to Missile Station Mines
+      Grapple Beam and Space Jump Boots
+  > Dock to Quarantine Access B
+      Grapple Beam and Space Jump Boots
+  > Pickup (Missile)
+      Trivial
+
+> Pickup (Missile); Heals? False
+  * Pickup 87; Major Location? False
+  > Dock to Phazon Mining Tunnel
+      Space Jump Boots
 
 ----------------
 Elevator B
 Asset id: 3900266464
 > Dock to Elevator Access B; Heals? False
-  * Normal Door to Elevator Access B/Dock to Elevator B
+  * Plasma Door to Elevator Access B/Dock to Elevator B
+  > Dock to Fungal Hall Access
+      Scan Visor
 
 > Dock to Fungal Hall Access; Heals? False
-  * Normal Door to Fungal Hall Access/Dock to Elevator B
+  * Plasma Door to Fungal Hall Access/Dock to Elevator B
+  > Dock to Elevator Access B
+      Trivial
 
 ----------------
 Missile Station Mines
 Asset id: 2961781534
 > Dock to Fungal Hall B; Heals? False
-  * Normal Door to Fungal Hall B/Dock to Missile Station Mines
+  * Plasma Door to Fungal Hall B/Dock to Missile Station Mines
 
 ----------------
 Phazon Mining Tunnel
 Asset id: 3153742515
 > Dock to Fungal Hall B; Heals? False
-  * Normal Door to Fungal Hall B/Dock to Phazon Mining Tunnel
+  * Plasma Door to Fungal Hall B/Dock to Phazon Mining Tunnel
+  > Dock to Fungal Hall A
+      Power Bomb and Morph Ball and Boost Ball
+  > Pickup (Artifact of Newborn)
+      Morph Ball Bomb and Morph Ball and Phazon Suit
 
 > Dock to Fungal Hall A; Heals? False
-  * Normal Door to Fungal Hall A/Dock to Phazon Mining Tunnel
+  * Plasma Door to Fungal Hall A/Dock to Phazon Mining Tunnel
+  > Dock to Fungal Hall B
+      Power Bomb and Morph Ball and Boost Ball
+
+> Pickup (Artifact of Newborn); Heals? False
+  * Pickup 88; Major Location? True
+  > Dock to Fungal Hall B
+      Missile and Morph Ball Bomb and Phazon Suit
 
 ----------------
 Fungal Hall Access
 Asset id: 3734860277
 > Dock to Fungal Hall A; Heals? False
-  * Normal Door to Fungal Hall A/Dock to Fungal Hall Access
+  * Plasma Door to Fungal Hall A/Dock to Fungal Hall Access
+  > Dock to Elevator B
+      Space Jump Boots
 
 > Dock to Elevator B; Heals? False
-  * Normal Door to Elevator B/Dock to Fungal Hall Access
+  * Plasma Door to Elevator B/Dock to Fungal Hall Access
+  > Dock to Fungal Hall A
+      Trivial
+  > Pickup (Missile)
+      Morph Ball
+
+> Pickup (Missile); Heals? False
+  * Pickup 89; Major Location? False
+  > Dock to Elevator B
+      Space Jump Boots and Morph Ball
 
 ----------------
 Fungal Hall A
 Asset id: 257062865
 > Dock to Phazon Mining Tunnel; Heals? False
-  * Normal Door to Phazon Mining Tunnel/Dock to Fungal Hall A
+  * Ice Door to Phazon Mining Tunnel/Dock to Fungal Hall A
+  > Dock to Fungal Hall Access
+      Space Jump Boots
 
 > Dock to Fungal Hall Access; Heals? False
-  * Normal Door to Fungal Hall Access/Dock to Fungal Hall A
+  * Ice Door to Fungal Hall Access/Dock to Fungal Hall A
+  > Dock to Phazon Mining Tunnel
+      Grapple Beam and Space Jump Boots
 
 ====================
 Tallon Overworld
@@ -3219,7 +4775,13 @@ Asset id: 2584347627
 > Event - Flaahgra; Heals? False
   * Event Flaahgra
   > Pickup (Varia Suit)
-      Morph Ball Bomb and Morph Ball
+      Any of the following:
+          All of the following:
+              Morph Ball
+              Any of the following:
+                  Morph Ball Bomb
+                  Power Bomb ≥ 4 and Combat (Beginner)
+          Wave Beam and Missile ≥ 230 and Wavebuster and Combat (Hypermode)
 
 > Event - Chozo Ghosts; Heals? False
   * Event Chozo Ghosts (Sunchamber)

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -2162,9 +2162,7 @@ Asset id: 3835971118
 > Dock to Twin Fires; Heals? False
   * Normal Door to Twin Fires/Dock to Twin Fires Tunnel
   > Dock to Transport to Tallon Overworld West
-      Any of the following:
-          Morph Ball and Boost Ball and Heat-Resisting Suit
-          Space Jump Boots and Heated Rooms Damage ≥ 165
+      Space Jump Boots and Heated Rooms Damage ≥ 165
 
 > Dock to Transport to Tallon Overworld West; Heals? False
   * Normal Door to Transport to Tallon Overworld West/Dock to Twin Fires Tunnel

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -1214,8 +1214,6 @@ Asset id: 1423896872
 
 > Dock to Security Cave; Heals? False
   * Morph Ball Door to Security Cave/Dock to Phendrana's Edge
-  > Dock to Lower Edge Tunnel
-      Morph Ball
   > Dock to Upper Edge Tunnel
       Morph Ball
   > Dock to Storage Cave

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -3098,15 +3098,11 @@ Asset id: 3964125762
 > Dock to Missile Station Mines; Heals? False
   * Plasma Door to Missile Station Mines/Dock to Fungal Hall B
   > Dock to Phazon Mining Tunnel
-      Space Jump Boots
-  > Pickup (Missile)
       Trivial
 
 > Dock to Quarantine Access B; Heals? False
   * Plasma Door to Quarantine Access B/Dock to Fungal Hall B
   > Dock to Phazon Mining Tunnel
-      Space Jump Boots
-  > Pickup (Missile)
       Trivial
 
 > Dock to Phazon Mining Tunnel; Heals? False; Spawn Point
@@ -3116,12 +3112,16 @@ Asset id: 3964125762
   > Dock to Quarantine Access B
       Grapple Beam and Space Jump Boots
   > Pickup (Missile)
-      Trivial
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Morph Ball Bomb
+              Power Bomb and Knowledge (Beginner)
 
 > Pickup (Missile); Heals? False
   * Pickup 87; Major Location? False
   > Dock to Phazon Mining Tunnel
-      Space Jump Boots
+      Trivial
 
 ----------------
 Elevator B
@@ -3148,19 +3148,23 @@ Asset id: 3153742515
 > Dock to Fungal Hall B; Heals? False
   * Plasma Door to Fungal Hall B/Dock to Phazon Mining Tunnel
   > Dock to Fungal Hall A
-      Power Bomb and Morph Ball and Boost Ball
+      All of the following:
+          Power Bomb and Morph Ball
+          Morph Ball Bomb or Boost Ball
   > Pickup (Artifact of Newborn)
       Morph Ball Bomb and Morph Ball and Phazon Suit
 
 > Dock to Fungal Hall A; Heals? False; Spawn Point
   * Plasma Door to Fungal Hall A/Dock to Phazon Mining Tunnel
   > Dock to Fungal Hall B
-      Power Bomb and Morph Ball and Boost Ball
+      All of the following:
+          Power Bomb and Morph Ball
+          Morph Ball Bomb or Boost Ball
 
 > Pickup (Artifact of Newborn); Heals? False
   * Pickup 88; Major Location? True
   > Dock to Fungal Hall B
-      Missile and Morph Ball Bomb and Phazon Suit
+      Morph Ball Bomb and Morph Ball and Phazon Suit
 
 ----------------
 Fungal Hall Access
@@ -3180,7 +3184,7 @@ Asset id: 3734860277
 > Pickup (Missile); Heals? False
   * Pickup 89; Major Location? False
   > Dock to Elevator B
-      Space Jump Boots and Morph Ball
+      Space Jump Boots
 
 ----------------
 Fungal Hall A

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -689,7 +689,7 @@ Asset id: 1139067941
   > Dock to Observatory Access
       Scan Visor and After Research Lab Hydra Barrier Lowered
   > Event (Research Lab Hydra Barrier Lowered)
-      Scan Visor and Before Research Lab Hydra Barrier Lowered
+      Scan Visor
 
 > Dock to Observatory Access; Heals? False
   * Wave Door to Observatory Access/Dock to Research Lab Hydra

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -213,12 +213,12 @@ Asset id: 3289414871
 > Dock to Transport to Magmoor Caverns West; Heals? False
   * Normal Door to Transport to Magmoor Caverns West/Dock to Shoreline Entrance
   > Dock to Phendrana Shorelines
-      Missile or Charge Beam
+      Missile or Charge Beam ≥ 3
 
 > Dock to Phendrana Shorelines; Heals? False
   * Normal Door to Phendrana Shorelines/Dock to Shoreline Entrance
   > Dock to Transport to Magmoor Caverns West
-      Missile or Charge Beam
+      Missile ≥ 3 or Charge Beam
 
 ----------------
 Phendrana Shorelines
@@ -265,7 +265,7 @@ Asset id: 4146616697
   > Pickup (Missile Behind Ice)
       Plasma Beam
   > Pickup (Spider Track Missile)
-      Missile and Scan Visor and Super Missile and Morph Ball and Spider Ball
+      Scan Visor and Morph Ball and Spider Ball and Shoot Super Missile
 
 > Pickup (Missile Behind Ice); Heals? False
   * Pickup 35; Major Location? False
@@ -283,12 +283,20 @@ Asset id: 2245653401
 > Dock to Chozo Ice Temple; Heals? False
   * Normal Door to Chozo Ice Temple/Dock to Temple Entryway
   > Dock to Phendrana Shorelines
-      Plasma Beam or Missile or Charge Beam
+      Any of the following:
+          Plasma Beam or Missile
+          All of the following:
+              Charge Beam
+              Power Beam or Wave Beam
 
 > Dock to Phendrana Shorelines; Heals? False
   * Normal Door to Phendrana Shorelines/Dock to Temple Entryway
   > Dock to Chozo Ice Temple
-      Plasma Beam or Missile or Charge Beam
+      Any of the following:
+          Plasma Beam or Missile
+          All of the following:
+              Charge Beam
+              Power Beam or Wave Beam
 
 ----------------
 Save Station B
@@ -346,30 +354,32 @@ Chozo Ice Temple
 Asset id: 1716909342
 > Dock to Temple Entryway; Heals? False
   * Normal Door to Temple Entryway/Dock to Chozo Ice Temple
-  > Pickup (Artifact of Sun)
-      Plasma Beam and Morph Ball Bomb and Space Jump Boots and Morph Ball
-  > Event (Chozo Ice Temple Bomb Slot)
-      Morph Ball Bomb and Space Jump Boots and Morph Ball
+  > Front of Bomb Slot
+      Space Jump Boots
 
 > Dock to Chapel Tunnel; Heals? False
   * Normal Door to Chapel Tunnel/Dock to Chozo Ice Temple
-  > Dock to Temple Entryway
+  > Front of Bomb Slot
       After Chozo Ice Temple Bomb Slot
-  > Pickup (Artifact of Sun)
-      Plasma Beam and Missile and Morph Ball Bomb and Morph Ball and After Chozo Ice Temple Bomb Slot
 
 > Pickup (Artifact of Sun); Heals? False
   * Pickup 37; Major Location? True
-  > Dock to Temple Entryway
-      Morph Ball
-  > Dock to Chapel Tunnel
+  > Front of Bomb Slot
       Morph Ball
 
 > Event (Chozo Ice Temple Bomb Slot); Heals? False
+  > Front of Bomb Slot
+      Trivial
+
+> Front of Bomb Slot; Heals? False
   > Dock to Temple Entryway
       Trivial
   > Dock to Chapel Tunnel
-      Trivial
+      After Chozo Ice Temple Bomb Slot
+  > Pickup (Artifact of Sun)
+      Plasma Beam and Space Jump Boots and Morph Ball
+  > Event (Chozo Ice Temple Bomb Slot)
+      Missile and Morph Ball Bomb and Morph Ball
 
 ----------------
 Ice Ruins West
@@ -377,17 +387,11 @@ Asset id: 3006924320
 > Dock to Ruins Entryway; Heals? False
   * Normal Door to Ruins Entryway/Dock to Ice Ruins West
   > Dock to Courtyard Entryway
-      All of the following:
-          Space Jump Boots
-          Any of the following:
-              Missile
-              Power Beam and Charge Beam and Super Missile
+      Missile and Space Jump Boots
   > Dock to Canyon Entryway
       Trivial
   > Pickup (Power Bomb)
-      All of the following:
-          Plasma Beam and Space Jump Boots
-          Missile or Super Missile
+      Plasma Beam and Missile and Space Jump Boots
 
 > Dock to Courtyard Entryway; Heals? False
   * Wave Door to Courtyard Entryway/Dock to Ice Ruins West
@@ -477,10 +481,13 @@ Asset id: 1086671081
   * Wave Door to Chapel Tunnel/Dock to Chapel of the Elders
   > Pickup (Wave Beam)
       Any of the following:
-          Missile
+          Missile ≥ 25
           All of the following:
               Morph Ball
-              Morph Ball Bomb or Power Bomb
+              Any of the following:
+                  Morph Ball Bomb
+                  Power Bomb and Combat (Beginner)
+          Missile ≥ 17 and Combat (Beginner)
 
 > Pickup (Wave Beam); Heals? False
   * Pickup 41; Major Location? True
@@ -494,7 +501,7 @@ Asset id: 421627757
   * Normal Door to Courtyard Entryway/Dock to Ruined Courtyard
   > Dock to Save Station A
       All of the following:
-          Missile and Space Jump Boots and Morph Ball
+          Space Jump Boots and Morph Ball
           Any of the following:
               Spider Ball
               Morph Ball Bomb and Boost Ball
@@ -507,7 +514,7 @@ Asset id: 421627757
       Space Jump Boots
   > Dock to Quarantine Access
       All of the following:
-          Wave Beam and Super Missile and Space Jump Boots
+          Wave Beam and Space Jump Boots and Shoot Super Missile
           Thermal Visor or Invisible Objects (Beginner)
   > Pickup (Energy Tank)
       Morph Ball Bomb and Space Jump Boots and Morph Ball
@@ -517,14 +524,14 @@ Asset id: 421627757
   > Dock to Courtyard Entryway
       Trivial
   > Dock to Save Station A
-      Missile and Space Jump Boots
+      Space Jump Boots
 
 > Dock to Quarantine Access; Heals? False
   * Normal Door to Quarantine Access/Dock to Ruined Courtyard
   > Dock to Courtyard Entryway
       Trivial
   > Dock to Save Station A
-      Missile and Space Jump Boots
+      Space Jump Boots
 
 > Pickup (Energy Tank); Heals? False
   * Pickup 42; Major Location? False
@@ -537,12 +544,12 @@ Asset id: 2718594133
 > Dock to Canyon Entryway; Heals? False
   * Normal Door to Canyon Entryway/Dock to Phendrana Canyon
   > Pickup (Boost Ball)
-      Space Jump Boots
+      Scan Visor or Space Jump Boots
 
 > Pickup (Boost Ball); Heals? False
   * Pickup 43; Major Location? True
   > Dock to Canyon Entryway
-      Boost Ball
+      Space Jump Boots or Boost Ball
 
 ----------------
 Save Station A
@@ -654,11 +661,9 @@ Asset id: 1880625556
       Trivial
 
 > Dock to Quarantine Monitor; Heals? False
-  * Normal Door to Quarantine Monitor/Dock to Quarantine Cave
-  > Dock to North Quarantine Tunnel
-      Morph Ball
+  * Morph Ball Door to Quarantine Monitor/Dock to Quarantine Cave
   > Dock to South Quarantine Tunnel
-      Morph Ball
+      Grapple Beam
   > Event (Thardus)
       Trivial
 
@@ -691,7 +696,7 @@ Asset id: 1139067941
   > Dock to Hydra Lab Entryway
       After Research Lab Hydra Barrier Lowered
   > Pickup (Missile)
-      Power Beam and Charge Beam and Super Missile
+      Shoot Super Missile
 
 > Event (Research Lab Hydra Barrier Lowered); Heals? False
   * Event Research Lab Hydra Barrier Lowered
@@ -720,7 +725,7 @@ Asset id: 3538349
 Quarantine Monitor
 Asset id: 563191901
 > Dock to Quarantine Cave; Heals? False
-  * Normal Door to Quarantine Cave/Dock to Quarantine Monitor
+  * Morph Ball Door to Quarantine Cave/Dock to Quarantine Monitor
   > Pickup (Missile)
       Trivial
 
@@ -740,7 +745,7 @@ Asset id: 935047996
 > Dock to Research Lab Hydra; Heals? False
   * Wave Door to Research Lab Hydra/Dock to Observatory Access
   > Dock to Observatory
-      Space Jump Boots
+      Trivial
 
 ----------------
 Transport to Magmoor Caverns South
@@ -749,13 +754,13 @@ Asset id: 3708487481
   * Ice Door to Transport Access/Dock to Transport to Magmoor Caverns South
   > Dock to South Quarantine Tunnel
       Morph Ball
-  > Elevator - Transport to Phendrana Drifts South
-      Scan Visor
 
 > Dock to South Quarantine Tunnel; Heals? False
   * Wave Door to South Quarantine Tunnel/Dock to Transport to Magmoor Caverns South
   > Dock to Transport Access
       Morph Ball and Spider Ball
+  > Elevator - Transport to Phendrana Drifts South
+      Scan Visor
 
 > Elevator - Transport to Phendrana Drifts South; Heals? False
   * Teleporter to Magmoor Caverns - Transport to Phendrana Drifts South
@@ -770,7 +775,7 @@ Asset id: 1068802894
   > Dock to Save Station D
       Space Jump Boots and After Observatory Activated
   > Event (Observatory Activated)
-      Scan Visor and Morph Ball Bomb and Space Jump Boots and Morph Ball and Boost Ball and Before Research Core Power Outage and Before Observatory Activated
+      Scan Visor and Morph Ball Bomb and Space Jump Boots and Morph Ball and Boost Ball and Before Research Core Power Outage
 
 > Dock to West Tower Entrance; Heals? False
   * Wave Door to West Tower Entrance/Dock to Observatory
@@ -998,23 +1003,13 @@ Asset id: 1282373491
 > Dock to Frost Cave Access; Heals? False
   * Wave Door to Frost Cave Access/Dock to Frost Cave
   > Dock to Save Station C
-      All of the following:
-          Space Jump Boots
-          Any of the following:
-              Missile
-              Power Beam and Charge Beam and Super Missile
+      Missile and Space Jump Boots
   > Dock to Upper Edge Tunnel
       All of the following:
           Space Jump Boots
-          Any of the following:
-              Missile or Grapple Beam
-              Power Beam and Charge Beam and Super Missile
+          Missile or Grapple Beam
   > Pickup (Missile)
-      All of the following:
-          Grapple Beam
-          Any of the following:
-              Missile
-              Power Beam and Charge Beam and Super Missile
+      Missile and Grapple Beam
 
 > Dock to Upper Edge Tunnel; Heals? False
   * Wave Door to Upper Edge Tunnel/Dock to Frost Cave
@@ -1024,19 +1019,13 @@ Asset id: 1282373491
 > Pickup (Missile); Heals? False
   * Pickup 51; Major Location? False
   > Dock to Save Station C
-      All of the following:
-          Space Jump Boots and Gravity Suit
-          Any of the following:
-              Missile
-              Power Beam and Charge Beam and Super Missile
+      Missile and Space Jump Boots and Gravity Suit
   > Dock to Frost Cave Access
       Space Jump Boots and Gravity Suit
   > Dock to Upper Edge Tunnel
       All of the following:
           Space Jump Boots and Gravity Suit
-          Any of the following:
-              Missile or Grapple Beam
-              Power Beam and Charge Beam and Super Missile
+          Missile or Grapple Beam
 
 ----------------
 Hunter Cave
@@ -1046,33 +1035,20 @@ Asset id: 516396314
   > Dock to Lower Edge Tunnel
       Any of the following:
           Space Jump Boots
-          All of the following:
-              Grapple Beam
-              Any of the following:
-                  Missile
-                  Power Beam and Charge Beam and Super Missile
+          Missile ≥ 3 and Grapple Beam
   > Dock to Chamber Access
       Trivial
 
 > Dock to Lower Edge Tunnel; Heals? False
   * Wave Door to Lower Edge Tunnel/Dock to Hunter Cave
   > Dock to Hunter Cave Access
-      All of the following:
-          Grapple Beam and Space Jump Boots
-          Any of the following:
-              Missile
-              Power Beam and Charge Beam and Super Missile
+      Missile ≥ 3 and Grapple Beam and Space Jump Boots
   > Dock to Chamber Access
-      All of the following:
-          Grapple Beam and Space Jump Boots
-          Any of the following:
-              Missile
-              Power Beam and Charge Beam and Super Missile
+      Missile ≥ 3 and Grapple Beam and Space Jump Boots
   > Dock to Lake Tunnel
       Any of the following:
-          Missile
+          Missile ≥ 3
           Space Jump Boots and Gravity Suit
-          Power Beam and Charge Beam and Super Missile
 
 > Dock to Chamber Access; Heals? False
   * Wave Door to Chamber Access/Dock to Hunter Cave
@@ -1105,7 +1081,7 @@ Asset id: 3639150045
 > Dock to Research Core; Heals? False
   * Wave Door to Research Core/Dock to Research Core Access
   > Dock to Research Lab Aether
-      Space Jump Boots
+      Trivial
 
 > Dock to Research Lab Aether; Heals? False
   * Wave Door to Research Lab Aether/Dock to Research Core Access
@@ -1207,7 +1183,6 @@ Asset id: 565493750
       Any of the following:
           Missile
           Power Bomb and Morph Ball
-          Power Beam and Charge Beam and Super Missile
 
 > Pickup (Energy Tank); Heals? False
   * Pickup 52; Major Location? False
@@ -1234,7 +1209,7 @@ Asset id: 1423896872
   > Dock to Storage Cave
       Power Bomb and Grapple Beam and Space Jump Boots and Morph Ball
   > Dock to Security Cave
-      Grapple Beam and Space Jump Boots and Morph Ball
+      Grapple Beam and Space Jump Boots
 
 > Dock to Storage Cave; Heals? False
   * Plasma Door to Storage Cave/Dock to Phendrana's Edge
@@ -1242,11 +1217,11 @@ Asset id: 1423896872
       Power Bomb and Morph Ball
 
 > Dock to Security Cave; Heals? False
-  * Normal Door to Security Cave/Dock to Phendrana's Edge
+  * Morph Ball Door to Security Cave/Dock to Phendrana's Edge
   > Dock to Lower Edge Tunnel
-      Morph Ball
+      Trivial
   > Dock to Upper Edge Tunnel
-      Morph Ball
+      Trivial
   > Dock to Storage Cave
       Power Bomb and Morph Ball
 
@@ -1292,7 +1267,7 @@ Asset id: 4157096768
 Security Cave
 Asset id: 1016369381
 > Dock to Phendrana's Edge; Heals? False
-  * Normal Door to Phendrana's Edge/Dock to Security Cave
+  * Morph Ball Door to Phendrana's Edge/Dock to Security Cave
   > Pickup (Power Bomb)
       Trivial
 
@@ -1740,10 +1715,8 @@ Asset id: 2758909034
                       Space Jump Boots and Heated Rooms Damage ≥ 539
   > Pickup (Artifact of Nature)
       Any of the following:
-          All of the following:
-              Grapple Beam and Heat-Resisting Suit
-              Missile or Shoot Super Missile
-          Missile and Space Jump Boots and Heated Rooms Damage ≥ 161
+          Missile ≥ 2 and Grapple Beam and Heat-Resisting Suit
+          Missile ≥ 2 and Space Jump Boots and Heated Rooms Damage ≥ 161
           Space Jump Boots and Heated Rooms Damage ≥ 145 and Shoot Super Missile
 
 > Dock to Pit Tunnel; Heals? False
@@ -1766,10 +1739,9 @@ Asset id: 2758909034
       All of the following:
           Space Jump Boots and Morph Ball
           Any of the following:
-              Missile and Morph Ball Bomb and Heated Rooms Damage ≥ 404
+              Missile ≥ 2 and Morph Ball Bomb and Heated Rooms Damage ≥ 404
               Morph Ball Bomb and Heated Rooms Damage ≥ 430 and Shoot Super Missile
               Missile and Power Bomb ≥ 2 and Heated Rooms Damage ≥ 479
-              Power Bomb ≥ 2 and Heated Rooms Damage ≥ 494 and Shoot Super Missile
 
 > Pickup (Artifact of Nature); Heals? False
   * Pickup 90; Major Location? True
@@ -1790,20 +1762,24 @@ Asset id: 3660499860
 > Dock to Triclops Pit; Heals? False
   * Normal Door to Triclops Pit/Dock to Pit Tunnel
   > Dock to Lava Lake
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Heated Rooms Damage ≥ 95
-              Boost Ball and Heated Rooms Damage ≥ 91
+      Any of the following:
+          All of the following:
+              Morph Ball
+              Any of the following:
+                  Heated Rooms Damage ≥ 95
+                  Boost Ball and Heated Rooms Damage ≥ 91
+          Space Jump Boots and Heated Rooms Damage ≥ 91
 
 > Dock to Lava Lake; Heals? False
   * Normal Door to Lava Lake/Dock to Pit Tunnel
   > Dock to Triclops Pit
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Heated Rooms Damage ≥ 86
-              Boost Ball and Heated Rooms Damage ≥ 72
+      Any of the following:
+          All of the following:
+              Morph Ball
+              Any of the following:
+                  Heated Rooms Damage ≥ 86
+                  Boost Ball and Heated Rooms Damage ≥ 72
+          Space Jump Boots and Heated Rooms Damage ≥ 91
 
 ----------------
 Triclops Pit
@@ -2536,7 +2512,7 @@ Asset id: 2507085138
 > Dock to Security Access A; Heals? False
   * Ice Door to Security Access A/Dock to Mine Security Station
   > Dock to Security Access B
-      Wave Beam and Space Jump Boots
+      Wave Beam
   > Dock to Storage Depot A
       Wave Beam and Scan Visor and Power Bomb and Morph Ball
 
@@ -2602,7 +2578,7 @@ Asset id: 2718040532
 > Dock to Mine Security Station; Heals? False
   * Wave Door to Mine Security Station/Dock to Security Access B
   > Dock to Elite Research
-      Space Jump Boots
+      Trivial
 
 ----------------
 Storage Depot A
@@ -2701,7 +2677,7 @@ Asset id: 3305828730
   > Dock to Maintenance Tunnel
       Trivial
   > Dock to Ventilation Shaft
-      Space Jump Boots and After Elite Control Barriers Lowered
+      After Elite Control Barriers Lowered
   > Event (Elite Control Barriers Lowered)
       Scan Visor
 
@@ -2853,7 +2829,7 @@ Asset id: 4111966698
 > Dock to Central Dynamo; Heals? False
   * Ice Door to Central Dynamo/Dock to Dynamo Access
   > Dock to Omega Research
-      Space Jump Boots
+      Trivial
 
 > Dock to Omega Research; Heals? False
   * Ice Door to Omega Research/Dock to Dynamo Access

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -70,7 +70,7 @@ Asset id: 1238049635
   > Dock to Crater Entry Point
       Trivial
 
-> Dock to Crater Entry Point; Heals? False
+> Dock to Crater Entry Point; Heals? False; Spawn Point
   * Plasma Door to Crater Entry Point/Dock to Crater Tunnel A
   > Dock to Phazon Core
       Trivial
@@ -85,7 +85,7 @@ Asset id: 3180620483
   > Dock to Crater Tunnel B
       Space Jump Boots
 
-> Dock to Crater Tunnel A; Heals? False
+> Dock to Crater Tunnel A; Heals? False; Spawn Point
   * Plasma Door to Crater Tunnel A/Dock to Phazon Core
   > Dock to Crater Missile Station
       Space Jump Boots
@@ -98,7 +98,7 @@ Asset id: 3180620483
 ----------------
 Crater Missile Station
 Asset id: 1296329791
-> Dock to Phazon Core; Heals? False
+> Dock to Phazon Core; Heals? False; Spawn Point
   * Plasma Door to Phazon Core/Dock to Crater Missile Station
   > Missile Station
       Trivial
@@ -115,7 +115,7 @@ Asset id: 852861312
   > Dock to Phazon Core
       Morph Ball Bomb and Morph Ball and Spider Ball
 
-> Dock to Phazon Core; Heals? False
+> Dock to Phazon Core; Heals? False; Spawn Point
   * Plasma Door to Phazon Core/Dock to Crater Tunnel B
   > Dock to Phazon Infusion Chamber
       Morph Ball Bomb and Morph Ball and Spider Ball
@@ -126,7 +126,7 @@ Asset id: 1729456653
 > Dock to Subchamber One; Heals? False
   * Other Door to Subchamber One/Dock to Phazon Infusion Chamber
 
-> Dock to Crater Tunnel B; Heals? False
+> Dock to Crater Tunnel B; Heals? False; Spawn Point
   * Plasma Door to Crater Tunnel B/Dock to Phazon Infusion Chamber
   > Dock to Subchamber One
       Trivial
@@ -134,7 +134,7 @@ Asset id: 1729456653
 ----------------
 Subchamber One
 Asset id: 3672049347
-> Dock to Phazon Infusion Chamber; Heals? False
+> Dock to Phazon Infusion Chamber; Heals? False; Spawn Point
   * Other Door to Phazon Infusion Chamber/Dock to Subchamber One
   > Dock to Subchamber Two
       Charge Beam and Have all Beams
@@ -145,7 +145,7 @@ Asset id: 3672049347
 ----------------
 Subchamber Two
 Asset id: 122281798
-> Dock to Subchamber One; Heals? False
+> Dock to Subchamber One; Heals? False; Spawn Point
   * Other Door to Subchamber One/Dock to Subchamber Two
   > Dock to Subchamber Three
       Charge Beam and Have all Beams
@@ -159,7 +159,7 @@ Asset id: 2050677022
 > Dock to Subchamber Four; Heals? False
   * Other Door to Subchamber Four/Dock to Subchamber Three
 
-> Dock to Subchamber Two; Heals? False
+> Dock to Subchamber Two; Heals? False; Spawn Point
   * Other Door to Subchamber Two/Dock to Subchamber Three
   > Dock to Subchamber Four
       Charge Beam and Have all Beams
@@ -170,7 +170,7 @@ Asset id: 2813067419
 > Dock to Subchamber Five; Heals? False
   * Other Door to Subchamber Five/Dock to Subchamber Four
 
-> Dock to Subchamber Three; Heals? False
+> Dock to Subchamber Three; Heals? False; Spawn Point
   * Other Door to Subchamber Three/Dock to Subchamber Four
   > Dock to Subchamber Five
       Charge Beam and Have all Beams
@@ -178,7 +178,7 @@ Asset id: 2813067419
 ----------------
 Subchamber Five
 Asset id: 2003911832
-> Dock to Subchamber Four; Heals? False
+> Dock to Subchamber Four; Heals? False; Spawn Point
   * Other Door to Subchamber Four/Dock to Subchamber Five
   > Dock to Metroid Prime Lair
       Charge Beam and Phazon Suit and All Beams
@@ -189,7 +189,7 @@ Asset id: 2003911832
 ----------------
 Metroid Prime Lair
 Asset id: 442920021
-> Dock to Subchamber Five; Heals? False
+> Dock to Subchamber Five; Heals? False; Spawn Point
   * Normal Door to Subchamber Five/Dock to Metroid Prime Lair
 
 ====================
@@ -202,7 +202,7 @@ Asset id: 3222157185
   > Elevator - Transport to Phendrana Drifts North
       Scan Visor
 
-> Elevator - Transport to Phendrana Drifts North; Heals? False
+> Elevator - Transport to Phendrana Drifts North; Heals? False; Spawn Point
   * Teleporter to Magmoor Caverns - Transport to Phendrana Drifts North
   > Dock to Shoreline Entrance
       Trivial
@@ -210,7 +210,7 @@ Asset id: 3222157185
 ----------------
 Shoreline Entrance
 Asset id: 3289414871
-> Dock to Transport to Magmoor Caverns West; Heals? False
+> Dock to Transport to Magmoor Caverns West; Heals? False; Spawn Point
   * Normal Door to Transport to Magmoor Caverns West/Dock to Shoreline Entrance
   > Dock to Phendrana Shorelines
       Missile ≥ 3 or Charge Beam
@@ -223,7 +223,7 @@ Asset id: 3289414871
 ----------------
 Phendrana Shorelines
 Asset id: 4146616697
-> Dock to Shoreline Entrance; Heals? False
+> Dock to Shoreline Entrance; Heals? False; Spawn Point
   * Normal Door to Shoreline Entrance/Dock to Phendrana Shorelines
   > Dock to Temple Entryway
       Space Jump Boots
@@ -289,7 +289,7 @@ Asset id: 2245653401
               Charge Beam
               Power Beam or Wave Beam
 
-> Dock to Phendrana Shorelines; Heals? False
+> Dock to Phendrana Shorelines; Heals? False; Spawn Point
   * Normal Door to Phendrana Shorelines/Dock to Temple Entryway
   > Dock to Chozo Ice Temple
       Any of the following:
@@ -306,7 +306,7 @@ Asset id: 92367261
   > Save Station
       Trivial
 
-> Save Station; Heals? True
+> Save Station; Heals? True; Spawn Point
   > Dock to Phendrana Shorelines
       Trivial
 
@@ -318,7 +318,7 @@ Asset id: 1007903802
   > Dock to Phendrana Shorelines
       Trivial
 
-> Dock to Phendrana Shorelines; Heals? False
+> Dock to Phendrana Shorelines; Heals? False; Spawn Point
   * Normal Door to Phendrana Shorelines/Dock to Ruins Entryway
   > Dock to Ice Ruins West
       Trivial
@@ -331,7 +331,7 @@ Asset id: 3356578450
   > Dock to Ice Ruins East
       Trivial
 
-> Dock to Ice Ruins East; Heals? False
+> Dock to Ice Ruins East; Heals? False; Spawn Point
   * Normal Door to Ice Ruins East/Dock to Plaza Walkway
   > Dock to Phendrana Shorelines
       Trivial
@@ -344,7 +344,7 @@ Asset id: 1317347388
   > Dock to Phendrana Shorelines
       Plasma Beam or Missile or Charge Beam
 
-> Dock to Phendrana Shorelines; Heals? False
+> Dock to Phendrana Shorelines; Heals? False; Spawn Point
   * Normal Door to Phendrana Shorelines/Dock to Ice Ruins Access
   > Dock to Ice Ruins East
       Plasma Beam or Missile or Charge Beam
@@ -352,7 +352,7 @@ Asset id: 1317347388
 ----------------
 Chozo Ice Temple
 Asset id: 1716909342
-> Dock to Temple Entryway; Heals? False
+> Dock to Temple Entryway; Heals? False; Spawn Point
   * Normal Door to Temple Entryway/Dock to Chozo Ice Temple
   > Front of Bomb Slot
       Space Jump Boots
@@ -384,7 +384,7 @@ Asset id: 1716909342
 ----------------
 Ice Ruins West
 Asset id: 3006924320
-> Dock to Ruins Entryway; Heals? False
+> Dock to Ruins Entryway; Heals? False; Spawn Point
   * Normal Door to Ruins Entryway/Dock to Ice Ruins West
   > Dock to Courtyard Entryway
       Missile and Space Jump Boots
@@ -411,7 +411,7 @@ Asset id: 3006924320
 ----------------
 Ice Ruins East
 Asset id: 3673997935
-> Dock to Ice Ruins Access; Heals? False
+> Dock to Ice Ruins Access; Heals? False; Spawn Point
   * Normal Door to Ice Ruins Access/Dock to Ice Ruins East
   > Dock to Plaza Walkway
       Space Jump Boots
@@ -438,7 +438,7 @@ Asset id: 3673997935
 ----------------
 Chapel Tunnel
 Asset id: 4016524108
-> Dock to Chapel of the Elders; Heals? False
+> Dock to Chapel of the Elders; Heals? False; Spawn Point
   * Normal Door to Chapel of the Elders/Dock to Chapel Tunnel
   > Dock to Chozo Ice Temple
       Morph Ball Bomb and Morph Ball
@@ -451,7 +451,7 @@ Asset id: 4016524108
 ----------------
 Courtyard Entryway
 Asset id: 3484986321
-> Dock to Ruined Courtyard; Heals? False
+> Dock to Ruined Courtyard; Heals? False; Spawn Point
   * Normal Door to Ruined Courtyard/Dock to Courtyard Entryway
   > Dock to Ice Ruins West
       Trivial
@@ -469,7 +469,7 @@ Asset id: 55410999
   > Dock to Ice Ruins West
       Trivial
 
-> Dock to Ice Ruins West; Heals? False
+> Dock to Ice Ruins West; Heals? False; Spawn Point
   * Missile Blast Shield to Ice Ruins West/Dock to Canyon Entryway
   > Dock to Phendrana Canyon
       Trivial
@@ -477,7 +477,7 @@ Asset id: 55410999
 ----------------
 Chapel of the Elders
 Asset id: 1086671081
-> Dock to Chapel Tunnel; Heals? False
+> Dock to Chapel Tunnel; Heals? False; Spawn Point
   * Wave Door to Chapel Tunnel/Dock to Chapel of the Elders
   > Pickup (Wave Beam)
       Any of the following:
@@ -526,7 +526,7 @@ Asset id: 421627757
   > Dock to Save Station A
       Space Jump Boots
 
-> Dock to Quarantine Access; Heals? False
+> Dock to Quarantine Access; Heals? False; Spawn Point
   * Normal Door to Quarantine Access/Dock to Ruined Courtyard
   > Dock to Courtyard Entryway
       Trivial
@@ -541,7 +541,7 @@ Asset id: 421627757
 ----------------
 Phendrana Canyon
 Asset id: 2718594133
-> Dock to Canyon Entryway; Heals? False
+> Dock to Canyon Entryway; Heals? False; Spawn Point
   * Normal Door to Canyon Entryway/Dock to Phendrana Canyon
   > Pickup (Boost Ball)
       Scan Visor or Space Jump Boots
@@ -559,7 +559,7 @@ Asset id: 1452580971
   > Save Station
       Trivial
 
-> Save Station; Heals? True
+> Save Station; Heals? True; Spawn Point
   > Dock to Ruined Courtyard
       Trivial
 
@@ -571,7 +571,7 @@ Asset id: 3544306395
   > Dock to Ruined Courtyard
       Trivial
 
-> Dock to Ruined Courtyard; Heals? False
+> Dock to Ruined Courtyard; Heals? False; Spawn Point
   * Wave Door to Ruined Courtyard/Dock to Specimen Storage
   > Dock to Research Entrance
       Trivial
@@ -584,7 +584,7 @@ Asset id: 3937607887
   > Dock to Ruined Courtyard
       Trivial
 
-> Dock to Ruined Courtyard; Heals? False
+> Dock to Ruined Courtyard; Heals? False; Spawn Point
   * Normal Door to Ruined Courtyard/Dock to Quarantine Access
   > Dock to North Quarantine Tunnel
       Trivial
@@ -592,7 +592,7 @@ Asset id: 3937607887
 ----------------
 Research Entrance
 Asset id: 3038760489
-> Dock to Specimen Storage; Heals? False
+> Dock to Specimen Storage; Heals? False; Spawn Point
   * Wave Door to Specimen Storage/Dock to Research Entrance
   > Dock to Map Station
       Trivial
@@ -617,7 +617,7 @@ Asset id: 98670126
   > Dock to Quarantine Access
       Morph Ball
 
-> Dock to Quarantine Access; Heals? False
+> Dock to Quarantine Access; Heals? False; Spawn Point
   * Wave Door to Quarantine Access/Dock to North Quarantine Tunnel
   > Dock to Quarantine Cave
       Morph Ball
@@ -625,13 +625,13 @@ Asset id: 98670126
 ----------------
 Map Station
 Asset id: 2199198515
-> Dock to Research Entrance; Heals? False
+> Dock to Research Entrance; Heals? False; Spawn Point
   * Normal Door to Research Entrance/Dock to Map Station
 
 ----------------
 Hydra Lab Entryway
 Asset id: 961011783
-> Dock to Research Entrance; Heals? False
+> Dock to Research Entrance; Heals? False; Spawn Point
   * Wave Door to Research Entrance/Dock to Hydra Lab Entryway
   > Dock to Research Lab Hydra
       Trivial
@@ -644,7 +644,7 @@ Asset id: 961011783
 ----------------
 Quarantine Cave
 Asset id: 1880625556
-> Dock to North Quarantine Tunnel; Heals? False
+> Dock to North Quarantine Tunnel; Heals? False; Spawn Point
   * Wave Door to North Quarantine Tunnel/Dock to Quarantine Cave
   > Dock to South Quarantine Tunnel
       Morph Ball and Spider Ball and After Thardus
@@ -684,7 +684,7 @@ Asset id: 1880625556
 ----------------
 Research Lab Hydra
 Asset id: 1139067941
-> Dock to Hydra Lab Entryway; Heals? False
+> Dock to Hydra Lab Entryway; Heals? False; Spawn Point
   * Wave Door to Hydra Lab Entryway/Dock to Research Lab Hydra
   > Dock to Observatory Access
       Scan Visor and After Research Lab Hydra Barrier Lowered
@@ -716,7 +716,7 @@ Asset id: 3538349
   > Dock to Transport to Magmoor Caverns South
       Morph Ball
 
-> Dock to Transport to Magmoor Caverns South; Heals? False
+> Dock to Transport to Magmoor Caverns South; Heals? False; Spawn Point
   * Wave Door to Transport to Magmoor Caverns South/Dock to South Quarantine Tunnel
   > Dock to Quarantine Cave
       Morph Ball
@@ -724,7 +724,7 @@ Asset id: 3538349
 ----------------
 Quarantine Monitor
 Asset id: 563191901
-> Dock to Quarantine Cave; Heals? False
+> Dock to Quarantine Cave; Heals? False; Spawn Point
   * Morph Ball Door to Quarantine Cave/Dock to Quarantine Monitor
   > Pickup (Missile)
       Morph Ball
@@ -742,7 +742,7 @@ Asset id: 935047996
   > Dock to Research Lab Hydra
       Trivial
 
-> Dock to Research Lab Hydra; Heals? False
+> Dock to Research Lab Hydra; Heals? False; Spawn Point
   * Wave Door to Research Lab Hydra/Dock to Observatory Access
   > Dock to Observatory
       Trivial
@@ -762,7 +762,7 @@ Asset id: 3708487481
   > Elevator - Transport to Phendrana Drifts South
       Scan Visor
 
-> Elevator - Transport to Phendrana Drifts South; Heals? False
+> Elevator - Transport to Phendrana Drifts South; Heals? False; Spawn Point
   * Teleporter to Magmoor Caverns - Transport to Phendrana Drifts South
   > Dock to Transport Access
       Trivial
@@ -770,7 +770,7 @@ Asset id: 3708487481
 ----------------
 Observatory
 Asset id: 1068802894
-> Dock to Observatory Access; Heals? False
+> Dock to Observatory Access; Heals? False; Spawn Point
   * Wave Door to Observatory Access/Dock to Observatory
   > Dock to Save Station D
       Space Jump Boots and After Observatory Activated
@@ -819,7 +819,7 @@ Asset id: 3600136536
   > Dock to Frozen Pike
       Trivial
 
-> Dock to Frozen Pike; Heals? False
+> Dock to Frozen Pike; Heals? False; Spawn Point
   * Wave Door to Frozen Pike/Dock to Transport Access
   > Dock to Transport to Magmoor Caverns South
       Trivial
@@ -834,7 +834,7 @@ Asset id: 3600136536
 ----------------
 West Tower Entrance
 Asset id: 508080527
-> Dock to West Tower ; Heals? False
+> Dock to West Tower ; Heals? False; Spawn Point
   * Missile Blast Shield to West Tower /Dock to West Tower Entrance
   > Dock to Observatory
       Trivial
@@ -852,14 +852,14 @@ Asset id: 1901867502
   > Save Station
       Trivial
 
-> Save Station; Heals? True
+> Save Station; Heals? True; Spawn Point
   > Dock to Observatory
       Trivial
 
 ----------------
 Frozen Pike
 Asset id: 3617515525
-> Dock to Pike Access; Heals? False
+> Dock to Pike Access; Heals? False; Spawn Point
   * Wave Door to Pike Access/Dock to Frozen Pike
   > Dock to Transport Access
       Morph Ball Bomb and Space Jump Boots and Morph Ball
@@ -886,7 +886,7 @@ Asset id: 3617515525
 ----------------
 West Tower 
 Asset id: 3617418143
-> Dock to West Tower Entrance; Heals? False
+> Dock to West Tower Entrance; Heals? False; Spawn Point
   * Missile Blast Shield to West Tower Entrance/Dock to West Tower 
   > Dock to Control Tower
       Scan Visor
@@ -904,7 +904,7 @@ Asset id: 1980658458
   > Dock to Research Core
       Trivial
 
-> Dock to Research Core; Heals? False
+> Dock to Research Core; Heals? False; Spawn Point
   * Ice Door to Research Core/Dock to Pike Access
   > Dock to Frozen Pike
       Trivial
@@ -912,7 +912,7 @@ Asset id: 1980658458
 ----------------
 Frost Cave Access
 Asset id: 969347001
-> Dock to Frozen Pike; Heals? False
+> Dock to Frozen Pike; Heals? False; Spawn Point
   * Wave Door to Frozen Pike/Dock to Frost Cave Access
   > Dock to Frost Cave
       Morph Ball
@@ -925,7 +925,7 @@ Asset id: 969347001
 ----------------
 Hunter Cave Access
 Asset id: 552213808
-> Dock to Frozen Pike; Heals? False
+> Dock to Frozen Pike; Heals? False; Spawn Point
   * Wave Door to Frozen Pike/Dock to Hunter Cave Access
   > Dock to Hunter Cave
       Trivial
@@ -945,7 +945,7 @@ Asset id: 3015914057
   > Pickup (Artifact of Elder)
       Plasma Beam and Missile and Space Jump Boots and Morph Ball
 
-> Dock to West Tower ; Heals? False
+> Dock to West Tower ; Heals? False; Spawn Point
   * Wave Door to West Tower /Dock to Control Tower
   > Dock to East Tower
       Trivial
@@ -969,7 +969,7 @@ Asset id: 2761631044
   > Pickup (Thermal Visor)
       Scan Visor
 
-> Dock to Research Core Access; Heals? False
+> Dock to Research Core Access; Heals? False; Spawn Point
   * Wave Door to Research Core Access/Dock to Research Core
   > Dock to Pike Access
       Trivial
@@ -996,7 +996,7 @@ Asset id: 1282373491
   > Dock to Frost Cave Access
       Space Jump Boots
 
-> Dock to Frost Cave Access; Heals? False
+> Dock to Frost Cave Access; Heals? False; Spawn Point
   * Wave Door to Frost Cave Access/Dock to Frost Cave
   > Dock to Save Station C
       Missile and Space Jump Boots
@@ -1035,7 +1035,7 @@ Asset id: 516396314
   > Dock to Chamber Access
       Trivial
 
-> Dock to Lower Edge Tunnel; Heals? False
+> Dock to Lower Edge Tunnel; Heals? False; Spawn Point
   * Wave Door to Lower Edge Tunnel/Dock to Hunter Cave
   > Dock to Hunter Cave Access
       Missile ≥ 3 and Grapple Beam and Space Jump Boots
@@ -1066,7 +1066,7 @@ Asset id: 1359550769
   > Dock to Control Tower
       Trivial
 
-> Dock to Control Tower; Heals? False
+> Dock to Control Tower; Heals? False; Spawn Point
   * Wave Door to Control Tower/Dock to East Tower
   > Dock to Aether Lab Entryway
       Scan Visor
@@ -1074,7 +1074,7 @@ Asset id: 1359550769
 ----------------
 Research Core Access
 Asset id: 3639150045
-> Dock to Research Core; Heals? False
+> Dock to Research Core; Heals? False; Spawn Point
   * Wave Door to Research Core/Dock to Research Core Access
   > Dock to Research Lab Aether
       Trivial
@@ -1092,14 +1092,14 @@ Asset id: 3470637624
   > Save Station
       Trivial
 
-> Save Station; Heals? True
+> Save Station; Heals? True; Spawn Point
   > Dock to Frost Cave
       Trivial
 
 ----------------
 Upper Edge Tunnel
 Asset id: 624850611
-> Dock to Phendrana's Edge; Heals? False
+> Dock to Phendrana's Edge; Heals? False; Spawn Point
   * Wave Door to Phendrana's Edge/Dock to Upper Edge Tunnel
   > Dock to Frost Cave
       Morph Ball
@@ -1112,7 +1112,7 @@ Asset id: 624850611
 ----------------
 Lower Edge Tunnel
 Asset id: 1400901764
-> Dock to Phendrana's Edge; Heals? False
+> Dock to Phendrana's Edge; Heals? False; Spawn Point
   * Wave Door to Phendrana's Edge/Dock to Lower Edge Tunnel
   > Dock to Hunter Cave
       Morph Ball
@@ -1125,7 +1125,7 @@ Asset id: 1400901764
 ----------------
 Chamber Access
 Asset id: 3396124754
-> Dock to Hunter Cave; Heals? False
+> Dock to Hunter Cave; Heals? False; Spawn Point
   * Wave Door to Hunter Cave/Dock to Chamber Access
   > Dock to Gravity Chamber
       Trivial
@@ -1138,7 +1138,7 @@ Asset id: 3396124754
 ----------------
 Lake Tunnel
 Asset id: 2312609958
-> Dock to Hunter Cave; Heals? False
+> Dock to Hunter Cave; Heals? False; Spawn Point
   * Wave Door to Hunter Cave/Dock to Lake Tunnel
   > Dock to Gravity Chamber
       Trivial
@@ -1151,7 +1151,7 @@ Asset id: 2312609958
 ----------------
 Aether Lab Entryway
 Asset id: 2564604705
-> Dock to East Tower; Heals? False
+> Dock to East Tower; Heals? False; Spawn Point
   * Wave Door to East Tower/Dock to Aether Lab Entryway
   > Dock to Research Lab Aether
       Trivial
@@ -1164,7 +1164,7 @@ Asset id: 2564604705
 ----------------
 Research Lab Aether
 Asset id: 565493750
-> Dock to Aether Lab Entryway; Heals? False
+> Dock to Aether Lab Entryway; Heals? False; Spawn Point
   * Wave Door to Aether Lab Entryway/Dock to Research Lab Aether
   > Dock to Research Core Access
       Trivial
@@ -1198,7 +1198,7 @@ Asset id: 1423896872
   > Dock to Upper Edge Tunnel
       Space Jump Boots
 
-> Dock to Upper Edge Tunnel; Heals? False
+> Dock to Upper Edge Tunnel; Heals? False; Spawn Point
   * Wave Door to Upper Edge Tunnel/Dock to Phendrana's Edge
   > Dock to Lower Edge Tunnel
       Trivial
@@ -1222,7 +1222,7 @@ Asset id: 1423896872
 ----------------
 Gravity Chamber
 Asset id: 1226265714
-> Dock to Lake Tunnel; Heals? False
+> Dock to Lake Tunnel; Heals? False; Spawn Point
   * Wave Door to Lake Tunnel/Dock to Gravity Chamber
   > Pickup (Gravity Suit)
       Space Jump Boots
@@ -1247,7 +1247,7 @@ Asset id: 1226265714
 ----------------
 Storage Cave
 Asset id: 4157096768
-> Dock to Phendrana's Edge; Heals? False
+> Dock to Phendrana's Edge; Heals? False; Spawn Point
   * Plasma Door to Phendrana's Edge/Dock to Storage Cave
   > Pickup (Artifact of Spirit)
       Trivial
@@ -1260,7 +1260,7 @@ Asset id: 4157096768
 ----------------
 Security Cave
 Asset id: 1016369381
-> Dock to Phendrana's Edge; Heals? False
+> Dock to Phendrana's Edge; Heals? False; Spawn Point
   * Morph Ball Door to Phendrana's Edge/Dock to Security Cave
   > Pickup (Power Bomb)
       Morph Ball
@@ -1282,7 +1282,7 @@ Asset id: 3508802073
   > Teleport to Landing Site
       After Parasite Queen Defeated
 
-> Ship Save; Heals? True
+> Ship Save; Heals? True; Spawn Point
   > Dock to Air Lock
       Scan Visor
 
@@ -1295,7 +1295,7 @@ Asset id: 123995650
 > Dock to Deck Alpha Access Hall; Heals? False
   * Normal Door to Deck Alpha Access Hall/Dock to Air Lock
 
-> Dock to Exterior Docking Hangar; Heals? False
+> Dock to Exterior Docking Hangar; Heals? False; Spawn Point
   * Normal Door to Exterior Docking Hangar/Dock to Air Lock
   > Dock to Deck Alpha Access Hall
       Scan Visor
@@ -1308,7 +1308,7 @@ Asset id: 123995650
 ----------------
 Deck Alpha Access Hall
 Asset id: 1649363258
-> Dock to Air Lock; Heals? False
+> Dock to Air Lock; Heals? False; Spawn Point
   * Normal Door to Air Lock/Dock to Deck Alpha Access Hall
   > Dock to Emergency Evacuation Area
       Trivial
@@ -1319,7 +1319,7 @@ Asset id: 1649363258
 ----------------
 Deck Alpha Mech Shaft
 Asset id: 3365346969
-> Dock to Connection Elevator to Deck Alpha; Heals? False
+> Dock to Connection Elevator to Deck Alpha; Heals? False; Spawn Point
   * Normal Door to Connection Elevator to Deck Alpha/Dock to Deck Alpha Mech Shaft
   > Dock to Air Lock
       Trivial
@@ -1333,7 +1333,7 @@ Asset id: 551846422
 > Dock to Deck Alpha Umbilical Hall; Heals? False
   * Normal Door to Deck Alpha Umbilical Hall/Dock to Emergency Evacuation Area
 
-> Dock to Deck Alpha Access Hall; Heals? False
+> Dock to Deck Alpha Access Hall; Heals? False; Spawn Point
   * Normal Door to Deck Alpha Access Hall/Dock to Emergency Evacuation Area
   > Dock to Deck Alpha Umbilical Hall
       Trivial
@@ -1341,7 +1341,7 @@ Asset id: 551846422
 ----------------
 Connection Elevator to Deck Alpha
 Asset id: 2921253053
-> Dock to Biotech Research Area 2; Heals? False
+> Dock to Biotech Research Area 2; Heals? False; Spawn Point
   * Normal Door to Biotech Research Area 2/Dock to Connection Elevator to Deck Alpha
   > Event (Item Loss) UNIMPLEMENTED
       Scan Visor
@@ -1356,7 +1356,7 @@ Asset id: 2921253053
 ----------------
 Deck Alpha Umbilical Hall
 Asset id: 3995189286
-> Dock to Emergency Evacuation Area; Heals? False
+> Dock to Emergency Evacuation Area; Heals? False; Spawn Point
   * Normal Door to Emergency Evacuation Area/Dock to Deck Alpha Umbilical Hall
   > Dock to Map Facility
       All of the following:
@@ -1369,7 +1369,7 @@ Asset id: 3995189286
 ----------------
 Biotech Research Area 2
 Asset id: 3319675910
-> Dock to Main Ventilation Shaft Section F; Heals? False
+> Dock to Main Ventilation Shaft Section F; Heals? False; Spawn Point
   * Normal Door to Main Ventilation Shaft Section F/Dock to Biotech Research Area 2
   > Dock to Connection Elevator to Deck Alpha
       Grapple Beam or Space Jump Boots
@@ -1380,7 +1380,7 @@ Asset id: 3319675910
 ----------------
 Map Facility
 Asset id: 3454403824
-> Dock to Deck Alpha Umbilical Hall; Heals? False
+> Dock to Deck Alpha Umbilical Hall; Heals? False; Spawn Point
   * Normal Door to Deck Alpha Umbilical Hall/Dock to Map Facility
   > Dock to Connection Elevator to Deck Beta
       Trivial
@@ -1394,7 +1394,7 @@ Asset id: 274035036
 > Dock to Biotech Research Area 2; Heals? False
   * Normal Door to Biotech Research Area 2/Dock to Main Ventilation Shaft Section F
 
-> Dock to Main Ventilation Shaft Section E; Heals? False
+> Dock to Main Ventilation Shaft Section E; Heals? False; Spawn Point
   * Normal Door to Main Ventilation Shaft Section E/Dock to Main Ventilation Shaft Section F
   > Dock to Biotech Research Area 2
       Trivial
@@ -1402,7 +1402,7 @@ Asset id: 274035036
 ----------------
 Connection Elevator to Deck Beta
 Asset id: 834947875
-> Dock to Map Facility; Heals? False
+> Dock to Map Facility; Heals? False; Spawn Point
   * Normal Door to Map Facility/Dock to Connection Elevator to Deck Beta
   > Dock to Deck Beta Conduit Hall
       Scan Visor
@@ -1416,7 +1416,7 @@ Asset id: 690871324
 > Dock to Main Ventilation Shaft Section F; Heals? False
   * Normal Door to Main Ventilation Shaft Section F/Dock to Main Ventilation Shaft Section E
 
-> Dock to Main Ventilation Shaft Section D; Heals? False
+> Dock to Main Ventilation Shaft Section D; Heals? False; Spawn Point
   * Normal Door to Main Ventilation Shaft Section D/Dock to Main Ventilation Shaft Section E
   > Dock to Main Ventilation Shaft Section F
       Trivial
@@ -1427,7 +1427,7 @@ Asset id: 2827042742
 > Dock to Biotech Research Area 1; Heals? False
   * Normal Door to Biotech Research Area 1/Dock to Deck Beta Conduit Hall
 
-> Dock to Connection Elevator to Deck Beta; Heals? False
+> Dock to Connection Elevator to Deck Beta; Heals? False; Spawn Point
   * Normal Door to Connection Elevator to Deck Beta/Dock to Deck Beta Conduit Hall
   > Dock to Biotech Research Area 1
       Morph Ball
@@ -1435,7 +1435,7 @@ Asset id: 2827042742
 ----------------
 Main Ventilation Shaft Section D
 Asset id: 1040562396
-> Dock to Main Ventilation Shaft Section C; Heals? False
+> Dock to Main Ventilation Shaft Section C; Heals? False; Spawn Point
   * Normal Door to Main Ventilation Shaft Section C/Dock to Main Ventilation Shaft Section D
   > Dock to Main Ventilation Shaft Section E
       Trivial
@@ -1449,7 +1449,7 @@ Asset id: 2237107796
 > Dock to Deck Beta Security Hall; Heals? False
   * Normal Door to Deck Beta Security Hall/Dock to Biotech Research Area 1
 
-> Dock to Deck Beta Conduit Hall; Heals? False
+> Dock to Deck Beta Conduit Hall; Heals? False; Spawn Point
   * Normal Door to Deck Beta Conduit Hall/Dock to Biotech Research Area 1
   > Dock to Deck Beta Security Hall
       Before Parasite Queen Defeated
@@ -1468,7 +1468,7 @@ Asset id: 1541179036
 > Dock to Main Ventilation Shaft Section D; Heals? False
   * Normal Door to Main Ventilation Shaft Section D/Dock to Main Ventilation Shaft Section C
 
-> Dock to Main Ventilation Shaft Section B; Heals? False
+> Dock to Main Ventilation Shaft Section B; Heals? False; Spawn Point
   * Normal Door to Main Ventilation Shaft Section B/Dock to Main Ventilation Shaft Section C
   > Dock to Main Ventilation Shaft Section D
       Trivial
@@ -1479,7 +1479,7 @@ Asset id: 1237686565
 > Dock to Biohazard Containment; Heals? False
   * Normal Door to Biohazard Containment/Dock to Deck Beta Security Hall
 
-> Dock to Biotech Research Area 1; Heals? False
+> Dock to Biotech Research Area 1; Heals? False; Spawn Point
   * Normal Door to Biotech Research Area 1/Dock to Deck Beta Security Hall
   > Dock to Biohazard Containment
       Trivial
@@ -1490,7 +1490,7 @@ Asset id: 1859330843
 > Dock to Biotech Research Area 1; Heals? False
   * Normal Door to Biotech Research Area 1/Dock to Connection Elevator to Deck Beta
 
-> Dock to Deck Gamma Monitor Hall; Heals? False
+> Dock to Deck Gamma Monitor Hall; Heals? False; Spawn Point
   * Normal Door to Deck Gamma Monitor Hall/Dock to Connection Elevator to Deck Beta
   > Dock to Biotech Research Area 1
       Scan Visor
@@ -1498,7 +1498,7 @@ Asset id: 1859330843
 ----------------
 Subventilation Shaft Section A
 Asset id: 154468580
-> Dock to Biotech Research Area 1; Heals? False
+> Dock to Biotech Research Area 1; Heals? False; Spawn Point
   * Normal Door to Biotech Research Area 1/Dock to Subventilation Shaft Section A
   > Dock to Subventilation Shaft Section B
       Trivial
@@ -1509,7 +1509,7 @@ Asset id: 154468580
 ----------------
 Main Ventilation Shaft Section B
 Asset id: 1291117148
-> Dock to Main Ventilation Shaft Section A; Heals? False
+> Dock to Main Ventilation Shaft Section A; Heals? False; Spawn Point
   * Normal Door to Main Ventilation Shaft Section A/Dock to Main Ventilation Shaft Section B
   > Dock to Main Ventilation Shaft Section C
       Trivial
@@ -1520,7 +1520,7 @@ Asset id: 1291117148
 ----------------
 Biohazard Containment
 Asset id: 3513460432
-> Dock to Deck Beta Transit Hall; Heals? False
+> Dock to Deck Beta Transit Hall; Heals? False; Spawn Point
   * Normal Door to Deck Beta Transit Hall/Dock to Biohazard Containment
 
 > Dock to Deck Beta Security Hall; Heals? False
@@ -1531,7 +1531,7 @@ Asset id: 3513460432
 ----------------
 Deck Gamma Monitor Hall
 Asset id: 3865556485
-> Dock to Reactor Core; Heals? False
+> Dock to Reactor Core; Heals? False; Spawn Point
   * Normal Door to Reactor Core/Dock to Deck Gamma Monitor Hall
   > Dock to Connection Elevator to Deck Beta
       Trivial
@@ -1545,7 +1545,7 @@ Asset id: 3233526410
 > Dock to Cargo Freight Lift to Deck Gamma; Heals? False
   * Normal Door to Cargo Freight Lift to Deck Gamma/Dock to Subventilation Shaft Section B
 
-> Dock to Subventilation Shaft Section A; Heals? False
+> Dock to Subventilation Shaft Section A; Heals? False; Spawn Point
   * Normal Door to Subventilation Shaft Section A/Dock to Subventilation Shaft Section B
   > Dock to Cargo Freight Lift to Deck Gamma
       Trivial
@@ -1553,7 +1553,7 @@ Asset id: 3233526410
 ----------------
 Main Ventilation Shaft Section A
 Asset id: 1972129564
-> Dock to Cargo Freight Lift to Deck Gamma; Heals? False
+> Dock to Cargo Freight Lift to Deck Gamma; Heals? False; Spawn Point
   * Normal Door to Cargo Freight Lift to Deck Gamma/Dock to Main Ventilation Shaft Section A
   > Dock to Main Ventilation Shaft Section B
       Trivial
@@ -1567,7 +1567,7 @@ Asset id: 748855907
 > Dock to Cargo Freight Lift to Deck Gamma; Heals? False
   * Normal Door to Cargo Freight Lift to Deck Gamma/Dock to Deck Beta Transit Hall
 
-> Dock to Biohazard Containment; Heals? False
+> Dock to Biohazard Containment; Heals? False; Spawn Point
   * Normal Door to Biohazard Containment/Dock to Deck Beta Transit Hall
   > Dock to Cargo Freight Lift to Deck Gamma
       Trivial
@@ -1575,7 +1575,7 @@ Asset id: 748855907
 ----------------
 Reactor Core
 Asset id: 2269457857
-> Dock to Reactor Core Entrance; Heals? False
+> Dock to Reactor Core Entrance; Heals? False; Spawn Point
   * Normal Door to Reactor Core Entrance/Dock to Reactor Core
   > Event (Parasite Queen Defeated)
       Trivial
@@ -1591,7 +1591,7 @@ Asset id: 2269457857
 ----------------
 Cargo Freight Lift to Deck Gamma
 Asset id: 1878064482
-> Dock to Deck Beta Transit Hall; Heals? False
+> Dock to Deck Beta Transit Hall; Heals? False; Spawn Point
   * Normal Door to Deck Beta Transit Hall/Dock to Cargo Freight Lift to Deck Gamma
   > Dock to Reactor Core Entrance
       Scan Visor and Morph Ball
@@ -1620,7 +1620,7 @@ Asset id: 1050775790
 > Dock to Reactor Core; Heals? False
   * Normal Door to Reactor Core/Dock to Reactor Core Entrance
 
-> Save Station; Heals? True
+> Save Station; Heals? True; Spawn Point
   > Dock to Cargo Freight Lift to Deck Gamma
       Trivial
 
@@ -1647,7 +1647,7 @@ Asset id: 1833127758
   > Dock to Save Station Magmoor A
       Trivial
 
-> Dock to Transport to Chozo Ruins North; Heals? False
+> Dock to Transport to Chozo Ruins North; Heals? False; Spawn Point
   * Normal Door to Transport to Chozo Ruins North/Dock to Burning Trail
   > Dock to Save Station Magmoor A
       Trivial
@@ -1669,7 +1669,7 @@ Asset id: 2037927229
           Heated Rooms Damage ≥ 100
           Space Jump Boots and Heated Rooms Damage ≥ 91
 
-> Dock to Burning Trail; Heals? False
+> Dock to Burning Trail; Heals? False; Spawn Point
   * Normal Door to Burning Trail/Dock to Lake Tunnel
   > Dock to Lava Lake
       Any of the following:
@@ -1684,14 +1684,14 @@ Asset id: 162783260
   > Save Station
       Trivial
 
-> Save Station; Heals? True
+> Save Station; Heals? True; Spawn Point
   > Dock to Burning Trail
       Trivial
 
 ----------------
 Lava Lake
 Asset id: 2758909034
-> Dock to Lake Tunnel; Heals? False
+> Dock to Lake Tunnel; Heals? False; Spawn Point
   * Normal Door to Lake Tunnel/Dock to Lava Lake
   > Dock to Pit Tunnel
       All of the following:
@@ -1763,7 +1763,7 @@ Asset id: 3660499860
                   Boost Ball and Heated Rooms Damage ≥ 91
           Space Jump Boots and Heated Rooms Damage ≥ 91
 
-> Dock to Lava Lake; Heals? False
+> Dock to Lava Lake; Heals? False; Spawn Point
   * Normal Door to Lava Lake/Dock to Pit Tunnel
   > Dock to Triclops Pit
       Any of the following:
@@ -1777,7 +1777,7 @@ Asset id: 3660499860
 ----------------
 Triclops Pit
 Asset id: 3134844351
-> Dock to Monitor Tunnel; Heals? False
+> Dock to Monitor Tunnel; Heals? False; Spawn Point
   * Normal Door to Monitor Tunnel/Dock to Triclops Pit
   > Dock to Storage Cavern
       All of the following:
@@ -1858,7 +1858,7 @@ Asset id: 3134844351
 ----------------
 Monitor Tunnel
 Asset id: 231492556
-> Dock to Monitor Station; Heals? False
+> Dock to Monitor Station; Heals? False; Spawn Point
   * Normal Door to Monitor Station/Dock to Monitor Tunnel
   > Dock to Triclops Pit
       Heated Rooms Damage ≥ 113
@@ -1871,7 +1871,7 @@ Asset id: 231492556
 ----------------
 Storage Cavern
 Asset id: 2918155326
-> Dock to Triclops Pit; Heals? False
+> Dock to Triclops Pit; Heals? False; Spawn Point
   * Normal Door to Triclops Pit/Dock to Storage Cavern
   > Pickup (Missile)
       Trivial
@@ -1884,7 +1884,7 @@ Asset id: 2918155326
 ----------------
 Monitor Station
 Asset id: 207070785
-> Dock to Monitor Tunnel; Heals? False
+> Dock to Monitor Tunnel; Heals? False; Spawn Point
   * Normal Door to Monitor Tunnel/Dock to Monitor Station
   > Dock to Transport Tunnel A
       Any of the following:
@@ -1969,7 +1969,7 @@ Asset id: 207070785
 ----------------
 Transport Tunnel A
 Asset id: 1207091335
-> Dock to Transport to Phendrana Drifts North; Heals? False
+> Dock to Transport to Phendrana Drifts North; Heals? False; Spawn Point
   * Normal Door to Transport to Phendrana Drifts North/Dock to Transport Tunnel A
   > Dock to Monitor Station
       All of the following:
@@ -2001,7 +2001,7 @@ Asset id: 1207091335
 ----------------
 Warrior Shrine
 Asset id: 2309409677
-> Dock to Monitor Station; Heals? False
+> Dock to Monitor Station; Heals? False; Spawn Point
   * Normal Door to Monitor Station/Dock to Warrior Shrine
   > Dock to Fiery Shores
       Power Bomb and Morph Ball and Heated Rooms Damage ≥ 96
@@ -2023,7 +2023,7 @@ Asset id: 2309409677
 ----------------
 Shore Tunnel
 Asset id: 2416984287
-> Dock to Monitor Station; Heals? False
+> Dock to Monitor Station; Heals? False; Spawn Point
   * Normal Door to Monitor Station/Dock to Shore Tunnel
   > Dock to Fiery Shores
       Any of the following:
@@ -2064,7 +2064,7 @@ Asset id: 3702104715
   > Elevator - Transport to Magmoor Caverns West
       Scan Visor
 
-> Elevator - Transport to Magmoor Caverns West; Heals? False
+> Elevator - Transport to Magmoor Caverns West; Heals? False; Spawn Point
   * Teleporter to Phendrana Drifts - Transport to Magmoor Caverns West
   > Dock to Transport Tunnel A
       Trivial
@@ -2072,7 +2072,7 @@ Asset id: 3702104715
 ----------------
 Fiery Shores
 Asset id: 4126087266
-> Dock to Shore Tunnel; Heals? False
+> Dock to Shore Tunnel; Heals? False; Spawn Point
   * Normal Door to Shore Tunnel/Dock to Fiery Shores
   > Dock to Transport Tunnel B
       Any of the following:
@@ -2125,7 +2125,7 @@ Asset id: 860276342
                   Heated Rooms Damage ≥ 95
                   Boost Ball and Heated Rooms Damage ≥ 87
 
-> Dock to Fiery Shores; Heals? False
+> Dock to Fiery Shores; Heals? False; Spawn Point
   * Normal Door to Fiery Shores/Dock to Transport Tunnel B
   > Dock to Transport to Tallon Overworld West
       Any of the following:
@@ -2159,7 +2159,7 @@ Asset id: 1279075404
 ----------------
 Twin Fires Tunnel
 Asset id: 3835971118
-> Dock to Twin Fires; Heals? False
+> Dock to Twin Fires; Heals? False; Spawn Point
   * Normal Door to Twin Fires/Dock to Twin Fires Tunnel
   > Dock to Transport to Tallon Overworld West
       Any of the following:
@@ -2179,7 +2179,7 @@ Asset id: 1282952170
   > Dock to Twin Fires Tunnel
       Grapple Beam or Space Jump Boots or Gravity Suit
 
-> Dock to Twin Fires Tunnel; Heals? False
+> Dock to Twin Fires Tunnel; Heals? False; Spawn Point
   * Normal Door to Twin Fires Tunnel/Dock to Twin Fires
   > Dock to North Core Tunnel
       Grapple Beam or Space Jump Boots or Gravity Suit
@@ -2187,7 +2187,7 @@ Asset id: 1282952170
 ----------------
 North Core Tunnel
 Asset id: 2805715168
-> Dock to Twin Fires; Heals? False
+> Dock to Twin Fires; Heals? False; Spawn Point
   * Wave Door to Twin Fires/Dock to North Core Tunnel
   > Dock to Geothermal Core
       Space Jump Boots or Gravity Suit
@@ -2210,7 +2210,7 @@ Asset id: 3226044022
   > Dock to North Core Tunnel
       After Geothermal Core Opened
 
-> Dock to South Core Tunnel; Heals? False
+> Dock to South Core Tunnel; Heals? False; Spawn Point
   * Normal Door to South Core Tunnel/Dock to Geothermal Core
   > Dock to North Core Tunnel
       Trivial
@@ -2225,7 +2225,7 @@ Asset id: 3226044022
 ----------------
 Plasma Processing
 Asset id: 1287753306
-> Dock to Geothermal Core; Heals? False
+> Dock to Geothermal Core; Heals? False; Spawn Point
   * Plasma Door to Geothermal Core/Dock to Plasma Processing
   > Pickup (Plasma Beam)
       Trivial
@@ -2238,7 +2238,7 @@ Asset id: 1287753306
 ----------------
 South Core Tunnel
 Asset id: 1893290168
-> Dock to Geothermal Core; Heals? False
+> Dock to Geothermal Core; Heals? False; Spawn Point
   * Wave Door to Geothermal Core/Dock to South Core Tunnel
   > Dock to Magmoor Workstation
       Trivial
@@ -2267,7 +2267,7 @@ Asset id: 2327753667
   > Dock to South Core Tunnel
       Trivial
 
-> Dock to Transport Tunnel C; Heals? False
+> Dock to Transport Tunnel C; Heals? False; Spawn Point
   * Wave Door to Transport Tunnel C/Dock to Magmoor Workstation
   > Dock to South Core Tunnel
       Trivial
@@ -2285,7 +2285,7 @@ Asset id: 74274377
   > Dock to Magmoor Workstation
       Power Bomb and Morph Ball
 
-> Dock to Magmoor Workstation; Heals? False
+> Dock to Magmoor Workstation; Heals? False; Spawn Point
   * Normal Door to Magmoor Workstation/Dock to Workstation Tunnel
   > Dock to Transport to Phazon Mines West
       Power Bomb and Morph Ball
@@ -2298,7 +2298,7 @@ Asset id: 3549419025
   > Dock to Magmoor Workstation
       Trivial
 
-> Dock to Magmoor Workstation; Heals? False
+> Dock to Magmoor Workstation; Heals? False; Spawn Point
   * Wave Door to Magmoor Workstation/Dock to Transport Tunnel C
   > Dock to Transport to Phendrana Drifts South
       Trivial
@@ -2311,7 +2311,7 @@ Asset id: 4012840000
   > Elevator - Transport to Magmoor Caverns South
       Scan Visor
 
-> Elevator - Transport to Magmoor Caverns South; Heals? False
+> Elevator - Transport to Magmoor Caverns South; Heals? False; Spawn Point
   * Teleporter to Phazon Mines - Transport to Magmoor Caverns South
   > Dock to Workstation Tunnel
       Trivial
@@ -2331,7 +2331,7 @@ Asset id: 3249312307
   > Dock to Save Station Magmoor B
       Trivial
 
-> Elevator - Transport to Magmoor Caverns South; Heals? False
+> Elevator - Transport to Magmoor Caverns South; Heals? False; Spawn Point
   * Teleporter to Phendrana Drifts - Transport to Magmoor Caverns South
   > Dock to Save Station Magmoor B
       Trivial
@@ -2344,7 +2344,7 @@ Asset id: 2136398113
   > Save Station
       Trivial
 
-> Save Station; Heals? True
+> Save Station; Heals? True; Spawn Point
   > Dock to Transport to Phendrana Drifts South
       Trivial
 
@@ -2371,7 +2371,7 @@ Asset id: 1758230360
   > Dock to Transport to Tallon Overworld South
       Trivial
 
-> Dock to Transport to Tallon Overworld South; Heals? False
+> Dock to Transport to Tallon Overworld South; Heals? False; Spawn Point
   * Wave Door to Transport to Tallon Overworld South/Dock to Quarry Access
   > Dock to Main Quarry
       Trivial
@@ -2384,7 +2384,7 @@ Asset id: 1681720207
   > Dock to Quarry Access
       Trivial
 
-> Dock to Quarry Access; Heals? False
+> Dock to Quarry Access; Heals? False; Spawn Point
   * Wave Door to Quarry Access/Dock to Main Quarry
   > Dock to Waste Disposal
       Grapple Beam and Space Jump Boots
@@ -2429,7 +2429,7 @@ Asset id: 665031095
   > Dock to Ore Processing
       Morph Ball Bomb and Morph Ball
 
-> Dock to Ore Processing; Heals? False
+> Dock to Ore Processing; Heals? False; Spawn Point
   * Ice Door to Ore Processing/Dock to Waste Disposal
   > Dock to Main Quarry
       Morph Ball Bomb and Morph Ball
@@ -2442,14 +2442,14 @@ Asset id: 907887024
   > Save Station
       Trivial
 
-> Save Station; Heals? True
+> Save Station; Heals? True; Spawn Point
   > Dock to Main Quarry
       Trivial
 
 ----------------
 Security Access A
 Asset id: 3345300114
-> Dock to Main Quarry; Heals? False
+> Dock to Main Quarry; Heals? False; Spawn Point
   * Ice Door to Main Quarry/Dock to Security Access A
   > Dock to Mine Security Station
       Trivial
@@ -2490,7 +2490,7 @@ Asset id: 2547167990
   > Dock to Elevator Access A
       Trivial
 
-> Dock to Elevator Access A; Heals? False
+> Dock to Elevator Access A; Heals? False; Spawn Point
   * Ice Door to Elevator Access A/Dock to Ore Processing
   > Dock to Research Access
       Trivial
@@ -2500,7 +2500,7 @@ Asset id: 2547167990
 ----------------
 Mine Security Station
 Asset id: 2507085138
-> Dock to Security Access A; Heals? False
+> Dock to Security Access A; Heals? False; Spawn Point
   * Ice Door to Security Access A/Dock to Mine Security Station
   > Dock to Security Access B
       Wave Beam
@@ -2520,7 +2520,7 @@ Asset id: 2507085138
 ----------------
 Research Access
 Asset id: 1128703815
-> Dock to Ore Processing; Heals? False
+> Dock to Ore Processing; Heals? False; Spawn Point
   * Ice Door to Ore Processing/Dock to Research Access
   > Dock to Elite Research
       Morph Ball and Spider Ball
@@ -2533,7 +2533,7 @@ Asset id: 1128703815
 ----------------
 Storage Depot B
 Asset id: 3818665003
-> Dock to Ore Processing; Heals? False
+> Dock to Ore Processing; Heals? False; Spawn Point
   * Ice Door to Ore Processing/Dock to Storage Depot B
   > Pickup (Grapple Beam)
       Trivial
@@ -2546,7 +2546,7 @@ Asset id: 3818665003
 ----------------
 Elevator Access A
 Asset id: 639736833
-> Dock to Ore Processing; Heals? False
+> Dock to Ore Processing; Heals? False; Spawn Point
   * Ice Door to Ore Processing/Dock to Elevator Access A
   > Dock to Elevator A
       Trivial
@@ -2564,7 +2564,7 @@ Asset id: 2718040532
   > Dock to Mine Security Station
       Trivial
 
-> Dock to Mine Security Station; Heals? False
+> Dock to Mine Security Station; Heals? False; Spawn Point
   * Wave Door to Mine Security Station/Dock to Security Access B
   > Dock to Elite Research
       Trivial
@@ -2572,7 +2572,7 @@ Asset id: 2718040532
 ----------------
 Storage Depot A
 Asset id: 902158134
-> Dock to Mine Security Station; Heals? False
+> Dock to Mine Security Station; Heals? False; Spawn Point
   * Plasma Door to Mine Security Station/Dock to Storage Depot A
   > Pickup (Flamethrower)
       Trivial
@@ -2592,7 +2592,7 @@ Asset id: 2325199700
   > Pickup (Missile)
       Scan Visor and Morph Ball and Boost Ball and After Rock Wall in Elite Research Destroyed
 
-> Dock to Security Access B; Heals? False
+> Dock to Security Access B; Heals? False; Spawn Point
   * Ice Door to Security Access B/Dock to Elite Research
   > Dock to Research Access
       Scan Visor and Space Jump Boots and After Rock Wall in Elite Research Destroyed
@@ -2621,7 +2621,7 @@ Asset id: 2325199700
 ----------------
 Elevator A
 Asset id: 21425475
-> Dock to Elevator Access A; Heals? False
+> Dock to Elevator Access A; Heals? False; Spawn Point
   * Ice Door to Elevator Access A/Dock to Elevator A
   > Dock to Elite Control Access
       Scan Visor
@@ -2634,7 +2634,7 @@ Asset id: 21425475
 ----------------
 Elite Control Access
 Asset id: 2307445195
-> Dock to Elevator A; Heals? False
+> Dock to Elevator A; Heals? False; Spawn Point
   * Ice Door to Elevator A/Dock to Elite Control Access
   > Dock to Elite Control
       Trivial
@@ -2659,7 +2659,7 @@ Asset id: 3305828730
   > Dock to Elite Control Access
       Trivial
 
-> Dock to Elite Control Access; Heals? False
+> Dock to Elite Control Access; Heals? False; Spawn Point
   * Wave Door to Elite Control Access/Dock to Elite Control
   > Dock to Maintenance Tunnel
       Trivial
@@ -2681,7 +2681,7 @@ Asset id: 3305828730
 ----------------
 Maintenance Tunnel
 Asset id: 3975146125
-> Dock to Elite Control; Heals? False
+> Dock to Elite Control; Heals? False; Spawn Point
   * Ice Door to Elite Control/Dock to Maintenance Tunnel
   > Dock to Phazon Processing Center
       Power Bomb and Morph Ball
@@ -2701,7 +2701,7 @@ Asset id: 2423298732
   > Pickup (Energy Tank)
       Scan Visor and Morph Ball Bomb and Power Bomb and Morph Ball
 
-> Dock to Elite Control; Heals? False
+> Dock to Elite Control; Heals? False; Spawn Point
   * Ice Door to Elite Control/Dock to Ventilation Shaft
   > Dock to Omega Research
       Trivial
@@ -2719,7 +2719,7 @@ Asset id: 2905505465
   > Dock to Maintenance Tunnel
       Trivial
 
-> Dock to Maintenance Tunnel; Heals? False
+> Dock to Maintenance Tunnel; Heals? False; Spawn Point
   * Ice Door to Maintenance Tunnel/Dock to Phazon Processing Center
   > Dock to Transport Access
       Space Jump Boots and Morph Ball and Spider Ball
@@ -2756,7 +2756,7 @@ Asset id: 1060593356
   > Dock to Ventilation Shaft
       Power Bomb and Morph Ball
 
-> Dock to Ventilation Shaft; Heals? False
+> Dock to Ventilation Shaft; Heals? False; Spawn Point
   * Ice Door to Ventilation Shaft/Dock to Omega Research
   > Dock to Map Station Mines
       Power Bomb and Morph Ball
@@ -2771,7 +2771,7 @@ Asset id: 1060593356
 ----------------
 Transport Access
 Asset id: 1120185073
-> Dock to Phazon Processing Center; Heals? False
+> Dock to Phazon Processing Center; Heals? False; Spawn Point
   * Ice Door to Phazon Processing Center/Dock to Transport Access
   > Dock to Transport to Magmoor Caverns South
       Grapple Beam or Space Jump Boots
@@ -2789,7 +2789,7 @@ Asset id: 3983402811
   > Dock to Elite Quarters
       After Processing Center Access Barrier Opened
 
-> Dock to Elite Quarters; Heals? False
+> Dock to Elite Quarters; Heals? False; Spawn Point
   * Plasma Door to Elite Quarters/Dock to Processing Center Access
   > Dock to Phazon Processing Center
       After Processing Center Access Barrier Opened
@@ -2811,13 +2811,13 @@ Asset id: 3983402811
 ----------------
 Map Station Mines
 Asset id: 428864988
-> Dock to Omega Research; Heals? False
+> Dock to Omega Research; Heals? False; Spawn Point
   * Ice Door to Omega Research/Dock to Map Station Mines
 
 ----------------
 Dynamo Access
 Asset id: 4111966698
-> Dock to Central Dynamo; Heals? False
+> Dock to Central Dynamo; Heals? False; Spawn Point
   * Ice Door to Central Dynamo/Dock to Dynamo Access
   > Dock to Omega Research
       Trivial
@@ -2835,7 +2835,7 @@ Asset id: 3804417848
   > Elevator - Transport to Phazon Mines West
       Scan Visor
 
-> Elevator - Transport to Phazon Mines West; Heals? False
+> Elevator - Transport to Phazon Mines West; Heals? False; Spawn Point
   * Teleporter to Magmoor Caverns - Transport to Phazon Mines West
   > Dock to Transport Access
       Trivial
@@ -2843,7 +2843,7 @@ Asset id: 3804417848
 ----------------
 Elite Quarters
 Asset id: 961790803
-> Dock to Elite Quarters Access; Heals? False
+> Dock to Elite Quarters Access; Heals? False; Spawn Point
   * Plasma Door to Elite Quarters Access/Dock to Elite Quarters
   > Dock to Processing Center Access
       Scan Visor and After Omega Pirate Defeated
@@ -2901,7 +2901,7 @@ Asset id: 4272124642
   > Event (Central Dynamo Bendezium Destroyed)
       Power Bomb and Morph Ball and After Security Drone Defeated
 
-> Event (Security Drone Defeated); Heals? False
+> Event (Security Drone Defeated); Heals? False; Spawn Point
   * Event Security Drone Defeated
   > Pickup (Main Power Bombs)
       Morph Ball Bomb and Morph Ball
@@ -2919,7 +2919,7 @@ Asset id: 4272124642
 ----------------
 Elite Quarters Access
 Asset id: 1899248703
-> Dock to Metroid Quarantine B; Heals? False
+> Dock to Metroid Quarantine B; Heals? False; Spawn Point
   * Plasma Door to Metroid Quarantine B/Dock to Elite Quarters Access
   > Dock to Elite Quarters
       After Elite Quarters Access Barrier Opened
@@ -2939,7 +2939,7 @@ Asset id: 1899248703
 ----------------
 Quarantine Access A
 Asset id: 1522461728
-> Dock to Central Dynamo; Heals? False
+> Dock to Central Dynamo; Heals? False; Spawn Point
   * Ice Door to Central Dynamo/Dock to Quarantine Access A
   > Dock to Metroid Quarantine A
       Trivial
@@ -2957,14 +2957,14 @@ Asset id: 2077614267
   > Save Station
       Trivial
 
-> Save Station; Heals? True
+> Save Station; Heals? True; Spawn Point
   > Dock to Central Dynamo
       Trivial
 
 ----------------
 Metroid Quarantine B
 Asset id: 3141205070
-> Dock to Quarantine Access B; Heals? False
+> Dock to Quarantine Access B; Heals? False; Spawn Point
   * Plasma Door to Quarantine Access B/Dock to Metroid Quarantine B
   > Dock to Save Station Mines C
       Grapple Beam and Space Jump Boots and Morph Ball and Spider Ball and After Metroid Quarantine B Barrier Lowered
@@ -2998,7 +2998,7 @@ Asset id: 3141205070
 ----------------
 Metroid Quarantine A
 Asset id: 4211416922
-> Dock to Quarantine Access A; Heals? False
+> Dock to Quarantine Access A; Heals? False; Spawn Point
   * Wave Door to Quarantine Access A/Dock to Metroid Quarantine A
   > Dock to Elevator Access B
       All of the following:
@@ -3039,7 +3039,7 @@ Asset id: 340985721
   > Dock to Fungal Hall B
       Space Jump Boots
 
-> Dock to Fungal Hall B; Heals? False
+> Dock to Fungal Hall B; Heals? False; Spawn Point
   * Plasma Door to Fungal Hall B/Dock to Quarantine Access B
   > Dock to Metroid Quarantine B
       Space Jump Boots
@@ -3052,14 +3052,14 @@ Asset id: 1724960771
   > Save Station
       Trivial
 
-> Save Station; Heals? True
+> Save Station; Heals? True; Spawn Point
   > Dock to Metroid Quarantine B
       Trivial
 
 ----------------
 Elevator Access B
 Asset id: 1071241062
-> Dock to Metroid Quarantine A; Heals? False
+> Dock to Metroid Quarantine A; Heals? False; Spawn Point
   * Ice Door to Metroid Quarantine A/Dock to Elevator Access B
   > Dock to Elevator B
       Trivial
@@ -3086,7 +3086,7 @@ Asset id: 3964125762
   > Pickup (Missile)
       Trivial
 
-> Dock to Phazon Mining Tunnel; Heals? False
+> Dock to Phazon Mining Tunnel; Heals? False; Spawn Point
   * Plasma Door to Phazon Mining Tunnel/Dock to Fungal Hall B
   > Dock to Missile Station Mines
       Grapple Beam and Space Jump Boots
@@ -3103,7 +3103,7 @@ Asset id: 3964125762
 ----------------
 Elevator B
 Asset id: 3900266464
-> Dock to Elevator Access B; Heals? False
+> Dock to Elevator Access B; Heals? False; Spawn Point
   * Plasma Door to Elevator Access B/Dock to Elevator B
   > Dock to Fungal Hall Access
       Scan Visor
@@ -3116,7 +3116,7 @@ Asset id: 3900266464
 ----------------
 Missile Station Mines
 Asset id: 2961781534
-> Dock to Fungal Hall B; Heals? False
+> Dock to Fungal Hall B; Heals? False; Spawn Point
   * Plasma Door to Fungal Hall B/Dock to Missile Station Mines
 
 ----------------
@@ -3129,7 +3129,7 @@ Asset id: 3153742515
   > Pickup (Artifact of Newborn)
       Morph Ball Bomb and Morph Ball and Phazon Suit
 
-> Dock to Fungal Hall A; Heals? False
+> Dock to Fungal Hall A; Heals? False; Spawn Point
   * Plasma Door to Fungal Hall A/Dock to Phazon Mining Tunnel
   > Dock to Fungal Hall B
       Power Bomb and Morph Ball and Boost Ball
@@ -3147,7 +3147,7 @@ Asset id: 3734860277
   > Dock to Elevator B
       Space Jump Boots
 
-> Dock to Elevator B; Heals? False
+> Dock to Elevator B; Heals? False; Spawn Point
   * Plasma Door to Elevator B/Dock to Fungal Hall Access
   > Dock to Fungal Hall A
       Trivial
@@ -3167,7 +3167,7 @@ Asset id: 257062865
   > Dock to Fungal Hall Access
       Space Jump Boots
 
-> Dock to Fungal Hall Access; Heals? False
+> Dock to Fungal Hall Access; Heals? False; Spawn Point
   * Ice Door to Fungal Hall Access/Dock to Fungal Hall A
   > Dock to Phazon Mining Tunnel
       Grapple Beam and Space Jump Boots
@@ -3976,7 +3976,7 @@ Asset id: 3086062890
   > Dock to Transport to Tallon Overworld North
       Trivial
 
-> Dock to Transport to Tallon Overworld North; Heals? False
+> Dock to Transport to Tallon Overworld North; Heals? False; Spawn Point
   * Normal Door to Transport to Tallon Overworld North/Dock to Ruins Entrance
   > Dock to Main Plaza
       Trivial
@@ -3991,7 +3991,7 @@ Asset id: 3587029001
   > Pickup (Missile Expansion 2)
       Space Jump Boots and Shoot Super Missile
 
-> Dock to Ruins Entrance; Heals? False
+> Dock to Ruins Entrance; Heals? False; Spawn Point
   * Normal Door to Ruins Entrance/Dock to Main Plaza
   > Dock to Ruined Fountain Access
       Trivial
@@ -4054,7 +4054,7 @@ Asset id: 1443741240
   > Dock to Ruined Fountain
       Morph Ball
 
-> Dock to Ruined Fountain; Heals? False
+> Dock to Ruined Fountain; Heals? False; Spawn Point
   * Normal Door to Ruined Fountain/Dock to Ruined Fountain Access
   > Dock to Main Plaza
       Morph Ball
@@ -4062,7 +4062,7 @@ Asset id: 1443741240
 ----------------
 Ruined Shrine Access
 Asset id: 3748948704
-> Dock to Ruined Shrine; Heals? False
+> Dock to Ruined Shrine; Heals? False; Spawn Point
   * Normal Door to Ruined Shrine/Dock to Ruined Shrine Access
   > Dock to Main Plaza
       Trivial
@@ -4075,7 +4075,7 @@ Asset id: 3748948704
 ----------------
 Nursery Access
 Asset id: 153979389
-> Dock to Eyon Tunnel; Heals? False
+> Dock to Eyon Tunnel; Heals? False; Spawn Point
   * Normal Door to Eyon Tunnel/Dock to Nursery Access
   > Dock to Main Plaza
       Trivial
@@ -4093,7 +4093,7 @@ Asset id: 1396020311
   > Dock to Vault
       Trivial
 
-> Dock to Vault; Heals? False
+> Dock to Vault; Heals? False; Spawn Point
   * Normal Door to Vault/Dock to Plaza Access
   > Dock to Main Plaza
       Trivial
@@ -4106,7 +4106,7 @@ Asset id: 725556462
   > Dock to Training Chamber
       Morph Ball
 
-> Dock to Training Chamber; Heals? False
+> Dock to Training Chamber; Heals? False; Spawn Point
   * Morph Ball Door to Training Chamber/Dock to Piston Tunnel
   > Dock to Main Plaza
       Morph Ball
@@ -4133,7 +4133,7 @@ Asset id: 375016937
   > Pickup (Missile Expansion)
       Morph Ball and Spider Ball and After Flaahgra
 
-> Pickup (Missile Expansion); Heals? False
+> Pickup (Missile Expansion); Heals? False; Spawn Point
   * Pickup 4; Major Location? False
   > Dock to Meditation Fountain
       Morph Ball and Spider Ball
@@ -4146,7 +4146,7 @@ Asset id: 1014518864
   > Pit
       Trivial
 
-> Dock to Ruined Shrine Access; Heals? False
+> Dock to Ruined Shrine Access; Heals? False; Spawn Point
   * Normal Door to Ruined Shrine Access/Dock to Ruined Shrine
   > Dock to Tower of Light Access
       Morph Ball and Boost Ball and Spider Ball
@@ -4186,7 +4186,7 @@ Asset id: 3407776267
   > Dock to Nursery Access
       Trivial
 
-> Dock to Nursery Access; Heals? False
+> Dock to Nursery Access; Heals? False; Spawn Point
   * Normal Door to Nursery Access/Dock to Eyon Tunnel
   > Dock to Ruined Nursery
       Trivial
@@ -4201,7 +4201,7 @@ Asset id: 4010184729
   > Pickup (Missile Expansion)
       Morph Ball Bomb and Morph Ball
 
-> Dock to Plaza Access; Heals? False
+> Dock to Plaza Access; Heals? False; Spawn Point
   * Normal Door to Plaza Access/Dock to Vault
   > Dock to Vault Access
       Trivial
@@ -4214,7 +4214,7 @@ Asset id: 4010184729
 ----------------
 Training Chamber
 Asset id: 1057288964
-> Dock to Training Chamber Access; Heals? False
+> Dock to Training Chamber Access; Heals? False; Spawn Point
   * Wave Door to Training Chamber Access/Dock to Training Chamber
   > Dock to Piston Tunnel
       After Unlock Training Chamber morph track
@@ -4250,7 +4250,7 @@ Asset id: 2265646373
   > Dock to Ruined Fountain
       Trivial
 
-> Dock to Ruined Fountain; Heals? False
+> Dock to Ruined Fountain; Heals? False; Spawn Point
   * Normal Door to Ruined Fountain/Dock to Arboretum Access
   > Dock to Arboretum
       Trivial
@@ -4263,7 +4263,7 @@ Asset id: 673912500
   > Dock to Ruined Fountain
       Trivial
 
-> Dock to Ruined Fountain; Heals? False
+> Dock to Ruined Fountain; Heals? False; Spawn Point
   * Normal Door to Ruined Fountain/Dock to Meditation Fountain
   > Dock to Magma Pool
       Trivial
@@ -4276,7 +4276,7 @@ Asset id: 1507858510
   > Dock to Ruined Shrine
       Trivial
 
-> Dock to Ruined Shrine; Heals? False
+> Dock to Ruined Shrine; Heals? False; Spawn Point
   * Wave Door to Ruined Shrine/Dock to Tower of Light Access
   > Dock to Tower of Light
       Trivial
@@ -4296,7 +4296,7 @@ Asset id: 3260509773
   > Dock to Eyon Tunnel
       Trivial
 
-> Dock to Eyon Tunnel; Heals? False
+> Dock to Eyon Tunnel; Heals? False; Spawn Point
   * Normal Door to Eyon Tunnel/Dock to Ruined Nursery
   > Dock to North Atrium
       Trivial
@@ -4311,7 +4311,7 @@ Asset id: 3260509773
 ----------------
 Vault Access
 Asset id: 2768802193
-> Dock to Vault; Heals? False
+> Dock to Vault; Heals? False; Spawn Point
   * Normal Door to Vault/Dock to Vault Access
   > Dock to Transport to Magmoor Caverns North
       Morph Ball
@@ -4324,7 +4324,7 @@ Asset id: 2768802193
 ----------------
 Training Chamber Access
 Asset id: 416384699
-> Dock to Magma Pool; Heals? False
+> Dock to Magma Pool; Heals? False; Spawn Point
   * Wave Door to Magma Pool/Dock to Training Chamber Access
   > Dock to Training Chamber
       Trivial
@@ -4351,7 +4351,7 @@ Asset id: 413884678
   > In front of gate
       Morph Ball Bomb and Morph Ball and After Unlock Arboretum gate
 
-> Dock to Arboretum Access; Heals? False
+> Dock to Arboretum Access; Heals? False; Spawn Point
   * Missile Blast Shield to Arboretum Access/Dock to Arboretum
   > Dock to Gathering Hall Access
       Trivial
@@ -4388,7 +4388,7 @@ Asset id: 1226570426
   > Pickup (Power Bomb Expansion)
       Power Bomb and Morph Ball
 
-> Dock to Meditation Fountain; Heals? False
+> Dock to Meditation Fountain; Heals? False; Spawn Point
   * Normal Door to Meditation Fountain/Dock to Magma Pool
   > Dock to Training Chamber Access
       All of the following:
@@ -4403,7 +4403,7 @@ Asset id: 1226570426
 ----------------
 Tower of Light
 Asset id: 225636855
-> Dock to Tower of Light Access; Heals? False
+> Dock to Tower of Light Access; Heals? False; Spawn Point
   * Wave Door to Tower of Light Access/Dock to Tower of Light
   > Dock to Tower Chamber
       Space Jump Boots and Gravity Suit
@@ -4428,14 +4428,14 @@ Asset id: 492718124
   > Save Station
       Trivial
 
-> Save Station; Heals? True
+> Save Station; Heals? True; Spawn Point
   > Dock to Ruined Nursery
       Trivial
 
 ----------------
 North Atrium
 Asset id: 1177115808
-> Dock to Ruined Nursery; Heals? False
+> Dock to Ruined Nursery; Heals? False; Spawn Point
   * Normal Door to Ruined Nursery/Dock to North Atrium
   > Dock to Ruined Gallery
       Trivial
@@ -4480,7 +4480,7 @@ Asset id: 1025740749
   > Dock to Sunchamber Access
       Trivial
 
-> Dock to Sunchamber Access; Heals? False
+> Dock to Sunchamber Access; Heals? False; Spawn Point
   * Normal Door to Sunchamber Access/Dock to Sunchamber Lobby
   > Dock to Arboretum
       Trivial
@@ -4493,7 +4493,7 @@ Asset id: 2515665310
   > Dock to Arboretum
       Trivial
 
-> Dock to Arboretum; Heals? False
+> Dock to Arboretum; Heals? False; Spawn Point
   * Missile Blast Shield to Arboretum/Dock to Gathering Hall Access
   > Dock to Gathering Hall
       Trivial
@@ -4501,7 +4501,7 @@ Asset id: 2515665310
 ----------------
 Tower Chamber
 Asset id: 297624503
-> Dock to Tower of Light; Heals? False
+> Dock to Tower of Light; Heals? False; Spawn Point
   * Wave Door to Tower of Light/Dock to Tower Chamber
   > Pickup (Artifact of Lifegiver)
       Trivial
@@ -4525,7 +4525,7 @@ Asset id: 3813660971
   > Pickup (Missile Expansion 2)
       Morph Ball Bomb and Morph Ball
 
-> Dock to Totem Access; Heals? False
+> Dock to Totem Access; Heals? False; Spawn Point
   * Normal Door to Totem Access/Dock to Ruined Gallery
   > Dock to North Atrium
       Trivial
@@ -4548,7 +4548,7 @@ Asset id: 3813660971
 ----------------
 Sun Tower
 Asset id: 3725988722
-> Dock to Sun Tower Access; Heals? False
+> Dock to Sun Tower Access; Heals? False; Spawn Point
   * Normal Door to Sun Tower Access/Dock to Sun Tower
   > Dock to Transport to Magmoor Caverns North
       Trivial
@@ -4579,7 +4579,7 @@ Asset id: 3725988722
 ----------------
 Transport Access North
 Asset id: 986845711
-> Dock to Hive Totem; Heals? False
+> Dock to Hive Totem; Heals? False; Spawn Point
   * Missile Blast Shield to Hive Totem/Dock to Transport Access North
   > Dock to Transport to Magmoor Caverns North
       Morph Ball
@@ -4604,7 +4604,7 @@ Asset id: 1422133653
   > Dock to Sunchamber Lobby
       Trivial
 
-> Dock to Sunchamber Lobby; Heals? False
+> Dock to Sunchamber Lobby; Heals? False; Spawn Point
   * Normal Door to Sunchamber Lobby/Dock to Sunchamber Access
   > Dock to Sunchamber
       Trivial
@@ -4626,7 +4626,7 @@ Asset id: 1206336453
   > Dock to East Atrium
       Morph Ball
 
-> Dock to Save Station 2; Heals? False
+> Dock to Save Station 2; Heals? False; Spawn Point
   * Missile Blast Shield to Save Station 2/Dock to Gathering Hall
   > Dock to Gathering Hall Access
       Trivial
@@ -4644,7 +4644,7 @@ Asset id: 1206336453
 ----------------
 Totem Access
 Asset id: 3934929011
-> Dock to Ruined Gallery; Heals? False
+> Dock to Ruined Gallery; Heals? False; Spawn Point
   * Normal Door to Ruined Gallery/Dock to Totem Access
   > Dock to Hive Totem
       Trivial
@@ -4657,7 +4657,7 @@ Asset id: 3934929011
 ----------------
 Map Station
 Asset id: 442183190
-> Dock to Ruined Gallery; Heals? False
+> Dock to Ruined Gallery; Heals? False; Spawn Point
   * Missile Blast Shield to Ruined Gallery/Dock to Map Station
   > Map Station
       Trivial
@@ -4674,7 +4674,7 @@ Asset id: 1103925484
   > Dock to Sun Tower
       Trivial
 
-> Dock to Sun Tower; Heals? False
+> Dock to Sun Tower; Heals? False; Spawn Point
   * Normal Door to Sun Tower/Dock to Sun Tower Access
   > Dock to Sunchamber
       Trivial
@@ -4682,7 +4682,7 @@ Asset id: 1103925484
 ----------------
 Hive Totem
 Asset id: 3358629366
-> Dock to Totem Access; Heals? False
+> Dock to Totem Access; Heals? False; Spawn Point
   * Normal Door to Totem Access/Dock to Hive Totem
   > Dock to Transport Access North
       After Hive Mecha
@@ -4735,7 +4735,7 @@ Asset id: 2584347627
   > Dock to Sun Tower Access
       Trivial
 
-> Event - Flaahgra; Heals? False
+> Event - Flaahgra; Heals? False; Spawn Point
   * Event Flaahgra
   > Pickup (Varia Suit)
       Any of the following:
@@ -4754,7 +4754,7 @@ Asset id: 2584347627
 ----------------
 Watery Hall Access
 Asset id: 4008477565
-> Dock to Gathering Hall; Heals? False
+> Dock to Gathering Hall; Heals? False; Spawn Point
   * Normal Door to Gathering Hall/Dock to Watery Hall Access
   > Dock to Watery Hall
       Trivial
@@ -4779,14 +4779,14 @@ Asset id: 4158166350
   > Save Station
       Trivial
 
-> Save Station; Heals? True
+> Save Station; Heals? True; Spawn Point
   > Dock to Gathering Hall
       Trivial
 
 ----------------
 East Atrium
 Asset id: 1899364579
-> Dock to Gathering Hall; Heals? False
+> Dock to Gathering Hall; Heals? False; Spawn Point
   * Normal Door to Gathering Hall/Dock to East Atrium
   > Dock to Energy Core Access
       Trivial
@@ -4804,8 +4804,8 @@ Asset id: 1227669322
   > Dock to Watery Hall Access
       Morph Ball Bomb and Morph Ball and After Unlock Watery Hall gate
 
-> Dock to Watery Hall Access; Heals? False
-  * Normal Door to Watery Hall Access/Dock to Watery Hall
+> Dock to Watery Hall Access; Heals? False; Spawn Point
+  * Missile Blast Shield to Watery Hall Access/Dock to Watery Hall
   > Dock to Dynamo Access
       Morph Ball Bomb and Morph Ball and After Unlock Watery Hall gate
   > Pickup (Charge Beam)
@@ -4833,7 +4833,7 @@ Asset id: 1227669322
 ----------------
 Energy Core Access
 Asset id: 1178406190
-> Dock to Energy Core; Heals? False
+> Dock to Energy Core; Heals? False; Spawn Point
   * Normal Door to Energy Core/Dock to Energy Core Access
   > Dock to East Atrium
       Trivial
@@ -4851,7 +4851,7 @@ Asset id: 255867655
   > Dock to Dynamo
       Trivial
 
-> Dock to Dynamo; Heals? False
+> Dock to Dynamo; Heals? False; Spawn Point
   * Missile Blast Shield to Dynamo/Dock to Dynamo Access
   > Dock to Watery Hall
       Trivial
@@ -4871,7 +4871,7 @@ Asset id: 3386190780
   > Dock to Energy Core Access
       Trivial
 
-> Dock to Energy Core Access; Heals? False
+> Dock to Energy Core Access; Heals? False; Spawn Point
   * Normal Door to Energy Core Access/Dock to Energy Core
   > Dock to Burn Dome Access
       Morph Ball
@@ -4886,7 +4886,7 @@ Asset id: 3386190780
 ----------------
 Dynamo
 Asset id: 81183365
-> Dock to Dynamo Access; Heals? False
+> Dock to Dynamo Access; Heals? False; Spawn Point
   * Missile Blast Shield to Dynamo Access/Dock to Dynamo
   > Pickup (Missile Expansion)
       Missile
@@ -4911,7 +4911,7 @@ Asset id: 4018058640
   > Dock to Energy Core
       Morph Ball Bomb and Morph Ball
 
-> Dock to Energy Core; Heals? False
+> Dock to Energy Core; Heals? False; Spawn Point
   * Morph Ball Door to Energy Core/Dock to Burn Dome Access
   > Dock to Burn Dome
       Morph Ball
@@ -4924,7 +4924,7 @@ Asset id: 3262208600
   > Dock to Furnace
       Trivial
 
-> Dock to Furnace; Heals? False
+> Dock to Furnace; Heals? False; Spawn Point
   * Normal Door to Furnace/Dock to West Furnace Access
   > Dock to Energy Core
       Trivial
@@ -4932,7 +4932,7 @@ Asset id: 3262208600
 ----------------
 Burn Dome
 Asset id: 1095301040
-> Dock to Burn Dome Access; Heals? False
+> Dock to Burn Dome Access; Heals? False; Spawn Point
   * Normal Door to Burn Dome Access/Dock to Burn Dome
   > Pickup (Morph Ball Bombs)
       Trivial
@@ -4952,7 +4952,7 @@ Asset id: 1095301040
 ----------------
 Furnace
 Asset id: 774997107
-> Dock to East Furnace Access; Heals? False
+> Dock to East Furnace Access; Heals? False; Spawn Point
   * Ice Door to East Furnace Access/Dock to Furnace
   > Under Spider Track
       Trivial
@@ -4992,7 +4992,7 @@ Asset id: 774997107
 ----------------
 East Furnace Access
 Asset id: 1155868918
-> Dock to Hall of the Elders; Heals? False
+> Dock to Hall of the Elders; Heals? False; Spawn Point
   * Ice Door to Hall of the Elders/Dock to East Furnace Access
   > Dock to Furnace
       Trivial
@@ -5005,7 +5005,7 @@ Asset id: 1155868918
 ----------------
 Crossway Access West
 Asset id: 3655831216
-> Dock to Crossway; Heals? False
+> Dock to Crossway; Heals? False; Spawn Point
   * Wave Door to Crossway/Dock to Crossway Access West
   > Dock to Furnace
       Morph Ball
@@ -5083,7 +5083,7 @@ Asset id: 335540505
   > Dock to Crossway Access West
       Trivial
 
-> Dock to Crossway Access West; Heals? False
+> Dock to Crossway Access West; Heals? False; Spawn Point
   * Normal Door to Crossway Access West/Dock to Crossway
   > Dock to Crossway Access South
       Trivial
@@ -5112,7 +5112,7 @@ Asset id: 335540505
 ----------------
 Reflecting Pool Access
 Asset id: 2639359389
-> Dock to Reflecting Pool; Heals? False
+> Dock to Reflecting Pool; Heals? False; Spawn Point
   * Normal Door to Reflecting Pool/Dock to Reflecting Pool Access
   > Dock to Hall of the Elders
       Trivial
@@ -5125,7 +5125,7 @@ Asset id: 2639359389
 ----------------
 Elder Hall Access
 Asset id: 3788397521
-> Dock to Hall of the Elders; Heals? False
+> Dock to Hall of the Elders; Heals? False; Spawn Point
   * Normal Door to Hall of the Elders/Dock to Elder Hall Access
   > Dock to Crossway
       Trivial
@@ -5138,7 +5138,7 @@ Asset id: 3788397521
 ----------------
 Crossway Access South
 Asset id: 1733962111
-> Dock to Crossway; Heals? False
+> Dock to Crossway; Heals? False; Spawn Point
   * Ice Door to Crossway/Dock to Crossway Access South
   > Dock to Hall of the Elders
       Morph Ball
@@ -5151,7 +5151,7 @@ Asset id: 1733962111
 ----------------
 Elder Chamber
 Asset id: 3784843004
-> Dock to Hall of the Elders; Heals? False
+> Dock to Hall of the Elders; Heals? False; Spawn Point
   * Ice Door to Hall of the Elders/Dock to Elder Chamber
   > Pickup (Artifact of World)
       Trivial
@@ -5174,7 +5174,7 @@ Asset id: 907987628
   > Dock to Antechamber
       Trivial
 
-> Dock to Reflecting Pool Access; Heals? False
+> Dock to Reflecting Pool Access; Heals? False; Spawn Point
   * Normal Door to Reflecting Pool Access/Dock to Reflecting Pool
   > Dock to Antechamber
       Morph Ball and Boost Ball and After Unlock West Furnace Access door
@@ -5210,14 +5210,14 @@ Asset id: 411706287
   > Dock to Reflecting Pool
       Morph Ball Bomb and Morph Ball
 
-> Save Station; Heals? True
+> Save Station; Heals? True; Spawn Point
   > Dock to Reflecting Pool
       Trivial
 
 ----------------
 Transport Access South
 Asset id: 2734230611
-> Dock to Reflecting Pool; Heals? False
+> Dock to Reflecting Pool; Heals? False; Spawn Point
   * Ice Door to Reflecting Pool/Dock to Transport Access South
   > Dock to Transport to Tallon Overworld South
       Trivial
@@ -5230,7 +5230,7 @@ Asset id: 2734230611
 ----------------
 Antechamber
 Asset id: 2951734903
-> Dock to Reflecting Pool; Heals? False
+> Dock to Reflecting Pool; Heals? False; Spawn Point
   * Ice Door to Reflecting Pool/Dock to Antechamber
   > Pickup (Ice Beam)
       Trivial

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -663,7 +663,7 @@ Asset id: 1880625556
 > Dock to Quarantine Monitor; Heals? False
   * Morph Ball Door to Quarantine Monitor/Dock to Quarantine Cave
   > Dock to South Quarantine Tunnel
-      Grapple Beam
+      Grapple Beam and Morph Ball
   > Event (Thardus)
       Trivial
 
@@ -727,12 +727,12 @@ Asset id: 563191901
 > Dock to Quarantine Cave; Heals? False
   * Morph Ball Door to Quarantine Cave/Dock to Quarantine Monitor
   > Pickup (Missile)
-      Trivial
+      Morph Ball
 
 > Pickup (Missile); Heals? False
   * Pickup 46; Major Location? False
   > Dock to Quarantine Cave
-      Trivial
+      Morph Ball
 
 ----------------
 Observatory Access
@@ -943,11 +943,7 @@ Asset id: 3015914057
   > Dock to West Tower 
       Trivial
   > Pickup (Artifact of Elder)
-      All of the following:
-          Space Jump Boots and Morph Ball
-          Any of the following:
-              Missile
-              Power Beam and Charge Beam and Super Missile
+      Plasma Beam or Missile or Space Jump Boots
 
 > Dock to West Tower ; Heals? False
   * Wave Door to West Tower /Dock to Control Tower
@@ -957,7 +953,7 @@ Asset id: 3015914057
 > Pickup (Artifact of Elder); Heals? False
   * Pickup 49; Major Location? True
   > Dock to East Tower
-      Morph Ball Bomb or Morph Ball
+      Morph Ball Bomb and Morph Ball
 
 ----------------
 Research Core
@@ -1209,7 +1205,7 @@ Asset id: 1423896872
   > Dock to Storage Cave
       Power Bomb and Grapple Beam and Space Jump Boots and Morph Ball
   > Dock to Security Cave
-      Grapple Beam and Space Jump Boots
+      Grapple Beam and Space Jump Boots and Morph Ball
 
 > Dock to Storage Cave; Heals? False
   * Plasma Door to Storage Cave/Dock to Phendrana's Edge
@@ -1219,9 +1215,9 @@ Asset id: 1423896872
 > Dock to Security Cave; Heals? False
   * Morph Ball Door to Security Cave/Dock to Phendrana's Edge
   > Dock to Lower Edge Tunnel
-      Trivial
+      Morph Ball
   > Dock to Upper Edge Tunnel
-      Trivial
+      Morph Ball
   > Dock to Storage Cave
       Power Bomb and Morph Ball
 
@@ -1269,12 +1265,12 @@ Asset id: 1016369381
 > Dock to Phendrana's Edge; Heals? False
   * Morph Ball Door to Phendrana's Edge/Dock to Security Cave
   > Pickup (Power Bomb)
-      Trivial
+      Morph Ball
 
 > Pickup (Power Bomb); Heals? False
   * Pickup 57; Major Location? False
   > Dock to Phendrana's Edge
-      Trivial
+      Morph Ball
 
 ====================
 Space Pirate Frigate

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -1703,7 +1703,7 @@ Asset id: 2758909034
                       Heated Rooms Damage ≥ 514
                       Space Jump Boots and Heated Rooms Damage ≥ 458
               All of the following:
-                  Power Bomb ≥ 2
+                  Power Bomb ≥ 2 and Knowledge (Beginner)
                   Any of the following:
                       Heated Rooms Damage ≥ 586
                       Space Jump Boots and Heated Rooms Damage ≥ 539
@@ -1725,7 +1725,7 @@ Asset id: 2758909034
                       Heated Rooms Damage ≥ 507
                       Space Jump Boots and Heated Rooms Damage ≥ 458
               All of the following:
-                  Power Bomb ≥ 2
+                  Power Bomb ≥ 2 and Knowledge (Beginner)
                   Any of the following:
                       Heated Rooms Damage ≥ 565
                       Space Jump Boots and Heated Rooms Damage ≥ 548
@@ -1734,8 +1734,7 @@ Asset id: 2758909034
           Space Jump Boots and Morph Ball
           Any of the following:
               Missile ≥ 2 and Morph Ball Bomb and Heated Rooms Damage ≥ 404
-              Morph Ball Bomb and Heated Rooms Damage ≥ 430 and Shoot Super Missile
-              Missile and Power Bomb ≥ 2 and Heated Rooms Damage ≥ 479
+              Missile and Power Bomb ≥ 2 and Knowledge (Beginner) and Heated Rooms Damage ≥ 479
 
 > Pickup (Artifact of Nature); Heals? False
   * Pickup 90; Major Location? True
@@ -1748,7 +1747,7 @@ Asset id: 2758909034
           Morph Ball
           Any of the following:
               Morph Ball Bomb and Heated Rooms Damage ≥ 389
-              Power Bomb ≥ 2 and Heated Rooms Damage ≥ 470
+              Power Bomb ≥ 2 and Knowledge (Beginner) and Heated Rooms Damage ≥ 470
 
 ----------------
 Pit Tunnel

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -2162,7 +2162,9 @@ Asset id: 3835971118
 > Dock to Twin Fires; Heals? False
   * Normal Door to Twin Fires/Dock to Twin Fires Tunnel
   > Dock to Transport to Tallon Overworld West
-      Space Jump Boots and Heated Rooms Damage ≥ 165
+      Any of the following:
+          Space Jump Boots and Heated Rooms Damage ≥ 165
+          Morph Ball and Spider Ball and Heat-Resisting Suit
 
 > Dock to Transport to Tallon Overworld West; Heals? False
   * Normal Door to Transport to Tallon Overworld West/Dock to Twin Fires Tunnel

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -665,7 +665,7 @@ Asset id: 1880625556
   > Dock to South Quarantine Tunnel
       Grapple Beam and Morph Ball
   > Event (Thardus)
-      Trivial
+      Morph Ball
 
 > Event (Thardus); Heals? False
   * Event Thardus
@@ -2460,9 +2460,7 @@ Asset id: 3345300114
   > Dock to Mine Security Station
       Trivial
   > Pickup (Missile)
-      All of the following:
-          Power Bomb and Morph Ball
-          X-Ray Visor or Invisible Objects (Beginner)
+      Power Bomb and Morph Ball
 
 > Dock to Mine Security Station; Heals? False
   * Ice Door to Mine Security Station/Dock to Security Access A
@@ -2510,18 +2508,25 @@ Asset id: 2507085138
   * Ice Door to Security Access A/Dock to Mine Security Station
   > Dock to Security Access B
       Wave Beam
-  > Dock to Storage Depot A
-      Wave Beam and Scan Visor and Power Bomb and Morph Ball
 
 > Dock to Security Access B; Heals? False
   * Wave Door to Security Access B/Dock to Mine Security Station
   > Dock to Security Access A
-      Wave Beam
+      After Mine Security Station Barrier Opened
+  > Dock to Storage Depot A
+      After Mine Security Station Barrier Opened
+  > Event (Mine Security Station Barrier Opened)
+      Scan Visor and Power Bomb and Morph Ball
 
 > Dock to Storage Depot A; Heals? False
   * Plasma Door to Storage Depot A/Dock to Mine Security Station
-  > Dock to Security Access A
-      Wave Beam
+  > Dock to Security Access B
+      After Mine Security Station Barrier Opened
+
+> Event (Mine Security Station Barrier Opened); Heals? False
+  * Event Mine Security Station Barrier Opened
+  > Dock to Security Access B
+      Trivial
 
 ----------------
 Research Access
@@ -2593,21 +2598,15 @@ Elite Research
 Asset id: 2325199700
 > Dock to Research Access; Heals? False
   * Ice Door to Research Access/Dock to Elite Research
-  > Dock to Security Access B
+  > Top Floor
       After Rock Wall in Elite Research Destroyed
-  > Pickup (Missile)
-      Scan Visor and Morph Ball and Boost Ball and After Rock Wall in Elite Research Destroyed
 
 > Dock to Security Access B; Heals? False; Spawn Point
   * Ice Door to Security Access B/Dock to Elite Research
-  > Dock to Research Access
-      Scan Visor and Space Jump Boots and After Rock Wall in Elite Research Destroyed
-  > Event (Rock Wall in Elite Research Destroyed)
-      Scan Visor and Space Jump Boots and Morph Ball and Boost Ball
-  > Pickup (Missile)
-      Scan Visor and Space Jump Boots and Morph Ball and Boost Ball
   > Pickup (Artifact of Warrior)
       Power Bomb and Morph Ball and After Security Drone Defeated
+  > Top Floor
+      Scan Visor and Space Jump Boots
 
 > Event (Rock Wall in Elite Research Destroyed); Heals? False
   * Event Rock Wall in Elite Research Destroyed
@@ -2616,13 +2615,27 @@ Asset id: 2325199700
 
 > Pickup (Missile); Heals? False
   * Pickup 78; Major Location? False
-  > Dock to Security Access B
-      Trivial
+  > Top Floor
+      Space Jump Boots
 
 > Pickup (Artifact of Warrior); Heals? False
   * Pickup 77; Major Location? True
   > Dock to Security Access B
       Trivial
+
+> Top Floor; Heals? False
+  > Dock to Research Access
+      After Rock Wall in Elite Research Destroyed
+  > Dock to Security Access B
+      Trivial
+  > Event (Rock Wall in Elite Research Destroyed)
+      All of the following:
+          Scan Visor and Morph Ball and Boost Ball
+          Morph Ball Bomb or Power Bomb
+  > Pickup (Missile)
+      All of the following:
+          Scan Visor and Space Jump Boots and Morph Ball and Boost Ball
+          Morph Ball Bomb or Power Bomb
 
 ----------------
 Elevator A
@@ -2705,7 +2718,7 @@ Asset id: 2423298732
   > Dock to Elite Control
       Morph Ball and Boost Ball
   > Pickup (Energy Tank)
-      Scan Visor and Morph Ball Bomb and Power Bomb and Morph Ball
+      Scan Visor and Power Bomb and Morph Ball
 
 > Dock to Elite Control; Heals? False; Spawn Point
   * Ice Door to Elite Control/Dock to Ventilation Shaft
@@ -2732,9 +2745,7 @@ Asset id: 2905505465
   > Dock to Processing Center Access
       Trivial
   > Pickup (Missile)
-      All of the following:
-          Power Bomb and Morph Ball
-          Thermal Visor or X-Ray Visor or Invisible Objects (Beginner)
+      Power Bomb and Morph Ball
 
 > Dock to Processing Center Access; Heals? False
   * Plasma Door to Processing Center Access/Dock to Phazon Processing Center

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -2512,7 +2512,7 @@ Asset id: 2507085138
 > Dock to Security Access B; Heals? False
   * Wave Door to Security Access B/Dock to Mine Security Station
   > Dock to Security Access A
-      After Mine Security Station Barrier Opened
+      Wave Beam
   > Dock to Storage Depot A
       After Mine Security Station Barrier Opened
   > Event (Mine Security Station Barrier Opened)

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -213,7 +213,7 @@ Asset id: 3289414871
 > Dock to Transport to Magmoor Caverns West; Heals? False
   * Normal Door to Transport to Magmoor Caverns West/Dock to Shoreline Entrance
   > Dock to Phendrana Shorelines
-      Missile or Charge Beam ≥ 3
+      Missile ≥ 3 or Charge Beam
 
 > Dock to Phendrana Shorelines; Heals? False
   * Normal Door to Phendrana Shorelines/Dock to Shoreline Entrance

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -2440,9 +2440,15 @@ Asset id: 907887024
 > Dock to Main Quarry; Heals? True
   * Wave Door to Main Quarry/Dock to Save Station Mines A
   > Save Station
-      Trivial
+      After Phazon Mines Save Station A Barrier Opened
+  > Event (Save Station A Barrier Opened)
+      Scan Visor
 
 > Save Station; Heals? True; Spawn Point
+  > Dock to Main Quarry
+      After Phazon Mines Save Station A Barrier Opened
+
+> Event (Save Station A Barrier Opened); Heals? False
   > Dock to Main Quarry
       Trivial
 
@@ -2876,17 +2882,21 @@ Asset id: 4272124642
       After Security Drone Defeated
   > Event (Security Drone Defeated)
       Any of the following:
-          Thermal Visor
+          X-Ray Visor
           Combat (Beginner) and Invisible Objects (Beginner)
 
 > Dock to Quarantine Access A; Heals? False
   * Ice Door to Quarantine Access A/Dock to Central Dynamo
   > Dock to Save Station Mines B
-      After Security Drone Defeated
+      After Security Drone Defeated and After Central Dynamo Bendezium Destroyed
   > Event (Security Drone Defeated)
-      Any of the following:
-          Thermal Visor
-          Combat (Beginner) and Invisible Objects (Beginner)
+      All of the following:
+          Space Jump Boots and After Central Dynamo Bendezium Destroyed
+          Any of the following:
+              X-Ray Visor
+              Combat (Beginner) and Invisible Objects (Beginner)
+  > Event (Central Dynamo Bendezium Destroyed)
+      Power Bomb and Morph Ball
 
 > Dock to Save Station Mines B; Heals? False
   * Ice Door to Save Station Mines B/Dock to Central Dynamo
@@ -2895,9 +2905,11 @@ Asset id: 4272124642
   > Dock to Quarantine Access A
       After Security Drone Defeated and After Central Dynamo Bendezium Destroyed
   > Event (Security Drone Defeated)
-      Any of the following:
-          Thermal Visor
-          Combat (Beginner) and Invisible Objects (Beginner)
+      All of the following:
+          Space Jump Boots
+          Any of the following:
+              X-Ray Visor
+              Combat (Beginner) and Invisible Objects (Beginner)
   > Event (Central Dynamo Bendezium Destroyed)
       Power Bomb and Morph Ball and After Security Drone Defeated
 
@@ -4715,6 +4727,8 @@ Asset id: 2584347627
   * Normal Door to Sun Tower Access/Dock to Sunchamber
   > Dock to Sunchamber Access
       After Chozo Ghosts (Sunchamber)
+  > Event - Flaahgra
+      Before Flaahgra
   > Event - Chozo Ghosts
       After Activate Sunchamber Chozo Ghosts layer
 

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -943,7 +943,7 @@ Asset id: 3015914057
   > Dock to West Tower 
       Trivial
   > Pickup (Artifact of Elder)
-      Plasma Beam or Missile or Space Jump Boots
+      Plasma Beam and Missile and Space Jump Boots and Morph Ball
 
 > Dock to West Tower ; Heals? False
   * Wave Door to West Tower /Dock to Control Tower
@@ -2486,8 +2486,6 @@ Asset id: 2547167990
 
 > Dock to Waste Disposal; Heals? False
   * Ice Door to Waste Disposal/Dock to Ore Processing
-  > Dock to Research Access
-      Trivial
   > Dock to Storage Depot B
       Grapple Beam
   > Dock to Elevator Access A
@@ -2514,8 +2512,6 @@ Asset id: 2507085138
   * Wave Door to Security Access B/Dock to Mine Security Station
   > Dock to Security Access A
       Wave Beam
-  > Dock to Storage Depot A
-      Wave Beam and Scan Visor and Power Bomb and Morph Ball
 
 > Dock to Storage Depot A; Heals? False
   * Plasma Door to Storage Depot A/Dock to Mine Security Station
@@ -2611,8 +2607,6 @@ Asset id: 2325199700
 > Event (Rock Wall in Elite Research Destroyed); Heals? False
   * Event Rock Wall in Elite Research Destroyed
   > Dock to Research Access
-      Trivial
-  > Dock to Security Access B
       Trivial
 
 > Pickup (Missile); Heals? False
@@ -3028,10 +3022,6 @@ Asset id: 4211416922
   * Pickup 86; Major Location? False
   > Dock to Quarantine Access A
       Space Jump Boots and After Metroid Quarantine A Barrier Lowered
-  > Dock to Elevator Access B
-      All of the following:
-          Morph Ball Bomb and Space Jump Boots and Morph Ball and Spider Ball
-          X-Ray Visor or Invisible Objects (Intermediate)
 
 > Event (Metroid Quarantine A Barrier Lowered); Heals? False
   * Event Metroid Quarantine A Barrier Lowered


### PR DESCRIPTION
For Metroid Prime 1's Internal Database:

-Added a basic set of tricks
-Added damage types with appropriate suit resistances
-Added Phendrana Drifts logic
-Added Magmoor Caverns logic
-Added Frigate Orpheon logic
-Added Phazon Mines logic
-Added the ability for Flaahgra to be defeated with 4 powerbombs as a beginner trick
-Added the ability for Flaahgra to be defeated with wavebuster & 230 missiles as a hypermode trick

NOTE: I've done some basic vetting (Checking all the doors, pickups, save stations, elevators, making sure every node leads to at least one other node) but this logic is still basically untested; treat this as highly experimental.

NOTE: Trick integration is very minimal, and only includes some trivial difficulty tricks in logic for portions which I worked on.

Also I'm bad at Git hopefully I did this right.