### PR TITLE
Feature: Starting area quick fill by world checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Fixed: Multiworld sessions should no longer occasionally duplicate messages.
 
+    Added: Starting locations tab has checkboxes to easily select all locations in an area
+
 ## [2.0.0] - 2020-11-15
 
 This version is dedicated to SpaghettiToastBook, a great member of our community who sadly lost her life this year.

--- a/randovania/gui/dialog/logic_settings_window.py
+++ b/randovania/gui/dialog/logic_settings_window.py
@@ -468,11 +468,10 @@ class LogicSettingsWindow(QDialog, Ui_LogicSettingsWindow):
         world_areas = [world_list.area_to_area_location(area)
                        for area in world.areas if check.is_dark_world == area.in_dark_aether]
         with self._editor as editor:
-            for area in world_areas:
-                editor.set_layout_configuration_field(
-                    "starting_location",
-                    editor.layout_configuration.starting_location.ensure_has_location(area, check.isChecked())
-                )
+            editor.set_layout_configuration_field(
+                "starting_location",
+                editor.layout_configuration.starting_location.ensure_has_locations(world_areas, check.isChecked())
+            )
 
     def _starting_location_on_select_ship(self):
         with self._editor as editor:

--- a/randovania/gui/dialog/logic_settings_window.py
+++ b/randovania/gui/dialog/logic_settings_window.py
@@ -399,7 +399,10 @@ class LogicSettingsWindow(QDialog, Ui_LogicSettingsWindow):
                 group_box = QGroupBox(self.starting_locations_contents)
                 world_check = QtWidgets.QCheckBox(group_box)
                 world_check.setText(world.correct_name(is_dark_world))
-                world_check.setTristate(True)
+                world_check.world_asset_id = world.world_asset_id
+                world_check.is_dark_world = is_dark_world
+                world_check.stateChanged.connect(functools.partial(self._on_check_starting_world, world_check))
+                #world_check.setTristate(True)
                 vertical_layout = QVBoxLayout(group_box)
                 vertical_layout.setContentsMargins(8, 4, 8, 4)
                 vertical_layout.setSpacing(2)
@@ -438,6 +441,18 @@ class LogicSettingsWindow(QDialog, Ui_LogicSettingsWindow):
                 editor.layout_configuration.starting_location.ensure_has_location(check.area_location,
                                                                                   check.isChecked())
             )
+
+    def _on_check_starting_world(self, check, _):
+        world_list = self.game_description.world_list
+        world = world_list.world_by_asset_id(check.world_asset_id)
+        world_areas = [world_list.area_to_area_location(area)
+                       for area in world.areas if check.is_dark_world == area.in_dark_aether]
+        with self._editor as editor:
+            for area in world_areas:
+                editor.set_layout_configuration_field(
+                    "starting_location",
+                    editor.layout_configuration.starting_location.ensure_has_location(area, check.isChecked())
+                )
 
     def _starting_location_on_select_ship(self):
         with self._editor as editor:

--- a/randovania/gui/dialog/logic_settings_window.py
+++ b/randovania/gui/dialog/logic_settings_window.py
@@ -397,12 +397,19 @@ class LogicSettingsWindow(QDialog, Ui_LogicSettingsWindow):
         for row, world in enumerate(game_description.world_list.worlds):
             for column, is_dark_world in enumerate([False, True]):
                 group_box = QGroupBox(self.starting_locations_contents)
-                group_box.setTitle(world.correct_name(is_dark_world))
+                world_check = QtWidgets.QCheckBox(group_box)
+                world_check.setText(world.correct_name(is_dark_world))
+                world_check.setTristate(True)
                 vertical_layout = QVBoxLayout(group_box)
                 vertical_layout.setContentsMargins(8, 4, 8, 4)
                 vertical_layout.setSpacing(2)
                 vertical_layout.setAlignment(QtCore.Qt.AlignTop)
+                separator = QtWidgets.QFrame()
+                separator.setFrameShape(QtWidgets.QFrame.HLine)
+                separator.setFrameShadow(QtWidgets.QFrame.Sunken)
                 group_box.vertical_layout = vertical_layout
+                group_box.vertical_layout.addWidget(world_check)
+                group_box.vertical_layout.addWidget(separator)
 
                 world_to_group[world.correct_name(is_dark_world)] = group_box
                 self.starting_locations_layout.addWidget(group_box, row, column)

--- a/randovania/gui/dialog/logic_settings_window.py
+++ b/randovania/gui/dialog/logic_settings_window.py
@@ -58,6 +58,7 @@ class LogicSettingsWindow(QDialog, Ui_LogicSettingsWindow):
     _combo_for_gate: Dict[TranslatorGate, QComboBox]
     _location_pool_for_node: Dict[PickupNode, QtWidgets.QCheckBox]
     _starting_location_for_area: Dict[int, QtWidgets.QCheckBox]
+    _starting_location_for_world: Dict[str, QtWidgets.QCheckBox]
     _slider_for_trick: Dict[TrickResourceInfo, QtWidgets.QSlider]
     _editor: PresetEditor
     world_list: WorldList
@@ -149,10 +150,25 @@ class LogicSettingsWindow(QDialog, Ui_LogicSettingsWindow):
 
         self._during_batch_check_update = True
         for world in self.game_description.world_list.worlds:
-            for area in world.areas:
-                if area.valid_starting_location:
-                    is_checked = AreaLocation(world.world_asset_id, area.area_asset_id) in starting_locations
-                    self._starting_location_for_area[area.area_asset_id].setChecked(is_checked)
+            for is_dark_world in [False, True]:
+                all_areas = True
+                no_areas = True
+                areas = [area for area in world.areas if area.in_dark_aether == is_dark_world]
+                correct_name = world.correct_name(is_dark_world)
+                for area in areas:
+                    if area.valid_starting_location:
+                        is_checked = AreaLocation(world.world_asset_id, area.area_asset_id) in starting_locations
+                        if is_checked:
+                            no_areas = False
+                        else:
+                            all_areas = False
+                        self._starting_location_for_area[area.area_asset_id].setChecked(is_checked)
+                if all_areas:
+                    self._starting_location_for_world[correct_name].setCheckState(Qt.Checked)
+                elif no_areas:
+                    self._starting_location_for_world[correct_name].setCheckState(Qt.Unchecked)
+                else:
+                    self._starting_location_for_world[correct_name].setCheckState(Qt.PartiallyChecked)
         self._during_batch_check_update = False
 
         # Location Pool
@@ -392,6 +408,7 @@ class LogicSettingsWindow(QDialog, Ui_LogicSettingsWindow):
     def setup_starting_area_elements(self):
         game_description = self.game_description
         world_to_group = {}
+        self._starting_location_for_world = {}
         self._starting_location_for_area = {}
 
         for row, world in enumerate(game_description.world_list.worlds):
@@ -402,7 +419,7 @@ class LogicSettingsWindow(QDialog, Ui_LogicSettingsWindow):
                 world_check.world_asset_id = world.world_asset_id
                 world_check.is_dark_world = is_dark_world
                 world_check.stateChanged.connect(functools.partial(self._on_check_starting_world, world_check))
-                #world_check.setTristate(True)
+                world_check.setTristate(True)
                 vertical_layout = QVBoxLayout(group_box)
                 vertical_layout.setContentsMargins(8, 4, 8, 4)
                 vertical_layout.setSpacing(2)
@@ -416,6 +433,7 @@ class LogicSettingsWindow(QDialog, Ui_LogicSettingsWindow):
 
                 world_to_group[world.correct_name(is_dark_world)] = group_box
                 self.starting_locations_layout.addWidget(group_box, row, column)
+                self._starting_location_for_world[world.correct_name(is_dark_world)] = world_check
 
         for world in game_description.world_list.worlds:
             for area in sorted(world.areas, key=lambda a: a.name):
@@ -443,6 +461,8 @@ class LogicSettingsWindow(QDialog, Ui_LogicSettingsWindow):
             )
 
     def _on_check_starting_world(self, check, _):
+        if self._during_batch_check_update:
+            return
         world_list = self.game_description.world_list
         world = world_list.world_by_asset_id(check.world_asset_id)
         world_areas = [world_list.area_to_area_location(area)

--- a/randovania/layout/starting_location.py
+++ b/randovania/layout/starting_location.py
@@ -74,3 +74,13 @@ class StartingLocation(BitPackValue):
             new_locations.remove(area_location)
 
         return StartingLocation.with_elements(iter(new_locations))
+
+    def ensure_has_locations(self, area_locations: list, enabled: bool) -> "StartingLocation":
+        new_locations = set(self.locations)
+        for area_location in area_locations:
+            if enabled:
+                new_locations.add(area_location)
+            elif area_location in new_locations:
+                new_locations.remove(area_location)
+        return StartingLocation.with_elements(iter(new_locations))
+

--- a/test/gui/dialog/test_logic_settings_window.py
+++ b/test/gui/dialog/test_logic_settings_window.py
@@ -1,5 +1,6 @@
 from randovania.gui.dialog.logic_settings_window import LogicSettingsWindow
 from randovania.interface_common.preset_editor import PresetEditor
+from PySide2.QtCore import Qt
 
 
 def test_on_preset_changed(skip_qtbot, default_preset):
@@ -9,3 +10,27 @@ def test_on_preset_changed(skip_qtbot, default_preset):
 
     # Run
     window.on_preset_changed(editor.create_custom_preset_with())
+
+
+def test_starting_location_world_select(skip_qtbot, default_preset):
+    # Setup
+    editor = PresetEditor(default_preset)
+    window = LogicSettingsWindow(None, editor)
+    skip_qtbot.addWidget(window)
+
+    # Run
+    checkbox_list = window._starting_location_for_world
+    window.on_preset_changed(editor.create_custom_preset_with())
+    assert len(checkbox_list) == 10
+    temple_grounds_checkbox = checkbox_list["Temple Grounds"]
+    assert temple_grounds_checkbox.checkState() == Qt.PartiallyChecked
+    skip_qtbot.mouseClick(temple_grounds_checkbox, Qt.LeftButton)
+    assert temple_grounds_checkbox.checkState() == Qt.Checked
+    assert len(editor.layout_configuration.starting_location.locations) == 40
+    skip_qtbot.mouseClick(temple_grounds_checkbox, Qt.LeftButton)
+    assert temple_grounds_checkbox.checkState() == Qt.Unchecked
+    assert len(editor.layout_configuration.starting_location.locations) == 0
+    skip_qtbot.mouseClick(temple_grounds_checkbox, Qt.LeftButton)
+    window.on_preset_changed(editor.create_custom_preset_with())
+    assert temple_grounds_checkbox.checkState() == Qt.Checked
+    assert len(editor.layout_configuration.starting_location.locations) == 40


### PR DESCRIPTION
On starting locations tab, replaced the world group titles with tristate checkboxes. Clicking this checkbox will select or unselect all areas in that world. Selecting only some of the areas in that world will set the world checkbox to partially selected.