### PR TITLE
Multiworld: Autoscroll game session history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-   Changed: Multiworld session history now auto-scrolls to the bottom
+
 ## [2.0.2] - 2020-11-21
 
 -   Added: Starting locations tab has checkboxes to easily select all locations in an area

--- a/randovania/gui/game_session_window.py
+++ b/randovania/gui/game_session_window.py
@@ -677,11 +677,15 @@ class GameSessionWindow(QtWidgets.QMainWindow, Ui_GameSessionWindow, BackgroundT
         self.reset_session_action.setEnabled(self_is_admin and game_session.state != GameSessionState.SETUP)
 
     def update_session_actions(self):
+        scrollbar = self.history_table_widget.verticalScrollBar()
+        autoscroll = scrollbar.value() == scrollbar.maximum()
         self.history_table_widget.horizontalHeader().setVisible(True)
         self.history_table_widget.setRowCount(len(self._game_session.actions))
         for i, action in enumerate(self._game_session.actions):
             self.history_table_widget.setItem(i, 0, QtWidgets.QTableWidgetItem(action.message))
             self.history_table_widget.setItem(i, 1, QtWidgets.QTableWidgetItem(action.time.astimezone().strftime("%c")))
+        if autoscroll:
+            self.history_table_widget.scrollToBottom()
 
     async def update_multiworld_client_status(self):
         game_session_in_progress = self._game_session.state == GameSessionState.IN_PROGRESS


### PR DESCRIPTION
Implements #959.  
Auto-scrolls to bottom of session history until user scrolls up. Auto-scrolling will resume once user has scrolled back to bottom.