### PR TITLE
Main Reactor Logic Bug Fix

### DIFF
--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -4217,15 +4217,14 @@ Asset id: 3436835742
           Knowledge (Beginner) and Use Screw Attack (No Space Jump)
   > Event - Dark Samus 1
       Trivial
-  > Before Pickup
+  > Next to Pickup
       All of the following:
           Morph Ball and After Dark Samus 1 and After Main Reactor Reloaded after DS1
           Any of the following:
               Screw Attack into Tunnels (Intermediate) and Use Screw Attack (Space Jump)
               All of the following:
-                  Space Jump Boots and Standable Terrain (Intermediate)
+                  Space Jump Boots and Standable Terrain (Advanced)
                   Any of the following:
-                      Morph Ball Bomb and Bomb Space Jump (Intermediate)
                       Slope Jump (Advanced) and Roll Jump (Advanced)
                       Scan Visor and Combat/Scan Dash (Expert)
   > Room Bottom
@@ -4246,7 +4245,7 @@ Asset id: 3436835742
   > Door to Ventilation Area A
       Trivial
 
-> Before Pickup; Heals? False
+> Next to Pickup; Heals? False
   > Pickup (Missile)
       All of the following:
           Morph Ball
@@ -4268,8 +4267,8 @@ Asset id: 3436835742
   > Door to Storage D
       After Dark Samus 1
   > Door to Security Station B
-      Morph Ball and Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Advanced) and Standable Terrain (Beginner)
-  > Before Pickup
+      Morph Ball and Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Advanced) and Standable Terrain (Advanced)
+  > Next to Pickup
       All of the following:
           Morph Ball and Spider Ball and After Dark Samus 1 and After Main Reactor Reloaded after DS1
           Any of the following:

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -4188,7 +4188,7 @@ Asset id: 3436835742
       Morph Ball and Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Intermediate) and Single Room Out of Bounds (Intermediate) and Standable Terrain (Intermediate)
   > Keybearer Corpse (B-Stl)
       After Dark Samus 1
-  > Room Bottom
+  > Bottom Floor (Center)
       After Dark Samus 1
 
 > Door to Sand Processing; Heals? False; Spawn Point
@@ -4204,7 +4204,7 @@ Asset id: 3436835742
       Any of the following:
           Shoot Dark Beam
           Knowledge (Beginner) and Use Screw Attack (No Space Jump)
-  > Room Bottom
+  > Bottom Floor (Center)
       After Dark Samus 1
 
 > Door to Security Station B; Heals? False
@@ -4227,17 +4227,17 @@ Asset id: 3436835742
                   Any of the following:
                       Slope Jump (Advanced) and Roll Jump (Advanced)
                       Scan Visor and Combat/Scan Dash (Expert)
-  > Room Bottom
+  > Bottom Floor (Center)
       After Dark Samus 1
 
 > Pickup (Missile); Heals? False
   * Pickup 49; Major Location? False
-  > Room Bottom
+  > Next to Pickup
       Trivial
 
 > Event - Dark Samus 1; Heals? False
   * Event Dark Samus 1
-  > Room Bottom
+  > Bottom Floor (Center)
       Trivial
 
 > Keybearer Corpse (B-Stl); Heals? False
@@ -4254,15 +4254,15 @@ Asset id: 3436835742
               All of the following:
                   Knowledge (Beginner)
                   Power Beam or Boost Ball or Screw Attack
-  > Room Bottom
+  > Bottom Floor (Center)
       Morph Ball
 
-> Room Bottom; Heals? False
+> Bottom Floor (Center); Heals? False
   > Door to Ventilation Area A
       All of the following:
-          Morph Ball
+          Morph Ball and After Dark Samus 1 and After Main Reactor Reloaded after DS1
           Any of the following:
-              Spider Ball and After Dark Samus 1 and After Main Reactor Reloaded after DS1
+              Spider Ball
               Morph Ball Bomb and Bomb Space Jump (Expert) and Use Screw Attack (Space Jump)
   > Door to Storage D
       After Dark Samus 1


### PR DESCRIPTION
- Removed Intermediate path for reaching item from Security Station B door without Screw Attack since it was broken and impossible.
- Renamed "Before Pickup" to "Next to Pickup" for more clarity