### PR TITLE
Update Linux Support for Focal (fixes #1248)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ target/
 # macOS
 .DS_Store
 
+# Vim
+*.swp
+
 # Usual dev server db
 /tools/test.db
 /network-storage

--- a/randovania/data/ClarisEchoesMenu/EchoesMenu.exe.config
+++ b/randovania/data/ClarisEchoesMenu/EchoesMenu.exe.config
@@ -1,0 +1,3 @@
+<configuration>
+	<dllmap dll="lzo2.dll" target="liblzo2.so.2" os="!windows"/>
+</configuration>

--- a/randovania/data/ClarisPrimeRandomizer/Randomizer.exe.config
+++ b/randovania/data/ClarisPrimeRandomizer/Randomizer.exe.config
@@ -1,0 +1,3 @@
+<configuration>
+	<dllmap dll="lzo2.dll" target="liblzo2.so.2" os="!windows"/>
+</configuration>

--- a/randovania/games/prime/claris_randomizer.py
+++ b/randovania/games/prime/claris_randomizer.py
@@ -3,6 +3,7 @@ import json
 import platform
 import re
 import shutil
+import sys
 from asyncio import StreamWriter, StreamReader
 from pathlib import Path
 from typing import Callable, List, Union, Optional
@@ -44,10 +45,17 @@ async def _write_data(stream: StreamWriter, data: str):
 
 async def _read_data(stream: StreamReader, read_callback: Callable[[str], None]):
     while True:
-        try:
-            line = await stream.readuntil(b"\r")
-        except asyncio.streams.IncompleteReadError as incomplete:
-            line = incomplete.partial
+        # 3.7 uses a different exception name than 3.8
+        if sys.version_info[1] > 7:
+            try:
+                line = await stream.readuntil(b"\r")
+            except asyncio.exceptions.IncompleteReadError as incomplete:
+                line = incomplete.partial
+        else:
+            try:
+                line = await stream.readuntil(b"\r")
+            except asyncio.streams.IncompleteReadError as incomplete:
+                line = incomplete.partial
         if line:
             try:
                 decoded = line.decode()


### PR DESCRIPTION
This PR contains two minor commits to fix a couple issues with Linux support, mostly on Ubuntu Focal but also for any Debian derivatives and distros that ship Python 3.8, and fixes #1248 . Namely:

* `e368f47` - On Debian derivatives, `liblzo2.so.2` is not actually mapped to `lzo2.dll` in the system-wide Mono configs by default, and since `/usr/lib/x86_64-linux-gnu` isn't in Mono's library search path, it was wholly unable to find the library. This caused the randomizer and the menu mod patcher to die on startup. By adding .config files for those two applications, we add those library mappings ourselves, fixing the issue. This will require that the user have `liblzo2-2` installed system-wide, but this is a common dependency of most desktop environments and should not be a serious issue.

* `b1dd229` - In Python 3.8, one of the asyncio exceptions was moved from asyncio.streams to asyncio.exceptions. A separate code path was added for Python 3.8 in claris_randomizer.py that uses the new exception name, fixing basic patching functionality.

Between the two of these, I'm now able to use Randovania natively on my machine!

I was unable to do any testing on Windows; you'll want to verify that there are no regressions in that regard, especially with regard to the Mono `.config` files. Testing Python 3.8 on Windows may also be of interest.