### PR TITLE
Add dangerous tank to PrimeConfiguration

### DIFF
--- a/randovania/gui/lib/preset_describer.py
+++ b/randovania/gui/lib/preset_describer.py
@@ -366,6 +366,7 @@ def _prime_format_params(configuration: PrimeConfiguration) -> dict:
     major_items = configuration.major_items_configuration
 
     format_params = {"energy_tank": f"{configuration.energy_per_tank} energy",
+                     "dangerous_energy_tank": _bool_to_str(configuration.dangerous_energy_tank),
                      "include_final_bosses": _bool_to_str(not configuration.skip_final_bosses),
                      "elevators": configuration.elevators.value
                      }

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -199,9 +199,7 @@ def _migrate_v5(preset: dict) -> dict:
 
 
 def _migrate_v6(preset: dict) -> dict:
-    if preset["game"] in ("prime2", "prime3"):
-        preset["configuration"]["dangerous_energy_tank"] = False
-
+    preset["configuration"]["dangerous_energy_tank"] = False
     return preset
 
 

--- a/randovania/layout/prime_configuration.py
+++ b/randovania/layout/prime_configuration.py
@@ -18,6 +18,7 @@ class PrimeConfiguration(BaseConfiguration):
     elevators: LayoutElevators
     skip_final_bosses: bool
     energy_per_tank: float = dataclasses.field(metadata={"min": 1.0, "max": 1000.0, "precision": 1.0})
+    dangerous_energy_tank: bool
 
     @classmethod
     def game_enum(cls) -> RandovaniaGame:


### PR DESCRIPTION
Adds dangerous tank to PrimeConfiguration. Fixes a bug that prevents user from editing Prime 1 presets.