### PR TITLE
Open folder for previous game history on non-Windows plaforms

### DIFF
--- a/randovania/gui/main_window.py
+++ b/randovania/gui/main_window.py
@@ -544,9 +544,9 @@ class MainWindow(WindowManager, Ui_MainWindow):
             if platform.system() == "Windows":
                 os.startfile(path)
             elif platform.system() == "Darwin":
-                subprocess.Popen(["open"], path)
+                subprocess.run(["open", path])
             else:
-                subprocess.Popen(["xdg-open", path])
+                subprocess.run(["xdg-open", path])
         except OSError:
             box = QtWidgets.QMessageBox(QtWidgets.QMessageBox.Information, "Game History",
                                         f"Previously generated games can be found at:\n{path}",

--- a/randovania/gui/main_window.py
+++ b/randovania/gui/main_window.py
@@ -548,6 +548,7 @@ class MainWindow(WindowManager, Ui_MainWindow):
             else:
                 subprocess.run(["xdg-open", path])
         except OSError:
+            print("Exception thrown :)")
             box = QtWidgets.QMessageBox(QtWidgets.QMessageBox.Information, "Game History",
                                         f"Previously generated games can be found at:\n{path}",
                                         QtWidgets.QMessageBox.Ok, self)

--- a/randovania/gui/main_window.py
+++ b/randovania/gui/main_window.py
@@ -3,6 +3,7 @@ import functools
 import json
 import os
 import platform
+import subprocess
 from functools import partial
 from typing import Optional, List
 
@@ -539,9 +540,14 @@ class MainWindow(WindowManager, Ui_MainWindow):
 
     def _on_menu_action_previously_generated_games(self):
         path = self._options.data_dir.joinpath("game_history")
-        if platform.system() == "Windows":
-            os.startfile(path)
-        else:
+        try:
+            if platform.system() == "Windows":
+                os.startfile(path)
+            elif platform.system() == "Darwin":
+                subprocess.Popen(["open"], path)
+            else:
+                subprocess.Popen(["xdg-open", path])
+        except OSError:
             box = QtWidgets.QMessageBox(QtWidgets.QMessageBox.Information, "Game History",
                                         f"Previously generated games can be found at:\n{path}",
                                         QtWidgets.QMessageBox.Ok, self)

--- a/test/gui/test_main_window.py
+++ b/test/gui/test_main_window.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import subprocess
 from typing import Union
 
 import pytest
@@ -150,7 +151,9 @@ async def test_generate_seed_from_permalink(default_main_window, mocker):
 @pytest.mark.parametrize("is_windows", [False, True])
 def test_on_menu_action_previously_generated_games(default_main_window, mocker, is_windows, monkeypatch):
     mock_start_file = MagicMock()
+    mock_popen = MagicMock()
     monkeypatch.setattr(os, "startfile", mock_start_file, raising=False)
+    monkeypatch.setattr(subprocess, "Popen", mock_popen, raising=False)
     mock_system = mocker.patch("platform.system", return_value="Windows" if is_windows else "Other")
     mock_message_box = mocker.patch("PySide2.QtWidgets.QMessageBox")
 
@@ -158,13 +161,12 @@ def test_on_menu_action_previously_generated_games(default_main_window, mocker, 
     default_main_window._on_menu_action_previously_generated_games()
 
     # Assert
-    mock_system.assert_called_once_with()
     if is_windows:
         mock_start_file.assert_called_once()
         mock_message_box.return_value.show.assert_not_called()
     else:
-        mock_start_file.assert_not_called()
-        mock_message_box.return_value.show.assert_called_once()
+        mock_popen.assert_called_once()
+        mock_message_box.return_value.show.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/test/gui/test_main_window.py
+++ b/test/gui/test_main_window.py
@@ -148,24 +148,24 @@ async def test_generate_seed_from_permalink(default_main_window, mocker):
     default_main_window.open_game_details.assert_called_once_with(mock_generate_layout.return_value)
 
 
-@pytest.mark.parametrize("is_windows", [False, True])
-def test_on_menu_action_previously_generated_games(default_main_window, mocker, is_windows, monkeypatch):
+@pytest.mark.parametrize("os_type", ["Windows", "Darwin", "Linux"])
+def test_on_menu_action_previously_generated_games(default_main_window, mocker, os_type, monkeypatch):
     mock_start_file = MagicMock()
-    mock_popen = MagicMock()
+    mock_subprocess_run = MagicMock()
     monkeypatch.setattr(os, "startfile", mock_start_file, raising=False)
-    monkeypatch.setattr(subprocess, "Popen", mock_popen, raising=False)
-    mock_system = mocker.patch("platform.system", return_value="Windows" if is_windows else "Other")
+    monkeypatch.setattr(subprocess, "run", mock_subprocess_run, raising=False)
+    mocker.patch("platform.system", return_value=os_type)
     mock_message_box = mocker.patch("PySide2.QtWidgets.QMessageBox")
 
     # Run
     default_main_window._on_menu_action_previously_generated_games()
 
     # Assert
-    if is_windows:
+    if os_type == "Windows":
         mock_start_file.assert_called_once()
         mock_message_box.return_value.show.assert_not_called()
     else:
-        mock_popen.assert_called_once()
+        mock_subprocess_run.assert_called_once()
         mock_message_box.return_value.show.assert_not_called()
 
 


### PR DESCRIPTION
Clicking on "Previous Game History" in "Open" menu opens the folder in Finder on macOS or the default file manager for Linux based systems. Falls back to showing the textbox with the path if this fails.