### PR TITLE
Fix Corruption landing sites with ship upgrades

### DIFF
--- a/randovania/data/json_data/prime3.json
+++ b/randovania/data/json_data/prime3.json
@@ -15245,7 +15245,7 @@
                     "in_dark_aether": false,
                     "asset_id": 12448241480574438186,
                     "default_node_index": 7,
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "nodes": [
                         {
                             "name": "Door to Hangar Bay Hall",
@@ -15504,15 +15504,6 @@
                                             ]
                                         }
                                     ]
-                                },
-                                "Event - Ship Upgrade": {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 1,
-                                        "index": 35,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
                                 },
                                 "Samus Ship": {
                                     "type": "and",

--- a/randovania/data/json_data/prime3.json
+++ b/randovania/data/json_data/prime3.json
@@ -925,7 +925,7 @@
             },
             {
                 "index": 97,
-                "long_name": "SkyTown Federation Landing Site Item",
+                "long_name": "SkyTown Federation Landing Site Unlocked",
                 "short_name": "Event97"
             },
             {
@@ -31075,7 +31075,7 @@
                     "in_dark_aether": false,
                     "asset_id": 18200553231954089224,
                     "default_node_index": 2,
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "nodes": [
                         {
                             "name": "Door to Landing Access",
@@ -31101,7 +31101,7 @@
                                         "negate": false
                                     }
                                 },
-                                "Event - Landing Site Item": {
+                                "Event - Landing Site Unlocked": {
                                     "type": "and",
                                     "data": [
                                         {
@@ -31158,17 +31158,21 @@
                                 "Door to Landing Access": {
                                     "type": "and",
                                     "data": []
+                                },
+                                "Pickup (Ship Grapple)": {
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         },
                         {
-                            "name": "Event - Landing Site Item",
+                            "name": "Event - Landing Site Unlocked",
                             "heal": false,
                             "coordinates": null,
                             "node_type": "event",
                             "event_index": 97,
                             "connections": {
-                                "Pickup (Ship Grapple)": {
+                                "Door to Landing Access": {
                                     "type": "and",
                                     "data": []
                                 }

--- a/randovania/data/json_data/prime3.txt
+++ b/randovania/data/json_data/prime3.txt
@@ -2559,8 +2559,6 @@ Asset id: 12448241480574438186
                   Space Jump Boots
                   Grapple Lasso or Screw Attack or Movement (Intermediate)
               Grapple Lasso and Boost Ball and Bomb/Spring Space Jump (Expert)
-  > Event - Ship Upgrade
-      After Hangar Bay Ceiling
   > Samus Ship
       All of the following:
           After Hangar Bay Ceiling
@@ -2592,7 +2590,7 @@ Asset id: 12448241480574438186
       Trivial
 
 > Samus Ship; Heals? True; Spawn Point
-  * Player Ship (Unlocked by After Hangar Bay Ceiling)
+  * Player Ship (Unlocked by Trivial)
   > Door to Ruined Shrine
       Trivial
   > Event - Ship Upgrade

--- a/randovania/data/json_data/prime3.txt
+++ b/randovania/data/json_data/prime3.txt
@@ -5128,7 +5128,7 @@ Asset id: 6708692299270885612
       Use Screw Attack (Space Jump)
   > Pickup (Missile Expansion)
       All of the following:
-          Space Jump Boots and Morph Ball and After SkyTown Federation Landing Site Item
+          Space Jump Boots and Morph Ball and After SkyTown Federation Landing Site Unlocked
           Any of the following:
               Screw Attack
               Boost Ball and Bomb/Spring Space Jump (Intermediate)
@@ -5240,8 +5240,8 @@ Asset id: 18200553231954089224
 > Door to Landing Access; Heals? False
   * Normal Door to Landing Access/Door to SkyTown Federation Landing Site
   > Samus Ship
-      After SkyTown Federation Landing Site Item
-  > Event - Landing Site Item
+      After SkyTown Federation Landing Site Unlocked
+  > Event - Landing Site Unlocked
       Morph Ball Bomb and Morph Ball
 
 > Pickup (Ship Grapple); Heals? False
@@ -5250,13 +5250,15 @@ Asset id: 18200553231954089224
       Trivial
 
 > Samus Ship; Heals? True; Spawn Point
-  * Player Ship (Unlocked by After SkyTown Federation Landing Site Item)
+  * Player Ship (Unlocked by After SkyTown Federation Landing Site Unlocked)
   > Door to Landing Access
       Trivial
-
-> Event - Landing Site Item; Heals? False
-  * Event SkyTown Federation Landing Site Item
   > Pickup (Ship Grapple)
+      Trivial
+
+> Event - Landing Site Unlocked; Heals? False
+  * Event SkyTown Federation Landing Site Unlocked
+  > Door to Landing Access
       Trivial
 
 ----------------

--- a/randovania/game_description/world_list.py
+++ b/randovania/game_description/world_list.py
@@ -142,7 +142,11 @@ class WorldList:
         area = self.area_by_area_location(connection)
         if area.default_node_index is None:
             raise IndexError("Area '{}' does not have a default_node_index".format(area.name))
-        return area.nodes[area.default_node_index]
+        try:
+            return area.nodes[area.default_node_index]
+        except IndexError:
+            raise IndexError("Area '{}' default_node_index ({}), but there's only {} nodes".format(
+                area.name, area.default_node_index, len(area.nodes)))
 
     def connections_from(self, node: Node, patches: GamePatches) -> Iterator[Tuple[Node, Requirement]]:
         """

--- a/randovania/resolver/event_pickup.py
+++ b/randovania/resolver/event_pickup.py
@@ -69,6 +69,10 @@ def replace_with_event_pickups(game: GameDescription):
                 event_node.index,
                 event_node, next_node)
 
+            # If the default node index is beyond one of the removed nodes, then fix it
+            if area.default_node_index >= min(area.nodes.index(event_node), area.nodes.index(next_node)):
+                object.__setattr__(area, "default_node_index", area.default_node_index - 1)
+
             area.nodes[area.nodes.index(event_node)] = combined_node
             game.world_list.add_new_node(area, combined_node)
             area.nodes.remove(next_node)


### PR DESCRIPTION
Fixes #1485

There was a path from Door -> Event -> Pickup, not caring about Command Visor/Ship Node.
Leaving only the path Ship Node -> Pickup means that only if "the ship is there" will the pickup node be reachable.

These areas also break in-game if they're the starting location, and logic gets stuck because it can't leave a ship node that's not unlocked anyway.