### PR TITLE
Potential NSJ SA Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Added: Method of reaching the pickup in Hive Gyro Chamber with Space Jump, Boost Ball, and a Boost Jump (Expert and above).
 
+-   Changed: Logic paths that require Screw Attack without Space Jump now make sure to not have Space Jump to be valid.
+
 ## [2.5.2] - 2021-02-28
 
 -   Added: The number of items in the pool is now included in the summary.

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -5,7 +5,7 @@ Templates
       Morph Ball and Space Jump Boots and Screw Attack
 
 * Use Screw Attack (No Space Jump):
-      Morph Ball and No Space Jump Boots and Screw Attack
+      Morph Ball and Screw Attack
 
 * Shoot Dark Beam:
       All of the following:
@@ -3165,7 +3165,7 @@ Asset id: 2384714559
               Any of the following:
                   Screw Attack and Bomb Space Jump (Advanced) and Dark World Damage ≥ 35
                   Bomb Space Jump (Expert) and Dark World Damage ≥ 40
-          Screw Attack at Z-Axis (Advanced) and Dark World Damage ≥ 7 and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
+          No Space Jump Boots and Screw Attack at Z-Axis (Advanced) and Dark World Damage ≥ 7 and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
   > Central Safe Zone
       Dark World Damage ≥ 6
 
@@ -10276,7 +10276,7 @@ Asset id: 3312357786
           After Temple Access (Sanctuary) Quad
           Any of the following:
               Slope Jump (Intermediate) and Use Screw Attack (Space Jump)
-              Screw Attack at Z-Axis (Beginner) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
+              No Space Jump Boots and Screw Attack at Z-Axis (Beginner) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
               All of the following:
                   Morph Ball
                   Any of the following:

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -5,7 +5,7 @@ Templates
       Morph Ball and Space Jump Boots and Screw Attack
 
 * Use Screw Attack (No Space Jump):
-      Morph Ball and Screw Attack
+      Morph Ball and No Space Jump Boots and Screw Attack
 
 * Shoot Dark Beam:
       All of the following:


### PR DESCRIPTION
Ensures that logic paths that use NSJ Screw Attacks are ignored if Space Jump is on the logical path prior to it.

Example: Having Space Jump but attempting to leave Sanctuary Temple Access in reverse, which can be done on Beginner Z-Axis, but impossible with Space Jump. Logic assumes it is possible to cross regardless.