### PR TITLE
Show correct game name in description label of GameInputDialog

### DIFF
--- a/randovania/gui/dialog/game_input_dialog.py
+++ b/randovania/gui/dialog/game_input_dialog.py
@@ -4,6 +4,7 @@ from typing import Optional
 from PySide2.QtWidgets import QMessageBox, QDialog
 
 from randovania.games.patcher import Patcher
+from randovania.games.game import RandovaniaGame
 from randovania.gui.generated.game_input_dialog_ui import Ui_GameInputDialog
 from randovania.gui.lib import common_qt_lib
 from randovania.interface_common.options import Options
@@ -16,7 +17,7 @@ class GameInputDialog(QDialog, Ui_GameInputDialog):
     _prompt_input_file: bool
     _current_lock_state: bool = True
 
-    def __init__(self, options: Options, patcher: Patcher, word_hash: str, spoiler: bool):
+    def __init__(self, options: Options, patcher: Patcher, word_hash: str, spoiler: bool, game: RandovaniaGame):
         super().__init__()
         self.setupUi(self)
         common_qt_lib.set_default_window_icon(self)
@@ -26,6 +27,12 @@ class GameInputDialog(QDialog, Ui_GameInputDialog):
         self.patcher = patcher
         self.default_output_name = patcher.default_output_file(word_hash)
         self.check_extracted_game()
+        
+        description_text = "<html><head/><body><p>In order to create the randomized game, an ISO file of {} for the Nintendo Gamecube is necessary.</p>".format(game.long_name)
+        if not patcher.uses_input_file_directly:
+            description_text += "<p>After using it once, a copy is kept by Randovania for later use.</p>"
+        description_text += "</body></html>"
+        self.description_label.setText(description_text)
 
         # Input
         self.input_file_edit.textChanged.connect(self._validate_input_file)

--- a/randovania/gui/game_session_window.py
+++ b/randovania/gui/game_session_window.py
@@ -1029,7 +1029,7 @@ class GameSessionWindow(QtWidgets.QMainWindow, Ui_GameSessionWindow, BackgroundT
                 "Error: Unable to save multiple ISOs at the same time,"
                 "another window is saving an ISO right now.")
 
-        dialog = GameInputDialog(options, patcher, self._game_session.word_hash, False)
+        dialog = GameInputDialog(options, patcher, self._game_session.word_hash, False, game)
         result = await async_dialog.execute_dialog(dialog)
 
         if result != QtWidgets.QDialog.Accepted:

--- a/randovania/gui/seed_details_window.py
+++ b/randovania/gui/seed_details_window.py
@@ -191,7 +191,7 @@ class SeedDetailsWindow(CloseEventWidget, Ui_SeedDetailsWindow, BackgroundTaskMi
         if game == RandovaniaGame.PRIME3:
             return await self._show_dialog_for_prime3_layout()
 
-        dialog = GameInputDialog(options, patcher, layout.shareable_word_hash, has_spoiler)
+        dialog = GameInputDialog(options, patcher, layout.shareable_word_hash, has_spoiler, game)
         result = await async_dialog.execute_dialog(dialog)
         if result != QDialog.Accepted:
             return

--- a/test/gui/dialog/test_game_input_dialog.py
+++ b/test/gui/dialog/test_game_input_dialog.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from PySide2 import QtCore
 
 from randovania.gui.dialog.game_input_dialog import GameInputDialog
+from randovania.games.game import RandovaniaGame
 
 
 def test_on_output_file_button_exists(skip_qtbot, tmpdir, mocker):
@@ -14,7 +15,7 @@ def test_on_output_file_button_exists(skip_qtbot, tmpdir, mocker):
     temp_path = Path(tmpdir)
     options = MagicMock()
     options.output_directory = None
-    window = GameInputDialog(options, patcher, "MyHash", True)
+    window = GameInputDialog(options, patcher, "MyHash", True, RandovaniaGame.PRIME2)
     mock_prompt.return_value = temp_path.joinpath("foo", "game.iso")
 
     # Run
@@ -35,7 +36,7 @@ def test_on_output_file_button_cancel(skip_qtbot, tmpdir, mocker):
     patcher = MagicMock()
     options = MagicMock()
     options.output_directory = None
-    window = GameInputDialog(options, patcher, "MyHash", True)
+    window = GameInputDialog(options, patcher, "MyHash", True, RandovaniaGame.PRIME2)
     mock_prompt.return_value = None
 
     # Run


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22754714/119584376-5ee8ef00-bd96-11eb-9b86-e6cff077ba3e.png)

Show the correct game name in the description label above the input file entry.
Don't show the text about randovania saving a copy of the game if the patcher uses input file directly.  
Minor grammar fix changing "a ISO" to "an ISO"
