### PR TITLE
ruined shrine fix and op modification

### DIFF
--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -28910,10 +28910,6 @@
                                     "type": "and",
                                     "data": [
                                         {
-                                            "type": "template",
-                                            "data": "Have all Beams"
-                                        },
-                                        {
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
@@ -28921,6 +28917,112 @@
                                                 "amount": 1,
                                                 "negate": false
                                             }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "template",
+                                                            "data": "Have all Beams"
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 10,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 10,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 2,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "or",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 3,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "and",
+                                                                    "data": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": 0,
+                                                                                "index": 11,
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": 0,
+                                                                                "index": 4,
+                                                                                "amount": 50,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 7,
+                                                                "amount": 3,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 2,
+                                                                "amount": 3,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -39673,51 +39775,65 @@
                             "dock_weakness_index": 2,
                             "connections": {
                                 "Pickup (Missile Expansion Half Pipe)": {
-                                    "type": "or",
+                                    "type": "and",
                                     "data": [
                                         {
-                                            "type": "and",
-                                            "data": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 15,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 2,
-                                                        "index": 12,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
                                         },
                                         {
-                                            "type": "and",
+                                            "type": "or",
                                             "data": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 0,
-                                                        "index": 5,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 15,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 12,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 2,
-                                                        "index": 0,
-                                                        "amount": 2,
-                                                        "negate": false
-                                                    }
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 5,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 0,
+                                                                "amount": 2,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
                                                 }
                                             ]
                                         }

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -29000,7 +29000,7 @@
                                                     ]
                                                 },
                                                 {
-                                                    "type": "or",
+                                                    "type": "and",
                                                     "data": [
                                                         {
                                                             "type": "resource",

--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -10382,7 +10382,7 @@
                                             "data": {
                                                 "type": 2,
                                                 "index": 11,
-                                                "amount": 4,
+                                                "amount": 3,
                                                 "negate": false
                                             }
                                         }
@@ -23834,7 +23834,7 @@
                                             "data": {
                                                 "type": 2,
                                                 "index": 11,
-                                                "amount": 4,
+                                                "amount": 3,
                                                 "negate": false
                                             }
                                         }

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -3921,7 +3921,19 @@ Asset id: 961790803
   > Dock to Processing Center Access
       Scan Visor and After Omega Pirate
   > Event - Omega Pirate
-      X-Ray Visor and Have all Beams
+      All of the following:
+          X-Ray Visor
+          Any of the following:
+              Power Bomb ≥ 3 or Combat (Advanced)
+              All of the following:
+                  Charge Beam
+                  Any of the following:
+                      Have all Beams
+                      All of the following:
+                          Combat (Beginner)
+                          Any of the following:
+                              Plasma Beam
+                              Missile ≥ 50 and Super Missile
 
 > Dock to Processing Center Access; Heals? False
   * Plasma Door to Processing Center Access/Dock to Elite Quarters
@@ -5589,9 +5601,11 @@ Asset id: 1014518864
 > Dock to Tower of Light Access; Heals? False
   * Wave Door to Tower of Light Access/Dock to Ruined Shrine
   > Pickup (Missile Expansion Half Pipe)
-      Any of the following:
-          Space Jump Boots and R-Jump (Beginner)
-          Scan Visor and Combat/Scan Dash (Intermediate)
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Space Jump Boots and R-Jump (Beginner)
+              Scan Visor and Combat/Scan Dash (Intermediate)
   > Pit
       Trivial
 

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -1518,7 +1518,7 @@ Asset id: 1423896872
   * Plasma Door to Storage Cave/Dock to Phendrana's Edge
   > Front of Storage Cave
       Any of the following:
-          Phase Through Objects (Expert)
+          Phase Through Objects (Advanced)
           Power Bomb and Morph Ball
 
 > Dock to Security Cave; Heals? False
@@ -3127,7 +3127,7 @@ Asset id: 3226044022
 > Dock to Plasma Processing; Heals? False
   * Ice Door to Plasma Processing/Dock to Geothermal Core
   > Dock to North Core Tunnel
-      After Geothermal Core Puzzle or Phase Through Objects (Expert)
+      After Geothermal Core Puzzle or Phase Through Objects (Advanced)
 
 > Dock to South Core Tunnel; Heals? False; Spawn Point
   * Normal Door to South Core Tunnel/Dock to Geothermal Core

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -3924,16 +3924,13 @@ Asset id: 961790803
       All of the following:
           X-Ray Visor
           Any of the following:
-              Power Bomb ≥ 3 or Combat (Advanced)
+              Charge Beam and Have all Beams
               All of the following:
-                  Charge Beam
+                  Charge Beam and Combat (Beginner)
                   Any of the following:
-                      Have all Beams
-                      All of the following:
-                          Combat (Beginner)
-                          Any of the following:
-                              Plasma Beam
-                              Missile ≥ 50 and Super Missile
+                      Plasma Beam
+                      Missile ≥ 50 and Super Missile
+              Power Bomb ≥ 3 and Combat (Advanced)
 
 > Dock to Processing Center Access; Heals? False
   * Plasma Door to Processing Center Access/Dock to Elite Quarters


### PR DESCRIPTION
- fixed ruined shrine, missed a morph ball requirement
- OP isn't finished yet, but made it so that players using tricks are not required to have all beams for omega pirate