### PR TITLE
Life Grove Fix

### DIFF
--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -38454,6 +38454,43 @@
                                                                             }
                                                                         }
                                                                     ]
+                                                                },
+                                                                {
+                                                                    "type": "or",
+                                                                    "data": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": 0,
+                                                                                "index": 15,
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": [
+                                                                                {
+                                                                                    "type": "resource",
+                                                                                    "data": {
+                                                                                        "type": 0,
+                                                                                        "index": 6,
+                                                                                        "amount": 1,
+                                                                                        "negate": false
+                                                                                    }
+                                                                                },
+                                                                                {
+                                                                                    "type": "resource",
+                                                                                    "data": {
+                                                                                        "type": 2,
+                                                                                        "index": 9,
+                                                                                        "amount": 3,
+                                                                                        "negate": false
+                                                                                    }
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
                                                                 }
                                                             ]
                                                         },

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -5347,6 +5347,9 @@ Asset id: 2263559682
               All of the following:
                   Boost Ball or Spinners without Boost (Advanced)
                   Any of the following:
+                      Space Jump Boots
+                      Morph Ball Bomb and Bomb Jump (Advanced)
+                  Any of the following:
                       Morph Ball Bomb
                       Power Bomb and Knowledge (Beginner)
 


### PR DESCRIPTION
Require that you can actually reach the item after using the spinner.
This seed is impossible because of the lack of this check: [Prime Randomizer - Radion Transport Warrior.txt](https://github.com/randovania/randovania/files/6606945/Prime.Randomizer.-.Radion.Transport.Warrior.txt)

I wasn't really sure where to put the bomb jump difficulty. I put it at advanced since it needs to be laddered, but it's not very hard