### PR TITLE
Allow moving through Hydro Access Tunnel from left to right

### DIFF
--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -37544,6 +37544,89 @@
                             "dock_type": 0,
                             "dock_weakness_index": 0,
                             "connections": {
+                                "Dock to Great Tree Hall": {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 6,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 21,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 18,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 21,
+                                                                "amount": 1,
+                                                                "negate": true
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 14,
+                                                                "amount": 3,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 5,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
                                 "Pickup (Energy Tank)": {
                                     "type": "and",
                                     "data": [

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -5183,6 +5183,12 @@ Asset id: 4290029926
 
 > Dock to Connection Elevator to Deck Beta; Heals? False
   * Normal Door to Connection Elevator to Deck Beta/Dock to Hydro Access Tunnel
+  > Dock to Great Tree Hall
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Morph Ball Bomb and Gravity Suit
+              Boost Ball and No Gravity Suit and Wall Boost (Advanced) and Enabled Allow Underwater Movement without Gravity Suit
   > Pickup (Energy Tank)
       All of the following:
           Morph Ball


### PR DESCRIPTION
Currently, the database has no way of getting to Great Tree Hall from HAT. This was causing "Validate Prime Vanilla" to fail. This adds a path from Connection Elevator to Deck Beta to Great Tree Hall and lets the prime 1 vanilla validation pass