### PR TITLE
Remove scan visor requirement from major elevators

### DIFF
--- a/randovania/data/json_data/prime1.json
+++ b/randovania/data/json_data/prime1.json
@@ -2200,17 +2200,7 @@
                             "connections": {
                                 "Elevator - Transport to Phendrana Drifts North": {
                                     "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "data": []
                                 }
                             }
                         },
@@ -6304,18 +6294,8 @@
                                     ]
                                 },
                                 "Elevator - Transport to Phendrana Drifts South": {
-                                    "type": "or",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         },
@@ -13286,13 +13266,8 @@
                             "dock_weakness_index": 0,
                             "connections": {
                                 "Elevator to Chozo Ruins - Transport to Magmoor Caverns North": {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 0,
-                                        "index": 5,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         },
@@ -20200,13 +20175,8 @@
                             "dock_weakness_index": 0,
                             "connections": {
                                 "Elevator - Transport to Magmoor Caverns West": {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 0,
-                                        "index": 5,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         },
@@ -22651,13 +22621,8 @@
                                     "data": []
                                 },
                                 "Elevator to Tallon Overworld - Transport to Magmoor Caverns East": {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 0,
-                                        "index": 5,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         },
@@ -25559,13 +25524,8 @@
                             "dock_weakness_index": 1,
                             "connections": {
                                 "Elevator - Transport to Magmoor Caverns South": {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 0,
-                                        "index": 5,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         },
@@ -25616,13 +25576,8 @@
                                     "data": []
                                 },
                                 "Elevator - Transport to Magmoor Caverns South": {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 0,
-                                        "index": 5,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         },
@@ -25740,17 +25695,7 @@
                             "connections": {
                                 "Elevator to Tallon Overworld - Transport to Phazon Mines East": {
                                     "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "data": []
                                 }
                             }
                         },
@@ -29629,17 +29574,7 @@
                             "connections": {
                                 "Elevator - Transport to Phazon Mines West": {
                                     "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "data": []
                                 }
                             }
                         },
@@ -34584,17 +34519,7 @@
                             "connections": {
                                 "Elevator to Chozo Ruins - Transport to Tallon Overworld North": {
                                     "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "data": []
                                 }
                             }
                         },
@@ -35649,17 +35574,7 @@
                             "connections": {
                                 "Elevator to Chozo Ruins - Transport to Tallon Overworld East": {
                                     "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "data": []
                                 }
                             }
                         },
@@ -35707,17 +35622,7 @@
                             "connections": {
                                 "Elevator to Magmoor Caverns - Transport to Tallon Overworld West": {
                                     "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "data": []
                                 }
                             }
                         },
@@ -39112,17 +39017,7 @@
                             "connections": {
                                 "Elevator to Chozo Ruins - Transport to Tallon Overworld South": {
                                     "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "data": []
                                 }
                             }
                         },
@@ -39569,17 +39464,7 @@
                             "connections": {
                                 "Elevator to Phazon Mines - Transport to Tallon Overworld South": {
                                     "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 5,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
+                                    "data": []
                                 }
                             }
                         },
@@ -39633,13 +39518,8 @@
                             "dock_weakness_index": 0,
                             "connections": {
                                 "Elevator to Tallon Overworld - Transport to Chozo Ruins West": {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 0,
-                                        "index": 5,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         },
@@ -43410,13 +43290,8 @@
                                     "data": []
                                 },
                                 "Elevator to Magmoor Caverns - Transport to Chozo Ruins North": {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 0,
-                                        "index": 5,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         },
@@ -48931,13 +48806,8 @@
                             "dock_weakness_index": 0,
                             "connections": {
                                 "Elevator to Tallon Overworld - Transport to Chozo Ruins East": {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 0,
-                                        "index": 5,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         },
@@ -48984,13 +48854,8 @@
                             "dock_weakness_index": 0,
                             "connections": {
                                 "Elevator to Tallon Overworld - Transport to Chozo Ruins South": {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 0,
-                                        "index": 5,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "and",
+                                    "data": []
                                 }
                             }
                         },

--- a/randovania/data/json_data/prime1.txt
+++ b/randovania/data/json_data/prime1.txt
@@ -248,7 +248,7 @@ Asset id: 3222157185
 > Dock to Shoreline Entrance; Heals? False
   * Normal Door to Shoreline Entrance/Dock to Transport to Magmoor Caverns West
   > Elevator - Transport to Phendrana Drifts North
-      Scan Visor
+      Trivial
 
 > Elevator - Transport to Phendrana Drifts North; Heals? False; Spawn Point
   * Teleporter to Magmoor Caverns - Transport to Phendrana Drifts North
@@ -934,7 +934,7 @@ Asset id: 3708487481
               Morph Ball Bomb and Slope Jump (Expert) and Standable Terrain (Expert) and Complex Bomb Jump (Expert)
               Space Jump Boots and Standable Terrain (Beginner)
   > Elevator - Transport to Phendrana Drifts South
-      Scan Visor
+      Trivial
 
 > Elevator - Transport to Phendrana Drifts South; Heals? False; Spawn Point
   * Teleporter to Magmoor Caverns - Transport to Phendrana Drifts South
@@ -2028,7 +2028,7 @@ Asset id: 1005235657
 > Dock to Burning Trail; Heals? False
   * Normal Door to Burning Trail/Dock to Transport to Chozo Ruins North
   > Elevator to Chozo Ruins - Transport to Magmoor Caverns North
-      Scan Visor
+      Trivial
 
 > Elevator to Chozo Ruins - Transport to Magmoor Caverns North; Heals? False; Spawn Point
   * Teleporter to Chozo Ruins - Transport to Magmoor Caverns North
@@ -2794,7 +2794,7 @@ Asset id: 3702104715
 > Dock to Transport Tunnel A; Heals? False
   * Normal Door to Transport Tunnel A/Dock to Transport to Phendrana Drifts North
   > Elevator - Transport to Magmoor Caverns West
-      Scan Visor
+      Trivial
 
 > Elevator - Transport to Magmoor Caverns West; Heals? False; Spawn Point
   * Teleporter to Phendrana Drifts - Transport to Magmoor Caverns West
@@ -3025,7 +3025,7 @@ Asset id: 1279075404
   > Dock to Twin Fires Tunnel
       Trivial
   > Elevator to Tallon Overworld - Transport to Magmoor Caverns East
-      Scan Visor
+      Trivial
 
 > Elevator to Tallon Overworld - Transport to Magmoor Caverns East; Heals? False; Spawn Point
   * Teleporter to Tallon Overworld - Transport to Magmoor Caverns East
@@ -3328,7 +3328,7 @@ Asset id: 4012840000
 > Dock to Workstation Tunnel; Heals? False
   * Ice Door to Workstation Tunnel/Dock to Transport to Phazon Mines West
   > Elevator - Transport to Magmoor Caverns South
-      Scan Visor
+      Trivial
 
 > Elevator - Transport to Magmoor Caverns South; Heals? False; Spawn Point
   * Teleporter to Phazon Mines - Transport to Magmoor Caverns South
@@ -3343,7 +3343,7 @@ Asset id: 3249312307
   > Dock to Transport Tunnel C
       Trivial
   > Elevator - Transport to Magmoor Caverns South
-      Scan Visor
+      Trivial
 
 > Dock to Transport Tunnel C; Heals? False
   * Wave Door to Transport Tunnel C/Dock to Transport to Phendrana Drifts South
@@ -3375,7 +3375,7 @@ Asset id: 1125030300
 > Dock to Quarry Access; Heals? False
   * Wave Door to Quarry Access/Dock to Transport to Tallon Overworld South
   > Elevator to Tallon Overworld - Transport to Phazon Mines East
-      Scan Visor
+      Trivial
 
 > Elevator to Tallon Overworld - Transport to Phazon Mines East; Heals? False; Spawn Point
   * Teleporter to Tallon Overworld - Transport to Phazon Mines East
@@ -3975,7 +3975,7 @@ Asset id: 3804417848
 > Dock to Transport Access; Heals? False
   * Ice Door to Transport Access/Dock to Transport to Magmoor Caverns South
   > Elevator - Transport to Phazon Mines West
-      Scan Visor
+      Trivial
 
 > Elevator - Transport to Phazon Mines West; Heals? False; Spawn Point
   * Teleporter to Magmoor Caverns - Transport to Phazon Mines West
@@ -4717,7 +4717,7 @@ Asset id: 295707720
 > Dock to Transport Tunnel A; Heals? False
   * Normal Door to Transport Tunnel A/Dock to Transport to Chozo Ruins West
   > Elevator to Chozo Ruins - Transport to Tallon Overworld North
-      Scan Visor
+      Trivial
 
 > Elevator to Chozo Ruins - Transport to Tallon Overworld North; Heals? False; Spawn Point
   * Teleporter to Chozo Ruins - Transport to Tallon Overworld North
@@ -4889,7 +4889,7 @@ Asset id: 2318493278
 > Dock to Transport Tunnel C; Heals? False
   * Ice Door to Transport Tunnel C/Dock to Transport to Chozo Ruins East
   > Elevator to Chozo Ruins - Transport to Tallon Overworld East
-      Scan Visor
+      Trivial
 
 > Elevator to Chozo Ruins - Transport to Tallon Overworld East; Heals? False; Spawn Point
   * Teleporter to Chozo Ruins - Transport to Tallon Overworld East
@@ -4902,7 +4902,7 @@ Asset id: 366411659
 > Dock to Transport Tunnel B; Heals? False
   * Normal Door to Transport Tunnel B/Dock to Transport to Magmoor Caverns East
   > Elevator to Magmoor Caverns - Transport to Tallon Overworld West
-      Scan Visor
+      Trivial
 
 > Elevator to Magmoor Caverns - Transport to Tallon Overworld West; Heals? False; Spawn Point
   * Teleporter to Magmoor Caverns - Transport to Tallon Overworld West
@@ -5383,7 +5383,7 @@ Asset id: 212145392
 > Dock to Transport Tunnel D; Heals? False
   * Ice Door to Transport Tunnel D/Dock to Transport to Chozo Ruins South
   > Elevator to Chozo Ruins - Transport to Tallon Overworld South
-      Scan Visor
+      Trivial
 
 > Elevator to Chozo Ruins - Transport to Tallon Overworld South; Heals? False; Spawn Point
   * Teleporter to Chozo Ruins - Transport to Tallon Overworld South
@@ -5440,7 +5440,7 @@ Asset id: 2098226800
 > Dock to Transport Tunnel E; Heals? False
   * Ice Door to Transport Tunnel E/Dock to Transport to Phazon Mines East
   > Elevator to Phazon Mines - Transport to Tallon Overworld South
-      Scan Visor
+      Trivial
 
 > Elevator to Phazon Mines - Transport to Tallon Overworld South; Heals? False; Spawn Point
   * Teleporter to Phazon Mines - Transport to Tallon Overworld South
@@ -5455,7 +5455,7 @@ Asset id: 1047210935
 > Dock to Ruins Entrance; Heals? False
   * Normal Door to Ruins Entrance/Dock to Transport to Tallon Overworld North
   > Elevator to Tallon Overworld - Transport to Chozo Ruins West
-      Scan Visor
+      Trivial
 
 > Elevator to Tallon Overworld - Transport to Chozo Ruins West; Heals? False; Spawn Point
   * Teleporter to Tallon Overworld - Transport to Chozo Ruins West
@@ -6086,7 +6086,7 @@ Asset id: 2199318005
   > Dock to Vault Access
       Trivial
   > Elevator to Magmoor Caverns - Transport to Chozo Ruins North
-      Scan Visor
+      Trivial
 
 > Elevator to Magmoor Caverns - Transport to Chozo Ruins North; Heals? False; Spawn Point
   * Teleporter to Magmoor Caverns - Transport to Chozo Ruins North
@@ -7047,7 +7047,7 @@ Asset id: 2784651681
 > Dock to Save Station 3; Heals? False
   * Normal Door to Save Station 3/Dock to Transport to Tallon Overworld East
   > Elevator to Tallon Overworld - Transport to Chozo Ruins East
-      Scan Visor
+      Trivial
 
 > Elevator to Tallon Overworld - Transport to Chozo Ruins East; Heals? False; Spawn Point
   * Teleporter to Tallon Overworld - Transport to Chozo Ruins East
@@ -7060,7 +7060,7 @@ Asset id: 594418447
 > Dock to Transport Access South; Heals? False
   * Normal Door to Transport Access South/Dock to Transport to Tallon Overworld South
   > Elevator to Tallon Overworld - Transport to Chozo Ruins South
-      Scan Visor
+      Trivial
 
 > Elevator to Tallon Overworld - Transport to Chozo Ruins South; Heals? False; Spawn Point
   * Teleporter to Tallon Overworld - Transport to Chozo Ruins South


### PR DESCRIPTION
Randomprime pre-activates these elevators if scan visor is shuffled.