### PR TITLE
Support multiple output formats for supported patchers

### DIFF
--- a/randovania/games/patchers/claris_patcher.py
+++ b/randovania/games/patchers/claris_patcher.py
@@ -46,7 +46,7 @@ class ClarisPatcher(Patcher):
             shutil.rmtree(game_files_path)
 
     def default_output_file(self, seed_hash: str) -> str:
-        return "Echoes Randomizer - {}.iso".format(seed_hash)
+        return "Echoes Randomizer - {}".format(seed_hash)
 
     @property
     def valid_input_file_types(self) -> List[str]:

--- a/randovania/games/patchers/randomprime_patcher.py
+++ b/randovania/games/patchers/randomprime_patcher.py
@@ -158,7 +158,7 @@ class RandomprimePatcher(Patcher):
         pass
 
     def default_output_file(self, seed_hash: str) -> str:
-        return "Prime Randomizer - {}.iso".format(seed_hash)
+        return "Prime Randomizer - {}".format(seed_hash)
 
     @property
     def valid_input_file_types(self) -> List[str]:
@@ -166,7 +166,7 @@ class RandomprimePatcher(Patcher):
 
     @property
     def valid_output_file_types(self) -> List[str]:
-        return ["iso"]
+        return ["iso", "ciso", "gcz"]
 
     def create_patch_data(self, description: LayoutDescription, players_config: PlayersConfiguration,
                           cosmetic_patches: PrimeCosmeticPatches):

--- a/randovania/gui/dialog/game_input_dialog.py
+++ b/randovania/gui/dialog/game_input_dialog.py
@@ -2,7 +2,7 @@ import dataclasses
 from pathlib import Path
 from typing import Optional
 
-from PySide2.QtWidgets import QMessageBox, QDialog, QLabel, QRadioButton, QGroupBox
+from PySide2.QtWidgets import QMessageBox, QDialog, QLabel, QRadioButton
 
 from randovania.games.game import RandovaniaGame
 from randovania.games.patcher import Patcher

--- a/randovania/gui/ui_files/game_input_dialog.ui
+++ b/randovania/gui/ui_files/game_input_dialog.ui
@@ -7,29 +7,22 @@
     <x>0</x>
     <y>0</y>
     <width>508</width>
-    <height>235</height>
+    <height>270</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Game Patching</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="6" column="0">
+   <item row="9" column="0">
     <widget class="QPushButton" name="accept_button">
      <property name="text">
       <string>Accept</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QCheckBox" name="auto_save_spoiler_check">
-     <property name="text">
-      <string>Include a spoiler log on same directory</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="2">
-    <widget class="QPushButton" name="output_file_button">
+   <item row="2" column="2">
+    <widget class="QPushButton" name="input_file_button">
      <property name="maximumSize">
       <size>
        <width>100</width>
@@ -41,10 +34,16 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QLineEdit" name="output_file_edit">
-     <property name="placeholderText">
-      <string>Path where to place randomized game</string>
+   <item row="5" column="2">
+    <widget class="QPushButton" name="output_file_button">
+     <property name="maximumSize">
+      <size>
+       <width>100</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Select File</string>
      </property>
     </widget>
    </item>
@@ -61,6 +60,23 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QLineEdit" name="input_file_edit">
+     <property name="placeholderText">
+      <string>Path to vanilla Gamecube ISO</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <layout class="QHBoxLayout" name="output_format_layout"/>
+   </item>
+   <item row="9" column="2">
+    <widget class="QPushButton" name="cancel_button">
+     <property name="text">
+      <string>Cancel</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0" colspan="3">
     <widget class="QLabel" name="description_label">
      <property name="text">
@@ -71,21 +87,14 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QLineEdit" name="input_file_edit">
+   <item row="5" column="0" colspan="2">
+    <widget class="QLineEdit" name="output_file_edit">
      <property name="placeholderText">
-      <string>Path to vanilla Gamecube ISO</string>
+      <string>Path where to place randomized game</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="2">
-    <widget class="QPushButton" name="cancel_button">
-     <property name="text">
-      <string>Cancel</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <widget class="QLabel" name="output_file_label">
      <property name="maximumSize">
       <size>
@@ -98,16 +107,10 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
-    <widget class="QPushButton" name="input_file_button">
-     <property name="maximumSize">
-      <size>
-       <width>100</width>
-       <height>16777215</height>
-      </size>
-     </property>
+   <item row="8" column="0">
+    <widget class="QCheckBox" name="auto_save_spoiler_check">
      <property name="text">
-      <string>Select File</string>
+      <string>Include a spoiler log on same directory</string>
      </property>
     </widget>
    </item>

--- a/randovania/interface_common/options.py
+++ b/randovania/interface_common/options.py
@@ -82,7 +82,7 @@ class PerGameOptions:
         return PerGameOptions(
             cosmetic_patches=cosmetic_patches,
             input_path=decode_if_not_none(value["input_path"], Path),
-            output_format=decode_if_not_none(value["output_format"], str),
+            output_format=value["output_format"],
             output_directory=decode_if_not_none(value["output_directory"], Path),
         )
 

--- a/randovania/interface_common/options.py
+++ b/randovania/interface_common/options.py
@@ -61,6 +61,7 @@ class PerGameOptions:
     cosmetic_patches: AnyCosmeticPatches
     input_path: Optional[Path] = None
     output_directory: Optional[Path] = None
+    output_format: Optional[str] = None
 
     @property
     def as_json(self):
@@ -68,6 +69,7 @@ class PerGameOptions:
             "cosmetic_patches": self.cosmetic_patches.as_json,
             "input_path": str(self.input_path) if self.input_path is not None else None,
             "output_directory": str(self.output_directory) if self.output_directory is not None else None,
+            "output_format": self.output_format if self.output_format is not None else None,
         }
 
     @classmethod
@@ -80,6 +82,7 @@ class PerGameOptions:
         return PerGameOptions(
             cosmetic_patches=cosmetic_patches,
             input_path=decode_if_not_none(value["input_path"], Path),
+            output_format=decode_if_not_none(value["output_format"], str),
             output_directory=decode_if_not_none(value["output_directory"], Path),
         )
 

--- a/randovania/interface_common/persisted_options.py
+++ b/randovania/interface_common/persisted_options.py
@@ -1,4 +1,4 @@
-_CURRENT_OPTIONS_FILE_VERSION = 14
+_CURRENT_OPTIONS_FILE_VERSION = 15
 
 
 def _convert_logic(layout_logic: str) -> str:
@@ -55,8 +55,16 @@ def _convert_v13(options: dict) -> dict:
                 "cosmetic_patches": cosmetic_patches,
                 "input_path": None,
                 "output_directory": output_directory,
+                "output_format": None,
             }
         }
+
+    return options
+
+
+def _convert_v14(options: dict) -> dict:
+    for game in options["per_game_options"]:
+        options["per_game_options"][game]["output_format"] = None
 
     return options
 
@@ -65,6 +73,7 @@ _CONVERTER_FOR_VERSION = {
     11: _convert_v11,
     12: _convert_v12,
     13: _convert_v13,
+    14: _convert_v14,
 }
 
 

--- a/test/gui/dialog/test_game_input_dialog.py
+++ b/test/gui/dialog/test_game_input_dialog.py
@@ -26,6 +26,7 @@ def test_on_output_file_button_exists(skip_qtbot, tmp_path, mocker, has_output_d
     patcher.default_output_file.return_value = "MyHashGame.iso"
     options = MagicMock()
     options.options_for_game.return_value.output_directory = output_directory
+    options.options_for_game.return_value.output_format = "iso"
     window = GameInputDialog(options, patcher, "MyHash", True, RandovaniaGame.PRIME2)
     mock_prompt.return_value = tmp_path.joinpath("foo", "game.iso")
 
@@ -34,7 +35,7 @@ def test_on_output_file_button_exists(skip_qtbot, tmp_path, mocker, has_output_d
 
     # Assert
     patcher.default_output_file.assert_called_once_with("MyHash")
-    mock_prompt.assert_called_once_with(window, expected_default_name,
+    mock_prompt.assert_called_once_with(window, expected_default_name + ".iso",
                                         patcher.valid_output_file_types)
     assert window.output_file_edit.text() == str(tmp_path.joinpath("foo", "game.iso"))
     assert tmp_path.joinpath("foo").is_dir()
@@ -47,6 +48,8 @@ def test_on_output_file_button_cancel(skip_qtbot, tmpdir, mocker):
     patcher = MagicMock()
     options = MagicMock()
     options.options_for_game.return_value.output_directory = None
+    options.options_for_game.return_value.output_format = "iso"
+    patcher.default_output_file.return_value = "Echoes Randomizer - MyHash"
     window = GameInputDialog(options, patcher, "MyHash", True, RandovaniaGame.PRIME2)
     mock_prompt.return_value = None
 
@@ -55,7 +58,7 @@ def test_on_output_file_button_cancel(skip_qtbot, tmpdir, mocker):
 
     # Assert
     patcher.default_output_file.assert_called_once_with("MyHash")
-    mock_prompt.assert_called_once_with(window, patcher.default_output_file.return_value,
+    mock_prompt.assert_called_once_with(window, patcher.default_output_file.return_value + ".iso",
                                         patcher.valid_output_file_types)
     assert window.output_file_edit.text() == ""
 
@@ -63,6 +66,7 @@ def test_on_output_file_button_cancel(skip_qtbot, tmpdir, mocker):
 def test_save_options(skip_qtbot, tmp_path):
     options = Options(tmp_path)
     patcher = MagicMock()
+    patcher.valid_output_file_types = ["iso"]
     window = GameInputDialog(options, patcher, "MyHash", True, RandovaniaGame.PRIME2)
     window.output_file_edit.setText("somewhere/game.iso")
 

--- a/test/interface_common/test_options.py
+++ b/test/interface_common/test_options.py
@@ -44,6 +44,7 @@ def test_migrate_from_v11(option):
                 },
                 'input_path': None,
                 'output_directory': None,
+                'output_format': None,
             },
         }
     }


### PR DESCRIPTION
Since dol patching is handled by randomprime now, randovania should be able to save .ciso and .gcz for prime 1 now with no issue.  
If a patcher has multiple output formats supported, a set of radio buttons will appear to let the user select which format they want.  
![image](https://user-images.githubusercontent.com/22754714/121794541-02c7fc80-cbd7-11eb-9f13-033d856b6d35.png)
Output format preference is saved per-game via the Options class. As a note, I had to bump the options file version to 15.