### PR TITLE
Origin/echoes difficulty adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Methods of crossing Torvus Bog - Fortress Transport Access with Gravity Boost or Bombs (No Tricks/Advanced and above).
 
+-   Method of traversing Vault without Space Jump or Screw Attack using Extended Dashes (Advanced and above).
+
+-   Method of reaching Windchamber Gateway item with only Scan Visor using Extended Dashes (Expert and above).
+
+-   Method of reaching Kinetic Orb Cannon in Gathering Hall using Extended Dashes (Expert and above).
+
 #### Changed
 
 -   Reaching the pickup in Temple Transport B with a Wall Boost is now Hypermode (from Expert).
@@ -96,6 +102,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Activating Controller Access rooms Bomb Slots without Bombs is now Advanced (from Expert).
 
 -   Reaching the Abandoned Worksite/Brooding Ground door from the bridge in Dark/Forgotten Bridge with an Extended Dash is now Hypermode (from Expert).
+
+-   The initial Terminal Fall Abuses in Vault from the scan portal are separate from the final and are now Advanced (from Expert).
+
+-   Catacombs NSJ dash to Transit Tunnel South has been modified to account for Scan Visor, with the original difficulty being raised to Advanced (from Intermediate).
+
+-   Undertemple Shaft NSJ dash from bottom to top of cannon is now Intermediate (from Advanced).
+
+-   Simplified logic in Profane Path, Morph Ball is no longer required to reach the portal from the echo lock safe zone using the scan dash method.
+
+-   Various Standable Terrain tricks (Dark Agon - Portal Site, Temple Grounds - Sacred Path) have been lowered to Beginner/Intermediate (from Advanced). This is to
+    attempt to fix an old database limitation from before tricks had their own difficulty levels. 
+
+-   The dashes in Gathering Hall from Transit Tunnel South/West to the Kinetic Orb Cannon are now Intermediate (from Advanced).
+
+-   The Bomb Space Jump NSJ to reach Abandoned Worksite in Great Bridge is now Expert (from Hypermode).
+
+-   The dash to reach the portal in Aerial Training Site from Central Hive Transport West is now Hypermode (from Expert).
+
+-   The dash to leave Hive Temple after Quadraxis via Security Station is now Hypermode (from Expert).
+
+-   The dashes in Command Center (top level) and Accursed Lake without Space Jump are now Beginner (from Intermediate).
+
+-   The dash in Mining Station A to reach Temple Access without Space Jump or Missiles is now Advanced (from Intermediate).
+
+-   The dashes in Trial Grounds to Dark Transit Station without Space Jump are now Advanced (from Intermediate).
+
+-   The dashes in Undertemple Shaft to reach Sacrificial Chamber Tunnel (and back) are now Advanced (from Intermediate). 
+
+-   The dash in Hall of Combat Mastery to reach the upper area after the glass is now Advanced (from Intermediate).
 
 ## [2.6.1] - 2021-05-05
 

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -3170,7 +3170,7 @@ Asset id: 2260839223
           Any of the following:
               Space Jump Boots or Movement (Advanced)
               Screw Attack and Movement (Beginner)
-              Scan Visor and Combat/Scan Dash (Intermediate)
+              Scan Visor and Combat/Scan Dash (Advanced)
   > Portal to Mining Station B
       Any of the following:
           Dark World Damage ≥ 12
@@ -7412,7 +7412,7 @@ Asset id: 3000230508
           All of the following:
               Space Jump Boots
               Any of the following:
-                  Scan Visor and Combat/Scan Dash (Intermediate) and Dark World Damage ≥ 37
+                  Scan Visor and Combat/Scan Dash (Advanced) and Dark World Damage ≥ 37
                   Morph Ball and Roll Jump (Intermediate) and Dark World Damage ≥ 40
   > Top of Cannon
       Morph Ball and Dark World Damage ≥ 30
@@ -7444,7 +7444,7 @@ Asset id: 3000230508
           All of the following:
               Space Jump Boots
               Any of the following:
-                  Scan Visor and Combat/Scan Dash (Intermediate) and Dark World Damage ≥ 35
+                  Scan Visor and Combat/Scan Dash (Advanced) and Dark World Damage ≥ 35
                   Morph Ball and Roll Jump (Intermediate) and Dark World Damage ≥ 40
   > Door to Undertemple Access
       Dark World Damage ≥ 15
@@ -7471,7 +7471,7 @@ Asset id: 3000230508
           All of the following:
               Space Jump Boots and Dark World Damage ≥ 30
               Any of the following:
-                  Scan Visor and Combat/Scan Dash (Intermediate)
+                  Scan Visor and Combat/Scan Dash (Advanced)
                   Morph Ball and Roll Jump (Advanced)
   > Top of Cannon
       Morph Ball and Dark World Damage ≥ 30
@@ -8979,7 +8979,7 @@ Asset id: 1433528478
       Any of the following:
           Space Jump Boots or Before Hall of Combat Mastery Glass Tunnel
           Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner)
-          Scan Visor and Combat/Scan Dash (Intermediate)
+          Scan Visor and Combat/Scan Dash (Advanced)
   > Event - Hall of Combat Mastery Glass Tunnel
       Morph Ball and Power Bomb
 

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -996,6 +996,7 @@ Asset id: 1966181726
                   Scan Visor and Combat/Scan Dash (Intermediate)
                   Morph Ball and Roll Jump (Intermediate)
           Morph Ball and Boost Ball and Boost Jump (Advanced)
+          Scan Visor and Extended Dash (Expert)
 
 > Pickup (Energy Tank); Heals? False
   * Pickup 4; Major Location? True
@@ -1105,7 +1106,7 @@ Asset id: 1263425809
   > Door to Dynamo Chamber
       Any of the following:
           Scan Visor or Space Jump Boots
-          Before Temple Assembly Site Light Block and Combat/Scan Dash (Intermediate) and Standable Terrain (Intermediate)
+          Before Temple Assembly Site Light Block and Combat/Scan Dash (Advanced) and Standable Terrain (Intermediate)
           All of the following:
               Morph Ball
               Any of the following:
@@ -1735,7 +1736,7 @@ Asset id: 2681312991
               All of the following:
                   Morph Ball
                   Any of the following:
-                      Morph Ball Bomb and Combat/Scan Dash (Intermediate) and Bomb Jump (Intermediate) and Dark World Damage ≥ 40
+                      Morph Ball Bomb and Combat/Scan Dash (Beginner) and Bomb Jump (Intermediate) and Dark World Damage ≥ 40
                       Light Suit and Gravity Boost and Air Underwater (Advanced)
 
 ----------------
@@ -1824,7 +1825,7 @@ Asset id: 3258777533
               Scan Visor
               Any of the following:
                   After Sacred Path Wall Broken
-                  Combat/Scan Dash (Advanced) and Slope Jump (Advanced) and Standable Terrain (Advanced)
+                  Combat/Scan Dash (Advanced) and Slope Jump (Advanced) and Standable Terrain (Beginner)
           Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner)
           Movement (Intermediate) and Use Screw Attack (No Space Jump)
   > Event - Sacred Path Wall Broken
@@ -1906,11 +1907,8 @@ Asset id: 1692811478
                   Any of the following:
                       Space Jump Boots
                       Movement (Beginner) and Use Screw Attack (No Space Jump)
-              All of the following:
-                  Morph Ball
-                  Any of the following:
-                      Morph Ball Bomb and Bomb Jump (Intermediate) and Dark World Damage ≥ 25
-                      Scan Visor and Combat/Scan Dash (Advanced) and Dark World Damage ≥ 70
+              Morph Ball and Morph Ball Bomb and Bomb Jump (Intermediate) and Dark World Damage ≥ 25
+              Scan Visor and Combat/Scan Dash (Advanced) and Standable Terrain (Beginner) and Dark World Damage ≥ 70
   > Pickup (Dark Ammo)
       All of the following:
           Annihilator Beam and Echo Visor and Dark World Damage ≥ 55
@@ -2909,7 +2907,7 @@ Asset id: 3820941951
 > Room Center; Heals? False
   > Door to Temple Access
       Any of the following:
-          Space Jump Boots or Missile or Combat/Scan Dash (Intermediate)
+          Space Jump Boots or Missile or Combat/Scan Dash (Advanced)
           Movement (Beginner) and Use Screw Attack (No Space Jump)
           Morph Ball and Boost Ball and Boost Jump (Advanced)
   > Door to Central Station Access
@@ -3684,7 +3682,7 @@ Asset id: 3212793644
                   Dark World Damage ≥ 20 or Activate Safe Zone
                   Any of the following:
                       Space Jump Boots
-                      Scan Visor and Combat/Scan Dash (Advanced) and Standable Terrain (Advanced)
+                      Scan Visor and Combat/Scan Dash (Advanced) and Standable Terrain (Beginner)
               All of the following:
                   Dark World Damage ≥ 10 or Activate Safe Zone
                   Any of the following:
@@ -4355,7 +4353,7 @@ Asset id: 834819415
       All of the following:
           Scan Visor
           Any of the following:
-              Space Jump Boots or Combat/Scan Dash (Intermediate)
+              Space Jump Boots or Combat/Scan Dash (Beginner)
               Movement (Beginner) and Use Screw Attack (No Space Jump)
   > Morph Ball Door to Command Center Access
       Morph Ball and After Command Center Gate Closed and After Command Center Gate Opened
@@ -5834,7 +5832,7 @@ Asset id: 3822429534
           All of the following:
               Morph Ball and Morph Ball Bomb
               Any of the following:
-                  Bomb Space Jump (Hypermode)
+                  Bomb Space Jump (Expert)
                   Space Jump Boots and Bomb Space Jump (Intermediate)
           Movement (Beginner) and Use Screw Attack (Space Jump)
           Space Jump Boots and Slope Jump (Expert)
@@ -7430,7 +7428,7 @@ Asset id: 3000230508
           Morph Ball
           Any of the following:
               Space Jump Boots and Dark World Damage ≥ 50
-              Scan Visor and Morph Ball Bomb and Combat/Scan Dash (Advanced) and Bomb Jump (Advanced) and Dark World Damage ≥ 80
+              Scan Visor and Morph Ball Bomb and Combat/Scan Dash (Intermediate) and Bomb Jump (Advanced) and Dark World Damage ≥ 80
 
 > Door to Save Station 2; Heals? True
   * Missile Blast Shield to Save Station 2/Door to Undertemple Shaft
@@ -7690,7 +7688,7 @@ Asset id: 889276218
   > Kinetic Orb Cannon
       Any of the following:
           Grapple Beam or Use Screw Attack (Space Jump)
-          Scan Visor and Space Jump Boots and Combat/Scan Dash (Advanced)
+          Scan Visor and Space Jump Boots and Combat/Scan Dash (Intermediate)
           Morph Ball and Gravity Boost and Air Underwater (Advanced)
 
 > Portal to Crypt; Heals? False
@@ -7713,7 +7711,7 @@ Asset id: 889276218
               Space Jump Boots
               Any of the following:
                   Use Screw Attack (Space Jump)
-                  Scan Visor and Combat/Scan Dash (Advanced)
+                  Scan Visor and Combat/Scan Dash (Intermediate)
 
 > Door to Gathering Access; Heals? False
   * Light Door to Gathering Access/Door to Gathering Hall
@@ -7733,6 +7731,7 @@ Asset id: 889276218
               Any of the following:
                   Morph Ball and Roll Jump (Intermediate)
                   Scan Visor and Combat/Scan Dash (Intermediate)
+          Scan Visor and Extended Dash (Expert)
 
 > Pickup (Missile); Heals? False
   * Pickup 84; Major Location? False
@@ -8053,7 +8052,11 @@ Asset id: 4217540043
       Any of the following:
           Space Jump Boots
           Morph Ball and Morph Ball Bomb and Bomb Jump (Beginner)
-          Combat/Scan Dash (Intermediate) and Standable Terrain (Intermediate)
+          All of the following:
+              Standable Terrain (Intermediate)
+              Any of the following:
+                  Combat/Scan Dash (Advanced)
+                  Scan Visor and Combat/Scan Dash (Intermediate)
           After Hydrochamber Storage Item and Jump Off Enemy (Advanced) and Normal Damage ≥ 10
   > Door to Catacombs Access
       Trivial
@@ -10054,7 +10057,7 @@ Asset id: 1089946750
               All of the following:
                   Scan Visor
                   Any of the following:
-                      Combat/Scan Dash (Expert) and Dark World Damage ≥ 50
+                      Combat/Scan Dash (Hypermode) and Dark World Damage ≥ 50
                       Extended Dash (Expert) and Dark World Damage ≥ 25
               Morph Ball and Boost Ball and Boost Jump (Advanced) and Dark World Damage ≥ 25
 
@@ -10566,10 +10569,11 @@ Asset id: 1378173793
           Any of the following:
               Space Jump Boots
               All of the following:
-                  Terminal Fall Abuse (Expert) and Normal Damage ≥ 10
+                  Terminal Fall Abuse (Advanced) and Normal Damage ≥ 10
                   Any of the following:
-                      Screw Attack at Z-Axis (Expert) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
-                      Scan Visor and Combat/Scan Dash (Expert) and Normal Damage ≥ 60
+                      Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
+                      Scan Visor and Combat/Scan Dash (Expert) and Terminal Fall Abuse (Hypermode) and Normal Damage ≥ 60
+                      Scan Visor and Extended Dash (Advanced)
   > Above Bomb Slot
       Space Jump Boots and After Vault Bomb Slot
 
@@ -10593,8 +10597,12 @@ Asset id: 1378173793
   > Above Bomb Slot
       Any of the following:
           Use Screw Attack (Space Jump)
-          Scan Visor and Space Jump Boots and Combat/Scan Dash (Intermediate)
-          Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
+          All of the following:
+              Scan Visor and Space Jump Boots
+              Any of the following:
+                  Extended Dash (Advanced)
+                  Combat/Scan Dash (Intermediate) and Terminal Fall Abuse (Intermediate) and Normal Damage ≥ 10
+          Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Use Screw Attack (Space Jump)
 
 > Event - Vault Bomb Slot; Heals? False
   * Event Vault Bomb Slot
@@ -11102,7 +11110,7 @@ Asset id: 2838429875
                       Screw Attack at Z-Axis (Beginner) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
               All of the following:
                   Scan Visor and Space Jump Boots and Dark World Damage ≥ 70
-                  Combat/Scan Dash (Expert) or Extended Dash (Expert)
+                  Combat/Scan Dash (Hypermode) or Extended Dash (Expert)
 
 > Before Quadraxis; Heals? False
   > Event - Quadraxis

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -10569,14 +10569,14 @@ Asset id: 1378173793
           Any of the following:
               Space Jump Boots
               All of the following:
-                  Terminal Fall Abuse (Advanced) and Normal Damage ≥ 10
+                  Terminal Fall Abuse (Advanced) and Normal Damage ≥ 20
                   Any of the following:
                       Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
                       All of the following:
                           Scan Visor
                           Any of the following:
                               Extended Dash (Advanced)
-                              Combat/Scan Dash (Expert) and Terminal Fall Abuse (Hypermode) and Normal Damage ≥ 10
+                              Combat/Scan Dash (Expert) and Terminal Fall Abuse (Hypermode) and Normal Damage ≥ 40
   > Above Bomb Slot
       Space Jump Boots and After Vault Bomb Slot
 

--- a/randovania/data/json_data/prime2.txt
+++ b/randovania/data/json_data/prime2.txt
@@ -6414,7 +6414,7 @@ Asset id: 2240736467
               Morph Ball and Morph Ball Bomb
               Any of the following:
                   Space Jump Boots and Bomb Space Jump (Intermediate) and Dark World Damage ≥ 35
-                  Bomb Space Jump (Hypermode) and Dark World Damage ≥ 55
+                  Bomb Space Jump (Expert) and Dark World Damage ≥ 55
   > Door to Dark Torvus Temple Access
       Any of the following:
           Dark World Damage ≥ 35
@@ -10572,8 +10572,11 @@ Asset id: 1378173793
                   Terminal Fall Abuse (Advanced) and Normal Damage ≥ 10
                   Any of the following:
                       Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Use Screw Attack (No Space Jump)
-                      Scan Visor and Combat/Scan Dash (Expert) and Terminal Fall Abuse (Hypermode) and Normal Damage ≥ 60
-                      Scan Visor and Extended Dash (Advanced)
+                      All of the following:
+                          Scan Visor
+                          Any of the following:
+                              Extended Dash (Advanced)
+                              Combat/Scan Dash (Expert) and Terminal Fall Abuse (Hypermode) and Normal Damage ≥ 10
   > Above Bomb Slot
       Space Jump Boots and After Vault Bomb Slot
 


### PR DESCRIPTION
- tweaked the difficulty of combat/scan dash tricks to form consistency and flesh out the difficulty levels
- updated the Vault NSJ logic to account for modern extended dash tricks
- added extended dashes to Gathering Hall and Windchamber Gateway
- different method of reaching portal in Profane Path from Echo Locks without SJ or Bombs