### PR TITLE
Update Randomprime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added: In-game crashes in Metroid Prime now automatically show the error screen.
+
 - Changed: Game Sessions - The window now uses docks for the different parts, meaning you can resize, reorder and even split off.
+
+- Fixed: Exporting a Metroid Prime ISO with Warp to Start enabled and starting at certain elevator rooms no longer fails.
 
 ## [3.0.1] - 2021-08-01
 

--- a/randovania/games/patchers/randomprime_patcher.py
+++ b/randovania/games/patchers/randomprime_patcher.py
@@ -273,6 +273,7 @@ class RandomprimePatcher(Patcher):
                 "obfuscateItems": False,
                 "mapDefaultState": map_default_state,
                 "artifactHintBehavior": None,
+                "automaticCrashScreen": True,
                 "trilogyDiscPath": None,
                 "quickplay": False,
                 "quiet": False,

--- a/requirements-small.txt
+++ b/requirements-small.txt
@@ -25,7 +25,7 @@ numpy==1.21.1
 pid==3.0.4
 Pillow==8.3.1
 psutil==5.8.0
-py-randomprime==0.3.6
+py-randomprime==0.4.0
 pyparsing==2.4.7
 pypresence==4.2.0
 pyqt-distutils==0.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ prometheus-client==0.11.0
 prometheus-flask-exporter==0.18.2
 psutil==5.8.0
 py==1.10.0
-py-randomprime==0.3.6
+py-randomprime==0.4.0
 pycparser==2.20
 pyinstaller==4.5
 pyinstaller-hooks-contrib==2021.2

--- a/test/games/patchers/test_randomprime_patcher.py
+++ b/test/games/patchers/test_randomprime_patcher.py
@@ -689,6 +689,7 @@ def test_create_patch_data(test_files_dir):
         'hasSpoiler': True,
         'preferences': {
             'artifactHintBehavior': None,
+            'automaticCrashScreen': True,
             'mapDefaultState': 'default',
             'obfuscateItems': False,
             'qolCosmetic': True,


### PR DESCRIPTION
- Added: In-game crashes in Metroid Prime now automatically show the error screen.
- Fixed: Exporting a Metroid Prime ISO with Warp to Start enabled and starting at certain elevator rooms no longer fails.