### PR TITLE
Prime 1 racetime.gg integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added: Metroid Prime 1 racetime.gg rooms are now viewable in the racetime.gg browser, with filters for each game
+- Fixed: Importing a permalink from the racetime.gg browser while a race is currently in progress now selects the correct racetime.gg room
+
 ## [3.0.3] - 2021-08-08
 
 - Fixed: "Open FAQ" in the main window now works correctly.

--- a/randovania/gui/ui_files/racetime_browser_dialog.ui
+++ b/randovania/gui/ui_files/racetime_browser_dialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>528</width>
+    <width>675</width>
     <height>453</height>
    </rect>
   </property>
@@ -33,6 +33,9 @@
      </property>
      <property name="sortingEnabled">
       <bool>true</bool>
+     </property>
+     <property name="columnCount">
+      <number>7</number>
      </property>
      <attribute name="verticalHeaderVisible">
       <bool>false</bool>
@@ -67,6 +70,7 @@
        <string>Info</string>
       </property>
      </column>
+     <column/>
     </widget>
    </item>
    <item>
@@ -75,24 +79,10 @@
       <string>Filters</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="4">
-       <widget class="QCheckBox" name="status_inprogress_check">
+      <item row="2" column="3">
+       <widget class="QCheckBox" name="status_pending_check">
         <property name="text">
-         <string>In Progress</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="7">
-       <widget class="QCheckBox" name="status_cancelled_check">
-        <property name="text">
-         <string>Cancelled</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="filter_status_label">
-        <property name="text">
-         <string>Status</string>
+         <string>Pending</string>
         </property>
        </widget>
       </item>
@@ -109,17 +99,13 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="6">
-       <widget class="QCheckBox" name="status_finished_check">
-        <property name="text">
-         <string>Finished</string>
-        </property>
-       </widget>
+      <item row="0" column="1" colspan="7">
+       <widget class="QLineEdit" name="filter_name_edit"/>
       </item>
-      <item row="2" column="2">
-       <widget class="QCheckBox" name="status_invitational_check">
+      <item row="2" column="0">
+       <widget class="QLabel" name="filter_status_label">
         <property name="text">
-         <string>Invitational</string>
+         <string>Status</string>
         </property>
        </widget>
       </item>
@@ -133,15 +119,43 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1" colspan="7">
-       <widget class="QLineEdit" name="filter_name_edit"/>
-      </item>
-      <item row="2" column="3">
-       <widget class="QCheckBox" name="status_pending_check">
+      <item row="2" column="4">
+       <widget class="QCheckBox" name="status_inprogress_check">
         <property name="text">
-         <string>Pending</string>
+         <string>In Progress</string>
         </property>
        </widget>
+      </item>
+      <item row="2" column="6">
+       <widget class="QCheckBox" name="status_finished_check">
+        <property name="text">
+         <string>Finished</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="7">
+       <widget class="QCheckBox" name="status_cancelled_check">
+        <property name="text">
+         <string>Cancelled</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QCheckBox" name="status_invitational_check">
+        <property name="text">
+         <string>Invitational</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="game_filter_label">
+        <property name="text">
+         <string>Game</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1" colspan="3">
+       <layout class="QHBoxLayout" name="game_check_layout"/>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Implements #2046  
Adds support for Prime 1 in the racetime.gg browser. A checkbox filter for each supported game allows users to filter out unwanted games.
![racetime_browser_update](https://user-images.githubusercontent.com/22754714/128646044-3c4ac86b-bd7a-4243-9467-b2044e7dfe18.png)

This also fixes #1434 and updates _TEST_RESPONSE to include this edge case.