### PR TITLE
fixes #392 - use different game ID with menu mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Randovania no longer errors when the last selected preset is for a hidden game.
 - Fixed: Quality of Life page link in Metroid Prime preset customization is now fixed.
 - Changed: Removed customization of Qt theme for decreasing whitespace.
+- Changed: Echoes now uses a different game ID when saving ISOs with menu mod enabled, preventing issues from incompatible save files.
 
 ### Metroid Prime - Patcher Changes
 

--- a/randovania/games/patchers/claris_patcher.py
+++ b/randovania/games/patchers/claris_patcher.py
@@ -104,7 +104,7 @@ class ClarisPatcher(Patcher):
         banner_patcher.patch_game_name_and_id(
             contents_files_path,
             "Metroid Prime 2: Randomizer - {}".format(patch_data["shareable_hash"]),
-            patch_data["game_id"]
+            patch_data["publisher_id"]
         )
         randomizer_data = copy.deepcopy(decode_randomizer_data())
 

--- a/randovania/games/patchers/claris_patcher.py
+++ b/randovania/games/patchers/claris_patcher.py
@@ -103,7 +103,8 @@ class ClarisPatcher(Patcher):
         # Apply patcher
         banner_patcher.patch_game_name_and_id(
             contents_files_path,
-            "Metroid Prime 2: Randomizer - {}".format(patch_data["shareable_hash"])
+            "Metroid Prime 2: Randomizer - {}".format(patch_data["shareable_hash"]),
+            patch_data["game_id"]
         )
         randomizer_data = copy.deepcopy(decode_randomizer_data())
 

--- a/randovania/games/patchers/claris_patcher_file.py
+++ b/randovania/games/patchers/claris_patcher_file.py
@@ -402,9 +402,9 @@ def create_patcher_file(description: LayoutDescription,
     result = {}
     _add_header_data_to_result(description, result)
 
-    result["game_id"] = "G2ME0R"
+    result["publisher_id"] = "0R"
     if configuration.menu_mod:
-        result["game_id"] = "G2ME1R"
+        result["publisher_id"] = "1R"
 
     result["convert_other_game_assets"] = cosmetic_patches.convert_other_game_assets
     result["credits"] = "\n\n\n\n\n" + credits_spoiler.prime_trilogy_credits(

--- a/randovania/games/patchers/claris_patcher_file.py
+++ b/randovania/games/patchers/claris_patcher_file.py
@@ -402,6 +402,10 @@ def create_patcher_file(description: LayoutDescription,
     result = {}
     _add_header_data_to_result(description, result)
 
+    result["game_id"] = "G2ME0R"
+    if configuration.menu_mod:
+        result["game_id"] = "G2ME1R"
+
     result["convert_other_game_assets"] = cosmetic_patches.convert_other_game_assets
     result["credits"] = "\n\n\n\n\n" + credits_spoiler.prime_trilogy_credits(
         configuration.major_items_configuration,

--- a/randovania/games/patchers/gamecube/banner_patcher.py
+++ b/randovania/games/patchers/gamecube/banner_patcher.py
@@ -3,17 +3,18 @@ from pathlib import Path
 from construct.core import Byte
 
 
-def patch_game_name_and_id(game_files_path: Path, new_name: str, game_id_replacement: str):
+def patch_game_name_and_id(game_files_path: Path, new_name: str, publisher_id: str):
     b = new_name.encode("ASCII")
     if len(b) > 40:
         raise ValueError("Name '{}' is bigger than 40 bytes".format(new_name))
     
-    gid = game_id_replacement.encode("ASCII")
-    if len(gid) != 6:
-        raise ValueError("Game ID '{}' is not exactly 6 bytes".format(game_id_replacement))
+    pid = publisher_id.encode("ASCII")
+    if len(pid) != 2:
+        raise ValueError("Publisher ID '{}' is not exactly 2 bytes".format(publisher_id))
 
     with game_files_path.joinpath("sys", "boot.bin").open("r+b") as boot_bin:
-        boot_bin.write(gid)
+        boot_bin.seek(0x4)
+        boot_bin.write(pid)
         boot_bin.seek(0x20)
         boot_bin.write(b)
 

--- a/randovania/games/patchers/gamecube/banner_patcher.py
+++ b/randovania/games/patchers/gamecube/banner_patcher.py
@@ -1,14 +1,19 @@
 from pathlib import Path
 
+from construct.core import Byte
 
-def patch_game_name_and_id(game_files_path: Path, new_name: str):
+
+def patch_game_name_and_id(game_files_path: Path, new_name: str, game_id_replacement: str):
     b = new_name.encode("ASCII")
     if len(b) > 40:
         raise ValueError("Name '{}' is bigger than 40 bytes".format(new_name))
+    
+    gid = game_id_replacement.encode("ASCII")
+    if len(gid) != 6:
+        raise ValueError("Game ID '{}' is not exactly 6 bytes".format(game_id_replacement))
 
     with game_files_path.joinpath("sys", "boot.bin").open("r+b") as boot_bin:
-        boot_bin.seek(0x5)
-        boot_bin.write(b"R")
+        boot_bin.write(gid)
         boot_bin.seek(0x20)
         boot_bin.write(b)
 


### PR DESCRIPTION
echoes uses a different game ID (GM2E1R) when saving ISOs with menu mod enabled, so that different save file formats aren't shared