### PR TITLE
fixes #473 - adds a joke hint requested in an issue from 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Randovania no longer errors when the last selected preset is for a hidden game.
 - Fixed: Quality of Life page link in Metroid Prime preset customization is now fixed.
 - Changed: Removed customization of Qt theme for decreasing whitespace.
+- Added: One joke hint, requested in 2019.
 
 ### Metroid Prime - Patcher Changes
 

--- a/randovania/games/prime/patcher_file_lib/hints.py
+++ b/randovania/games/prime/patcher_file_lib/hints.py
@@ -36,6 +36,7 @@ _JOKE_HINTS = [
     "While walking, holding L makes you move faster.",
     "I wonder how many players will see this message...?",
     "We've been trying to contact you about your ship's extended warranty.",
+    "The Scan Visor is useful for gathering information.",
 ]
 
 


### PR DESCRIPTION
adds "The Scan Visor is useful for gathering information." to joke hints
wouldn't normally be my kinda thing, but I figure this poor issue has been open for multiple years and deserves closure :P