### PR TITLE
fixed trivial logic walking in upper phendrana shorelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Sun tower now requires Knowledge (Intermediate) to collect the Sunchamber layer change event without falling down.
 - Added: Method of reaching Ruins Entryway from Plaza Walkway in Phendrana Shorelines with a Dash (Intermediate).
 - Fixed: Phendrana Shorelines now properly accounts for collecting the pickup on the Spider Ball track.
+- Fixed: Trivial logic for Plaza Walkway to Ruins Walkway
 - Fixed: Replaced Bomb Jump (Intermediate) with Dash (Beginner) trick to cross the gap to reach the Courtyard Access door in Ice Ruins West.
 - Fixed: NSJ logic now accounts for stalactite in Ice Ruins West.
 - Changed: Improved readability of Ruined Courtyard logic.

--- a/randovania/data/json_data/prime1/Phendrana Drifts.json
+++ b/randovania/data/json_data/prime1/Phendrana Drifts.json
@@ -488,13 +488,8 @@
                             "data": []
                         },
                         "Door to Ruins Entryway": {
-                            "type": "resource",
-                            "data": {
-                                "type": 2,
-                                "index": 0,
-                                "amount": 3,
-                                "negate": false
-                            }
+                            "type": "and",
+                            "data": []
                         }
                     }
                 },

--- a/randovania/data/json_data/prime1/Phendrana Drifts.txt
+++ b/randovania/data/json_data/prime1/Phendrana Drifts.txt
@@ -73,7 +73,7 @@ Asset id: 4146616697
   > Door to Shoreline Entrance
       Trivial
   > Door to Ruins Entryway
-      Combat/Scan Dash (Advanced)
+      Trivial
 
 > Door to Ice Ruins Access; Heals? False
   * Normal Door to Ice Ruins Access/Door to Phendrana Shorelines


### PR DESCRIPTION
If I'm understanding this right, this is preventing tourney seeds from logical access to ice ruins west from shorelines. This is a bug from the PR from 1 week ago.