### PR TITLE
Database - Difficulty Adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Reorganized Sunchamber logic to improve usage by generator/solver.
 - Changed: Picking up Sunchamber Ghosts item NSJ is now L-Jump (Beginner) instead of Intermediate.   
 - Changed: Crossing TFT to TF with Gravity+SJ now requires Movement (Beginner)
+- Changed: FCS Item Scan Dash method is now Intermediate without SJ.
 
 ### Metroid Prime 2: Echoes - Patcher Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed shorelines tower item custom scan sometimes showing the incorrect text for certain models
 - Certain pickups now always have the popup alert on collection during multiworlds.
 - If there are multiple pickups for other players next to each other, these pickups are forced to have a popup alert, so Randovania can properly detect they were picked up.
+- Fixed PCA crash patch not being applied when playing small samus.
 
 #### Cutscene Skips
 - Added `Competitive` cutscene skip option.
@@ -66,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Improved readability of Ruined Courtyard logic.
 - Changed: Reorganized Sunchamber logic to improve usage by generator/solver.
 - Changed: Picking up Sunchamber Ghosts item NSJ is now L-Jump (Beginner) instead of Intermediate.   
+- Changed: Crossing TFT to TF with Gravity+SJ now requires Movement (Beginner)
 
 ### Metroid Prime 2: Echoes - Patcher Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Picking up Sunchamber Ghosts item NSJ is now L-Jump (Beginner) instead of Intermediate.   
 - Changed: Crossing TFT to TF with Gravity+SJ now requires Movement (Beginner)
 - Changed: FCS Item Scan Dash method is now Intermediate without SJ.
+- Added: FCS Grapple strat - Movement (Beginner)
 
 ### Metroid Prime 2: Echoes - Patcher Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ so Randovania can properly detect they were picked up.
 - Fixed: Crossing the gap by Specimen Storage door no longer sometimes requires L-Jump (Intermediate) instead of Beginner.
 - Changed: Improved readability of Ruined Courtyard logic.
 - Changed: Reorganized Sunchamber logic to improve usage by generator/solver.
+- Changed: Picking up Sunchamber Ghosts item NSJ is now L-Jump (Beginner) instead of Intermediate.   
 
 ### Metroid Prime 2: Echoes - Patcher Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,16 +31,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Prime - Patcher Changes
 
+- Added `Pickup Scans` option to toggle the patching of item locations so that they can always be scanned.
+- Magmoor Workstation item scannable through the purple door (QoL Pickup Scan)
+- Fixed shorelines tower item custom scan sometimes showing the incorrect text for certain models
+- Certain pickups now always have the popup alert on collection during multiworlds.
+- If there are multiple pickups for other players next to each other, these pickups are forced to have a popup alert, so Randovania can properly detect they were picked up.
+
+#### Cutscene Skips
+- Added `Competitive` cutscene skip option.
 - Moved Shorelines Tower cutscene to major (it sometimes has a reposition that is sometimes useful in routing)
 - Removed Main Quarry Combat Visor switch
 - Speed up opening of gate in ice temple
 - Speed up opening of gate in sun tower
 - Fixed Thardus cutscene skip softlock
-- Magmoor Workstation item scannable through the purple door (QOL Pickup Scan)
-- Fixed shorelines tower item custom scan sometimes showing the incorrect text for certain models
-- Certain pickups now always have the popup alert on collection during multiworlds.
-- If there are multiple pickups for other players next to each other, these pickups are forced to have a popup alert, 
-so Randovania can properly detect they were picked up.  
 
 ### Metroid Prime - Logic Database 
 

--- a/randovania/data/json_data/prime1/Chozo Ruins.json
+++ b/randovania/data/json_data/prime1/Chozo Ruins.json
@@ -5662,7 +5662,7 @@
                                                     "data": {
                                                         "type": 2,
                                                         "index": 3,
-                                                        "amount": 2,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }

--- a/randovania/data/json_data/prime1/Chozo Ruins.txt
+++ b/randovania/data/json_data/prime1/Chozo Ruins.txt
@@ -972,7 +972,7 @@ Asset id: 2584347627
       All of the following:
           Power Beam and After Sunchamber Chozo Ghosts Layer Activated
           Charge Beam or Combat (Intermediate)
-          Space Jump Boots or L-Jump (Intermediate)
+          Space Jump Boots or L-Jump (Beginner)
 
 ----------------
 Watery Hall Access

--- a/randovania/data/json_data/prime1/Magmoor Caverns.json
+++ b/randovania/data/json_data/prime1/Magmoor Caverns.json
@@ -10061,6 +10061,15 @@
                                                                 "amount": 15,
                                                                 "negate": false
                                                             }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 6,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
                                                         }
                                                     ]
                                                 }

--- a/randovania/data/json_data/prime1/Magmoor Caverns.txt
+++ b/randovania/data/json_data/prime1/Magmoor Caverns.txt
@@ -1066,7 +1066,7 @@ Asset id: 3835971118
                   Heat Runs (Intermediate) and Heated Rooms Damage ≥ 85
               Any of the following:
                   R-Jump (Advanced)
-                  Gravity Suit and Lava Damage ≥ 15
+                  Gravity Suit and Movement (Beginner) and Lava Damage ≥ 15
           All of the following:
               Scan Visor
               Any of the following:

--- a/randovania/data/json_data/prime1/Tallon Overworld.json
+++ b/randovania/data/json_data/prime1/Tallon Overworld.json
@@ -1143,6 +1143,29 @@
                                             }
                                         }
                                     ]
+                                },
+                                {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 12,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 2,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 }
                             ]
                         }

--- a/randovania/data/json_data/prime1/Tallon Overworld.json
+++ b/randovania/data/json_data/prime1/Tallon Overworld.json
@@ -1083,13 +1083,41 @@
                                             }
                                         },
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 2,
-                                                "index": 0,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 0,
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 15,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 0,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
                                         }
                                     ]
                                 },

--- a/randovania/data/json_data/prime1/Tallon Overworld.txt
+++ b/randovania/data/json_data/prime1/Tallon Overworld.txt
@@ -195,6 +195,7 @@ Asset id: 3115044182
                   Combat/Scan Dash (Intermediate)
                   Space Jump Boots and Combat/Scan Dash (Beginner)
           Slope Jump (Advanced) and Enabled Allow Underwater Movement without Gravity Suit
+          Grapple Beam and Movement (Beginner)
 
 > Door to Frigate Access Tunnel; Heals? False
   * Ice Door to Frigate Access Tunnel/Door to Frigate Crash Site

--- a/randovania/data/json_data/prime1/Tallon Overworld.txt
+++ b/randovania/data/json_data/prime1/Tallon Overworld.txt
@@ -189,7 +189,11 @@ Asset id: 3115044182
           All of the following:
               Space Jump Boots
               Gravity Suit or Slope Jump (Beginner)
-          Scan Visor and Combat/Scan Dash (Beginner)
+          All of the following:
+              Scan Visor
+              Any of the following:
+                  Combat/Scan Dash (Intermediate)
+                  Space Jump Boots and Combat/Scan Dash (Beginner)
           Slope Jump (Advanced) and Enabled Allow Underwater Movement without Gravity Suit
 
 > Door to Frigate Access Tunnel; Heals? False


### PR DESCRIPTION
- Changed: Picking up Sunchamber Ghosts item NSJ is now L-Jump (Beginner) instead of Intermediate.   
- Changed: Crossing TFT to TF with Gravity+SJ now requires Movement (Beginner)
- Changed: FCS Item Scan Dash method is now Intermediate without SJ.
- Added: FCS Grapple strat - Movement (Beginner)
- Missing Patcher Changelog Entries