### PR TITLE
Adding tricks for forced damage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Knowledge (Beginner) trick to leave Central Dynamo without completing the maze or fighting the drone.
 - Fixed Backwards Lower Mines logic
 - Added additional Lower Mines NSJ logic
+- Added Movement tricks for logical forced damage in Magmoor Caverns, Phazon Mines, and Impact Crater.
 
 ### Discord Bot (Caretaker Class Drone)
 

--- a/randovania/data/json_data/prime1/Impact Crater.json
+++ b/randovania/data/json_data/prime1/Impact Crater.json
@@ -494,6 +494,15 @@
                                                                 "amount": 40,
                                                                 "negate": false
                                                             }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 6,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
                                                         }
                                                     ]
                                                 }
@@ -606,6 +615,15 @@
                                                                 "type": 3,
                                                                 "index": 1,
                                                                 "amount": 40,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 6,
+                                                                "amount": 1,
                                                                 "negate": false
                                                             }
                                                         }

--- a/randovania/data/json_data/prime1/Impact Crater.json
+++ b/randovania/data/json_data/prime1/Impact Crater.json
@@ -410,13 +410,36 @@
                             "type": "or",
                             "data": [
                                 {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 0,
-                                        "index": 15,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 2,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 1,
+                                                "amount": 5,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 },
                                 {
                                     "type": "and",
@@ -501,13 +524,36 @@
                             "type": "or",
                             "data": [
                                 {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 0,
-                                        "index": 15,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 15,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 2,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 1,
+                                                "amount": 5,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 },
                                 {
                                     "type": "and",

--- a/randovania/data/json_data/prime1/Impact Crater.txt
+++ b/randovania/data/json_data/prime1/Impact Crater.txt
@@ -77,7 +77,7 @@ Asset id: 852861312
   * Plasma Door to Phazon Infusion Chamber/Door to Crater Tunnel B
   > Door to Phazon Core
       Any of the following:
-          Space Jump Boots
+          Space Jump Boots and Movement (Beginner) and Normal Damage ≥ 5
           All of the following:
               Morph Ball Bomb and Morph Ball
               Any of the following:
@@ -88,7 +88,7 @@ Asset id: 852861312
   * Plasma Door to Phazon Core/Door to Crater Tunnel B
   > Door to Phazon Infusion Chamber
       Any of the following:
-          Space Jump Boots
+          Space Jump Boots and Movement (Beginner) and Normal Damage ≥ 5
           All of the following:
               Morph Ball Bomb and Morph Ball
               Any of the following:

--- a/randovania/data/json_data/prime1/Impact Crater.txt
+++ b/randovania/data/json_data/prime1/Impact Crater.txt
@@ -82,7 +82,7 @@ Asset id: 852861312
               Morph Ball Bomb and Morph Ball
               Any of the following:
                   Spider Ball
-                  Bomb Jump (Beginner) and Normal Damage ≥ 40
+                  Movement (Beginner) and Bomb Jump (Beginner) and Normal Damage ≥ 40
 
 > Door to Phazon Core; Heals? False; Spawn Point
   * Plasma Door to Phazon Core/Door to Crater Tunnel B
@@ -93,7 +93,7 @@ Asset id: 852861312
               Morph Ball Bomb and Morph Ball
               Any of the following:
                   Spider Ball
-                  Bomb Jump (Beginner) and Normal Damage ≥ 40
+                  Movement (Beginner) and Bomb Jump (Beginner) and Normal Damage ≥ 40
 
 ----------------
 Phazon Infusion Chamber

--- a/randovania/data/json_data/prime1/Magmoor Caverns.json
+++ b/randovania/data/json_data/prime1/Magmoor Caverns.json
@@ -7271,6 +7271,15 @@
                                                     ]
                                                 }
                                             ]
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 2,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
                                         }
                                     ]
                                 }
@@ -8362,6 +8371,15 @@
                                                     ]
                                                 }
                                             ]
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 2,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
                                         }
                                     ]
                                 },
@@ -8946,13 +8964,27 @@
                                     "type": "and",
                                     "data": [
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 3,
-                                                "index": 6,
-                                                "amount": 45,
-                                                "negate": false
-                                            }
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 6,
+                                                        "amount": 45,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         },
                                         {
                                             "type": "or",
@@ -9184,13 +9216,27 @@
                                     "type": "and",
                                     "data": [
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 3,
-                                                "index": 6,
-                                                "amount": 45,
-                                                "negate": false
-                                            }
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 6,
+                                                        "amount": 45,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         },
                                         {
                                             "type": "or",

--- a/randovania/data/json_data/prime1/Magmoor Caverns.txt
+++ b/randovania/data/json_data/prime1/Magmoor Caverns.txt
@@ -793,6 +793,7 @@ Asset id: 4126087266
       Any of the following:
           Grapple Beam and Heat-Resisting Suit
           All of the following:
+              Movement (Beginner)
               Heat Runs (Advanced) or Heat-Resisting Suit
               Any of the following:
                   Heated Rooms Damage ≥ 239 and Lava Damage ≥ 50
@@ -888,6 +889,7 @@ Asset id: 4126087266
                   Heat-Resisting Suit
                   L-Jump (Beginner) and Heat Runs (Advanced) and Heated Rooms Damage ≥ 250
           All of the following:
+              Movement (Beginner)
               Heat Runs (Advanced) or Heat-Resisting Suit
               Any of the following:
                   All of the following:
@@ -953,7 +955,7 @@ Asset id: 860276342
                   Heat Runs (Beginner) and Heated Rooms Damage ≥ 120
                   Heat Runs (Intermediate) and Heated Rooms Damage ≥ 99
           All of the following:
-              Lava Damage ≥ 45
+              Movement (Beginner) and Lava Damage ≥ 45
               Any of the following:
                   Heat-Resisting Suit
                   Heat Runs (Beginner) and Heated Rooms Damage ≥ 100
@@ -976,7 +978,7 @@ Asset id: 860276342
                   Heat Runs (Beginner) and Heated Rooms Damage ≥ 120
                   Heat Runs (Intermediate) and Heated Rooms Damage ≥ 99
           All of the following:
-              Lava Damage ≥ 45
+              Movement (Beginner) and Lava Damage ≥ 45
               Any of the following:
                   Heat-Resisting Suit
                   Heat Runs (Beginner) and Heated Rooms Damage ≥ 100

--- a/randovania/data/json_data/prime1/Phazon Mines.json
+++ b/randovania/data/json_data/prime1/Phazon Mines.json
@@ -3204,8 +3204,41 @@
                             ]
                         },
                         "Door to Processing Center Access": {
-                            "type": "and",
-                            "data": []
+                            "type": "or",
+                            "data": [
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": 0,
+                                        "index": 23,
+                                        "amount": 1,
+                                        "negate": false
+                                    }
+                                },
+                                {
+                                    "type": "and",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 2,
+                                                "index": 6,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 3,
+                                                "index": 3,
+                                                "amount": 45,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
                         },
                         "Pickup (Missile)": {
                             "type": "and",
@@ -3254,13 +3287,41 @@
                                     "type": "and",
                                     "data": [
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 3,
-                                                "index": 3,
-                                                "amount": 45,
-                                                "negate": false
-                                            }
+                                            "type": "or",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 23,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 6,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 3,
+                                                                "index": 3,
+                                                                "amount": 45,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
                                         },
                                         {
                                             "type": "resource",
@@ -3840,25 +3901,67 @@
                     "dock_weakness_index": 3,
                     "connections": {
                         "Door to Elite Quarters": {
-                            "type": "or",
+                            "type": "and",
                             "data": [
                                 {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 1,
-                                        "index": 32,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 1,
+                                                "index": 32,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 5,
+                                                "index": 5,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        }
+                                    ]
                                 },
                                 {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 5,
-                                        "index": 5,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 23,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 3,
+                                                        "amount": 99,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -3880,13 +3983,78 @@
                     "dock_weakness_index": 3,
                     "connections": {
                         "Door to Phazon Processing Center": {
-                            "type": "resource",
-                            "data": {
-                                "type": 1,
-                                "index": 32,
-                                "amount": 1,
-                                "negate": false
-                            }
+                            "type": "and",
+                            "data": [
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": 1,
+                                        "index": 32,
+                                        "amount": 1,
+                                        "negate": false
+                                    }
+                                },
+                                {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 23,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 3,
+                                                        "amount": 199,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 6,
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 3,
+                                                        "index": 3,
+                                                        "amount": 99,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
                         },
                         "Event - Processing Center Access Barrier Opened": {
                             "type": "resource",

--- a/randovania/data/json_data/prime1/Phazon Mines.json
+++ b/randovania/data/json_data/prime1/Phazon Mines.json
@@ -7019,13 +7019,69 @@
                                     }
                                 },
                                 {
-                                    "type": "resource",
-                                    "data": {
-                                        "type": 0,
-                                        "index": 6,
-                                        "amount": 1,
-                                        "negate": false
-                                    }
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 18,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 6,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 23,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 2,
+                                                                        "index": 6,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 3,
+                                                                        "index": 3,
+                                                                        "amount": 30,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
                                 }
                             ]
                         },
@@ -7222,7 +7278,7 @@
                                             "type": "resource",
                                             "data": {
                                                 "type": 0,
-                                                "index": 6,
+                                                "index": 18,
                                                 "amount": 1,
                                                 "negate": false
                                             }
@@ -7234,19 +7290,47 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": 0,
-                                                        "index": 18,
+                                                        "index": 6,
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": 2,
-                                                        "index": 6,
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 0,
+                                                                "index": 23,
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 2,
+                                                                        "index": 6,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 3,
+                                                                        "index": 3,
+                                                                        "amount": 30,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
                                                 }
                                             ]
                                         }

--- a/randovania/data/json_data/prime1/Phazon Mines.txt
+++ b/randovania/data/json_data/prime1/Phazon Mines.txt
@@ -994,7 +994,15 @@ Asset id: 3153742515
 > Door to Fungal Hall B; Heals? False
   * Plasma Door to Fungal Hall B/Door to Phazon Mining Tunnel
   > Door to Fungal Hall A
-      Morph Ball Bomb and Power Bomb and Morph Ball
+      All of the following:
+          Power Bomb and Morph Ball
+          Any of the following:
+              Boost Ball
+              All of the following:
+                  Morph Ball Bomb
+                  Any of the following:
+                      Phazon Suit
+                      Movement (Beginner) and Phazon Damage ≥ 30
   > Pickup (Artifact of Newborn)
       All of the following:
           Morph Ball Bomb and Morph Ball
@@ -1014,8 +1022,12 @@ Asset id: 3153742515
       All of the following:
           Power Bomb and Morph Ball
           Any of the following:
-              Morph Ball Bomb
-              Boost Ball and Movement (Beginner)
+              Boost Ball
+              All of the following:
+                  Morph Ball Bomb
+                  Any of the following:
+                      Phazon Suit
+                      Movement (Beginner) and Phazon Damage ≥ 30
 
 > Pickup (Artifact of Newborn); Heals? False
   * Pickup 88; Major Location? True

--- a/randovania/data/json_data/prime1/Phazon Mines.txt
+++ b/randovania/data/json_data/prime1/Phazon Mines.txt
@@ -492,7 +492,9 @@ Asset id: 2905505465
                   Spider Ball and Standable Terrain (Expert) and Bomb Jump (Expert)
                   L-Jump (Expert) and Standable Terrain (Hypermode) and Complex Bomb Jump (Hypermode)
   > Door to Processing Center Access
-      Trivial
+      Any of the following:
+          Phazon Suit
+          Movement (Beginner) and Phazon Damage ≥ 45
   > Pickup (Missile)
       Power Bomb and Morph Ball
 
@@ -501,7 +503,10 @@ Asset id: 2905505465
   > Door to Maintenance Tunnel
       Any of the following:
           All of the following:
-              Space Jump Boots and Phazon Damage ≥ 45
+              Space Jump Boots
+              Any of the following:
+                  Phazon Suit
+                  Movement (Beginner) and Phazon Damage ≥ 45
               Any of the following:
                   Standable Terrain (Beginner)
                   Morph Ball Bomb and Morph Ball and Spider Ball
@@ -563,12 +568,21 @@ Asset id: 3983402811
 > Door to Phazon Processing Center; Heals? False
   * Plasma Door to Phazon Processing Center/Door to Processing Center Access
   > Door to Elite Quarters
-      After Processing Center Access Barrier or Enabled Backwards Lower Mines
+      All of the following:
+          After Processing Center Access Barrier or Enabled Backwards Lower Mines
+          Any of the following:
+              Phazon Suit
+              Movement (Beginner) and Phazon Damage ≥ 99
 
 > Door to Elite Quarters; Heals? False; Spawn Point
   * Plasma Door to Elite Quarters/Door to Processing Center Access
   > Door to Phazon Processing Center
-      After Processing Center Access Barrier
+      All of the following:
+          After Processing Center Access Barrier
+          Any of the following:
+              Phazon Suit
+              Movement (Beginner) and Phazon Damage ≥ 199
+              Movement (Intermediate) and Phazon Damage ≥ 99
   > Event - Processing Center Access Barrier Opened
       Scan Visor
   > Pickup (Energy Tank)


### PR DESCRIPTION
Changes:
* Adds a Movement (Beginner) trick to Fiery Shores and Transport Tunnel B for forced lava damage
* Adds a Movement (Beginner) trick to Crater Tunnel B for forced red Phazon damage
Fixes:
* Fixes the Movement (Beginner) trick in Phazon Mining Tunnel to be with Morph Ball Bomb instead of Boost Ball and adds Phazon requirements for moving without Boost Ball
* Adds Phazon requirements to Processing Center Access and Phazon Processing Center from that door