### PR TITLE
adds additional method of climbing meeting grounds to db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Backwards Lower Mines logic
 - Added additional Lower Mines NSJ logic
 
+### Metroid Prime 2: Echoes - Logic Database
+
+- Added: method of climbing halfpipe in Meeting Grounds with Space Jump, Screw Attack, and Standable Terrain (Beginner and above)
+
 ### Discord Bot (Caretaker Class Drone)
 
 - Nothing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Prime 2: Echoes - Logic Database
 
-- Added: method of climbing halfpipe in Meeting Grounds with Space Jump, Screw Attack, and Standable Terrain (Beginner and above)
+- Added: Method of climbing halfpipe in Meeting Grounds with Space Jump, Screw Attack, and Standable Terrain (Beginner and above)
+- Changed: Simplified Meeting Grounds logic slightly, by removing the redundant Top of Halfpipe node
 
 ### Discord Bot (Caretaker Class Drone)
 

--- a/randovania/data/json_data/prime2/Temple Grounds.json
+++ b/randovania/data/json_data/prime2/Temple Grounds.json
@@ -1229,15 +1229,6 @@
                                             }
                                         },
                                         {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 2,
-                                                "index": 27,
-                                                "amount": 2,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
                                             "type": "or",
                                             "data": [
                                                 {
@@ -1259,6 +1250,15 @@
                                                                 "index": 32,
                                                                 "amount": 1,
                                                                 "negate": true
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 27,
+                                                                "amount": 2,
+                                                                "negate": false
                                                             }
                                                         }
                                                     ]
@@ -1290,6 +1290,33 @@
                                                                 "type": 2,
                                                                 "index": 4,
                                                                 "amount": 2,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 27,
+                                                                "amount": 2,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": [
+                                                        {
+                                                            "type": "template",
+                                                            "data": "Use Screw Attack (Space Jump)"
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": 2,
+                                                                "index": 27,
+                                                                "amount": 1,
                                                                 "negate": false
                                                             }
                                                         }

--- a/randovania/data/json_data/prime2/Temple Grounds.json
+++ b/randovania/data/json_data/prime2/Temple Grounds.json
@@ -1110,7 +1110,7 @@
                     "dock_type": 1,
                     "dock_weakness_index": 0,
                     "connections": {
-                        "Top of Halfpipe": {
+                        "Bottom of Halfpipe": {
                             "type": "resource",
                             "data": {
                                 "type": 0,
@@ -1178,6 +1178,126 @@
                     "coordinates": null,
                     "node_type": "generic",
                     "connections": {
+                        "Morph Ball Door to Service Access": {
+                            "type": "and",
+                            "data": [
+                                {
+                                    "type": "resource",
+                                    "data": {
+                                        "type": 0,
+                                        "index": 15,
+                                        "amount": 1,
+                                        "negate": false
+                                    }
+                                },
+                                {
+                                    "type": "or",
+                                    "data": [
+                                        {
+                                            "type": "resource",
+                                            "data": {
+                                                "type": 0,
+                                                "index": 16,
+                                                "amount": 1,
+                                                "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 27,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Screw Attack (Space Jump)"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 2,
+                                                        "index": 27,
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": 0,
+                                                        "index": 24,
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": [
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 1,
+                                                                        "index": 32,
+                                                                        "amount": 1,
+                                                                        "negate": true
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 2,
+                                                                        "index": 2,
+                                                                        "amount": 2,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "and",
+                                                            "data": [
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 0,
+                                                                        "index": 18,
+                                                                        "amount": 1,
+                                                                        "negate": false
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "resource",
+                                                                    "data": {
+                                                                        "type": 2,
+                                                                        "index": 4,
+                                                                        "amount": 2,
+                                                                        "negate": false
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
                         "Door to Hall of Eyes": {
                             "type": "and",
                             "data": []
@@ -1189,144 +1309,6 @@
                         "Translator Gate": {
                             "type": "and",
                             "data": []
-                        },
-                        "Top of Halfpipe": {
-                            "type": "or",
-                            "data": [
-                                {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 15,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 16,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        }
-                                    ]
-                                },
-                                {
-                                    "type": "and",
-                                    "data": [
-                                        {
-                                            "type": "resource",
-                                            "data": {
-                                                "type": 0,
-                                                "index": 24,
-                                                "amount": 1,
-                                                "negate": false
-                                            }
-                                        },
-                                        {
-                                            "type": "or",
-                                            "data": [
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 2,
-                                                                "index": 2,
-                                                                "amount": 2,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 1,
-                                                                "index": 32,
-                                                                "amount": 1,
-                                                                "negate": true
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 2,
-                                                                "index": 27,
-                                                                "amount": 2,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 15,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 0,
-                                                                "index": 18,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 2,
-                                                                "index": 4,
-                                                                "amount": 2,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 2,
-                                                                "index": 27,
-                                                                "amount": 2,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": [
-                                                        {
-                                                            "type": "template",
-                                                            "data": "Use Screw Attack (Space Jump)"
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": 2,
-                                                                "index": 27,
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
                         },
                         "Lore Scan": {
                             "type": "and",
@@ -1344,27 +1326,6 @@
                         "Door to Temple Transport C": {
                             "type": "and",
                             "data": []
-                        },
-                        "Bottom of Halfpipe": {
-                            "type": "and",
-                            "data": []
-                        }
-                    }
-                },
-                {
-                    "name": "Top of Halfpipe",
-                    "heal": false,
-                    "coordinates": null,
-                    "node_type": "generic",
-                    "connections": {
-                        "Morph Ball Door to Service Access": {
-                            "type": "resource",
-                            "data": {
-                                "type": 0,
-                                "index": 15,
-                                "amount": 1,
-                                "negate": false
-                            }
                         },
                         "Bottom of Halfpipe": {
                             "type": "and",

--- a/randovania/data/json_data/prime2/Temple Grounds.txt
+++ b/randovania/data/json_data/prime2/Temple Grounds.txt
@@ -180,7 +180,7 @@ Meeting Grounds
 Asset id: 2606692981
 > Morph Ball Door to Service Access; Heals? False
   * Morph Ball Door to Service Access/Morph Ball Door to Meeting Grounds
-  > Top of Halfpipe
+  > Bottom of Halfpipe
       Morph Ball
 
 > Door to Hall of Eyes; Heals? False
@@ -199,21 +199,23 @@ Asset id: 2606692981
       Trivial
 
 > Bottom of Halfpipe; Heals? False
+  > Morph Ball Door to Service Access
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Boost Ball
+              Standable Terrain (Beginner) and Use Screw Attack (Space Jump)
+              All of the following:
+                  Space Jump Boots and Standable Terrain (Intermediate)
+                  Any of the following:
+                      Before Torvus Energy Returned and Slope Jump (Intermediate)
+                      Morph Ball Bomb and Bomb Space Jump (Intermediate)
   > Door to Hall of Eyes
       Trivial
   > Door to Service Access
       Trivial
   > Translator Gate
       Trivial
-  > Top of Halfpipe
-      Any of the following:
-          Morph Ball and Boost Ball
-          All of the following:
-              Space Jump Boots
-              Any of the following:
-                  Before Torvus Energy Returned and Slope Jump (Intermediate) and Standable Terrain (Intermediate)
-                  Morph Ball and Morph Ball Bomb and Bomb Space Jump (Intermediate) and Standable Terrain (Intermediate)
-                  Standable Terrain (Beginner) and Use Screw Attack (Space Jump)
   > Lore Scan
       Trivial
 
@@ -221,12 +223,6 @@ Asset id: 2606692981
   * Translator Gate (TranslatorGate 1)
   > Door to Temple Transport C
       Trivial
-  > Bottom of Halfpipe
-      Trivial
-
-> Top of Halfpipe; Heals? False
-  > Morph Ball Door to Service Access
-      Morph Ball
   > Bottom of Halfpipe
       Trivial
 

--- a/randovania/data/json_data/prime2/Temple Grounds.txt
+++ b/randovania/data/json_data/prime2/Temple Grounds.txt
@@ -209,10 +209,11 @@ Asset id: 2606692981
       Any of the following:
           Morph Ball and Boost Ball
           All of the following:
-              Space Jump Boots and Standable Terrain (Intermediate)
+              Space Jump Boots
               Any of the following:
-                  Before Torvus Energy Returned and Slope Jump (Intermediate)
-                  Morph Ball and Morph Ball Bomb and Bomb Space Jump (Intermediate)
+                  Before Torvus Energy Returned and Slope Jump (Intermediate) and Standable Terrain (Intermediate)
+                  Morph Ball and Morph Ball Bomb and Bomb Space Jump (Intermediate) and Standable Terrain (Intermediate)
+                  Standable Terrain (Beginner) and Use Screw Attack (Space Jump)
   > Lore Scan
       Trivial
 


### PR DESCRIPTION
![20210923_160240](https://user-images.githubusercontent.com/2979303/134591730-d8653325-e11f-4e60-a252-668cd3552add.jpg)
Walk up to this spot on the halfpipe, screw attack across, then screw attack across to the top. Very easy, and quite lenient with the positioning