### PR TITLE
Prime - Shuffle Essence Teleporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,20 +20,23 @@ This feature comes with plenty of quality of life functionality for editing the 
 
 ### Metroid Prime
 
-- Start in any (uncrashed) Frigate room
-- 1-way cycles and 1-way anywhere elevators can lead to (uncrashed) Frigate rooms
-- Frigate Escape Sequence teleporter destination can now be shuffled 
+- Added: Start in any (uncrashed) Frigate room
+- Added: 1-way cycles and 1-way anywhere elevators can lead to (uncrashed) Frigate rooms
+- Added: Essence Death and Frigate Escape Cutscene teleporter destinations can now be shuffled
 
 #### Known Issues:
 - Small Samus doesn't work on NTSC-K
 
 #### Patcher Changes
 
-- Added: Support for NTSC-J and NTSC-K (Gamecube).
+- Added: Support for NTSC-U 0-01, NTSC-J and NTSC-K (Gamecube).
+- Added: QoL Game Breaking now fixes several crashes on Frigate Orpheon
+- Added: Option to disable item loss in Frigate (Enabled by default)
 - Fixed: Safeguard against blowing past layer limits.
 - Fixed: On Major custscene skip, Elite Quarters now stays locked until the player picks up the item. The hudmemo is now tied to the item rather than the death animation.
 - Fixed: Ruined fountain not always showing the right scan.
 - Changed: The vines in arboretum which cover the scan panel remain in the room on the ghost layer to help aid newer players.
+- Changed: Exo and Essence stay dead permanently if traversing Impact Crater multiple times
 
 #### Logic Database
 

--- a/randovania/games/prime1/json_data/Impact Crater.json
+++ b/randovania/games/prime1/json_data/Impact Crater.json
@@ -1533,7 +1533,7 @@
                         "area_name": "Credits"
                     },
                     "keep_name_when_vanilla": false,
-                    "editable": false,
+                    "editable": true,
                     "connections": {
                         "Dock to Subchamber Five": {
                             "type": "and",

--- a/randovania/games/prime1/json_data/Impact Crater.json
+++ b/randovania/games/prime1/json_data/Impact Crater.json
@@ -859,7 +859,7 @@
         },
         "Phazon Infusion Chamber": {
             "default_node": "Door to Crater Tunnel B",
-            "valid_starting_location": false,
+            "valid_starting_location": true,
             "extra": {
                 "asset_id": 1729456653
             },
@@ -1339,7 +1339,7 @@
         },
         "Subchamber Five": {
             "default_node": "Dock to Subchamber Four",
-            "valid_starting_location": false,
+            "valid_starting_location": true,
             "extra": {
                 "asset_id": 2003911832
             },

--- a/randovania/games/prime1/json_data/Impact Crater.txt
+++ b/randovania/games/prime1/json_data/Impact Crater.txt
@@ -119,6 +119,7 @@ Extra - asset_id: 852861312
 
 ----------------
 Phazon Infusion Chamber
+(Valid Starting Location)
 Extra - asset_id: 1729456653
 > Dock to Subchamber One; Heals? False
   * Open Passage to Subchamber One/Dock to Phazon Infusion Chamber
@@ -198,6 +199,7 @@ Extra - asset_id: 2813067419
 
 ----------------
 Subchamber Five
+(Valid Starting Location)
 Extra - asset_id: 2003911832
 > Dock to Subchamber Four; Heals? False; Spawn Point
   * Open Passage to Subchamber Four/Dock to Subchamber Five

--- a/randovania/games/prime1/patcher/prime1_elevators.py
+++ b/randovania/games/prime1/patcher/prime1_elevators.py
@@ -2,7 +2,7 @@
 # Used by the prime1 patcher
 RANDOM_PRIME_CUSTOM_NAMES = {
     ("Impact Crater", "Crater Entry Point"): 'Crater Entry Point',  # 2818083
-    ("Impact Crater", "Metroid Prime Lair"): 'Essence Dead Custscene',
+    ("Impact Crater", "Metroid Prime Lair"): 'Essence Dead Cutscene',
 
     ("Frigate Orpheon", "Exterior Docking Hangar"): 'Frigate Escape Cutscene',
 
@@ -68,7 +68,7 @@ UI_CUSTOM_NAMES = {
 
     # Impact Crater
     ("Impact Crater", "Crater Entry Point"): 'Crater Entry Point',
-    ("Impact Crater", "Metroid Prime Lair"): 'Essence Dead Custscene',
+    ("Impact Crater", "Metroid Prime Lair"): 'Essence Dead Cutscene',
 }
 
 # Names for use when "elevator" is implied

--- a/randovania/games/prime1/patcher/prime1_elevators.py
+++ b/randovania/games/prime1/patcher/prime1_elevators.py
@@ -2,7 +2,7 @@
 # Used by the prime1 patcher
 RANDOM_PRIME_CUSTOM_NAMES = {
     ("Impact Crater", "Crater Entry Point"): 'Crater Entry Point',  # 2818083
-    ("Impact Crater", "Essence Dead Custscene"): 'Essence Dead Custscene',
+    ("Impact Crater", "Metroid Prime Lair"): 'Essence Dead Custscene',
 
     ("Frigate Orpheon", "Exterior Docking Hangar"): 'Frigate Escape Cutscene',
 
@@ -65,6 +65,10 @@ UI_CUSTOM_NAMES = {
 
     # Frigate
     ("Frigate Orpheon", "Exterior Docking Hangar"): 'Frigate Escape Cutscene Teleporter',
+
+    # Impact Crater
+    ("Impact Crater", "Crater Entry Point"): 'Crater Entry Point',
+    ("Impact Crater", "Metroid Prime Lair"): 'Essence Dead Custscene',
 }
 
 # Names for use when "elevator" is implied
@@ -99,4 +103,8 @@ SHORT_UI_CUSTOM_NAMES = {
 
     # Frigate
     ("Frigate Orpheon", "Exterior Docking Hangar"): 'Frigate Destroyed',
+
+    # Impact Crater
+    ("Impact Crater", "Crater Entry Point"): 'Crater Entry Point',
+    ("Impact Crater", "Metroid Prime Lair"): 'Essence Dead',
 }

--- a/randovania/games/prime1/patcher/randomprime_patcher.py
+++ b/randovania/games/prime1/patcher/randomprime_patcher.py
@@ -189,7 +189,7 @@ def _starting_items_value_for(resource_database: ResourceDatabase,
 
 def _name_for_location(world_list: WorldList, location: AreaIdentifier) -> str:
     loc = location.as_tuple
-    if loc in prime1_elevators.RANDOM_PRIME_CUSTOM_NAMES:
+    if loc in prime1_elevators.RANDOM_PRIME_CUSTOM_NAMES and loc != ("Frigate Orpheon", "Exterior Docking Hangar"):
         return prime1_elevators.RANDOM_PRIME_CUSTOM_NAMES[loc]
     else:
         return world_list.area_name(world_list.area_by_area_location(location), separator=":")
@@ -291,6 +291,8 @@ class RandomprimePatcher(Patcher):
                         continue
 
                     identifier = db.world_list.identifier_for_node(node)
+                    print("\n")
+                    print(str(patches.elevator_connection))
                     target = _name_for_location(db.world_list, patches.elevator_connection[identifier])
 
                     source_name = prime1_elevators.RANDOM_PRIME_CUSTOM_NAMES[(

--- a/randovania/layout/description_migration.py
+++ b/randovania/layout/description_migration.py
@@ -153,7 +153,7 @@ def _migrate_v6(json_dict: dict) -> dict:
                 if identify_game == "prime1":
                     game["locations"]["Frigate Orpheon"] = dict()
                     game["teleporters"]["Frigate Orpheon/Exterior Docking Hangar/Teleport to Landing Site"] = "Tallon Overworld/Landing Site"
-                    game["teleporters"]["Impact Crater/Metroid Prime Lair/Teleporter to Credits"] = "Tallon Overworld/Landing Site"
+                    game["teleporters"]["Impact Crater/Metroid Prime Lair/Teleporter to Credits"] = "End of Game/Credits"
                 game["game"] = identify_game
                 break
     return json_dict

--- a/randovania/layout/description_migration.py
+++ b/randovania/layout/description_migration.py
@@ -153,6 +153,7 @@ def _migrate_v6(json_dict: dict) -> dict:
                 if identify_game == "prime1":
                     game["locations"]["Frigate Orpheon"] = dict()
                     game["teleporters"]["Frigate Orpheon/Exterior Docking Hangar/Teleport to Landing Site"] = "Tallon Overworld/Landing Site"
+                    game["teleporters"]["Impact Crater/Metroid Prime Lair/Teleporter to Credits"] = "Tallon Overworld/Landing Site"
                 game["game"] = identify_game
                 break
     return json_dict

--- a/randovania/layout/lib/teleporters.py
+++ b/randovania/layout/lib/teleporters.py
@@ -148,10 +148,10 @@ class TeleporterConfiguration(BitPackDataclass, JsonDataclass, DataclassPostInit
                     # Valid destinations must be valid starting areas
                     area = world_list.nodes_to_area(node)
                     if area.valid_starting_location:
-                        result.append(identifier)
+                        result.append(identifier.area_identifier)
                     # Hack for Metroid Prime 1, where the scripting for Metroid Prime Lair is dependent on the previous room
                     elif area.name == "Metroid Prime Lair":
-                        result.append(NodeIdentifier.from_string("Impact Crater/Subchamber Five/Dock to Metroid Prime Lair"))
+                        result.append(AreaIdentifier.from_string("Impact Crater/Subchamber Five"))
             return result
         else:
             return []

--- a/randovania/layout/lib/teleporters.py
+++ b/randovania/layout/lib/teleporters.py
@@ -145,7 +145,13 @@ class TeleporterConfiguration(BitPackDataclass, JsonDataclass, DataclassPostInit
             for identifier in self.editable_teleporters:
                 node = world_list.node_by_identifier(identifier)
                 if isinstance(node, TeleporterNode) and node.editable:
-                    result.append(identifier)
+                    # Valid destinations must be valid starting areas
+                    area = world_list.nodes_to_area(node)
+                    if area.valid_starting_location:
+                        result.append(identifier)
+                    # Hack for Metroid Prime 1, where the scripting for Metroid Prime Lair is dependent on the previous room
+                    elif area.name == "Metroid Prime Lair":
+                        result.append(NodeIdentifier.from_string("Impact Crater/Subchamber Five/Dock to Metroid Prime Lair"))
             return result
         else:
             return []

--- a/test/test_files/randomprime_expected_data.json
+++ b/test/test_files/randomprime_expected_data.json
@@ -101,7 +101,8 @@
         "Impact Crater": {
             "rooms": {},
             "transports": {
-                "Crater Entry Point": "Artifact Temple"
+                "Crater Entry Point": "Artifact Temple",
+                "Essence Dead Cutscene": "Credits"
             }
         },
         "Phendrana Drifts": {


### PR DESCRIPTION
* When populating list of valid elevator targets for 1-way elevators, do not use elevator destinations which are not marked as `valid_starting_location:true`
* Special handling for Metroid Prime Lair as a teleporter destination due to in-game scripting reasons
* Fixed usage of NodeIdentifier when AreaIdentifier was needed for 1-way teleporters