### PR TITLE
Move more stuff to be game-specific

### DIFF
--- a/randovania/games/dread/game_data.py
+++ b/randovania/games/dread/game_data.py
@@ -17,7 +17,7 @@ def _dread_gui():
     return GameGui(
         tab_provider=dread_preset_tabs,
         cosmetic_dialog=DreadCosmeticPatchesDialog,
-        input_file_text=("an extracted romfs folder", "the Nintendo Switch"),
+        input_file_text=("an extracted RomFS folder", "the Nintendo Switch", "RomFS folder"),
         progressive_item_gui_tuples=progressive_items.gui_tuples()
     )
 

--- a/randovania/games/dread/game_data.py
+++ b/randovania/games/dread/game_data.py
@@ -10,10 +10,12 @@ from randovania.games.game import GameData, GameGenerator, GameGui, GameLayout, 
 def _dread_gui():
     from randovania.games.dread.gui.dialog.dread_cosmetic_patches_dialog import DreadCosmeticPatchesDialog
     from randovania.games.dread.gui.preset_settings import dread_preset_tabs
+    from randovania.games.dread.item_database import progressive_items
 
     return GameGui(
         tab_provider=dread_preset_tabs,
-        cosmetic_dialog=DreadCosmeticPatchesDialog
+        cosmetic_dialog=DreadCosmeticPatchesDialog,
+        progressive_item_gui_tuples=progressive_items.gui_tuples()
     )
 
 

--- a/randovania/games/dread/game_data.py
+++ b/randovania/games/dread/game_data.py
@@ -16,6 +16,7 @@ def _dread_gui():
     return GameGui(
         tab_provider=dread_preset_tabs,
         cosmetic_dialog=DreadCosmeticPatchesDialog,
+        input_file_text=("an extracted romfs folder", "the Nintendo Switch"),
         progressive_item_gui_tuples=progressive_items.gui_tuples()
     )
 

--- a/randovania/games/dread/game_data.py
+++ b/randovania/games/dread/game_data.py
@@ -1,3 +1,4 @@
+from randovania.games.dread.generator.base_patches_factory import DreadBasePatchesFactory
 from randovania.games.dread.generator.pool_creator import pool_creator
 from randovania.games.dread.layout.dread_configuration import DreadConfiguration
 from randovania.games.dread.layout.dread_cosmetic_patches import DreadCosmeticPatches
@@ -44,6 +45,7 @@ game_data: GameData = GameData(
 
     generator=GameGenerator(
         item_pool_creator=pool_creator,
+        base_patches_factory=DreadBasePatchesFactory()
     ),
 
     patcher=OpenDreadPatcher()

--- a/randovania/games/dread/game_data.py
+++ b/randovania/games/dread/game_data.py
@@ -6,6 +6,7 @@ from randovania.games.dread.layout.preset_describer import dread_format_params, 
     dread_unexpected_items
 from randovania.games.dread.patcher.open_dread_patcher import OpenDreadPatcher
 from randovania.games.game import GameData, GameGenerator, GameGui, GameLayout, GamePresetDescriber
+from randovania.resolver.bootstrap import Bootstrap
 
 
 def _dread_gui():
@@ -46,7 +47,8 @@ game_data: GameData = GameData(
 
     generator=GameGenerator(
         item_pool_creator=pool_creator,
-        base_patches_factory=DreadBasePatchesFactory()
+        base_patches_factory=DreadBasePatchesFactory(),
+        bootstrap=Bootstrap()
     ),
 
     patcher=OpenDreadPatcher()

--- a/randovania/games/dread/generator/base_patches_factory.py
+++ b/randovania/games/dread/generator/base_patches_factory.py
@@ -1,0 +1,40 @@
+from random import Random
+
+from randovania.game_description.assignment import NodeConfigurationAssignment
+from randovania.game_description.game_description import GameDescription
+from randovania.game_description.requirements import (Requirement,
+                                                      RequirementAnd,
+                                                      ResourceRequirement)
+from randovania.game_description.world.node import ConfigurableNode
+from randovania.games.dread.layout.dread_configuration import \
+    DreadConfiguration
+from randovania.generator.base_patches_factory import BasePatchesFactory
+
+
+class DreadBasePatchesFactory(BasePatchesFactory):
+    def configurable_node_assignment(self, configuration: DreadConfiguration, game: GameDescription, rng: Random) -> NodeConfigurationAssignment:
+        result = {}
+
+        rsb = game.resource_database
+
+        requirement_for_type = {
+            "POWERBEAM": rsb.requirement_template["Shoot Beam"],
+            "BOMB": rsb.requirement_template["Lay Bomb"],
+            "MISSILE": ResourceRequirement(rsb.get_item("Missiles"), 1, False),
+            "SUPERMISSILE": rsb.requirement_template["Shoot Super Missile"],
+            "POWERBOMB": rsb.requirement_template["Lay Power Bomb"],
+            "SCREWATTACK": ResourceRequirement(rsb.get_item("Screw"), 1, False),
+            "WEIGHT": Requirement.impossible(),
+            "SPEEDBOOST": ResourceRequirement(rsb.get_item("Speed"), 1, False),
+        }
+
+        for node in game.world_list.all_nodes:
+            if not isinstance(node, ConfigurableNode):
+                continue
+
+            result[game.world_list.identifier_for_node(node)] = RequirementAnd([
+                requirement_for_type[block_type]
+                for block_type in node.extra["tile_types"]
+            ]).simplify()
+
+        return result

--- a/randovania/games/dread/item_database/progressive_items.py
+++ b/randovania/games/dread/item_database/progressive_items.py
@@ -1,0 +1,27 @@
+def gui_tuples():
+    return [
+        (
+            "Progressive Beam",
+            ("Wide Beam", "Plasma Beam", "Wave Beam")
+        ),
+        (
+            "Progressive Charge Beam",
+            ("Charge Beam", "Diffusion Beam")
+        ),
+        (
+            "Progressive Missiles",
+            ("Super Missiles", "Ice Missiles")
+        ),
+        (
+            "Progressive Suit",
+            ("Varia Suit", "Gravity Suit")
+        ),
+        (
+            "Progressive Bomb",
+            ("Bomb", "Cross Bomb")
+        ),
+        (
+            "Progressive Spin",
+            ("Spin Boost", "Space Jump")
+        )
+    ]

--- a/randovania/games/game.py
+++ b/randovania/games/game.py
@@ -8,6 +8,7 @@ from typing import Callable, Iterable, Optional, Type
 
 from randovania import get_file_path
 from randovania.bitpacking.bitpacking import BitPackEnum
+from randovania.resolver.bootstrap import Bootstrap
 
 if typing.TYPE_CHECKING:
     from randovania.game_description.resources.resource_database import ResourceDatabase
@@ -69,6 +70,9 @@ class GameGui:
 class GameGenerator:
     item_pool_creator: Callable[[PoolResults, BaseConfiguration, ResourceDatabase], None]
     """Extends the base item pools with any specific item pools such as Artifacts."""
+
+    bootstrap: Bootstrap = Bootstrap()
+    """(Optional) Modifies the resource database and starting resources before generation."""
 
 
 @dataclass(frozen=True)

--- a/randovania/games/game.py
+++ b/randovania/games/game.py
@@ -56,6 +56,9 @@ class GameGui:
     cosmetic_dialog: Type[BaseCosmeticPatchesDialog]
     """Dialog box for editing the game's cosmetic settings."""
 
+    progressive_item_gui_tuples: Iterable[tuple[str, tuple[str, ...]]] = frozenset()
+    """(Optional) A list of tuples mapping a progressive item's long name to a tuple of item long names replaced by the progressive item."""
+    
     spoiler_visualizer: tuple[Type[GameDetailsTab], ...] = tuple()
 
 

--- a/randovania/games/game.py
+++ b/randovania/games/game.py
@@ -8,8 +8,6 @@ from typing import Callable, Iterable, Optional, Type
 
 from randovania import get_file_path
 from randovania.bitpacking.bitpacking import BitPackEnum
-from randovania.generator.base_patches_factory import BasePatchesFactory
-from randovania.resolver.bootstrap import Bootstrap
 
 if typing.TYPE_CHECKING:
     from randovania.game_description.resources.resource_database import ResourceDatabase
@@ -23,6 +21,8 @@ if typing.TYPE_CHECKING:
     from randovania.layout.base.cosmetic_patches import BaseCosmeticPatches
     from randovania.layout.base.major_items_configuration import MajorItemsConfiguration
     from randovania.patching.patcher import Patcher
+    from randovania.generator.base_patches_factory import BasePatchesFactory
+    from randovania.resolver.bootstrap import Bootstrap
 
 
 @dataclass(frozen=True)
@@ -75,11 +75,11 @@ class GameGenerator:
     item_pool_creator: Callable[[PoolResults, BaseConfiguration, ResourceDatabase], None]
     """Extends the base item pools with any specific item pools such as Artifacts."""
 
-    bootstrap: Bootstrap = Bootstrap()
-    """(Optional) Modifies the resource database and starting resources before generation."""
+    bootstrap: Bootstrap
+    """Modifies the resource database and starting resources before generation."""
 
-    base_patches_factory: BasePatchesFactory = BasePatchesFactory()
-    """(Optional) Creates base patches, such as elevator or configurable node assignments."""
+    base_patches_factory: BasePatchesFactory
+    """Creates base patches, such as elevator or configurable node assignments."""
 
 
 @dataclass(frozen=True)

--- a/randovania/games/game.py
+++ b/randovania/games/game.py
@@ -61,8 +61,8 @@ class GameGui:
     cosmetic_dialog: Type[BaseCosmeticPatchesDialog]
     """Dialog box for editing the game's cosmetic settings."""
 
-    input_file_text: Optional[tuple[str, str]]
-    """Two strings used to describe the input file for the game. First is file format; second is platform."""
+    input_file_text: Optional[tuple[str, str, str]]
+    """Two strings used to describe the input file for the game."""
 
     progressive_item_gui_tuples: Iterable[tuple[str, tuple[str, ...]]] = frozenset()
     """(Optional) A list of tuples mapping a progressive item's long name to a tuple of item long names replaced by the progressive item."""

--- a/randovania/games/game.py
+++ b/randovania/games/game.py
@@ -47,6 +47,9 @@ class GameLayout:
     preset_describer: GamePresetDescriber = GamePresetDescriber()
     """(Optional) Contains game-specific preset descriptions, used by the preset screen and Discord bot."""
 
+    get_ingame_hash: Callable[[bytes], Optional[str]] = lambda hash: None
+    """(Optional) Takes a layout hash bytes and produces a string representing how the game will represent the hash in-game. Only override if the game cannot display arbitrary text on the title screen."""
+
 
 @dataclass(frozen=True)
 class GameGui:

--- a/randovania/games/game.py
+++ b/randovania/games/game.py
@@ -8,6 +8,7 @@ from typing import Callable, Iterable, Optional, Type
 
 from randovania import get_file_path
 from randovania.bitpacking.bitpacking import BitPackEnum
+from randovania.generator.base_patches_factory import BasePatchesFactory
 from randovania.resolver.bootstrap import Bootstrap
 
 if typing.TYPE_CHECKING:
@@ -73,6 +74,9 @@ class GameGenerator:
 
     bootstrap: Bootstrap = Bootstrap()
     """(Optional) Modifies the resource database and starting resources before generation."""
+
+    base_patches_factory: BasePatchesFactory = BasePatchesFactory()
+    """(Optional) Creates base patches, such as elevator or configurable node assignments."""
 
 
 @dataclass(frozen=True)

--- a/randovania/games/game.py
+++ b/randovania/games/game.py
@@ -61,9 +61,12 @@ class GameGui:
     cosmetic_dialog: Type[BaseCosmeticPatchesDialog]
     """Dialog box for editing the game's cosmetic settings."""
 
+    input_file_text: Optional[tuple[str, str]]
+    """Two strings used to describe the input file for the game. First is file format; second is platform."""
+
     progressive_item_gui_tuples: Iterable[tuple[str, tuple[str, ...]]] = frozenset()
     """(Optional) A list of tuples mapping a progressive item's long name to a tuple of item long names replaced by the progressive item."""
-    
+
     spoiler_visualizer: tuple[Type[GameDetailsTab], ...] = tuple()
 
 

--- a/randovania/games/prime1/game_data.py
+++ b/randovania/games/prime1/game_data.py
@@ -1,4 +1,5 @@
 from randovania.games.game import GameData, GameGenerator, GameGui, GameLayout, GamePresetDescriber
+from randovania.games.prime1.generator.bootstrap import PrimeBootstrap
 from randovania.games.prime1.layout.prime_configuration import PrimeConfiguration
 from randovania.games.prime1.layout.prime_cosmetic_patches import PrimeCosmeticPatches
 from randovania.games.prime1.generator.item_pool.pool_creator import prime1_specific_pool
@@ -45,7 +46,8 @@ game_data: GameData = GameData(
     gui=_prime_gui,
 
     generator=GameGenerator(
-        item_pool_creator=prime1_specific_pool
+        item_pool_creator=prime1_specific_pool,
+        bootstrap=PrimeBootstrap()
     ),
 
     patcher=RandomprimePatcher()

--- a/randovania/games/prime1/game_data.py
+++ b/randovania/games/prime1/game_data.py
@@ -5,6 +5,7 @@ from randovania.games.prime1.layout.prime_cosmetic_patches import PrimeCosmeticP
 from randovania.games.prime1.generator.item_pool.pool_creator import prime1_specific_pool
 from randovania.games.prime1.patcher.randomprime_patcher import RandomprimePatcher
 from randovania.games.prime1.layout.preset_describer import prime_expected_items, prime_unexpected_items, prime_format_params
+from randovania.generator.base_patches_factory import BasePatchesFactory
 
 
 def _prime_gui():
@@ -48,7 +49,8 @@ game_data: GameData = GameData(
 
     generator=GameGenerator(
         item_pool_creator=prime1_specific_pool,
-        bootstrap=PrimeBootstrap()
+        bootstrap=PrimeBootstrap(),
+        base_patches_factory=BasePatchesFactory()
     ),
 
     patcher=RandomprimePatcher()

--- a/randovania/games/prime1/game_data.py
+++ b/randovania/games/prime1/game_data.py
@@ -16,7 +16,7 @@ def _prime_gui():
     return GameGui(
         tab_provider=prime1_preset_tabs,
         cosmetic_dialog=PrimeCosmeticPatchesDialog,
-        input_file_text=("an ISO file", "the Nintendo Gamecube"),
+        input_file_text=("an ISO file", "the Nintendo Gamecube", "Gamecube ISO"),
         spoiler_visualizer=(TeleporterDetailsTab,),
     )
 

--- a/randovania/games/prime1/game_data.py
+++ b/randovania/games/prime1/game_data.py
@@ -5,7 +5,7 @@ from randovania.games.prime1.layout.prime_cosmetic_patches import PrimeCosmeticP
 from randovania.games.prime1.generator.item_pool.pool_creator import prime1_specific_pool
 from randovania.games.prime1.patcher.randomprime_patcher import RandomprimePatcher
 from randovania.games.prime1.layout.preset_describer import prime_expected_items, prime_unexpected_items, prime_format_params
-from randovania.generator.base_patches_factory import BasePatchesFactory
+from randovania.generator.base_patches_factory import PrimeTrilogyBasePatchesFactory
 
 
 def _prime_gui():
@@ -50,7 +50,7 @@ game_data: GameData = GameData(
     generator=GameGenerator(
         item_pool_creator=prime1_specific_pool,
         bootstrap=PrimeBootstrap(),
-        base_patches_factory=BasePatchesFactory()
+        base_patches_factory=PrimeTrilogyBasePatchesFactory()
     ),
 
     patcher=RandomprimePatcher()

--- a/randovania/games/prime1/game_data.py
+++ b/randovania/games/prime1/game_data.py
@@ -15,6 +15,7 @@ def _prime_gui():
     return GameGui(
         tab_provider=prime1_preset_tabs,
         cosmetic_dialog=PrimeCosmeticPatchesDialog,
+        input_file_text=("an ISO file", "the Nintendo Gamecube"),
         spoiler_visualizer=(TeleporterDetailsTab,),
     )
 

--- a/randovania/games/prime1/generator/bootstrap.py
+++ b/randovania/games/prime1/generator/bootstrap.py
@@ -1,0 +1,77 @@
+import copy
+import dataclasses
+from randovania.game_description.requirements import ResourceRequirement
+from randovania.game_description.resources.damage_resource_info import DamageReduction
+from randovania.game_description.resources.resource_database import ResourceDatabase
+from randovania.game_description.resources.resource_info import CurrentResources
+from randovania.game_description.resources.resource_type import ResourceType
+from randovania.layout.base.base_configuration import BaseConfiguration
+from randovania.resolver.bootstrap import Bootstrap
+
+
+class PrimeBootstrap(Bootstrap):
+    def _get_enabled_misc_resources(self, configuration: BaseConfiguration, resource_database: ResourceDatabase) -> set[str]:
+        enabled_resources = set()
+
+        logical_patches = {
+            "allow_underwater_movement_without_gravity": "NoGravity",
+            "main_plaza_door": "main_plaza_door",
+            "backwards_frigate": "backwards_frigate",
+            "backwards_labs": "backwards_labs",
+            "backwards_upper_mines": "backwards_upper_mines",
+            "backwards_lower_mines": "backwards_lower_mines",
+            "phazon_elite_without_dynamo": "phazon_elite_without_dynamo",
+            "small_samus": "small",
+        }
+        for name, index in logical_patches.items():
+            if getattr(configuration, name):
+                enabled_resources.add(index)
+        
+        return enabled_resources
+    
+    def prime1_progressive_damage_reduction(self, db: ResourceDatabase, current_resources: CurrentResources):
+        num_suits = sum(current_resources.get(db.get_item_by_name(suit), 0)
+                        for suit in ["Varia Suit", "Gravity Suit", "Phazon Suit"])
+        if num_suits >= 3:
+            return 0.5
+        elif num_suits == 2:
+            return 0.8
+        elif num_suits == 1:
+            return 0.9
+        else:
+            return 1
+
+
+    def prime1_absolute_damage_reduction(self, db: ResourceDatabase, current_resources: CurrentResources):
+        if current_resources.get(db.get_item_by_name("Phazon Suit"), 0) > 0:
+            return 0.5
+        elif current_resources.get(db.get_item_by_name("Gravity Suit"), 0) > 0:
+            return 0.8
+        elif current_resources.get(db.get_item_by_name("Varia Suit"), 0) > 0:
+            return 0.9
+        else:
+            return 1
+    
+    def patch_resource_database(self, db: ResourceDatabase, configuration: BaseConfiguration) -> ResourceDatabase:
+        base_damage_reduction = db.base_damage_reduction
+        damage_reductions = copy.copy(db.damage_reductions)
+        requirement_template = copy.copy(db.requirement_template)
+
+        suits = [db.get_item_by_name("Varia Suit")]
+        if configuration.heat_protection_only_varia:
+            requirement_template["Heat-Resisting Suit"] = ResourceRequirement(db.get_item_by_name("Varia Suit"),
+                                                                            1, False)
+        else:
+            suits.extend([db.get_item_by_name("Gravity Suit"), db.get_item_by_name("Phazon Suit")])
+
+        reductions = [DamageReduction(None, configuration.heat_damage / 10.0)]
+        reductions.extend([DamageReduction(suit, 0) for suit in suits])
+        damage_reductions[db.get_by_type_and_index(ResourceType.DAMAGE, "HeatDamage1")] = reductions
+
+        if configuration.progressive_damage_reduction:
+            base_damage_reduction = self.prime1_progressive_damage_reduction
+        else:
+            base_damage_reduction = self.prime1_absolute_damage_reduction
+
+        return dataclasses.replace(db, damage_reductions=damage_reductions, base_damage_reduction=base_damage_reduction,
+                                requirement_template=requirement_template)

--- a/randovania/games/prime2/game_data.py
+++ b/randovania/games/prime2/game_data.py
@@ -12,10 +12,12 @@ def _echoes_gui():
     from randovania.gui.game_details.teleporter_details_tab import TeleporterDetailsTab
     from randovania.games.prime2.gui.translator_gate_details_tab import TranslatorGateDetailsTab
     from randovania.games.prime2.gui.hint_details_tab import HintDetailsTab
+    from randovania.games.prime2.item_database import prime2_progressive_items
 
     return GameGui(
         tab_provider=prime2_preset_tabs,
         cosmetic_dialog=EchoesCosmeticPatchesDialog,
+        progressive_item_gui_tuples=prime2_progressive_items.gui_tuples()
         spoiler_visualizer=(TeleporterDetailsTab, TranslatorGateDetailsTab, HintDetailsTab),
     )
 

--- a/randovania/games/prime2/game_data.py
+++ b/randovania/games/prime2/game_data.py
@@ -1,4 +1,5 @@
 from randovania.games.game import GameData, GameGenerator, GameGui, GameLayout, GamePresetDescriber
+from randovania.games.prime2.generator.bootstrap import EchoesBootstrap
 from randovania.games.prime2.generator.item_pool.pool_creator import echoes_specific_pool
 from randovania.games.prime2.layout.echoes_configuration import EchoesConfiguration
 from randovania.games.prime2.layout.echoes_cosmetic_patches import EchoesCosmeticPatches
@@ -17,7 +18,7 @@ def _echoes_gui():
     return GameGui(
         tab_provider=prime2_preset_tabs,
         cosmetic_dialog=EchoesCosmeticPatchesDialog,
-        progressive_item_gui_tuples=prime2_progressive_items.gui_tuples()
+        progressive_item_gui_tuples=prime2_progressive_items.gui_tuples(),
         spoiler_visualizer=(TeleporterDetailsTab, TranslatorGateDetailsTab, HintDetailsTab),
     )
 
@@ -52,7 +53,8 @@ game_data: GameData = GameData(
     gui=_echoes_gui,
 
     generator=GameGenerator(
-        item_pool_creator=echoes_specific_pool
+        item_pool_creator=echoes_specific_pool,
+        bootstrap=EchoesBootstrap()
     ),
 
     patcher=ClarisPatcher()

--- a/randovania/games/prime2/game_data.py
+++ b/randovania/games/prime2/game_data.py
@@ -19,7 +19,7 @@ def _echoes_gui():
     return GameGui(
         tab_provider=prime2_preset_tabs,
         cosmetic_dialog=EchoesCosmeticPatchesDialog,
-        input_file_text=("an ISO file", "the Nintendo Gamecube"),
+        input_file_text=("an ISO file", "the Nintendo Gamecube", "Gamecube ISO"),
         progressive_item_gui_tuples=prime2_progressive_items.gui_tuples(),
         spoiler_visualizer=(TeleporterDetailsTab, TranslatorGateDetailsTab, HintDetailsTab),
     )

--- a/randovania/games/prime2/game_data.py
+++ b/randovania/games/prime2/game_data.py
@@ -1,4 +1,5 @@
 from randovania.games.game import GameData, GameGenerator, GameGui, GameLayout, GamePresetDescriber
+from randovania.games.prime2.generator.base_patches_factory import EchoesBasePatchesFactory
 from randovania.games.prime2.generator.bootstrap import EchoesBootstrap
 from randovania.games.prime2.generator.item_pool.pool_creator import echoes_specific_pool
 from randovania.games.prime2.layout.echoes_configuration import EchoesConfiguration
@@ -54,7 +55,8 @@ game_data: GameData = GameData(
 
     generator=GameGenerator(
         item_pool_creator=echoes_specific_pool,
-        bootstrap=EchoesBootstrap()
+        bootstrap=EchoesBootstrap(),
+        base_patches_factory=EchoesBasePatchesFactory()
     ),
 
     patcher=ClarisPatcher()

--- a/randovania/games/prime2/game_data.py
+++ b/randovania/games/prime2/game_data.py
@@ -19,6 +19,7 @@ def _echoes_gui():
     return GameGui(
         tab_provider=prime2_preset_tabs,
         cosmetic_dialog=EchoesCosmeticPatchesDialog,
+        input_file_text=("an ISO file", "the Nintendo Gamecube"),
         progressive_item_gui_tuples=prime2_progressive_items.gui_tuples(),
         spoiler_visualizer=(TeleporterDetailsTab, TranslatorGateDetailsTab, HintDetailsTab),
     )

--- a/randovania/games/prime2/generator/base_patches_factory.py
+++ b/randovania/games/prime2/generator/base_patches_factory.py
@@ -1,0 +1,121 @@
+import copy
+from random import Random
+
+from randovania.game_description.assignment import NodeConfigurationAssignment
+from randovania.game_description.game_description import GameDescription
+from randovania.game_description.game_patches import GamePatches
+from randovania.game_description.hint import (Hint, HintDarkTemple,
+                                              HintItemPrecision,
+                                              HintLocationPrecision, HintType,
+                                              PrecisionPair)
+from randovania.game_description.requirements import (RequirementAnd,
+                                                      ResourceRequirement)
+from randovania.game_description.resources import search
+from randovania.game_description.resources.pickup_index import PickupIndex
+from randovania.game_description.resources.resource_type import ResourceType
+from randovania.game_description.world.node import (ConfigurableNode,
+                                                    LogbookNode, LoreType)
+from randovania.game_description.world.world_list import WorldList
+from randovania.games.prime2.layout.echoes_configuration import \
+    EchoesConfiguration
+from randovania.games.prime2.layout.translator_configuration import \
+    LayoutTranslatorRequirement
+from randovania.generator.base_patches_factory import (BasePatchesFactory,
+                                                       MissingRng)
+from randovania.lib.enum_lib import iterate_enum
+
+
+class EchoesBasePatchesFactory(BasePatchesFactory):
+    def configurable_node_assignment(self, configuration: EchoesConfiguration, game: GameDescription, rng: Random) -> NodeConfigurationAssignment:
+        """
+        :param configuration:
+        :param game:
+        :param rng:
+        :return:
+        """
+
+        all_choices = list(LayoutTranslatorRequirement)
+        all_choices.remove(LayoutTranslatorRequirement.RANDOM)
+        all_choices.remove(LayoutTranslatorRequirement.RANDOM_WITH_REMOVED)
+        without_removed = copy.copy(all_choices)
+        without_removed.remove(LayoutTranslatorRequirement.REMOVED)
+        random_requirements = {LayoutTranslatorRequirement.RANDOM, LayoutTranslatorRequirement.RANDOM_WITH_REMOVED}
+
+        result = {}
+
+        scan_visor = search.find_resource_info_with_long_name(
+            game.resource_database.item,
+            "Scan Visor"
+        )
+        scan_visor_req = ResourceRequirement(scan_visor, 1, False)
+
+        for node in game.world_list.all_nodes:
+            if not isinstance(node, ConfigurableNode):
+                continue
+
+            identifier = game.world_list.identifier_for_node(node)
+            requirement = configuration.translator_configuration.translator_requirement[identifier]
+            if requirement in random_requirements:
+                if rng is None:
+                    raise MissingRng("Translator")
+                requirement = rng.choice(all_choices if requirement == LayoutTranslatorRequirement.RANDOM_WITH_REMOVED
+                                        else without_removed)
+
+            translator = game.resource_database.get_by_type_and_index(ResourceType.ITEM, requirement.item_name)
+            result[identifier] = RequirementAnd([
+                scan_visor_req,
+                ResourceRequirement(translator, 1, False),
+            ])
+
+        return result
+    
+    def add_default_hints_to_patches(self, rng: Random, patches: GamePatches, world_list: WorldList, num_joke: int, is_multiworld: bool) -> GamePatches:
+        for node in world_list.all_nodes:
+            if isinstance(node, LogbookNode) and node.lore_type == LoreType.LUMINOTH_WARRIOR:
+                patches = patches.assign_hint(node.resource(),
+                                            Hint(HintType.LOCATION,
+                                                PrecisionPair(HintLocationPrecision.KEYBEARER,
+                                                                HintItemPrecision.BROAD_CATEGORY,
+                                                                include_owner=True),
+                                                PickupIndex(node.hint_index)))
+
+        all_logbook_assets = [node.resource()
+                            for node in world_list.all_nodes
+                            if isinstance(node, LogbookNode)
+                            and node.resource() not in patches.hints
+                            and node.lore_type.holds_generic_hint]
+
+        rng.shuffle(all_logbook_assets)
+
+        # The 4 guaranteed hints
+        indices_with_hint = [
+            (PickupIndex(24), HintLocationPrecision.LIGHT_SUIT_LOCATION),  # Light Suit
+            (PickupIndex(43), HintLocationPrecision.GUARDIAN),  # Dark Suit (Amorbis)
+            (PickupIndex(79), HintLocationPrecision.GUARDIAN),  # Dark Visor (Chykka)
+            (PickupIndex(115), HintLocationPrecision.GUARDIAN),  # Annihilator Beam (Quadraxis)
+        ]
+        rng.shuffle(indices_with_hint)
+        for index, location_type in indices_with_hint:
+            if not all_logbook_assets:
+                break
+
+            logbook_asset = all_logbook_assets.pop()
+            patches = patches.assign_hint(logbook_asset, Hint(HintType.LOCATION,
+                                                            PrecisionPair(location_type, HintItemPrecision.DETAILED,
+                                                                            include_owner=False),
+                                                            index))
+
+        # Dark Temple hints
+        temple_hints = list(iterate_enum(HintDarkTemple))
+        while all_logbook_assets and temple_hints:
+            logbook_asset = all_logbook_assets.pop()
+            patches = patches.assign_hint(logbook_asset, Hint(HintType.RED_TEMPLE_KEY_SET, None,
+                                                            dark_temple=temple_hints.pop(0)))
+
+        # Jokes
+        while num_joke > 0 and all_logbook_assets:
+            logbook_asset = all_logbook_assets.pop()
+            patches = patches.assign_hint(logbook_asset, Hint(HintType.JOKE, None))
+            num_joke -= 1
+
+        return patches

--- a/randovania/games/prime2/generator/base_patches_factory.py
+++ b/randovania/games/prime2/generator/base_patches_factory.py
@@ -20,12 +20,12 @@ from randovania.games.prime2.layout.echoes_configuration import \
     EchoesConfiguration
 from randovania.games.prime2.layout.translator_configuration import \
     LayoutTranslatorRequirement
-from randovania.generator.base_patches_factory import (BasePatchesFactory,
+from randovania.generator.base_patches_factory import (PrimeTrilogyBasePatchesFactory,
                                                        MissingRng)
 from randovania.lib.enum_lib import iterate_enum
 
 
-class EchoesBasePatchesFactory(BasePatchesFactory):
+class EchoesBasePatchesFactory(PrimeTrilogyBasePatchesFactory):
     def configurable_node_assignment(self, configuration: EchoesConfiguration, game: GameDescription, rng: Random) -> NodeConfigurationAssignment:
         """
         :param configuration:

--- a/randovania/games/prime2/generator/bootstrap.py
+++ b/randovania/games/prime2/generator/bootstrap.py
@@ -1,0 +1,46 @@
+import copy
+import dataclasses
+from randovania.game_description.resources.damage_resource_info import DamageReduction
+from randovania.game_description.resources.resource_database import ResourceDatabase
+from randovania.game_description.resources.resource_type import ResourceType
+from randovania.layout.base.base_configuration import BaseConfiguration
+from randovania.resolver.bootstrap import Bootstrap
+
+
+class EchoesBootstrap(Bootstrap):
+    def _get_enabled_misc_resources(self, configuration: BaseConfiguration, resource_database: ResourceDatabase) -> set[str]:
+        enabled_resources = set()
+        allow_vanilla = {
+            "allow_jumping_on_dark_water": "DarkWaterJump",
+            "allow_vanilla_dark_beam": "VanillaDarkBeam",
+            "allow_vanilla_light_beam": "VanillaLightBeam",
+            "allow_vanilla_seeker_launcher": "VanillaSeekers",
+            "allow_vanilla_echo_visor": "VanillaEcho",
+            "allow_vanilla_dark_visor": "VanillaDarkVisor",
+            "allow_vanilla_screw_attack": "VanillaSA",
+            "allow_vanilla_gravity_boost": "VanillaGravity",
+            "allow_vanilla_boost_ball": "VanillaBoost",
+            "allow_vanilla_spider_ball": "VanillaSpider",
+        }
+        for name, index in allow_vanilla.items():
+            if getattr(configuration, name):
+                enabled_resources.add(index)
+
+        if configuration.elevators.is_vanilla:
+            # Vanilla Great Temple Emerald Translator Gate
+            enabled_resources.add("VanillaGreatTempleEmeraldGate")
+
+        if configuration.safe_zone.prevents_dark_aether:
+            # Safe Zone
+            enabled_resources.add("SafeZone")
+        
+        return enabled_resources
+    
+    def patch_resource_database(self, db: ResourceDatabase, configuration: BaseConfiguration) -> ResourceDatabase:
+        damage_reductions = copy.copy(db.damage_reductions)
+        damage_reductions[db.get_by_type_and_index(ResourceType.DAMAGE, "DarkWorld1")] = [
+            DamageReduction(None, configuration.varia_suit_damage / 6.0),
+            DamageReduction(db.get_item_by_name("Dark Suit"), configuration.dark_suit_damage / 6.0),
+            DamageReduction(db.get_item_by_name("Light Suit"), 0.0),
+        ]
+        return dataclasses.replace(db, damage_reductions=damage_reductions)

--- a/randovania/games/prime2/item_database/prime2_progressive_items.py
+++ b/randovania/games/prime2/item_database/prime2_progressive_items.py
@@ -1,0 +1,11 @@
+def gui_tuples():
+    return [
+        (
+            "Progressive Suit",
+            ("Dark Suit", "Light Suit")
+        ),
+        (
+            "Progressive Grapple",
+            ("Grapple Beam", "Screw Attack")
+        )
+    ]

--- a/randovania/games/prime3/game_data.py
+++ b/randovania/games/prime3/game_data.py
@@ -3,7 +3,7 @@ from randovania.games.prime3.generator.item_pool.pool_creator import corruption_
 from randovania.games.prime3.layout.corruption_configuration import CorruptionConfiguration
 from randovania.games.prime3.layout.corruption_cosmetic_patches import CorruptionCosmeticPatches
 from randovania.games.prime3.layout.preset_describer import corruption_format_params, corruption_unexpected_items, corruption_expected_items
-from randovania.generator.base_patches_factory import BasePatchesFactory
+from randovania.generator.base_patches_factory import PrimeTrilogyBasePatchesFactory
 from randovania.resolver.bootstrap import Bootstrap
 
 
@@ -46,6 +46,6 @@ game_data: GameData = GameData(
     generator=GameGenerator(
         item_pool_creator=corruption_specific_pool,
         bootstrap=Bootstrap(),
-        base_patches_factory=BasePatchesFactory()
+        base_patches_factory=PrimeTrilogyBasePatchesFactory()
     )
 )

--- a/randovania/games/prime3/game_data.py
+++ b/randovania/games/prime3/game_data.py
@@ -3,6 +3,8 @@ from randovania.games.prime3.generator.item_pool.pool_creator import corruption_
 from randovania.games.prime3.layout.corruption_configuration import CorruptionConfiguration
 from randovania.games.prime3.layout.corruption_cosmetic_patches import CorruptionCosmeticPatches
 from randovania.games.prime3.layout.preset_describer import corruption_format_params, corruption_unexpected_items, corruption_expected_items
+from randovania.generator.base_patches_factory import BasePatchesFactory
+from randovania.resolver.bootstrap import Bootstrap
 
 
 def _corruption_gui():
@@ -42,6 +44,8 @@ game_data: GameData = GameData(
     gui=_corruption_gui,
 
     generator=GameGenerator(
-        item_pool_creator=corruption_specific_pool
+        item_pool_creator=corruption_specific_pool,
+        bootstrap=Bootstrap(),
+        base_patches_factory=BasePatchesFactory()
     )
 )

--- a/randovania/games/prime3/game_data.py
+++ b/randovania/games/prime3/game_data.py
@@ -13,6 +13,7 @@ def _corruption_gui():
     return GameGui(
         tab_provider=prime3_preset_tabs,
         cosmetic_dialog=CorruptionCosmeticPatchesDialog,
+        input_file_text=None,
         progressive_item_gui_tuples=prime3_progressive_items.gui_tuples()
     )
 

--- a/randovania/games/prime3/game_data.py
+++ b/randovania/games/prime3/game_data.py
@@ -8,10 +8,12 @@ from randovania.games.prime3.layout.preset_describer import corruption_format_pa
 def _corruption_gui():
     from randovania.games.prime3.gui.preset_settings import prime3_preset_tabs
     from randovania.games.prime3.gui.dialog.corruption_cosmetic_patches_dialog import CorruptionCosmeticPatchesDialog
+    from randovania.games.prime3.item_database import prime3_progressive_items
 
     return GameGui(
         tab_provider=prime3_preset_tabs,
         cosmetic_dialog=CorruptionCosmeticPatchesDialog,
+        progressive_item_gui_tuples=prime3_progressive_items.gui_tuples()
     )
 
 

--- a/randovania/games/prime3/item_database/prime3_progressive_items.py
+++ b/randovania/games/prime3/item_database/prime3_progressive_items.py
@@ -1,0 +1,11 @@
+def gui_tuples():
+    return [
+        (
+            "Progressive Missile",
+            ("Ice Missile", "Seeker Missile")
+        ),
+        (
+            "Progressive Beam",
+            ("Plasma Beam", "Nova Beam")
+        )
+    ]

--- a/randovania/games/super_metroid/game_data.py
+++ b/randovania/games/super_metroid/game_data.py
@@ -12,6 +12,7 @@ def _super_metroid_gui():
     return GameGui(
         tab_provider=super_metroid_preset_tabs,
         cosmetic_dialog=BaseCosmeticPatchesDialog,
+        input_file_text=("an SFC/SMC file", "the Super Famicom/SNES"),
     )
 
 

--- a/randovania/games/super_metroid/game_data.py
+++ b/randovania/games/super_metroid/game_data.py
@@ -3,6 +3,8 @@ from randovania.games.super_metroid.layout.super_metroid_configuration import Su
 from randovania.games.super_metroid.layout.super_metroid_cosmetic_patches import SuperMetroidCosmeticPatches
 from randovania.games.game import GameData, GameGenerator, GameGui, GameLayout
 from randovania.games.super_metroid.patcher.super_duper_metroid_patcher import SuperDuperMetroidPatcher
+from randovania.generator.base_patches_factory import BasePatchesFactory
+from randovania.resolver.bootstrap import Bootstrap
 
 
 def _super_metroid_gui():
@@ -35,7 +37,9 @@ game_data: GameData = GameData(
     gui=_super_metroid_gui,
 
     generator=GameGenerator(
-        item_pool_creator=super_metroid_specific_pool
+        item_pool_creator=super_metroid_specific_pool,
+        bootstrap=Bootstrap(),
+        base_patches_factory=BasePatchesFactory()
     ),
 
     patcher=SuperDuperMetroidPatcher()

--- a/randovania/games/super_metroid/game_data.py
+++ b/randovania/games/super_metroid/game_data.py
@@ -14,7 +14,7 @@ def _super_metroid_gui():
     return GameGui(
         tab_provider=super_metroid_preset_tabs,
         cosmetic_dialog=BaseCosmeticPatchesDialog,
-        input_file_text=("an SFC/SMC file", "the Super Famicom/SNES"),
+        input_file_text=("an SFC/SMC file", "the Super Famicom/SNES", "SFC/SMC"),
     )
 
 

--- a/randovania/generator/base_patches_factory.py
+++ b/randovania/generator/base_patches_factory.py
@@ -6,259 +6,123 @@ from randovania.game_description import default_database
 from randovania.game_description.assignment import NodeConfigurationAssignment
 from randovania.game_description.game_description import GameDescription
 from randovania.game_description.game_patches import GamePatches
-from randovania.game_description.hint import Hint, HintType, PrecisionPair, HintLocationPrecision, HintItemPrecision, \
-    HintDarkTemple
-from randovania.game_description.requirements import RequirementAnd, ResourceRequirement, Requirement
-from randovania.game_description.resources import search
-from randovania.game_description.resources.pickup_index import PickupIndex
-from randovania.game_description.resources.resource_type import ResourceType
 from randovania.game_description.world.area_identifier import AreaIdentifier
-from randovania.game_description.world.node import LogbookNode, LoreType, ConfigurableNode
 from randovania.game_description.world.world_list import WorldList
-from randovania.games.game import RandovaniaGame
-from randovania.games.prime2.layout.echoes_configuration import EchoesConfiguration
-from randovania.games.prime2.layout.translator_configuration import LayoutTranslatorRequirement
 from randovania.generator import elevator_distributor
+from randovania.layout.base.base_configuration import BaseConfiguration
 from randovania.layout.lib.teleporters import TeleporterShuffleMode
-from randovania.lib.enum_lib import iterate_enum
 
 
 class MissingRng(Exception):
     pass
 
+class BasePatchesFactory:
+    def create_base_patches(self,
+                            configuration: BaseConfiguration,
+                            rng: Random,
+                            game: GameDescription,
+                            is_multiworld: bool,
+                            player_index: int,
+                            ) -> GamePatches:
+        """
+        """
+        patches = dataclasses.replace(game.create_game_patches(),
+                                    player_index=player_index)
 
-def add_elevator_connections_to_patches(configuration: EchoesConfiguration,
-                                        rng: Random,
-                                        patches: GamePatches) -> GamePatches:
-    """
-    :param configuration:
-    :param rng:
-    :param patches:
-    :return:
-    """
-    elevator_connection = copy.copy(patches.elevator_connection)
-    elevators = configuration.elevators
+        # Elevators
+        if hasattr(configuration, "elevators"):
+            patches = self.add_elevator_connections_to_patches(configuration, rng, patches)
 
-    if not elevators.is_vanilla:
-        if rng is None:
-            raise MissingRng("Elevator")
+        # Configurable Nodes
+        patches = patches.assign_node_configuration(
+            self.configurable_node_assignment(configuration, game, rng)
+        )
 
-        world_list = default_database.game_description_for(configuration.game).world_list
-        elevator_db = elevator_distributor.create_elevator_database(
-            world_list, elevators.editable_teleporters)
+        # Starting Location
+        patches = patches.assign_starting_location(
+            self.starting_location_for_configuration(configuration, game, rng))
 
-        if elevators.mode in {TeleporterShuffleMode.TWO_WAY_RANDOMIZED, TeleporterShuffleMode.TWO_WAY_UNCHECKED}:
-            connections = elevator_distributor.two_way_elevator_connections(
-                rng=rng,
-                elevator_database=elevator_db,
-                between_areas=elevators.mode == TeleporterShuffleMode.TWO_WAY_RANDOMIZED
-            )
-        else:
-            connections = elevator_distributor.one_way_elevator_connections(
-                rng=rng,
-                elevator_database=elevator_db,
-                target_locations=elevators.valid_targets,
-                replacement=elevators.mode != TeleporterShuffleMode.ONE_WAY_ELEVATOR,
-            )
+        # Hints
+        if rng is not None:
+            patches = self.add_default_hints_to_patches(rng, patches, game.world_list,
+                                                        num_joke=self.num_joke_hints, is_multiworld=is_multiworld)
 
-        elevator_connection.update(connections)
+        return patches
+    
+    def add_elevator_connections_to_patches(self,
+                                            configuration: BaseConfiguration,
+                                            rng: Random,
+                                            patches: GamePatches) -> GamePatches:
+        """
+        :param configuration:
+        :param rng:
+        :param patches:
+        :return:
+        """
+        elevator_connection = copy.copy(patches.elevator_connection)
+        elevators = configuration.elevators
 
-    for teleporter, destination in elevators.static_teleporters.items():
-        elevator_connection[teleporter] = destination
-
-    return dataclasses.replace(patches, elevator_connection=elevator_connection)
-
-
-def gate_assignment_for_configuration(configuration: EchoesConfiguration,
-                                      game: GameDescription,
-                                      rng: Random,
-                                      ) -> NodeConfigurationAssignment:
-    """
-    :param configuration:
-    :param game:
-    :param rng:
-    :return:
-    """
-
-    all_choices = list(LayoutTranslatorRequirement)
-    all_choices.remove(LayoutTranslatorRequirement.RANDOM)
-    all_choices.remove(LayoutTranslatorRequirement.RANDOM_WITH_REMOVED)
-    without_removed = copy.copy(all_choices)
-    without_removed.remove(LayoutTranslatorRequirement.REMOVED)
-    random_requirements = {LayoutTranslatorRequirement.RANDOM, LayoutTranslatorRequirement.RANDOM_WITH_REMOVED}
-
-    result = {}
-
-    scan_visor = search.find_resource_info_with_long_name(
-        game.resource_database.item,
-        "Scan Visor"
-    )
-    scan_visor_req = ResourceRequirement(scan_visor, 1, False)
-
-    for node in game.world_list.all_nodes:
-        if not isinstance(node, ConfigurableNode):
-            continue
-
-        identifier = game.world_list.identifier_for_node(node)
-        requirement = configuration.translator_configuration.translator_requirement[identifier]
-        if requirement in random_requirements:
+        if not elevators.is_vanilla:
             if rng is None:
-                raise MissingRng("Translator")
-            requirement = rng.choice(all_choices if requirement == LayoutTranslatorRequirement.RANDOM_WITH_REMOVED
-                                     else without_removed)
+                raise MissingRng("Elevator")
 
-        translator = game.resource_database.get_by_type_and_index(ResourceType.ITEM, requirement.item_name)
-        result[identifier] = RequirementAnd([
-            scan_visor_req,
-            ResourceRequirement(translator, 1, False),
-        ])
+            world_list = default_database.game_description_for(configuration.game).world_list
+            elevator_db = elevator_distributor.create_elevator_database(
+                world_list, elevators.editable_teleporters)
 
-    return result
+            if elevators.mode in {TeleporterShuffleMode.TWO_WAY_RANDOMIZED, TeleporterShuffleMode.TWO_WAY_UNCHECKED}:
+                connections = elevator_distributor.two_way_elevator_connections(
+                    rng=rng,
+                    elevator_database=elevator_db,
+                    between_areas=elevators.mode == TeleporterShuffleMode.TWO_WAY_RANDOMIZED
+                )
+            else:
+                connections = elevator_distributor.one_way_elevator_connections(
+                    rng=rng,
+                    elevator_database=elevator_db,
+                    target_locations=elevators.valid_targets,
+                    replacement=elevators.mode != TeleporterShuffleMode.ONE_WAY_ELEVATOR,
+                )
 
+            elevator_connection.update(connections)
 
-def starting_location_for_configuration(configuration: EchoesConfiguration,
-                                        game: GameDescription,
-                                        rng: Random,
-                                        ) -> AreaIdentifier:
-    locations = list(configuration.starting_location.locations)
-    if len(locations) == 0:
-        raise ValueError("No available starting locations")
-    elif len(locations) == 1:
-        location = locations[0]
-    else:
-        if rng is None:
-            raise MissingRng("Starting Location")
-        location = rng.choice(locations)
+        for teleporter, destination in elevators.static_teleporters.items():
+            elevator_connection[teleporter] = destination
 
-    return location
+        return dataclasses.replace(patches, elevator_connection=elevator_connection)
 
+    def starting_location_for_configuration(self,
+                                            configuration: BaseConfiguration,
+                                            game: GameDescription,
+                                            rng: Random,
+                                            ) -> AreaIdentifier:
+        locations = list(configuration.starting_location.locations)
+        if len(locations) == 0:
+            raise ValueError("No available starting locations")
+        elif len(locations) == 1:
+            location = locations[0]
+        else:
+            if rng is None:
+                raise MissingRng("Starting Location")
+            location = rng.choice(locations)
 
-def add_echoes_default_hints_to_patches(rng: Random,
-                                        patches: GamePatches,
-                                        world_list: WorldList,
-                                        num_joke: int,
-                                        is_multiworld: bool,
-                                        ) -> GamePatches:
-    """
-    Adds hints that are present on all games.
-    :param rng:
-    :param patches:
-    :param world_list:
-    :param num_joke
-    :param is_multiworld
-    :return:
-    """
+        return location
+    
+    def configurable_node_assignment(self, configuration: BaseConfiguration, game: GameDescription, rng: Random) -> NodeConfigurationAssignment:
+        return NodeConfigurationAssignment()
 
-    for node in world_list.all_nodes:
-        if isinstance(node, LogbookNode) and node.lore_type == LoreType.LUMINOTH_WARRIOR:
-            patches = patches.assign_hint(node.resource(),
-                                          Hint(HintType.LOCATION,
-                                               PrecisionPair(HintLocationPrecision.KEYBEARER,
-                                                             HintItemPrecision.BROAD_CATEGORY,
-                                                             include_owner=True),
-                                               PickupIndex(node.hint_index)))
+    @property
+    def num_joke_hints(self) -> int:
+        return 2
 
-    all_logbook_assets = [node.resource()
-                          for node in world_list.all_nodes
-                          if isinstance(node, LogbookNode)
-                          and node.resource() not in patches.hints
-                          and node.lore_type.holds_generic_hint]
-
-    rng.shuffle(all_logbook_assets)
-
-    # The 4 guaranteed hints
-    indices_with_hint = [
-        (PickupIndex(24), HintLocationPrecision.LIGHT_SUIT_LOCATION),  # Light Suit
-        (PickupIndex(43), HintLocationPrecision.GUARDIAN),  # Dark Suit (Amorbis)
-        (PickupIndex(79), HintLocationPrecision.GUARDIAN),  # Dark Visor (Chykka)
-        (PickupIndex(115), HintLocationPrecision.GUARDIAN),  # Annihilator Beam (Quadraxis)
-    ]
-    rng.shuffle(indices_with_hint)
-    for index, location_type in indices_with_hint:
-        if not all_logbook_assets:
-            break
-
-        logbook_asset = all_logbook_assets.pop()
-        patches = patches.assign_hint(logbook_asset, Hint(HintType.LOCATION,
-                                                          PrecisionPair(location_type, HintItemPrecision.DETAILED,
-                                                                        include_owner=False),
-                                                          index))
-
-    # Dark Temple hints
-    temple_hints = list(iterate_enum(HintDarkTemple))
-    while all_logbook_assets and temple_hints:
-        logbook_asset = all_logbook_assets.pop()
-        patches = patches.assign_hint(logbook_asset, Hint(HintType.RED_TEMPLE_KEY_SET, None,
-                                                          dark_temple=temple_hints.pop(0)))
-
-    # Jokes
-    while num_joke > 0 and all_logbook_assets:
-        logbook_asset = all_logbook_assets.pop()
-        patches = patches.assign_hint(logbook_asset, Hint(HintType.JOKE, None))
-        num_joke -= 1
-
-    return patches
-
-
-def block_assignment_for_configuration(configuration, game: GameDescription, rng: Random,
-                                       ) -> NodeConfigurationAssignment:
-    result = {}
-
-    rsb = game.resource_database
-
-    requirement_for_type = {
-        "POWERBEAM": rsb.requirement_template["Shoot Beam"],
-        "BOMB": rsb.requirement_template["Lay Bomb"],
-        "MISSILE": ResourceRequirement(rsb.get_item("Missiles"), 1, False),
-        "SUPERMISSILE": rsb.requirement_template["Shoot Super Missile"],
-        "POWERBOMB": rsb.requirement_template["Lay Power Bomb"],
-        "SCREWATTACK": ResourceRequirement(rsb.get_item("Screw"), 1, False),
-        "WEIGHT": Requirement.impossible(),
-        "SPEEDBOOST": ResourceRequirement(rsb.get_item("Speed"), 1, False),
-    }
-
-    for node in game.world_list.all_nodes:
-        if not isinstance(node, ConfigurableNode):
-            continue
-
-        result[game.world_list.identifier_for_node(node)] = RequirementAnd([
-            requirement_for_type[block_type]
-            for block_type in node.extra["tile_types"]
-        ]).simplify()
-
-    return result
-
-
-def create_base_patches(configuration: EchoesConfiguration,
-                        rng: Random,
-                        game: GameDescription,
-                        is_multiworld: bool,
-                        player_index: int,
-                        ) -> GamePatches:
-    """
-    """
-    patches = dataclasses.replace(game.create_game_patches(),
-                                  player_index=player_index)
-
-    if hasattr(configuration, "elevators"):
-        patches = add_elevator_connections_to_patches(configuration, rng, patches)
-
-    # Gates
-    if configuration.game == RandovaniaGame.METROID_PRIME_ECHOES:
-        patches = patches.assign_node_configuration(
-            gate_assignment_for_configuration(configuration, game, rng))
-
-    elif configuration.game == RandovaniaGame.METROID_DREAD:
-        patches = patches.assign_node_configuration(
-            block_assignment_for_configuration(configuration, game, rng))
-
-    # Starting Location
-    patches = patches.assign_starting_location(
-        starting_location_for_configuration(configuration, game, rng))
-
-    # Hints
-    if rng is not None and configuration.game == RandovaniaGame.METROID_PRIME_ECHOES:
-        patches = add_echoes_default_hints_to_patches(rng, patches, game.world_list,
-                                                      num_joke=2, is_multiworld=is_multiworld)
-
-    return patches
+    def add_default_hints_to_patches(self, rng: Random, patches: GamePatches, world_list: WorldList, num_joke: int, is_multiworld: bool) -> GamePatches:
+        """
+        Adds hints that are present on all games.
+        :param rng:
+        :param patches:
+        :param world_list:
+        :param num_joke
+        :param is_multiworld
+        :return:
+        """
+        return patches

--- a/randovania/generator/base_patches_factory.py
+++ b/randovania/generator/base_patches_factory.py
@@ -1,6 +1,7 @@
 import copy
 import dataclasses
 from random import Random
+from typing import Union
 
 from randovania.game_description import default_database
 from randovania.game_description.assignment import NodeConfigurationAssignment
@@ -11,6 +12,7 @@ from randovania.game_description.world.world_list import WorldList
 from randovania.generator import elevator_distributor
 from randovania.layout.base.base_configuration import BaseConfiguration
 from randovania.layout.lib.teleporters import TeleporterShuffleMode
+from randovania.games.prime2.layout.echoes_configuration import EchoesConfiguration
 
 
 class MissingRng(Exception):
@@ -30,8 +32,7 @@ class BasePatchesFactory:
                                     player_index=player_index)
 
         # Elevators
-        if hasattr(configuration, "elevators"):
-            patches = self.add_elevator_connections_to_patches(configuration, rng, patches)
+        patches = self.add_elevator_connections_to_patches(configuration, rng, patches)
 
         # Configurable Nodes
         patches = patches.assign_node_configuration(
@@ -54,42 +55,14 @@ class BasePatchesFactory:
                                             rng: Random,
                                             patches: GamePatches) -> GamePatches:
         """
+        Changes the connections between Teleporter nodes.
         :param configuration:
         :param rng:
         :param patches:
         :return:
         """
-        elevator_connection = copy.copy(patches.elevator_connection)
-        elevators = configuration.elevators
-
-        if not elevators.is_vanilla:
-            if rng is None:
-                raise MissingRng("Elevator")
-
-            world_list = default_database.game_description_for(configuration.game).world_list
-            elevator_db = elevator_distributor.create_elevator_database(
-                world_list, elevators.editable_teleporters)
-
-            if elevators.mode in {TeleporterShuffleMode.TWO_WAY_RANDOMIZED, TeleporterShuffleMode.TWO_WAY_UNCHECKED}:
-                connections = elevator_distributor.two_way_elevator_connections(
-                    rng=rng,
-                    elevator_database=elevator_db,
-                    between_areas=elevators.mode == TeleporterShuffleMode.TWO_WAY_RANDOMIZED
-                )
-            else:
-                connections = elevator_distributor.one_way_elevator_connections(
-                    rng=rng,
-                    elevator_database=elevator_db,
-                    target_locations=elevators.valid_targets,
-                    replacement=elevators.mode != TeleporterShuffleMode.ONE_WAY_ELEVATOR,
-                )
-
-            elevator_connection.update(connections)
-
-        for teleporter, destination in elevators.static_teleporters.items():
-            elevator_connection[teleporter] = destination
-
-        return dataclasses.replace(patches, elevator_connection=elevator_connection)
+        return patches
+        
 
     def starting_location_for_configuration(self,
                                             configuration: BaseConfiguration,
@@ -126,3 +99,37 @@ class BasePatchesFactory:
         :return:
         """
         return patches
+
+class PrimeTrilogyBasePatchesFactory(BasePatchesFactory):
+    def add_elevator_connections_to_patches(self, configuration: EchoesConfiguration, rng: Random, patches: GamePatches) -> GamePatches:
+        elevator_connection = copy.copy(patches.elevator_connection)
+        elevators = configuration.elevators
+
+        if not elevators.is_vanilla:
+            if rng is None:
+                raise MissingRng("Elevator")
+
+            world_list = default_database.game_description_for(configuration.game).world_list
+            elevator_db = elevator_distributor.create_elevator_database(
+                world_list, elevators.editable_teleporters)
+
+            if elevators.mode in {TeleporterShuffleMode.TWO_WAY_RANDOMIZED, TeleporterShuffleMode.TWO_WAY_UNCHECKED}:
+                connections = elevator_distributor.two_way_elevator_connections(
+                    rng=rng,
+                    elevator_database=elevator_db,
+                    between_areas=elevators.mode == TeleporterShuffleMode.TWO_WAY_RANDOMIZED
+                )
+            else:
+                connections = elevator_distributor.one_way_elevator_connections(
+                    rng=rng,
+                    elevator_database=elevator_db,
+                    target_locations=elevators.valid_targets,
+                    replacement=elevators.mode != TeleporterShuffleMode.ONE_WAY_ELEVATOR,
+                )
+
+            elevator_connection.update(connections)
+
+        for teleporter, destination in elevators.static_teleporters.items():
+            elevator_connection[teleporter] = destination
+
+        return dataclasses.replace(patches, elevator_connection=elevator_connection)

--- a/randovania/generator/filler/runner.py
+++ b/randovania/generator/filler/runner.py
@@ -20,7 +20,7 @@ from randovania.generator.filler.filler_library import should_have_hint, UnableT
 from randovania.generator.filler.player_state import PlayerState
 from randovania.generator.filler.retcon import retcon_playthrough_filler
 from randovania.layout.base.base_configuration import BaseConfiguration
-from randovania.resolver import bootstrap, debug, random_lib
+from randovania.resolver import debug, random_lib
 
 T = TypeVar("T")
 
@@ -344,7 +344,7 @@ async def run_filler(rng: Random,
         rng.shuffle(major_items)
         rng.shuffle(player_expansions[index])
 
-        new_game, state = bootstrap.logic_bootstrap(pool.configuration, pool.game, pool.patches)
+        new_game, state = pool.game.game.data.generator.bootstrap.logic_bootstrap(pool.configuration, pool.game, pool.patches)
 
         major_configuration = pool.configuration.major_items_configuration
         player_states.append(PlayerState(

--- a/randovania/generator/generator.py
+++ b/randovania/generator/generator.py
@@ -20,7 +20,7 @@ from randovania.layout.base.base_configuration import BaseConfiguration
 from randovania.layout.layout_description import LayoutDescription
 from randovania.layout.permalink import Permalink
 from randovania.layout.preset import Preset
-from randovania.resolver import resolver, bootstrap
+from randovania.resolver import resolver
 from randovania.resolver.exceptions import GenerationFailure, InvalidConfiguration, ImpossibleForSolver
 
 
@@ -36,7 +36,7 @@ def _validate_item_pool_size(item_pool: List[PickupEntry], game: GameDescription
 def create_player_pool(rng: Random, configuration: BaseConfiguration,
                        player_index: int, num_players: int) -> PlayerPool:
     game = default_database.game_description_for(configuration.game).make_mutable_copy()
-    game.resource_database = bootstrap.patch_resource_database(game.resource_database, configuration)
+    game.resource_database = game.game.data.generator.bootstrap.patch_resource_database(game.resource_database, configuration)
 
     base_patches = base_patches_factory.create_base_patches(configuration, rng, game, num_players > 1,
                                                             player_index=player_index)

--- a/randovania/generator/generator.py
+++ b/randovania/generator/generator.py
@@ -38,7 +38,7 @@ def create_player_pool(rng: Random, configuration: BaseConfiguration,
     game = default_database.game_description_for(configuration.game).make_mutable_copy()
     game.resource_database = game.game.data.generator.bootstrap.patch_resource_database(game.resource_database, configuration)
 
-    base_patches = base_patches_factory.create_base_patches(configuration, rng, game, num_players > 1,
+    base_patches = game.game.data.generator.base_patches_factory.create_base_patches(configuration, rng, game, num_players > 1,
                                                             player_index=player_index)
 
     item_pool, pickup_assignment, initial_items = pool_creator.calculate_pool_results(configuration,

--- a/randovania/gui/dialog/game_input_dialog.py
+++ b/randovania/gui/dialog/game_input_dialog.py
@@ -36,9 +36,9 @@ class GameInputDialog(QDialog, Ui_GameInputDialog):
 
         per_game = options.options_for_game(self._game)
 
-        file_format, platform = game.data.gui.input_file_text
+        file_format1, platform, file_format2 = game.data.gui().input_file_text
         description_text = "<html><head/><body><p>In order to create the randomized game, {} of {} for {} is necessary.</p>".format(
-            file_format, game.long_name, platform)
+            file_format1, game.long_name, platform)
         if not patcher.uses_input_file_directly:
             description_text += "<p>After using it once, a copy is kept by Randovania for later use.</p>"
         description_text += "</body></html>"
@@ -46,6 +46,8 @@ class GameInputDialog(QDialog, Ui_GameInputDialog):
 
         # Input
         if patcher.requires_input_file:
+            self.input_file_label.setText(f"Input File (Vanilla {file_format2})")
+            self.input_file_edit.setPlaceholderText(f"Path to vanilla {file_format2}")
             self.input_file_edit.textChanged.connect(self._validate_input_file)
             self.input_file_button.clicked.connect(self._on_input_file_button)
         else:

--- a/randovania/gui/dialog/game_input_dialog.py
+++ b/randovania/gui/dialog/game_input_dialog.py
@@ -36,8 +36,9 @@ class GameInputDialog(QDialog, Ui_GameInputDialog):
 
         per_game = options.options_for_game(self._game)
 
-        description_text = "<html><head/><body><p>In order to create the randomized game, an ISO file of {} for the Nintendo Gamecube is necessary.</p>".format(
-            game.long_name)
+        file_format, platform = game.data.gui.input_file_text
+        description_text = "<html><head/><body><p>In order to create the randomized game, {} of {} for {} is necessary.</p>".format(
+            file_format, game.long_name, platform)
         if not patcher.uses_input_file_directly:
             description_text += "<p>After using it once, a copy is kept by Randovania for later use.</p>"
         description_text += "</body></html>"
@@ -48,6 +49,7 @@ class GameInputDialog(QDialog, Ui_GameInputDialog):
             self.input_file_edit.textChanged.connect(self._validate_input_file)
             self.input_file_button.clicked.connect(self._on_input_file_button)
         else:
+            self.input_file_label.setVisible(False)
             self.input_file_edit.setVisible(False)
             self.input_file_button.setVisible(False)
             self.description_label.setVisible(False)

--- a/randovania/gui/dialog/game_input_dialog.py
+++ b/randovania/gui/dialog/game_input_dialog.py
@@ -51,7 +51,7 @@ class GameInputDialog(QDialog, Ui_GameInputDialog):
             self.input_file_edit.textChanged.connect(self._validate_input_file)
             self.input_file_button.clicked.connect(self._on_input_file_button)
         else:
-            self.input_file_label.setVisible(False)
+            self.input_file_label.setText("Game does not require input files.")
             self.input_file_edit.setVisible(False)
             self.input_file_button.setVisible(False)
             self.description_label.setVisible(False)

--- a/randovania/gui/dialog/game_input_dialog.py
+++ b/randovania/gui/dialog/game_input_dialog.py
@@ -44,8 +44,13 @@ class GameInputDialog(QDialog, Ui_GameInputDialog):
         self.description_label.setText(description_text)
 
         # Input
-        self.input_file_edit.textChanged.connect(self._validate_input_file)
-        self.input_file_button.clicked.connect(self._on_input_file_button)
+        if patcher.requires_input_file:
+            self.input_file_edit.textChanged.connect(self._validate_input_file)
+            self.input_file_button.clicked.connect(self._on_input_file_button)
+        else:
+            self.input_file_edit.setVisible(False)
+            self.input_file_button.setVisible(False)
+            self.description_label.setVisible(False)
 
         # Output
         self.output_file_edit.textChanged.connect(self._validate_output_file)
@@ -140,15 +145,18 @@ class GameInputDialog(QDialog, Ui_GameInputDialog):
 
     # Input file
     def _validate_input_file(self):
-        if self._prompt_input_file:
-            if self._selected_output_format:
-                has_error = not self.input_file.is_file()
-            elif self.input_file_edit.text():
-                has_error = not self.input_file.is_dir()
+        has_error = False
+
+        if self.patcher.requires_input_file:
+            if self._prompt_input_file:
+                if self._selected_output_format:
+                    has_error = not self.input_file.is_file()
+                elif self.input_file_edit.text():
+                    has_error = not self.input_file.is_dir()
+                else:
+                    has_error = True
             else:
-                has_error = True
-        else:
-            has_error = self.input_file_edit.text() != _VALID_GAME_TEXT
+                has_error = self.input_file_edit.text() != _VALID_GAME_TEXT
 
         common_qt_lib.set_error_border_stylesheet(self.input_file_edit, has_error)
         self._update_accept_button()

--- a/randovania/gui/dialog/trick_usage_popup.py
+++ b/randovania/gui/dialog/trick_usage_popup.py
@@ -18,7 +18,6 @@ from randovania.gui.lib.window_manager import WindowManager
 from randovania.layout.base.trick_level import LayoutTrickLevel
 from randovania.layout.base.trick_level_configuration import TrickLevelConfiguration
 from randovania.layout.preset import Preset
-from randovania.resolver import bootstrap
 
 
 def _area_requirement_sets(area: Area,
@@ -99,7 +98,7 @@ class TrickUsagePopup(QtWidgets.QDialog, Ui_TrickUsagePopup):
             return
 
         # Update
-        trick_resources = bootstrap.trick_resources_for_configuration(trick_level, database)
+        trick_resources = self._game_description.game.data.generator.bootstrap.trick_resources_for_configuration(trick_level, database)
 
         lines = []
 

--- a/randovania/gui/game_details/game_details_window.py
+++ b/randovania/gui/game_details/game_details_window.py
@@ -286,12 +286,16 @@ class GameDetailsWindow(CloseEventWidget, Ui_GameDetailsWindow, BackgroundTaskMi
         preset = description.permalink.get_preset(current_player)
 
         self.permalink_edit.setText(description.permalink.as_base64_str)
+
+        ingame_hash = preset.game.data.layout.get_ingame_hash(description._shareable_hash_bytes)
+        ingame_hash_str = f"In-game Hash: {ingame_hash}<br/>" if ingame_hash is not None else ""
         title_text = """
         <p>
             Seed Hash: {description.shareable_word_hash} ({description.shareable_hash})<br/>
+            {ingame_hash_str}
             Preset Name: {preset.name}
         </p>
-        """.format(description=description, preset=preset)
+        """.format(description=description, ingame_hash_str=ingame_hash_str, preset=preset)
         self.layout_title_label.setText(title_text)
 
         categories = list(preset_describer.describe(preset))

--- a/randovania/gui/game_session_window.py
+++ b/randovania/gui/game_session_window.py
@@ -1114,14 +1114,14 @@ class GameSessionWindow(QtWidgets.QMainWindow, Ui_GameSessionWindow, BackgroundT
         membership = self.current_player_membership
         if membership.is_observer:
             return await async_dialog.message_box(self, QtWidgets.QMessageBox.Critical,
-                                                  "Invalid action", "Observers can't generate an ISO.", QMessageBox.Ok)
+                                                  "Invalid action", "Observers can't export a game.", QMessageBox.Ok)
 
         if any(player.player is None for player in self.team_players):
             user_response = await async_dialog.warning(
                 self,
                 "Incomplete Session",
                 ("This session is currently missing a player.\n"
-                 "If you create an ISO right now, all references to that player will use a generic name instead.\n\n"
+                 "If you export your game right now, all references to that player will use a generic name instead.\n\n"
                  "Do you want to proceed?"),
                 QMessageBox.Yes | QMessageBox.No,
                 QMessageBox.No

--- a/randovania/gui/preset_settings/metroid_item_pool_tab.py
+++ b/randovania/gui/preset_settings/metroid_item_pool_tab.py
@@ -11,15 +11,12 @@ from randovania.gui.lib import signal_handling
 from randovania.gui.lib.scroll_protected import ScrollProtectedSpinBox
 from randovania.gui.preset_settings.item_pool_tab import PresetItemPool
 from randovania.gui.preset_settings.pickup_style_widget import PickupStyleWidget
-from randovania.gui.preset_settings.progressive_item_widget import ProgressiveItemWidget
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.base.major_item_state import DEFAULT_MAXIMUM_SHUFFLED
 from randovania.layout.preset import Preset
 
 
 class MetroidPresetItemPool(PresetItemPool):
-    _progressive_widgets: List[ProgressiveItemWidget]
-
     def __init__(self, editor: PresetEditor):
         super().__init__(editor)
         item_database = default_database.item_database_for_game(self.game)
@@ -29,7 +26,6 @@ class MetroidPresetItemPool(PresetItemPool):
 
         self._energy_tank_item = item_database.major_items["Energy Tank"]
         self._create_energy_tank_box(game_description.resource_database.energy_tank)
-        self._create_progressive_widgets(item_database)
         self._create_pickup_style_box(size_policy)
         signal_handling.on_checked(self.multi_pickup_placement_check, self._persist_multi_pickup_placement)
 
@@ -98,65 +94,3 @@ class MetroidPresetItemPool(PresetItemPool):
                 dataclasses.replace(major_configuration.items_state[self._energy_tank_item],
                                     num_shuffled_pickups=value)
             )
-
-    def _create_progressive_widgets(self, item_database: ItemDatabase):
-        self._progressive_widgets = []
-
-        all_progressive = []
-
-        if self.game == RandovaniaGame.METROID_PRIME_ECHOES:
-            all_progressive.append((
-                "Progressive Suit",
-                ("Dark Suit", "Light Suit"),
-            ))
-            all_progressive.append((
-                "Progressive Grapple",
-                ("Grapple Beam", "Screw Attack"),
-            ))
-        elif self.game == RandovaniaGame.METROID_PRIME_CORRUPTION:
-            all_progressive.append((
-                "Progressive Missile",
-                ("Ice Missile", "Seeker Missile"),
-            ))
-            all_progressive.append((
-                "Progressive Beam",
-                ("Plasma Beam", "Nova Beam"),
-            ))
-        elif self.game == RandovaniaGame.METROID_DREAD:
-            all_progressive.append((
-                "Progressive Beam",
-                ("Wide Beam", "Plasma Beam", "Wave Beam")
-            ))
-            all_progressive.append((
-                "Progressive Charge Beam",
-                ("Charge Beam", "Diffusion Beam")
-            ))
-            all_progressive.append((
-                "Progressive Missiles",
-                ("Super Missiles", "Ice Missiles")
-            ))
-            all_progressive.append((
-                "Progressive Suit",
-                ("Varia Suit", "Gravity Suit")
-            ))
-            all_progressive.append((
-                "Progressive Bomb",
-                ("Bomb", "Cross Bomb")
-            ))
-            all_progressive.append((
-                "Progressive Spin",
-                ("Spin Boost", "Space Jump")
-            ))
-
-        for (progressive_item_name, non_progressive_items) in all_progressive:
-            progressive_item = item_database.major_items[progressive_item_name]
-            parent, layout, _ = self._boxes_for_category[progressive_item.item_category.name]
-
-            widget = ProgressiveItemWidget(
-                parent, self._editor,
-                progressive_item=progressive_item,
-                non_progressive_items=[item_database.major_items[it] for it in non_progressive_items],
-            )
-            widget.setText("Use progressive {}".format(" → ".join(non_progressive_items)))
-            self._progressive_widgets.append(widget)
-            layout.addWidget(widget)

--- a/randovania/gui/tracker_window.py
+++ b/randovania/gui/tracker_window.py
@@ -42,7 +42,6 @@ from randovania.layout.lib.teleporters import TeleporterShuffleMode, TeleporterC
 from randovania.layout.preset import Preset
 from randovania.layout.versioned_preset import InvalidPreset, VersionedPreset
 from randovania.patching.prime import elevators
-from randovania.resolver.bootstrap import logic_bootstrap
 from randovania.resolver.logic import Logic
 from randovania.resolver.resolver_reach import ResolverReach
 from randovania.resolver.state import State, add_pickup_to_state
@@ -131,7 +130,8 @@ class TrackerWindow(QMainWindow, Ui_TrackerWindow):
 
         player_pool = generator.create_player_pool(Random(0), self.game_configuration, 0, 1)
         pool_patches = player_pool.patches
-        self.game_description, self._initial_state = logic_bootstrap(preset.configuration,
+        self.game_description, self._initial_state = self.game_configuration.game.data.generator.bootstrap.logic_bootstrap(
+                                                                     preset.configuration,
                                                                      player_pool.game,
                                                                      pool_patches)
         self.logic = Logic(self.game_description, preset.configuration)

--- a/randovania/gui/ui_files/game_details_window.ui
+++ b/randovania/gui/ui_files/game_details_window.ui
@@ -120,7 +120,7 @@
         <item row="1" column="4">
          <widget class="QPushButton" name="export_iso_button">
           <property name="text">
-           <string>Save ISO</string>
+           <string>Export Game</string>
           </property>
          </widget>
         </item>
@@ -267,7 +267,7 @@
      <x>0</x>
      <y>0</y>
      <width>624</width>
-     <height>22</height>
+     <height>20</height>
     </rect>
    </property>
   </widget>

--- a/randovania/gui/ui_files/game_session.ui
+++ b/randovania/gui/ui_files/game_session.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>739</width>
+    <width>770</width>
     <height>422</height>
    </rect>
   </property>
@@ -128,8 +128,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>739</width>
-     <height>22</height>
+     <width>770</width>
+     <height>20</height>
     </rect>
    </property>
   </widget>
@@ -182,7 +182,7 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>233</width>
+          <width>236</width>
           <height>176</height>
          </rect>
         </property>
@@ -288,7 +288,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Save ISO</string>
+        <string>Export Game</string>
        </property>
        <property name="popupMode">
         <enum>QToolButton::MenuButtonPopup</enum>

--- a/randovania/patching/patcher.py
+++ b/randovania/patching/patcher.py
@@ -54,6 +54,13 @@ class Patcher(ABC):
         raise NotImplementedError()
 
     @property
+    def requires_input_file(self) -> bool:
+        """
+        Does this patcher require an input file at all? Some patchers may include internal copies.
+        """
+        return True
+
+    @property
     @abstractmethod
     def valid_input_file_types(self) -> List[str]:
         raise NotImplementedError()

--- a/randovania/resolver/bootstrap.py
+++ b/randovania/resolver/bootstrap.py
@@ -1,18 +1,13 @@
 import copy
-import dataclasses
 from typing import Tuple
 
 from randovania.game_description import default_database
 from randovania.game_description.game_description import GameDescription
 from randovania.game_description.game_patches import GamePatches
-from randovania.game_description.requirements import ResourceRequirement
-from randovania.game_description.resources.damage_resource_info import DamageReduction
 from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.game_description.resources.resource_info import CurrentResources, \
     add_resource_gain_to_current_resources
-from randovania.game_description.resources.resource_type import ResourceType
 from randovania.game_description.world.node import PlayerShipNode
-from randovania.games.game import RandovaniaGame
 from randovania.layout.base.base_configuration import BaseConfiguration
 from randovania.layout.base.major_items_configuration import MajorItemsConfiguration
 from randovania.layout.base.trick_level import LayoutTrickLevel
@@ -20,238 +15,164 @@ from randovania.layout.base.trick_level_configuration import TrickLevelConfigura
 from randovania.resolver.state import State, StateGameData
 
 
-def trick_resources_for_configuration(configuration: TrickLevelConfiguration,
-                                      resource_database: ResourceDatabase,
-                                      ) -> CurrentResources:
-    """
-    :param configuration:
-    :param resource_database:
-    :return:
-    """
+class Bootstrap:
+    def trick_resources_for_configuration(self, configuration: TrickLevelConfiguration,
+                                        resource_database: ResourceDatabase,
+                                        ) -> CurrentResources:
+        """
+        :param configuration:
+        :param resource_database:
+        :return:
+        """
 
-    static_resources = {}
+        static_resources = {}
 
-    for trick in resource_database.trick:
-        if configuration.minimal_logic:
-            level = LayoutTrickLevel.maximum()
-        else:
-            level = configuration.level_for_trick(trick)
-        static_resources[trick] = level.as_number
+        for trick in resource_database.trick:
+            if configuration.minimal_logic:
+                level = LayoutTrickLevel.maximum()
+            else:
+                level = configuration.level_for_trick(trick)
+            static_resources[trick] = level.as_number
 
-    return static_resources
-
-
-def _add_minimal_logic_initial_resources(resources: CurrentResources,
-                                         game: GameDescription,
-                                         major_items: MajorItemsConfiguration,
-                                         ) -> None:
-    resource_database = game.resource_database
-
-    if game.minimal_logic is None:
-        raise ValueError(f"Minimal logic enabled, but {game.game} doesn't have support for it.")
-
-    item_db = default_database.item_database_for_game(game.game)
-
-    items_to_skip = set()
-    for it in game.minimal_logic.items_to_exclude:
-        if it.reason is None or major_items.items_state[item_db.major_items[it.reason]].num_shuffled_pickups != 0:
-            items_to_skip.add(it.name)
-
-    custom_item_count = game.minimal_logic.custom_item_amount
-    events_to_skip = {it.name for it in game.minimal_logic.events_to_exclude}
-
-    for event in resource_database.event:
-        if event.short_name not in events_to_skip:
-            resources[event] = 1
-
-    for item in resource_database.item:
-        if item.short_name not in items_to_skip:
-            resources[item] = custom_item_count.get(item.short_name, 1)
+        return static_resources
 
 
-def calculate_starting_state(game: GameDescription, patches: GamePatches, energy_per_tank: int) -> "State":
-    starting_node = game.world_list.resolve_teleporter_connection(patches.starting_location)
-    initial_resources = copy.copy(patches.starting_items)
+    def _add_minimal_logic_initial_resources(self, resources: CurrentResources,
+                                            game: GameDescription,
+                                            major_items: MajorItemsConfiguration,
+                                            ) -> None:
+        resource_database = game.resource_database
 
-    if isinstance(starting_node, PlayerShipNode):
-        add_resource_gain_to_current_resources(
-            starting_node.resource_gain_on_collect(patches, initial_resources, game.world_list.all_nodes,
-                                                   game.resource_database),
+        if game.minimal_logic is None:
+            raise ValueError(f"Minimal logic enabled, but {game.game} doesn't have support for it.")
+
+        item_db = default_database.item_database_for_game(game.game)
+
+        items_to_skip = set()
+        for it in game.minimal_logic.items_to_exclude:
+            if it.reason is None or major_items.items_state[item_db.major_items[it.reason]].num_shuffled_pickups != 0:
+                items_to_skip.add(it.name)
+
+        custom_item_count = game.minimal_logic.custom_item_amount
+        events_to_skip = {it.name for it in game.minimal_logic.events_to_exclude}
+
+        for event in resource_database.event:
+            if event.short_name not in events_to_skip:
+                resources[event] = 1
+
+        for item in resource_database.item:
+            if item.short_name not in items_to_skip:
+                resources[item] = custom_item_count.get(item.short_name, 1)
+
+
+    def calculate_starting_state(self, game: GameDescription, patches: GamePatches, energy_per_tank: int) -> "State":
+        starting_node = game.world_list.resolve_teleporter_connection(patches.starting_location)
+        initial_resources = copy.copy(patches.starting_items)
+
+        if isinstance(starting_node, PlayerShipNode):
+            add_resource_gain_to_current_resources(
+                starting_node.resource_gain_on_collect(patches, initial_resources, game.world_list.all_nodes,
+                                                    game.resource_database),
+                initial_resources,
+            )
+
+        initial_game_state = game.initial_states.get("Default")
+        if initial_game_state is not None:
+            add_resource_gain_to_current_resources(initial_game_state, initial_resources)
+
+        starting_state = State(
             initial_resources,
+            (),
+            99 + (100 * initial_resources.get(game.resource_database.energy_tank, 0)),
+            starting_node,
+            patches,
+            None,
+            StateGameData(
+                game.resource_database,
+                game.world_list,
+                energy_per_tank,
+            )
         )
 
-    initial_game_state = game.initial_states.get("Default")
-    if initial_game_state is not None:
-        add_resource_gain_to_current_resources(initial_game_state, initial_resources)
+        # Being present with value 0 is troublesome since this dict is used for a simplify_requirements later on
+        keys_to_remove = [resource for resource, quantity in initial_resources.items() if quantity == 0]
+        for resource in keys_to_remove:
+            del initial_resources[resource]
 
-    starting_state = State(
-        initial_resources,
-        (),
-        99 + (100 * initial_resources.get(game.resource_database.energy_tank, 0)),
-        starting_node,
-        patches,
-        None,
-        StateGameData(
-            game.resource_database,
-            game.world_list,
-            energy_per_tank,
-        )
-    )
-
-    # Being present with value 0 is troublesome since this dict is used for a simplify_requirements later on
-    keys_to_remove = [resource for resource, quantity in initial_resources.items() if quantity == 0]
-    for resource in keys_to_remove:
-        del initial_resources[resource]
-
-    return starting_state
+        return starting_state
 
 
-def version_resources_for_game(resource_database: ResourceDatabase) -> CurrentResources:
-    # All version differences are patched out from the game
-    return {
-        resource: 1 if resource.long_name == "NTSC" else 0
-        for resource in resource_database.version
-    }
-
-
-def misc_resources_for_configuration(configuration: BaseConfiguration,
-                                     resource_database: ResourceDatabase) -> CurrentResources:
-    enabled_resources = set()
-    if configuration.game == RandovaniaGame.METROID_PRIME:
-        logical_patches = {
-            "allow_underwater_movement_without_gravity": "NoGravity",
-            "main_plaza_door": "main_plaza_door",
-            "backwards_frigate": "backwards_frigate",
-            "backwards_labs": "backwards_labs",
-            "backwards_upper_mines": "backwards_upper_mines",
-            "backwards_lower_mines": "backwards_lower_mines",
-            "phazon_elite_without_dynamo": "phazon_elite_without_dynamo",
-            "small_samus": "small",
+    def version_resources_for_game(self,  configuration: BaseConfiguration, resource_database: ResourceDatabase) -> CurrentResources:
+        """
+        Determines which Version resources should be enabled, according to the configuration.
+        Override as needed.
+        """
+        # Only enable one specific version
+        return {
+            resource: 1 if resource.long_name == "NTSC" else 0
+            for resource in resource_database.version
         }
-        for name, index in logical_patches.items():
-            if getattr(configuration, name):
-                enabled_resources.add(index)
 
-    elif configuration.game == RandovaniaGame.METROID_PRIME_ECHOES:
-        enabled_resources = set()
-        allow_vanilla = {
-            "allow_jumping_on_dark_water": "DarkWaterJump",
-            "allow_vanilla_dark_beam": "VanillaDarkBeam",
-            "allow_vanilla_light_beam": "VanillaLightBeam",
-            "allow_vanilla_seeker_launcher": "VanillaSeekers",
-            "allow_vanilla_echo_visor": "VanillaEcho",
-            "allow_vanilla_dark_visor": "VanillaDarkVisor",
-            "allow_vanilla_screw_attack": "VanillaSA",
-            "allow_vanilla_gravity_boost": "VanillaGravity",
-            "allow_vanilla_boost_ball": "VanillaBoost",
-            "allow_vanilla_spider_ball": "VanillaSpider",
+
+    def _get_enabled_misc_resources(self, configuration: BaseConfiguration, resource_database: ResourceDatabase) -> set[str]:
+        """
+        Returns a set of strings corresponding to Misc resource short names which should be enabled.
+        Override as needed.
+        """
+        return set()
+    
+    def misc_resources_for_configuration(self, configuration: BaseConfiguration,
+                                        resource_database: ResourceDatabase) -> CurrentResources:
+        """
+        Determines which Misc resources should be enabled, according to the configuration.
+        """
+        enabled_resources = self._get_enabled_misc_resources(configuration, resource_database)
+        return {
+            resource: 1 if resource.short_name in enabled_resources else 0
+            for resource in resource_database.misc
         }
-        for name, index in allow_vanilla.items():
-            if getattr(configuration, name):
-                enabled_resources.add(index)
 
-        if configuration.elevators.is_vanilla:
-            # Vanilla Great Temple Emerald Translator Gate
-            enabled_resources.add("VanillaGreatTempleEmeraldGate")
-
-        if configuration.safe_zone.prevents_dark_aether:
-            # Safe Zone
-            enabled_resources.add("SafeZone")
-
-    return {
-        resource: 1 if resource.short_name in enabled_resources else 0
-        for resource in resource_database.misc
-    }
+    def patch_resource_database(self, db: ResourceDatabase, configuration: BaseConfiguration) -> ResourceDatabase:
+        """
+        Makes modifications to the resource database according to the configuration.
+        Requirement templates and damage reductions are common candidates for modification.
+        Override as needed.
+        """
+        return db
 
 
-def prime1_progressive_damage_reduction(db: ResourceDatabase, current_resources: CurrentResources):
-    num_suits = sum(current_resources.get(db.get_item_by_name(suit), 0)
-                    for suit in ["Varia Suit", "Gravity Suit", "Phazon Suit"])
-    if num_suits >= 3:
-        return 0.5
-    elif num_suits == 2:
-        return 0.8
-    elif num_suits == 1:
-        return 0.9
-    else:
-        return 1
+    def logic_bootstrap(self,
+                        configuration: BaseConfiguration,
+                        game: GameDescription,
+                        patches: GamePatches,
+                        ) -> Tuple[GameDescription, State]:
+        """
+        Core code for starting a new Logic/State.
+        :param configuration:
+        :param game:
+        :param patches:
+        :return:
+        """
+        if not game.mutable:
+            raise ValueError("Running logic_bootstrap with non-mutable game")
 
+        # FIXME
+        energy_per_tank = getattr(configuration, "energy_per_tank", 100)
+        starting_state = self.calculate_starting_state(game, patches, energy_per_tank)
 
-def prime1_absolute_damage_reduction(db: ResourceDatabase, current_resources: CurrentResources):
-    if current_resources.get(db.get_item_by_name("Phazon Suit"), 0) > 0:
-        return 0.5
-    elif current_resources.get(db.get_item_by_name("Gravity Suit"), 0) > 0:
-        return 0.8
-    elif current_resources.get(db.get_item_by_name("Varia Suit"), 0) > 0:
-        return 0.9
-    else:
-        return 1
+        if configuration.trick_level.minimal_logic:
+            self._add_minimal_logic_initial_resources(starting_state.resources,
+                                                game,
+                                                configuration.major_items_configuration)
 
+        static_resources = self.trick_resources_for_configuration(configuration.trick_level,
+                                                            game.resource_database)
+        static_resources.update(self.version_resources_for_game(game.resource_database))
+        static_resources.update(self.misc_resources_for_configuration(configuration, game.resource_database))
 
-def patch_resource_database(db: ResourceDatabase, configuration: BaseConfiguration) -> ResourceDatabase:
-    base_damage_reduction = db.base_damage_reduction
-    damage_reductions = copy.copy(db.damage_reductions)
-    requirement_template = copy.copy(db.requirement_template)
+        for resource, quantity in static_resources.items():
+            starting_state.resources[resource] = quantity
 
-    if configuration.game == RandovaniaGame.METROID_PRIME:
-        suits = [db.get_item_by_name("Varia Suit")]
-        if configuration.heat_protection_only_varia:
-            requirement_template["Heat-Resisting Suit"] = ResourceRequirement(db.get_item_by_name("Varia Suit"),
-                                                                              1, False)
-        else:
-            suits.extend([db.get_item_by_name("Gravity Suit"), db.get_item_by_name("Phazon Suit")])
+        game.patch_requirements(starting_state.resources, configuration.damage_strictness.value)
 
-        reductions = [DamageReduction(None, configuration.heat_damage / 10.0)]
-        reductions.extend([DamageReduction(suit, 0) for suit in suits])
-        damage_reductions[db.get_by_type_and_index(ResourceType.DAMAGE, "HeatDamage1")] = reductions
-
-        if configuration.progressive_damage_reduction:
-            base_damage_reduction = prime1_progressive_damage_reduction
-        else:
-            base_damage_reduction = prime1_absolute_damage_reduction
-
-    elif configuration.game == RandovaniaGame.METROID_PRIME_ECHOES:
-        damage_reductions[db.get_by_type_and_index(ResourceType.DAMAGE, "DarkWorld1")] = [
-            DamageReduction(None, configuration.varia_suit_damage / 6.0),
-            DamageReduction(db.get_item_by_name("Dark Suit"), configuration.dark_suit_damage / 6.0),
-            DamageReduction(db.get_item_by_name("Light Suit"), 0.0),
-        ]
-
-    return dataclasses.replace(db, damage_reductions=damage_reductions, base_damage_reduction=base_damage_reduction,
-                               requirement_template=requirement_template)
-
-
-def logic_bootstrap(configuration: BaseConfiguration,
-                    game: GameDescription,
-                    patches: GamePatches,
-                    ) -> Tuple[GameDescription, State]:
-    """
-    Core code for starting a new Logic/State.
-    :param configuration:
-    :param game:
-    :param patches:
-    :return:
-    """
-    if not game.mutable:
-        raise ValueError("Running logic_bootstrap with non-mutable game")
-
-    # FIXME
-    energy_per_tank = getattr(configuration, "energy_per_tank", 100)
-    starting_state = calculate_starting_state(game, patches, energy_per_tank)
-
-    if configuration.trick_level.minimal_logic:
-        _add_minimal_logic_initial_resources(starting_state.resources,
-                                             game,
-                                             configuration.major_items_configuration)
-
-    static_resources = trick_resources_for_configuration(configuration.trick_level,
-                                                         game.resource_database)
-    static_resources.update(version_resources_for_game(game.resource_database))
-    static_resources.update(misc_resources_for_configuration(configuration, game.resource_database))
-
-    for resource, quantity in static_resources.items():
-        starting_state.resources[resource] = quantity
-
-    game.patch_requirements(starting_state.resources, configuration.damage_strictness.value)
-
-    return game, starting_state
+        return game, starting_state

--- a/randovania/resolver/bootstrap.py
+++ b/randovania/resolver/bootstrap.py
@@ -167,7 +167,7 @@ class Bootstrap:
 
         static_resources = self.trick_resources_for_configuration(configuration.trick_level,
                                                             game.resource_database)
-        static_resources.update(self.version_resources_for_game(game.resource_database))
+        static_resources.update(self.version_resources_for_game(configuration, game.resource_database))
         static_resources.update(self.misc_resources_for_configuration(configuration, game.resource_database))
 
         for resource, quantity in static_resources.items():

--- a/randovania/resolver/resolver.py
+++ b/randovania/resolver/resolver.py
@@ -8,8 +8,7 @@ from randovania.game_description.world.node import PickupNode, ResourceNode, Eve
 from randovania.game_description.requirements import RequirementSet, RequirementList
 from randovania.game_description.resources.resource_info import ResourceInfo
 from randovania.layout.base.base_configuration import BaseConfiguration
-from randovania.resolver import debug, event_pickup, bootstrap
-from randovania.resolver.bootstrap import logic_bootstrap
+from randovania.resolver import debug, event_pickup
 from randovania.resolver.event_pickup import EventPickupNode
 from randovania.resolver.logic import Logic
 from randovania.resolver.resolver_reach import ResolverReach
@@ -176,10 +175,10 @@ async def resolve(configuration: BaseConfiguration,
         status_update = _quiet_print
 
     game = default_database.game_description_for(configuration.game).make_mutable_copy()
-    game.resource_database = bootstrap.patch_resource_database(game.resource_database, configuration)
+    game.resource_database = game.game.data.generator.bootstrap.patch_resource_database(game.resource_database, configuration)
     event_pickup.replace_with_event_pickups(game)
 
-    new_game, starting_state = bootstrap.logic_bootstrap(configuration, game, patches)
+    new_game, starting_state = game.game.data.generator.bootstrap.logic_bootstrap(configuration, game, patches)
     logic = Logic(new_game, configuration)
     starting_state.resources["add_self_as_requirement_to_resources"] = 1
     debug.log_resolve_start()

--- a/test/generator/filler/test_pickup_list.py
+++ b/test/generator/filler/test_pickup_list.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock
 from randovania.game_description.requirements import RequirementSet, RequirementList, ResourceRequirement
 from randovania.game_description.resources import search
 from randovania.generator.filler import pickup_list
-from randovania.resolver import bootstrap
 
 
 def test_requirement_lists_without_satisfied_resources(echoes_game_description):
@@ -11,7 +10,8 @@ def test_requirement_lists_without_satisfied_resources(echoes_game_description):
     def item(name):
         return search.find_resource_info_with_long_name(echoes_game_description.resource_database.item, name)
 
-    state = bootstrap.calculate_starting_state(echoes_game_description,
+    state = echoes_game_description.game.data.generator.bootstrap.calculate_starting_state(
+                                               echoes_game_description,
                                                echoes_game_description.create_game_patches(),
                                                100)
     state.resources[item("Seeker Launcher")] = 1

--- a/test/generator/test_base_patches_factory.py
+++ b/test/generator/test_base_patches_factory.py
@@ -263,10 +263,10 @@ def test_add_default_hints_to_patches(echoes_game_description, empty_patches, is
     assert result.hints == expected
 
 
-@patch("randovania.generator.base_patches_factory.add_echoes_default_hints_to_patches", autospec=True)
-@patch("randovania.generator.base_patches_factory.starting_location_for_configuration", autospec=True)
-@patch("randovania.generator.base_patches_factory.gate_assignment_for_configuration", autospec=True)
-@patch("randovania.generator.base_patches_factory.add_elevator_connections_to_patches", autospec=True)
+@patch("randovania.generator.base_patches_factory.BasePatchesFactory.add_default_hints_to_patches", autospec=True)
+@patch("randovania.generator.base_patches_factory.BasePatchesFactory.starting_location_for_configuration", autospec=True)
+@patch("randovania.generator.base_patches_factory.BasePatchesFactory.configurable_node_assignment", autospec=True)
+@patch("randovania.generator.base_patches_factory.BasePatchesFactory.add_elevator_connections_to_patches", autospec=True)
 def test_create_base_patches(mock_add_elevator_connections_to_patches: MagicMock,
                              mock_gate_assignment_for_configuration: MagicMock,
                              mock_starting_location_for_config: MagicMock,
@@ -289,24 +289,26 @@ def test_create_base_patches(mock_add_elevator_connections_to_patches: MagicMock
     patches.append(patches[-1].assign_node_configuration.return_value)
     patches.append(patches[-1].assign_starting_location.return_value)
 
+    factory = base_patches_factory.BasePatchesFactory()
+
     # Run
-    result = base_patches_factory.create_base_patches(layout_configuration, rng, game, is_multiworld, player_index=0)
+    result = factory.create_base_patches(layout_configuration, rng, game, is_multiworld, player_index=0)
 
     # Assert
     game.create_game_patches.assert_called_once_with()
     mock_replace.assert_called_once_with(game.create_game_patches.return_value, player_index=0)
-    mock_add_elevator_connections_to_patches.assert_called_once_with(layout_configuration, rng, patches[1])
+    mock_add_elevator_connections_to_patches.assert_called_once_with(factory, layout_configuration, rng, patches[1])
 
     # Gate Assignment
-    mock_gate_assignment_for_configuration.assert_called_once_with(layout_configuration, game, rng)
+    mock_gate_assignment_for_configuration.assert_called_once_with(factory, layout_configuration, game, rng)
     patches[2].assign_node_configuration.assert_called_once_with(mock_gate_assignment_for_configuration.return_value)
 
     # Starting Location
-    mock_starting_location_for_config.assert_called_once_with(layout_configuration, game, rng)
+    mock_starting_location_for_config.assert_called_once_with(factory, layout_configuration, game, rng)
     patches[3].assign_starting_location.assert_called_once_with(mock_starting_location_for_config.return_value)
 
     # Hints
-    mock_add_default_hints_to_patches.assert_called_once_with(rng, patches[4], game.world_list, num_joke=2,
+    mock_add_default_hints_to_patches.assert_called_once_with(factory, rng, patches[4], game.world_list, num_joke=2,
                                                               is_multiworld=is_multiworld)
 
     assert result is mock_add_default_hints_to_patches.return_value

--- a/test/generator/test_base_patches_factory.py
+++ b/test/generator/test_base_patches_factory.py
@@ -36,7 +36,7 @@ def test_add_elevator_connections_to_patches_vanilla(echoes_game_description,
                                                                skip_final_bosses=skip_final_bosses))
 
     # Run
-    result = base_patches_factory.add_elevator_connections_to_patches(
+    result = echoes_game_description.game.data.generator.base_patches_factory.add_elevator_connections_to_patches(
         config,
         Random(0),
         echoes_game_description.create_game_patches())
@@ -122,7 +122,7 @@ def test_add_elevator_connections_to_patches_random(echoes_game_description,
         elevator_connection=elevator_connection)
 
     # Run
-    result = base_patches_factory.add_elevator_connections_to_patches(
+    result = echoes_game_description.game.data.generator.base_patches_factory.add_elevator_connections_to_patches(
         layout_configuration,
         Random(0),
         game.create_game_patches(),
@@ -155,7 +155,7 @@ def test_gate_assignment_for_configuration_all_emerald(echoes_game_description, 
     rng = MagicMock()
 
     # Run
-    results = base_patches_factory.gate_assignment_for_configuration(configuration, echoes_game_description, rng)
+    results = echoes_game_description.game.data.generator.base_patches_factory.configurable_node_assignment(configuration, echoes_game_description, rng)
 
     # Assert
     assert list(results.values()) == [
@@ -195,7 +195,7 @@ def test_gate_assignment_for_configuration_all_random(echoes_game_description, d
     rng.choice.side_effect = choices * len(translator_configuration.translator_requirement)
 
     # Run
-    results = base_patches_factory.gate_assignment_for_configuration(configuration, echoes_game_description, rng)
+    results = echoes_game_description.game.data.generator.base_patches_factory.configurable_node_assignment(configuration, echoes_game_description, rng)
 
     # Assert
     assert list(results.values()) == requirements[:len(translator_configuration.translator_requirement)]
@@ -255,7 +255,7 @@ def test_add_default_hints_to_patches(echoes_game_description, empty_patches, is
     }
 
     # Run
-    result = base_patches_factory.add_echoes_default_hints_to_patches(
+    result = echoes_game_description.game.data.generator.base_patches_factory.add_default_hints_to_patches(
         rng, empty_patches, echoes_game_description.world_list, num_joke=2, is_multiworld=is_multiworld)
 
     # Assert

--- a/test/generator/test_generator_reach.py
+++ b/test/generator/test_generator_reach.py
@@ -41,7 +41,7 @@ def run_bootstrap(preset: Preset):
         spoiler=True,
         presets={0: preset},
     )
-    patches = base_patches_factory.create_base_patches(preset.configuration, Random(15000), game, False, player_index=0)
+    patches = game.game.data.generator.base_patches_factory.create_base_patches(preset.configuration, Random(15000), game, False, player_index=0)
     _, state = game.game.data.generator.bootstrap.logic_bootstrap(preset.configuration, game, patches)
 
     return game, state, permalink
@@ -211,7 +211,7 @@ def test_reach_size_from_start_echoes(small_echoes_game_description, default_lay
             game=RandovaniaGame.METROID_PRIME_ECHOES,
         )
     )
-    patches = base_patches_factory.create_base_patches(layout_configuration, Random(15000), game,
+    patches = game.game.data.generator.base_patches_factory.create_base_patches(layout_configuration, Random(15000), game,
                                                        False, player_index=0)
     state = game.game.data.generator.bootstrap.calculate_starting_state(game, patches, 100)
     state.resources[item("Combat Visor")] = 1

--- a/test/generator/test_generator_reach.py
+++ b/test/generator/test_generator_reach.py
@@ -30,20 +30,19 @@ from randovania.layout.base.trick_level import LayoutTrickLevel
 from randovania.layout.base.trick_level_configuration import TrickLevelConfiguration
 from randovania.layout.permalink import Permalink
 from randovania.layout.preset import Preset
-from randovania.resolver import bootstrap
 from randovania.resolver.state import State, add_pickup_to_state, StateGameData
 
 
 def run_bootstrap(preset: Preset):
     game = default_database.game_description_for(preset.game).make_mutable_copy()
-    game.resource_database = bootstrap.patch_resource_database(game.resource_database, preset.configuration)
+    game.resource_database = game.game.data.generator.bootstrap.patch_resource_database(game.resource_database, preset.configuration)
     permalink = Permalink(
         seed_number=15000,
         spoiler=True,
         presets={0: preset},
     )
     patches = base_patches_factory.create_base_patches(preset.configuration, Random(15000), game, False, player_index=0)
-    _, state = bootstrap.logic_bootstrap(preset.configuration, game, patches)
+    _, state = game.game.data.generator.bootstrap.logic_bootstrap(preset.configuration, game, patches)
 
     return game, state, permalink
 
@@ -214,7 +213,7 @@ def test_reach_size_from_start_echoes(small_echoes_game_description, default_lay
     )
     patches = base_patches_factory.create_base_patches(layout_configuration, Random(15000), game,
                                                        False, player_index=0)
-    state = bootstrap.calculate_starting_state(game, patches, 100)
+    state = game.game.data.generator.bootstrap.calculate_starting_state(game, patches, 100)
     state.resources[item("Combat Visor")] = 1
     state.resources[item("Amber Translator")] = 1
     state.resources[item("Scan Visor")] = 1

--- a/test/generator/test_retcon_filler_integration.py
+++ b/test/generator/test_retcon_filler_integration.py
@@ -10,7 +10,6 @@ from randovania.generator.filler import retcon
 from randovania.generator.filler.filler_configuration import FillerConfiguration
 from randovania.layout.base.available_locations import RandomizationMode
 from randovania.layout.base.logical_resource_action import LayoutLogicalResourceAction
-from randovania.resolver.bootstrap import logic_bootstrap
 
 
 @pytest.mark.parametrize("major_mode", [RandomizationMode.FULL, RandomizationMode.MAJOR_MINOR_SPLIT])
@@ -64,7 +63,7 @@ def test_retcon_filler_integration(default_layout_configuration):
     patches = game.create_game_patches()
     available_pickups = game.pickup_database.all_useful_pickups
 
-    new_game, state = logic_bootstrap(layout_configuration, game, patches)
+    new_game, state = game.game.data.generator.bootstrap.logic_bootstrap(layout_configuration, game, patches)
     new_game.patch_requirements(state.resources, layout_configuration.damage_strictness.value)
 
     filler_patches = retcon.retcon_playthrough_filler(new_game,

--- a/test/resolver/test_bootstrap.py
+++ b/test/resolver/test_bootstrap.py
@@ -33,9 +33,9 @@ def test_misc_resources_for_configuration(echoes_resource_database,
     }
 
 
-def test_logic_bootstrap(default_preset, echoes_game_description):
+def test_logic_bootstrap(default_echoes_preset, echoes_game_description):
     new_game, state = echoes_game_description.game.data.generator.bootstrap.logic_bootstrap(
-                                                default_preset.configuration,
+                                                default_echoes_preset.configuration,
                                                 echoes_game_description.make_mutable_copy(),
                                                 echoes_game_description.create_game_patches())
 

--- a/test/resolver/test_bootstrap.py
+++ b/test/resolver/test_bootstrap.py
@@ -4,7 +4,6 @@ import pytest
 
 from randovania.game_description.resources.resource_type import ResourceType
 from randovania.games.game import RandovaniaGame
-from randovania.resolver import bootstrap
 
 
 @pytest.mark.parametrize("vanilla_elevators", [False, True])
@@ -20,7 +19,7 @@ def test_misc_resources_for_configuration(echoes_resource_database,
     great_resource = echoes_resource_database.get_by_type_and_index(ResourceType.MISC, "VanillaGreatTempleEmeraldGate")
 
     # Run
-    result = bootstrap.misc_resources_for_configuration(configuration, echoes_resource_database)
+    result = configuration.game.data.generator.bootstrap.misc_resources_for_configuration(configuration, echoes_resource_database)
     relevant_tricks = {
         trick: result[trick]
         for trick in [gfmc_resource, torvus_resource, great_resource]
@@ -35,7 +34,8 @@ def test_misc_resources_for_configuration(echoes_resource_database,
 
 
 def test_logic_bootstrap(default_preset, echoes_game_description):
-    new_game, state = bootstrap.logic_bootstrap(default_preset.configuration,
+    new_game, state = echoes_game_description.game.data.generator.bootstrap.logic_bootstrap(
+                                                default_preset.configuration,
                                                 echoes_game_description.make_mutable_copy(),
                                                 echoes_game_description.create_game_patches())
 
@@ -58,7 +58,7 @@ def test_prime1_progressive_damage_reduction(prime1_resource_database, expected,
     }
 
     # Run
-    result = bootstrap.prime1_progressive_damage_reduction(prime1_resource_database, current_resources)
+    result = RandovaniaGame.METROID_PRIME.data.generator.bootstrap.prime1_progressive_damage_reduction(prime1_resource_database, current_resources)
 
     # Assert
     assert result == expected
@@ -82,7 +82,7 @@ def test_prime1_absolute_damage_reduction(prime1_resource_database, expected, su
     }
 
     # Run
-    result = bootstrap.prime1_absolute_damage_reduction(prime1_resource_database, current_resources)
+    result = RandovaniaGame.METROID_PRIME.data.generator.bootstrap.prime1_absolute_damage_reduction(prime1_resource_database, current_resources)
 
     # Assert
     assert result == expected


### PR DESCRIPTION
- Progressive item tuples for item pool tab
- Replaced "Save ISO" with "Export Game"
- Bootstrap
- Base patches factory

- Input file format/platform text
![image](https://user-images.githubusercontent.com/2979303/144549556-407c20c5-0d36-4bb5-9fed-8e0ef3573a14.png)
- Game-specific hash
![image](https://user-images.githubusercontent.com/2979303/144551227-63b8b752-38f5-4038-82c6-7eeba44776fa.png)
- Patchers with no input file
![image](https://user-images.githubusercontent.com/2979303/144551439-309b28b8-8a7d-4a65-b6a4-7ea5e1e29145.png)


TODO (in another PR): references to echoes/gamecube specific text throughout the UI