### PR TITLE
Hack a longer timeout in PyInstaller

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
         if: ${{ !matrix.executable }}
 
       - name: create executable
-        run: python tools/create_release.py
+        run: python -u tools/create_release.py
         if: matrix.executable
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -105,6 +105,14 @@ async def main():
 
     await download_nintendont()
 
+    if platform.system() == "Darwin":
+        # HACK: pyintaller calls lipo/codesign on macOS and frequently timeout in github actions
+        print("Will patch timeout in PyInstaller compat")
+        import PyInstaller.compat
+        compat_path = Path(PyInstaller.compat.__file__)
+        compat_text = compat_path.read_text().replace("timeout=60", "timeout=180")
+        compat_path.write_text(compat_text)
+
     subprocess.run([sys.executable, "-m", "PyInstaller",
                     "randovania.spec"],
                    check=True)


### PR DESCRIPTION
pyintaller calls lipo/codesign on macOS and frequently timeout in github actions