### PR TITLE
Fix & simplify blob events logic in Early Cloak room

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -1710,15 +1710,6 @@
                                 "items": []
                             }
                         },
-                        "Door to Path to Corpius": {
-                            "type": "resource",
-                            "data": {
-                                "type": "events",
-                                "name": "s010_cave:default:PRP_DB_CV_020",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
                         "Event - Early Cloak Blob": {
                             "type": "or",
                             "data": {
@@ -1747,6 +1738,15 @@
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Above Early Cloak Blob": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "s010_cave:default:PRP_DB_CV_020",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -1806,15 +1806,6 @@
                     "dock_type": "door",
                     "dock_weakness": "Power Beam Door",
                     "connections": {
-                        "Door to Save Station South": {
-                            "type": "resource",
-                            "data": {
-                                "type": "events",
-                                "name": "s010_cave:default:PRP_DB_CV_020",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
                         "Dock to EMMI Zone First Entrance (DoorEmmy10_000)": {
                             "type": "and",
                             "data": {
@@ -1822,7 +1813,7 @@
                                 "items": []
                             }
                         },
-                        "Event - Early Cloak Blob": {
+                        "Above Early Cloak Blob": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1853,6 +1844,13 @@
                     "dock_weakness": "EMMI Door",
                     "connections": {
                         "Door to Path to Corpius": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Above Early Cloak Blob": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1900,7 +1898,7 @@
                     },
                     "event_name": "s010_cave:default:PRP_DB_CV_020",
                     "connections": {
-                        "Door to Save Station South": {
+                        "Above Early Cloak Blob": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1962,7 +1960,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s010_cave:default:PRP_CV_PlatformCaveWater_B",
+                                            "name": "s010_cave:default:PRP_DB_CV_003",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -1988,6 +1986,49 @@
                             }
                         },
                         "Event - Water Introduction Blob": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Above Early Cloak Blob": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 9491.322824911142,
+                        "y": -1070.796631123474,
+                        "z": 0
+                    },
+                    "description": "",
+                    "extra": {},
+                    "connections": {
+                        "Door to Save Station South": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "s010_cave:default:PRP_DB_CV_020",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Door to Path to Corpius": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Dock to EMMI Zone First Entrance (DoorEmmy10_000)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Event - Early Cloak Blob": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -410,10 +410,10 @@ Extra - asset_id: collision_camera_004
   * Extra - right_shield_def: None
   > Door to Melee Tutorial Room
       Trivial
-  > Door to Path to Corpius
-      After Artaria - Early Cloak Blob
   > Event - Early Cloak Blob
       Wave Beam or Pseudo-Wave Beam (Intermediate) or Shoot Diffusion Beam
+  > Above Early Cloak Blob
+      After Artaria - Early Cloak Blob
 
 > Dock to EMMI Zone First Entrance (Main); Heals? False
   * EMMI Door to EMMI Zone First Entrance/Dock to Early Cloak Room (Water Blob)
@@ -430,11 +430,9 @@ Extra - asset_id: collision_camera_004
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Save Station South
-      After Artaria - Early Cloak Blob
   > Dock to EMMI Zone First Entrance (DoorEmmy10_000)
       Trivial
-  > Event - Early Cloak Blob
+  > Above Early Cloak Blob
       Trivial
 
 > Dock to EMMI Zone First Entrance (DoorEmmy10_000); Heals? False
@@ -442,6 +440,8 @@ Extra - asset_id: collision_camera_004
   * Extra - actor_name: DoorEmmy10_000
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to Path to Corpius
+      Trivial
+  > Above Early Cloak Blob
       Trivial
 
 > Event - Water Introduction Blob; Heals? False
@@ -455,7 +455,7 @@ Extra - asset_id: collision_camera_004
   * Event Artaria - Early Cloak Blob
   * Extra - actor_name: PRP_DB_CV_020
   * Extra - actor_def: actordef:actors/props/breakablecave020/charclasses/breakablecave020.bmsad
-  > Door to Save Station South
+  > Above Early Cloak Blob
       Trivial
 
 > Next to Water Introduction Blob; Heals? False
@@ -464,8 +464,18 @@ Extra - asset_id: collision_camera_004
           Can Slide Underwater
           Before Artaria - Water Introduction Blob and Can Slide
   > Dock to EMMI Zone First Entrance (Main)
-      Gravity Suit or After Artaria - EMMI Zone Water Device or Lay Cross Comb or Use Spin Boost
+      Gravity Suit or After Artaria - Water Introduction Blob or Lay Cross Comb or Use Spin Boost
   > Event - Water Introduction Blob
+      Trivial
+
+> Above Early Cloak Blob; Heals? False
+  > Door to Save Station South
+      After Artaria - Early Cloak Blob
+  > Door to Path to Corpius
+      Trivial
+  > Dock to EMMI Zone First Entrance (DoorEmmy10_000)
+      Trivial
+  > Event - Early Cloak Blob
       Trivial
 
 ----------------


### PR DESCRIPTION
Water blob logic was broken (had wrong event in checks), and early cloak blob was overly confusing.