### PR TITLE
Sun Tower Early Wild logic update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ This feature comes with plenty of quality of life functionality for editing the 
 - Changed: Ore Processing Storage Depot B to Waste Disposal NSJ Standable difficulty from Intermediate to Beginner
 - Changed: Ore Processing Storage Depot B to Waste Disposal R-Jump to L-Jump
 - Changed: Elite Research Spinners without Boost from Advanced to Intermediate
+- Changed: Sun Tower Early Wild now requires Intermediate Knowledge on all methods
 
 ### Metroid Prime 2: Echoes
 

--- a/randovania/games/prime1/json_data/Chozo Ruins.json
+++ b/randovania/games/prime1/json_data/Chozo Ruins.json
@@ -5555,7 +5555,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "https://youtu.be/spZZY6E95ZU",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -5590,7 +5590,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Roll down to the gap in the track and back up to trigger ghosts, skipping super missiles. This connection makes fighting Flaahgra without Spider Ball a dangerous action.",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -5600,20 +5600,20 @@
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Knowledge",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
                                                             }
                                                         ]
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Knowledge",
+                                            "amount": 2,
+                                            "negate": false
                                         }
                                     }
                                 ]

--- a/randovania/games/prime1/json_data/Chozo Ruins.txt
+++ b/randovania/games/prime1/json_data/Chozo Ruins.txt
@@ -871,10 +871,14 @@ Extra - asset_id: 3725988722
   * Event Sunchamber Chozo Ghosts Layer Activated
   > Door to Sun Tower Access
       All of the following:
-          Morph Ball
+          Morph Ball and Knowledge (Intermediate)
           Any of the following:
-              Morph Ball Bomb and Complex Bomb Jump (Intermediate) and Normal Damage ≥ 20
-              Spider Ball and Knowledge (Intermediate)
+              All of the following:
+                  # https://youtu.be/spZZY6E95ZU
+                  Morph Ball Bomb and Complex Bomb Jump (Intermediate) and Normal Damage ≥ 20
+              All of the following:
+                  # Roll down to the gap in the track and back up to trigger ghosts, skipping super missiles. This connection makes fighting Flaahgra without Spider Ball a dangerous action.
+                  Spider Ball
   > Door to Transport to Magmoor Caverns North
       Trivial
 


### PR DESCRIPTION
Amending the Sun Tower database entry to enforce Medium Knowledge with or without spider ball, and adding comments to explain/video link the trick (especially important since the trick falls outside Knowledge's current explanation).
