### PR TITLE
Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,28 @@
+<!-- The Begin and End comments throughout this document are used in order to pull specific sections of the readme into the main GUI window at runtime. -->
+
 # Randovania
 
 Welcome to Randovania, a randomizer platform for a multitude of games.
 
-<!-- Begin WELCOME -->
+<!-- Begin SUPPORTED -->
 
 ### Supported Games
  - Metroid Prime
  - Metroid Prime 2: Echoes
  - Cave Story
 
+<!-- End SUPPORTED -->
+
+<!-- Begin EXPERIMENTAL -->
+
 ### Experimental Games
  - Metroid Prime 3: Corruption
  - Metroid Dread
  - Super Metroid
+
+<!-- End EXPERIMENTAL -->
+
+<!-- Begin WELCOME -->
 
 Here you will be able to randomize many aspects of either game, while still being ensured it's possible to 
 finish without any trick or glitch! What can be randomized?

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # Randovania
 
-Welcome to Randovania, a randomizer for Metroid Prime and Metroid Prime 2: Echoes.
+Welcome to Randovania, a randomizer platform for a multitude of games.
+
+<!-- Begin WELCOME -->
+
+### Supported Games
+ - Metroid Prime
+ - Metroid Prime 2: Echoes
+ - Cave Story
+
+### Experimental Games
+ - Metroid Prime 3: Corruption
+ - Metroid Dread
+ - Super Metroid
 
 Here you will be able to randomize many aspects of either game, while still being ensured it's possible to 
 finish without any trick or glitch! What can be randomized?
@@ -18,43 +30,77 @@ you can even shuffle items you normally start with, like the Power Beam and Scan
 
 So have fun and start randomizing.
 
-## Installation
+<!-- End WELCOME -->
 
-### Windows
+# Installation
+
+## Windows
 
 In the [releases page](https://github.com/randovania/randovania/releases), we have zip files
 with everything ready to use. Just extract and run!
 
-## Community
+<!-- Begin COMMUNITY -->
 
-Join the Metroid Prime Randomizer Discord: <https://discord.gg/metroid-prime-randomizer>
+# Community
 
-## Credits
-Game patching written by [Claris](https://www.twitch.tv/claris).
+Join the Randovania Discord: <https://discord.gg/M23gCxj6fw>
+
+Invite links for specific games' servers can be found in the `#game-communities` channel in our server.
+
+<!-- End COMMUNITY -->
+
+<!-- Begin CREDITS -->
+
+# Credits
 
 GUI and logic written by [Henrique Gemignani](https://github.com/henriquegemignani/), with contributions 
-by [SpaghettiToastBook](https://www.twitch.tv/spaghettitoastbook) and [gollop](https://github.com/gollop).
+by [SpaghettiToastBook](https://www.twitch.tv/spaghettitoastbook), [gollop](https://github.com/gollop) and [many others](https://github.com/randovania/randovania/graphs/contributors).
 
-Many thanks to Claris for making the original Echoes Randomizer and both collecting and providing this
-incredible initial set of data which powers Randovania.
+[BashPrime](https://www.twitch.tv/bashprime), [Pwootage](https://github.com/Pwootage), and [April Wade](https://github.com/aprilwade) made <https://randomizer.metroidprime.run/>, from which the GUI was based.
 
-Claris also made the included [Menu Mod](https://www.dropbox.com/s/yhqqafaxfo3l4vn/Echoes%20Menu.7z),
-a tool for practicing Echoes. For more information, see the
+## Games
+
+### Metroid Prime 1
+* Game patching via [randomprime](https://github.com/aprilwade/randomprime) from April Wade, with contributions from [UltiNaruto](https://github.com/UltiNaruto), BashPrime and toasterparty.
+* Room data collected by UltiNaruto, [EthanArmbrust](https://github.com/EthanArmbrust) and [samuelroy21](https://github.com/samuelroy21).
+
+### Metroid Prime 2: Echoes
+* Game patching written by [Claris](https://www.twitch.tv/claris).
+* Room data initially collected by Claris, revamped by [Dyceron](https://www.twitch.tv/dyceron).
+* [Menu Mod](https://www.dropbox.com/s/yhqqafaxfo3l4vn/Echoes%20Menu.7z) created by Claris. For more information, see the
 [Menu Mod README](https://www.dropbox.com/s/yhqqafaxfo3l4vn/Echoes%20Menu.7z?file_subpath=%2FEchoes+Menu%2Freadme.txt).
 
-Also thanks to [Dyceron](https://www.twitch.tv/dyceron) for motivation and testing.
+### Metroid Prime 3: Corruption
+* Game patching written by gollop.
+* Room data collected by Dyceron and [KirbymastaH](https://www.twitch.tv/kirbymastah).
 
-## Developer Help
+### Cave Story
+* Patcher and logic written by [duncathan_salt](https://twitter.com/duncathan_salt).
+* Based on the [original randomizer](https://shru.itch.io/cave-story-randomizer) by shru.
+* Features contributions from [many others](https://github.com/cave-story-randomizer/cave-story-randomizer/graphs/contributors).
 
-### Dependencies
+## Auto Tracker
+
+Classic theme uses assets derived from [this spritesheet](https://www.spriters-resource.com/custom_edited/metroidcustoms/sheet/23198/) from ChaosMiles07 and Ridleymaster, with edits from SpaghettiToastBook.
+
+Game theme assets were provided by [MaskedTAS](https://twitter.com/MaskedKirby).
+
+## Multiworld
+Server and logic written by Henrique, including Dolphin and Nintendont integrations. These were based on [Dolphin Memory Engine](https://github.com/aldelaro5/Dolphin-memory-engine) and Pwootage's Nintendont fork, respectively. In-game message alert initially written by [encounter](https://github.com/encounter).
+
+<!-- End CREDITS -->
+
+# Developer Help
+
+## Dependencies
 
 * [Python 3.9 64-bit](https://www.python.org/ftp/python/3.9.5/python-3.9.5-amd64.exe)
 * [Git](https://git-scm.com/downloads)
 
-### Setup
+## Setup
 
 Getting started:
-   1. Clone this repository
+   1. Clone this repository (downloading the zip is *not* supported and will not work)
    2. Open a terminal in the repository root
    3. Run the following file:
       1. Windows: `tools/prepare_virtual_env.bat`
@@ -84,5 +130,6 @@ Suggested IDE: [PyCharm Community](https://www.jetbrains.com/pycharm/download/)
 
 # Documentation
 
+- Unfamiliar with a term? Check the [glossary](docs/GLOSSARY.md).
 - Adding a new game? Check the [dedicated guide](docs/NEW_GAME.md).
 - Changing a data format? Check the [migrations documentation](docs/MIGRATIONS.md).

--- a/randovania.spec
+++ b/randovania.spec
@@ -25,6 +25,7 @@ a = Analysis(['randovania/__main__.py', 'randovania/cli/__init__.py'],
                  *item_databases,
                  *presets,
                  *game_assets,
+                 ("README.md", "README.md")
              ],
              hiddenimports=[
                 "mock",

--- a/randovania.spec
+++ b/randovania.spec
@@ -25,7 +25,7 @@ a = Analysis(['randovania/__main__.py', 'randovania/cli/__init__.py'],
                  *item_databases,
                  *presets,
                  *game_assets,
-                 ("README.md", "README.md")
+                 ("README.md", "data/")
              ],
              hiddenimports=[
                 "mock",

--- a/randovania/__init__.py
+++ b/randovania/__init__.py
@@ -18,6 +18,11 @@ def get_file_path() -> Path:
         file_dir = Path(__file__).parent
     return file_dir
 
+def get_readme() -> Path:
+    if is_frozen():
+        return get_file_path().joinpath("README.md")
+    return get_file_path().parent.joinpath("README.md")
+
 def get_data_path() -> Path:
     return get_file_path().joinpath("data")
 

--- a/randovania/__init__.py
+++ b/randovania/__init__.py
@@ -20,7 +20,7 @@ def get_file_path() -> Path:
 
 def get_readme() -> Path:
     if is_frozen():
-        return get_file_path().joinpath("README.md")
+        return get_data_path().joinpath("README.md")
     return get_file_path().parent.joinpath("README.md")
 
 def get_data_path() -> Path:

--- a/randovania/gui/main_window.py
+++ b/randovania/gui/main_window.py
@@ -2,6 +2,7 @@ import functools
 import json
 import logging
 import os
+import re
 from functools import partial
 from pathlib import Path
 from typing import Optional, List
@@ -10,7 +11,7 @@ from PySide2 import QtCore, QtWidgets, QtGui
 from PySide2.QtCore import QUrl, Signal, Qt
 from qasync import asyncSlot
 
-from randovania import VERSION, get_readme
+from randovania import VERSION, get_data_path, get_readme
 from randovania.game_description.resources.trick_resource_info import TrickResourceInfo
 from randovania.games.game import RandovaniaGame
 from randovania.patching.patcher_provider import PatcherProvider
@@ -94,10 +95,12 @@ class MainWindow(WindowManager, Ui_MainWindow):
         common_qt_lib.set_default_window_icon(self)
 
         self.setup_about_text()
+        self.setup_welcome_text()
+
+        self.set_icon_data_paths(self.database_viewer_label)
+        self.set_icon_data_paths(self.tracker_label)
 
         self.browse_racetime_label.setText(self.browse_racetime_label.text().replace("color:#0000ff;", ""))
-
-        self.setup_welcome_text()
 
         self._preset_manager = preset_manager
         self.network_client = network_client
@@ -598,6 +601,13 @@ class MainWindow(WindowManager, Ui_MainWindow):
         self.games_supported_label.setText(supported)
         self.games_experimental_label.setText(experimental)
         self.intro_welcome_label.setText(welcome)
+    
+    def set_icon_data_paths(self, label: QtWidgets.QLabel):
+        image_pattern = re.compile('<img src="data/(.*?)"/>')
+
+        repl = f'<img src="{get_data_path().as_posix()}/\g<1>"/>'
+        new_text = image_pattern.sub(repl, label.text())
+        label.setText(new_text)
 
 def get_readme_section(section: str) -> str:
     readme = get_readme().read_text()

--- a/randovania/gui/main_window.py
+++ b/randovania/gui/main_window.py
@@ -10,7 +10,7 @@ from PySide2 import QtCore, QtWidgets, QtGui
 from PySide2.QtCore import QUrl, Signal, Qt
 from qasync import asyncSlot
 
-from randovania import VERSION
+from randovania import VERSION, get_readme
 from randovania.game_description.resources.trick_resource_info import TrickResourceInfo
 from randovania.games.game import RandovaniaGame
 from randovania.patching.patcher_provider import PatcherProvider
@@ -33,7 +33,6 @@ _DISABLE_VALIDATION_WARNING = """
 Do <span style=" font-weight:600;">not</span> disable if you're uncomfortable with possibly unbeatable seeds.
 </p><p align="center">Are you sure you want to disable validation?</p></body></html>
 """
-
 
 def _t(key: str, disambiguation: Optional[str] = None):
     return QtCore.QCoreApplication.translate("MainWindow", key, disambiguation)
@@ -94,16 +93,11 @@ class MainWindow(WindowManager, Ui_MainWindow):
         self.setAcceptDrops(True)
         common_qt_lib.set_default_window_icon(self)
 
-        # Remove all hardcoded link color
-        about_document: QtGui.QTextDocument = self.about_text_browser.document()
-        about_document.setHtml(about_document.toHtml().replace("color:#0000ff;", ""))
-        cursor: QtGui.QTextCursor = self.about_text_browser.textCursor()
-        cursor.setPosition(0)
-        self.about_text_browser.setTextCursor(cursor)
+        self.setup_about_text()
 
         self.browse_racetime_label.setText(self.browse_racetime_label.text().replace("color:#0000ff;", ""))
 
-        self.intro_label.setText(self.intro_label.text().format(version=VERSION))
+        self.setup_welcome_text()
 
         self._preset_manager = preset_manager
         self.network_client = network_client
@@ -567,3 +561,51 @@ class MainWindow(WindowManager, Ui_MainWindow):
         from randovania.gui.corruption_layout_editor import CorruptionLayoutEditor
         self.corruption_editor = CorruptionLayoutEditor()
         self.corruption_editor.show()
+    
+    def setup_about_text(self):
+        ABOUT_TEXT = "\n".join([
+            "# Randovania",
+            "",
+            "<https://github.com/randovania/randovania>",
+            "",
+            "This software is covered by the [GNU General Public License v3 (GPLv3)](https://www.gnu.org/licenses/gpl-3.0.en.html)",
+            "",
+            "{community}",
+            "",
+            "{credits}",
+        ])
+
+        about_document: QtGui.QTextDocument = self.about_text_browser.document()
+        
+        # Populate from README.md
+        community = get_readme_section("COMMUNITY")
+        credit = get_readme_section("CREDITS")
+        about_document.setMarkdown(ABOUT_TEXT.format(community=community, credits=credit))
+
+        # Remove all hardcoded link color
+        about_document.setHtml(about_document.toHtml().replace("color:#0000ff;", ""))
+        cursor: QtGui.QTextCursor = self.about_text_browser.textCursor()
+        cursor.setPosition(0)
+        self.about_text_browser.setTextCursor(cursor)
+    
+    def setup_welcome_text(self):
+        self.intro_label.setText(self.intro_label.text().format(version=VERSION))
+
+        welcome = get_readme_section("WELCOME")
+        supported = get_readme_section("SUPPORTED")
+        experimental = get_readme_section("EXPERIMENTAL")
+
+        self.games_supported_label.setText(supported)
+        self.games_experimental_label.setText(experimental)
+        self.intro_welcome_label.setText(welcome)
+
+def get_readme_section(section: str) -> str:
+    readme = get_readme().read_text()
+
+    start_comment = f"<!-- Begin {section} -->\n"
+    end_comment = f"<!-- End {section} -->"
+
+    start = readme.find(start_comment) + len(start_comment)
+    end = readme.find(end_comment)
+
+    return readme[start:end]

--- a/randovania/gui/ui_files/main_window.ui
+++ b/randovania/gui/ui_files/main_window.ui
@@ -49,14 +49,7 @@
         <property name="bottomMargin">
          <number>0</number>
         </property>
-        <item row="5" column="2">
-         <widget class="QPushButton" name="open_database_viewer_button">
-          <property name="text">
-           <string>Open Database Viewer</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
+        <item row="3" column="1">
          <spacer name="intro_vertical_spacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -69,20 +62,23 @@
           </property>
          </spacer>
         </item>
-        <item row="6" column="1">
-         <spacer name="intro_bottom_spacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
+        <item row="2" column="0" colspan="3">
+         <widget class="QLabel" name="intro_welcome_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
+          <property name="textFormat">
+           <enum>Qt::MarkdownText</enum>
           </property>
-         </spacer>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
         </item>
-        <item row="3" column="1">
+        <item row="5" column="1">
          <spacer name="intro_top_spacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -95,27 +91,14 @@
           </property>
          </spacer>
         </item>
-        <item row="5" column="0">
+        <item row="7" column="0">
          <widget class="QPushButton" name="open_faq_button">
           <property name="text">
            <string>Open FAQ</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="0" colspan="3">
-         <widget class="QLabel" name="help_offer_label">
-          <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;hr/&gt;&lt;p&gt;Want to learn more about the randomizer?&lt;/p&gt;&lt;p&gt;Check out the &lt;span style=&quot; font-weight:600;&quot;&gt;FAQ &lt;/span&gt;for surprising behaviour of the game.&lt;br/&gt;Check the Database to check what's required to progress in each room.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
+        <item row="4" column="1">
          <widget class="QPushButton" name="intro_play_now_button">
           <property name="font">
            <font>
@@ -132,7 +115,10 @@
         <item row="0" column="0" colspan="3">
          <widget class="QLabel" name="intro_label">
           <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Welcome to Randovania {version}, a randomizer for Metroid Prime and Metroid Prime 2: Echoes.&lt;/p&gt;&lt;p&gt;Here you will be able to randomize many aspects of either game, while still being ensured it's possible to finish without any trick or glitch! What can be randomized?&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Randomize what can be found in each pickup location, including major upgrades, expansions, keys and artifacts.&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Play with multiple people, via multiworld sessions. Your pickups will be shuffled among the games of everyone involved, no matter what game they're playing!&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Randomize where each teleporter goes, or what you need to unlock a translator gate. In either case, there's advanced options for how they're shuffled.&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The location you start the game in as well as the items you start with. If you're feeling brave, you can even shuffle items you normally start with, like the Power Beam and Scan Visor.&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;So have fun and start randomizing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>Welcome to Randovania {version}, a randomizer for a multitude of games.</string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::MarkdownText</enum>
           </property>
           <property name="scaledContents">
            <bool>false</bool>
@@ -153,6 +139,84 @@
            <bool>false</bool>
           </property>
          </widget>
+        </item>
+        <item row="6" column="0" colspan="3">
+         <widget class="QLabel" name="help_offer_label">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;hr/&gt;&lt;p&gt;Want to learn more about the randomizer?&lt;/p&gt;&lt;p&gt;Check out the &lt;span style=&quot; font-weight:600;&quot;&gt;FAQ &lt;/span&gt;for surprising behaviour of the game.&lt;br/&gt;Check the Database to check what's required to progress in each room.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="1">
+         <spacer name="intro_bottom_spacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="7" column="2">
+         <widget class="QPushButton" name="open_database_viewer_button">
+          <property name="text">
+           <string>Open Database Viewer</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0" colspan="3">
+         <layout class="QHBoxLayout" name="intro_games_layout">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <property name="sizeConstraint">
+           <enum>QLayout::SetMaximumSize</enum>
+          </property>
+          <item>
+           <widget class="QLabel" name="games_supported_label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Supported</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::MarkdownText</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="games_experimental_label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Experimental</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::MarkdownText</enum>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>
@@ -556,7 +620,7 @@
              <x>0</x>
              <y>0</y>
              <width>302</width>
-             <height>442</height>
+             <height>456</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="create_scroll_area_layout">
@@ -653,7 +717,7 @@
                  <x>0</x>
                  <y>0</y>
                  <width>603</width>
-                 <height>860</height>
+                 <height>724</height>
                 </rect>
                </property>
                <layout class="QGridLayout" name="multiworld_scroll_contents_layout">
@@ -703,8 +767,8 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>98</width>
-                 <height>1296</height>
+                 <width>84</width>
+                 <height>1328</height>
                 </rect>
                </property>
                <layout class="QVBoxLayout" name="tracker_scroll_area_layout">
@@ -754,8 +818,8 @@
                 <rect>
                  <x>0</x>
                  <y>0</y>
-                 <width>123</width>
-                 <height>2169</height>
+                 <width>122</width>
+                 <height>1845</height>
                 </rect>
                </property>
                <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -863,7 +927,7 @@
                      <x>0</x>
                      <y>0</y>
                      <width>613</width>
-                     <height>477</height>
+                     <height>488</height>
                     </rect>
                    </property>
                    <layout class="QGridLayout" name="gridLayout_10">
@@ -925,8 +989,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>35</height>
+                     <width>84</width>
+                     <height>31</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="differences_scroll_layout_5">
@@ -979,8 +1043,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>268</height>
+                     <width>84</width>
+                     <height>277</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="hints_scroll_layout_4">
@@ -1036,8 +1100,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>386</height>
+                     <width>88</width>
+                     <height>385</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="hint_item_names_scroll_layout_4">
@@ -1120,8 +1184,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>352</height>
+                     <width>88</width>
+                     <height>359</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="hint_scroll_layout_4">
@@ -1206,8 +1270,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>108</width>
-                     <height>2507</height>
+                     <width>111</width>
+                     <height>1962</height>
                     </rect>
                    </property>
                    <layout class="QGridLayout" name="gridLayout_8">
@@ -1257,8 +1321,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>123</width>
-                     <height>3942</height>
+                     <width>125</width>
+                     <height>3065</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="differences_scroll_layout_3">
@@ -1311,8 +1375,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>3486</height>
+                     <width>84</width>
+                     <height>3485</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="echoes_hints_scroll_layout">
@@ -1368,8 +1432,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>386</height>
+                     <width>88</width>
+                     <height>385</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="echoes_hint_item_names_scroll_layout">
@@ -1452,8 +1516,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>352</height>
+                     <width>88</width>
+                     <height>359</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="echoes_hint_scroll_layout">
@@ -1538,8 +1602,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>86</height>
+                     <width>84</width>
+                     <height>83</height>
                     </rect>
                    </property>
                    <layout class="QGridLayout" name="gridLayout_9">
@@ -1589,8 +1653,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>35</height>
+                     <width>84</width>
+                     <height>31</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="differences_scroll_layout_4">
@@ -1643,8 +1707,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>285</height>
+                     <width>84</width>
+                     <height>251</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="corruption_hints_scroll_layout">
@@ -1700,8 +1764,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>386</height>
+                     <width>88</width>
+                     <height>385</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="corruption_hint_item_names_scroll_layout">
@@ -1784,8 +1848,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>352</height>
+                     <width>88</width>
+                     <height>359</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="corruption_hint_scroll_layout">
@@ -1870,8 +1934,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>613</width>
-                     <height>488</height>
+                     <width>109</width>
+                     <height>1280</height>
                     </rect>
                    </property>
                    <layout class="QGridLayout" name="gridLayout_9">
@@ -1934,8 +1998,8 @@ If you're still stuck, join our [official Discord server](https://discord.gg/7zU
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>599</width>
-                     <height>685</height>
+                     <width>188</width>
+                     <height>1738</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="differences_scroll_layout_4">
@@ -2025,8 +2089,8 @@ Note that there are a few key differences from the vanilla game in order to impr
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>613</width>
-                     <height>488</height>
+                     <width>84</width>
+                     <height>771</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="cs_hints_scroll_layout">
@@ -2095,8 +2159,8 @@ Note that there are a few key differences from the vanilla game in order to impr
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>346</height>
+                     <width>88</width>
+                     <height>385</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="cs_hint_item_names_scroll_layout">
@@ -2179,8 +2243,8 @@ Note that there are a few key differences from the vanilla game in order to impr
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>98</width>
-                     <height>333</height>
+                     <width>88</width>
+                     <height>359</height>
                     </rect>
                    </property>
                    <layout class="QVBoxLayout" name="cs_hint_scroll_layout">
@@ -2242,28 +2306,6 @@ Note that there are a few key differences from the vanilla game in order to impr
           <property name="frameShape">
            <enum>QFrame::NoFrame</enum>
           </property>
-          <property name="html">
-           <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;Randovania&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/randovania/randovania&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/randovania/randovania&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;&lt;br /&gt;This software is covered by the &lt;/span&gt;&lt;a href=&quot;https://www.gnu.org/licenses/gpl-3.0.en.html&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;GNU General Public License v3 (GPLv3)&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;Community&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Make sure to visit the Metroid Prime Randomizer Discord server!&lt;br /&gt;&lt;/span&gt;&lt;a href=&quot;https://discordapp.com/invite/gymstUz&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;https://discordapp.com/invite/gymstUz&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;Credits&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;GUI and logic written by &lt;/span&gt;&lt;a href=&quot;https://github.com/henriquegemignani&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Henrique Gemignani&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, with contributions by &lt;/span&gt;&lt;a href=&quot;https://www.twitch.tv/spaghettitoastbook&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;SpaghettiToastBook&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, &lt;/span&gt;&lt;a href=&quot;https://github.com/gollop&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;gollop&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; and &lt;/span&gt;&lt;a href=&quot;https://www.twitch.tv/dyceron&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Dyceron&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://www.twitch.tv/bashprime&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;BashPrime&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, &lt;/span&gt;&lt;a href=&quot;https://github.com/Pwootage/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Pwootage&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, and &lt;/span&gt;&lt;a href=&quot;https://github.com/aprilwade&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;April Wade&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; made &lt;/span&gt;&lt;a href=&quot;https://randomizer.metroidprime.run/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;https://randomizer.metroidprime.run/&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, from which the GUI was based.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;Auto Tracker&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Classic theme uses assets derived from &lt;/span&gt;&lt;a href=&quot;https://www.spriters-resource.com/custom_edited/metroidcustoms/sheet/23198/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;this spritesheet&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; from ChaosMiles07 and Ridleymaster, with edits from SpaghettiToastBook.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Game theme assets were provided by &lt;/span&gt;&lt;a href=&quot;https://twitter.com/MaskedKirby&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;MaskedTAS&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;Multiworld&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Server and logic written by Henrique, including Dolphin and Nintendont integrations. These were based on &lt;/span&gt;&lt;a href=&quot;https://github.com/aldelaro5/Dolphin-memory-engine&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Dolphin Memory Engine&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; and Pwootage's Nintendont fork, respectively. In-game message alert initially written by &lt;/span&gt;&lt;a href=&quot;https://github.com/encounter&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;encounter&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;Metroid Prime 1&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;&lt;br /&gt;* Game patching via &lt;/span&gt;&lt;a href=&quot;https://github.com/aprilwade/randomprime&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;randomprime&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; from April Wade, with contributions from &lt;/span&gt;&lt;a href=&quot;https://github.com/UltiNaruto&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;UltiNaruto&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, BashPrime and &lt;/span&gt;&lt;a href=&quot;https://github.com/toasterparty/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;toasterparty&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;.&lt;br /&gt;* Room data collected by UltiNaruto, &lt;/span&gt;&lt;a href=&quot;https://github.com/EthanArmbrust&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;EthanArmbrust&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; and &lt;/span&gt;&lt;a href=&quot;https://github.com/samuelroy21&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;samuelroy21&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;Metroid Prime 2: Echoes&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;&lt;br /&gt;* Game patching written by &lt;/span&gt;&lt;a href=&quot;https://www.twitch.tv/claris&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Claris&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;.&lt;br /&gt;* Room data initially collected by Claris, revamped by Dyceron.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;Metroid Prime 3: Corruption&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;&lt;br /&gt;* Game patching written by gollop.&lt;br /&gt;* Room data collected by Dyceron and &lt;/span&gt;&lt;a href=&quot;https://www.twitch.tv/kirbymastah&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;KirbymastaH&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;Cave Story&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;&lt;br /&gt;* Created by duncathan_salt.&lt;br /&gt;* Based on the original randomizer by shru.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
           <property name="openExternalLinks">
            <bool>true</bool>
           </property>
@@ -2281,7 +2323,7 @@ p, li { white-space: pre-wrap; }
      <x>0</x>
      <y>0</y>
      <width>645</width>
-     <height>22</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_open">


### PR DESCRIPTION
Fixes #2595 

Updates README.md with the new games, discord link, and info from the GUI, and makes the GUI pull from sections in the README to populate its text so that we only need to keep it up to date in one place. Also fixes an unrelated issue where images in the Help tab weren't displayed when running from source.

![welcome tab](https://user-images.githubusercontent.com/2979303/149855115-f5ac1ce2-2e1b-4177-aadb-1559568bd07c.png)

![about tab](https://user-images.githubusercontent.com/2979303/149855170-62f40cee-d14f-4d70-8950-eca04078c6f9.png)
