### PR TITLE
Dread: Fix Artaria Dock to David Jaffe room logic

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -8489,35 +8489,72 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Charge",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "IBJ",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Lay Bomb"
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "events",
-                                                        "name": "s010_cave:default:PRP_CV_ThermalDevice",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Charge",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "events",
+                                                                                "name": "s010_cave:default:PRP_CV_ThermalDevice",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -8508,13 +8508,8 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Bomb",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
+                                                                "type": "template",
+                                                                "data": "Lay Bomb"
                                                             }
                                                         ]
                                                     }

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -8531,7 +8531,7 @@
                                                             {
                                                                 "type": "or",
                                                                 "data": {
-                                                                    "comment": null,
+                                                                    "comment": "TODO: Take doors into consideration without hard-setting the item requirements. This is done this way atm because of the doors that permit speed booster charging.",
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -8496,6 +8496,32 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Charge",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s010_cave:default:PRP_CV_ThermalDevice",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -8508,8 +8508,13 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "template",
-                                                                "data": "Lay Bomb"
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Bomb",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             }
                                                         ]
                                                     }

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -1950,7 +1950,7 @@ Extra - asset_id: collision_camera_022
       All of the following:
           Morph Ball
           Any of the following:
-              Bomb and Infinite Bomb Jump (Intermediate)
+              Infinite Bomb Jump (Intermediate) and Lay Bomb
               All of the following:
                   Speed Booster
                   Charge Beam or After Artaria - Thermal Device

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -1947,7 +1947,9 @@ Extra - asset_id: collision_camera_022
   > Door to Magma Flow Vista
       Trivial
   > Dock to David Jaffe Room
-      Morph Ball and Speed Booster
+      All of the following:
+          Morph Ball and Speed Booster
+          Charge Beam or After Artaria - Thermal Device
 
 > Door to Thermal Device; Heals? False
   * Artaria Thermal Door to Thermal Device/Door to Thermal Door Tutorial

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -1950,7 +1950,7 @@ Extra - asset_id: collision_camera_022
       All of the following:
           Morph Ball
           Any of the following:
-              Infinite Bomb Jump (Intermediate) and Lay Bomb
+              Bomb and Infinite Bomb Jump (Intermediate)
               All of the following:
                   Speed Booster
                   Charge Beam or After Artaria - Thermal Device

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -1948,8 +1948,12 @@ Extra - asset_id: collision_camera_022
       Trivial
   > Dock to David Jaffe Room
       All of the following:
-          Morph Ball and Speed Booster
-          Charge Beam or After Artaria - Thermal Device
+          Morph Ball
+          Any of the following:
+              Infinite Bomb Jump (Intermediate) and Lay Bomb
+              All of the following:
+                  Speed Booster
+                  Charge Beam or After Artaria - Thermal Device
 
 > Door to Thermal Device; Heals? False
   * Artaria Thermal Door to Thermal Device/Door to Thermal Door Tutorial

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -1953,7 +1953,9 @@ Extra - asset_id: collision_camera_022
               Infinite Bomb Jump (Intermediate) and Lay Bomb
               All of the following:
                   Speed Booster
-                  Charge Beam or After Artaria - Thermal Device
+                  Any of the following:
+                      # TODO: Take doors into consideration without hard-setting the item requirements. This is done this way atm because of the doors that permit speed booster charging.
+                      Charge Beam or After Artaria - Thermal Device
 
 > Door to Thermal Device; Heals? False
   * Artaria Thermal Door to Thermal Device/Door to Thermal Door Tutorial


### PR DESCRIPTION
Speed Booster+Morph Ball entrance is only possible when either Charge Beam door or Thermal door are open.