### PR TITLE
Fix Dread db to be strongly connected

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -13448,7 +13448,7 @@
                         "node_name": "Door to Chain Reaction Access"
                     },
                     "dock_type": "door",
-                    "dock_weakness": "Charge Beam Door",
+                    "dock_weakness": "Super Missile Door",
                     "connections": {
                         "Room Middle": {
                             "type": "and",
@@ -13611,7 +13611,7 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Shoot Super Missile"
+                                        "data": "Shoot Charge Beam"
                                     }
                                 ]
                             }
@@ -17585,7 +17585,7 @@
             }
         },
         "Proto EMMI CU": {
-            "default_node": "Start Point 2",
+            "default_node": "Start Point",
             "valid_starting_location": true,
             "extra": {
                 "total_boundings": {
@@ -17639,30 +17639,7 @@
                         }
                     }
                 },
-                "Start Point 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 22750.0,
-                        "y": -2350.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "PRP_CV_CentralUnitProto",
-                        "start_point_actor_def": "actordef:actors/props/centralunitprotocontroller/charclasses/centralunitprotocontroller.bmsad"
-                    },
-                    "connections": {
-                        "Event - Proto Central Unit": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point 2": {
+                "Start Point": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -3030,7 +3030,7 @@ Extra - asset_id: collision_camera_055
       Morph Ball
 
 > Door to Teleport to Cataris; Heals? False
-  * Charge Beam Door to Teleport to Cataris/Door to Chain Reaction Access
+  * Super Missile Door to Teleport to Cataris/Door to Chain Reaction Access
   * Extra - actor_name: Door054
   * Extra - actor_def: actordef:actors/props/doorchargecharge/charclasses/doorchargecharge.bmsad
   * Extra - left_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorshieldsupermissile_000
@@ -3075,7 +3075,7 @@ Extra - asset_id: collision_camera_055
   > Door to Teleport to Cataris
       All of the following:
           # TODO: The dock is a charge beam door with a super missile lock. Handle this with the dock, and not with a node path.
-          Shoot Super Missile
+          Shoot Charge Beam
   > Dock to Teleport to Cataris (Tunnel)
       Trivial
 
@@ -4017,13 +4017,7 @@ Extra - asset_id: collision_camera_074
   > Dock to Proto EMMI Battle
       Trivial
 
-> Start Point 1; Heals? False
-  * Extra - start_point_actor_name: PRP_CV_CentralUnitProto
-  * Extra - start_point_actor_def: actordef:actors/props/centralunitprotocontroller/charclasses/centralunitprotocontroller.bmsad
-  > Event - Proto Central Unit
-      Trivial
-
-> Start Point 2; Heals? False; Spawn Point
+> Start Point; Heals? False; Spawn Point
   * Extra - start_point_actor_name: SP_Checkpoint_CURoom
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Event - Proto Central Unit

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -142,7 +142,7 @@
             }
         },
         "Upper Burenia Hub": {
-            "default_node": "Start Point 2",
+            "default_node": "Start Point",
             "valid_starting_location": true,
             "extra": {
                 "total_boundings": {
@@ -268,6 +268,13 @@
                                 ]
                             }
                         },
+                        "Start Point": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Dock to Transport to Ghavoran": {
                             "type": "and",
                             "data": {
@@ -371,30 +378,7 @@
                         }
                     }
                 },
-                "Start Point 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -2600.0,
-                        "y": 5000.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_AccessPoint_5",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to Navigation Room North": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point 2": {
+                "Start Point": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -1812,29 +1796,6 @@
                         }
                     }
                 },
-                "Start Point": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 6900.0,
-                        "y": 6000.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "StartPoint0",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to Burenia Hub to Dairon": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Tram to Dairon - Upper Transport to Burenia": {
                     "node_type": "teleporter",
                     "heal": false,
@@ -2644,15 +2605,7 @@
                             "WEIGHT"
                         ]
                     },
-                    "connections": {
-                        "Dock to Underneath Drogyga (Upper)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
+                    "connections": {}
                 },
                 "Tile Group (WEIGHT) 2": {
                     "node_type": "generic",
@@ -2671,15 +2624,7 @@
                             "WEIGHT"
                         ]
                     },
-                    "connections": {
-                        "Dock to Underneath Drogyga (Upper)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
+                    "connections": {}
                 },
                 "Dock to Underneath Drogyga (Upper)": {
                     "node_type": "dock",
@@ -4400,7 +4345,15 @@
                     },
                     "dock_type": "other",
                     "dock_weakness": "Open Passage",
-                    "connections": {}
+                    "connections": {
+                        "Door to Flash Shift Room (Lower)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 },
                 "Door to collision_camera_012 (B)": {
                     "node_type": "dock",
@@ -4551,6 +4504,13 @@
                                 "items": []
                             }
                         },
+                        "Door to Flash Shift Room (Upper)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Upper Left Magnet Wall": {
                             "type": "and",
                             "data": {
@@ -4584,7 +4544,15 @@
                     },
                     "dock_type": "door",
                     "dock_weakness": "Phase Shift Door",
-                    "connections": {}
+                    "connections": {
+                        "Door to Save Station Middle": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 },
                 "Door to Flash Shift Room (Lower)": {
                     "node_type": "dock",
@@ -8128,29 +8096,6 @@
                         }
                     }
                 },
-                "Start Point": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 200.0,
-                        "y": -3000.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_Checkpoint_Trench",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to Main Hub Tower Middle (Plasma)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Tile Group (BOMB)": {
                     "node_type": "configurable_node",
                     "heal": false,
@@ -8724,52 +8669,6 @@
                                 "name": "Morph",
                                 "amount": 1,
                                 "negate": false
-                            }
-                        }
-                    }
-                },
-                "Start Point 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 12800.0,
-                        "y": -8000.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_Checkpoint_Cooldown",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Elevator to Artaria - Transport to Burenia": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point 2": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 11400.0,
-                        "y": -7900.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_AccessPoint_9B",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to Navigation Room South": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }
@@ -10018,6 +9917,13 @@
                     "dock_type": "door",
                     "dock_weakness": "Power Beam Door",
                     "connections": {
+                        "Start Point 4": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Tile Group (SCREWATTACK) 2": {
                             "type": "or",
                             "data": {
@@ -10325,6 +10231,13 @@
                     "dock_type": "door",
                     "dock_weakness": "Access Open",
                     "connections": {
+                        "Start Point 1": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Breakable Floor": {
                             "type": "resource",
                             "data": {
@@ -10565,7 +10478,15 @@
                         "start_point_actor_name": "SP_AccessPoint_9",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "connections": {}
+                    "connections": {
+                        "Door to Navigation Room South": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 },
                 "Tile Group (SCREWATTACK) 1": {
                     "node_type": "configurable_node",
@@ -11588,7 +11509,7 @@
                         "y": -11200.0,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "Door is normally a Power Beam door, but it's a missile door right now to dodge\nthe blast shield issue.\n\n",
                     "extra": {
                         "actor_name": "doorpowerpower_015",
                         "actor_def": "actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad",
@@ -11603,18 +11524,18 @@
                         "node_name": "Door to Gravity Suit Room (Upper)"
                     },
                     "dock_type": "door",
-                    "dock_weakness": "Power Beam Door",
+                    "dock_weakness": "Missile Door",
                     "connections": {
-                        "Pickup (Gravity Suit)": {
+                        "Event - Blob from above (db_reg_aq_004)": {
+                            "type": "template",
+                            "data": "Shoot Diffusion or Wave"
+                        },
+                        "Start Point": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
-                        },
-                        "Event - Blob from above (db_reg_aq_004)": {
-                            "type": "template",
-                            "data": "Shoot Diffusion or Wave"
                         }
                     }
                 },
@@ -11634,7 +11555,7 @@
                     "pickup_index": 79,
                     "major_location": true,
                     "connections": {
-                        "Door to Gravity Suit Tower (Upper)": {
+                        "Start Point": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11778,6 +11699,13 @@
                     },
                     "connections": {
                         "Door to Gravity Suit Tower (Upper)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Pickup (Gravity Suit)": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -64,6 +64,8 @@ Extra - asset_id: collision_camera_001
       Morph Ball
   > Door to Map Station
       Morph Ball and After Quiet Robe
+  > Start Point
+      Trivial
   > Dock to Transport to Ghavoran
       Morph Ball and After Quiet Robe
 
@@ -85,13 +87,7 @@ Extra - asset_id: collision_camera_001
   > Tile Group (MISSILE)
       Morph Ball
 
-> Start Point 1; Heals? False
-  * Extra - start_point_actor_name: SP_AccessPoint_5
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Navigation Room North
-      Trivial
-
-> Start Point 2; Heals? False; Spawn Point
+> Start Point; Heals? False; Spawn Point
   * Extra - start_point_actor_name: SP_Checkpoint_DoorProfessor
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to Navigation Room North
@@ -362,12 +358,6 @@ Extra - asset_id: collision_camera_003
   > Tram to Dairon - Upper Transport to Burenia
       Trivial
 
-> Start Point; Heals? False
-  * Extra - start_point_actor_name: StartPoint0
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Burenia Hub to Dairon
-      Trivial
-
 > Tram to Dairon - Upper Transport to Burenia; Heals? False; Spawn Point
   * Teleporter to Dairon - Upper Transport to Burenia
   * Extra - actor_name: wagontrain_baselab_000
@@ -546,16 +536,12 @@ Extra - asset_id: collision_camera_006
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('WEIGHT',)
-  > Dock to Underneath Drogyga (Upper)
-      Trivial
 
 > Tile Group (WEIGHT) 2; Heals? False
   * Extra - actor_name: breakabletilegroup_032
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('WEIGHT',)
-  > Dock to Underneath Drogyga (Upper)
-      Trivial
 
 > Dock to Underneath Drogyga (Upper); Heals? False
   * Morph Ball Tunnel to Underneath Drogyga/Dock to Transport to Ghavoran (Upper)
@@ -901,6 +887,8 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
 
 > Dock to Main Hub Tower Middle (Right); Heals? False
   * Open Passage to Main Hub Tower Middle/Dock to Main Hub Tower Top (Right)
+  > Door to Flash Shift Room (Lower)
+      Trivial
 
 > Door to collision_camera_012 (B); Heals? False
   * Phase Shift Door to collision_camera_012 (B)/Door to Main Hub Tower Top
@@ -938,6 +926,8 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
   * Extra - right_shield_def: None
   > Dock to Main Hub Tower Middle (Left)
       Trivial
+  > Door to Flash Shift Room (Upper)
+      Trivial
   > Upper Left Magnet Wall
       Trivial
 
@@ -949,6 +939,8 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  > Door to Save Station Middle
+      Trivial
 
 > Door to Flash Shift Room (Lower); Heals? False
   * Power Beam Door to Flash Shift Room/Door from Main Hub Tower Top
@@ -1632,12 +1624,6 @@ Extra - asset_id: collision_camera_015
   > Door from Gravity Suit Tower
       Trivial
 
-> Start Point; Heals? False
-  * Extra - start_point_actor_name: SP_Checkpoint_Trench
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Main Hub Tower Middle (Plasma)
-      Trivial
-
 > Tile Group (BOMB); Heals? False
   * Configurable Node
   * Extra - actor_name: breakabletilegroup_003
@@ -1771,18 +1757,6 @@ Extra - asset_id: collision_camera_017
       Flash Shift or Gravity Suit or Water Bomb Jump (Beginner) or Use Spin Boost
   > Tile Group (SCREWATTACK) 1
       Morph Ball
-
-> Start Point 1; Heals? False
-  * Extra - start_point_actor_name: SP_Checkpoint_Cooldown
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Elevator to Artaria - Transport to Burenia
-      Trivial
-
-> Start Point 2; Heals? False
-  * Extra - start_point_actor_name: SP_AccessPoint_9B
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Navigation Room South
-      Trivial
 
 > Tile Group (SCREWATTACK) 1; Heals? False
   * Configurable Node
@@ -2016,6 +1990,8 @@ Extra - asset_id: collision_camera_021
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  > Start Point 4
+      Trivial
   > Tile Group (SCREWATTACK) 2
       Flash Shift or Speed Booster or Simple IBJ or Use Spin Boost
   > Breakable Floor
@@ -2088,6 +2064,8 @@ Extra - asset_id: collision_camera_021
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  > Start Point 1
+      Trivial
   > Breakable Floor
       After Burenia - Destroy Gravity Suit Floor
   > Dock to Ammo Recharge Room (Tunnel)
@@ -2146,6 +2124,8 @@ Extra - asset_id: collision_camera_021
 > Start Point 4; Heals? False; Spawn Point
   * Extra - start_point_actor_name: SP_AccessPoint_9
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
+  > Door to Navigation Room South
+      Trivial
 
 > Tile Group (SCREWATTACK) 1; Heals? False
   * Configurable Node
@@ -2359,23 +2339,27 @@ Extra - total_boundings: {'x1': 2000.0, 'x2': 4100.0, 'y1': -12150.0, 'y2': -980
 Extra - polygon: [[4100.0, -9800.0], [2000.0, -9800.0], [2000.0, -12150.0], [3500.0, -12150.0], [3500.0, -12500.0], [4100.0, -12500.0]]
 Extra - asset_id: collision_camera_023_B
 > Door to Gravity Suit Tower (Upper); Heals? False
-  * Power Beam Door to Gravity Suit Tower/Door to Gravity Suit Room (Upper)
+  * Missile Door to Gravity Suit Tower/Door to Gravity Suit Room (Upper)
+  * Door is normally a Power Beam door, but it's a missile door right now to dodge
+the blast shield issue.
+
+
   * Extra - actor_name: doorpowerpower_015
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorshieldmissile_001
   * Extra - right_shield_def: actordef:actors/props/doorshieldmissile/charclasses/doorshieldmissile.bmsad
-  > Pickup (Gravity Suit)
-      Trivial
   > Event - Blob from above (db_reg_aq_004)
       Shoot Diffusion or Wave
+  > Start Point
+      Trivial
 
 > Pickup (Gravity Suit); Heals? False
   * Pickup 79; Major Location? True
   * Extra - actor_name: itemsphere_gravitysuit
   * Extra - actor_def: actordef:actors/items/itemsphere_gravitysuit/charclasses/itemsphere_gravitysuit.bmsad
-  > Door to Gravity Suit Tower (Upper)
+  > Start Point
       Trivial
 
 > Pickup (item_powerbombtank_000); Heals? False
@@ -2409,6 +2393,8 @@ Extra - asset_id: collision_camera_023_B
   * Extra - start_point_actor_name: SP_Checkpoint_GravitySuit
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to Gravity Suit Tower (Upper)
+      Trivial
+  > Pickup (Gravity Suit)
       Trivial
 
 > Tile Group (SPEEDBOOST); Heals? False

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -207,29 +207,6 @@
                         }
                     }
                 },
-                "Start Point 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 12925.0,
-                        "y": -1675.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "StartPoint0",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Elevator to Artaria - Transport to Cataris": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Elevator to Artaria - Transport to Cataris": {
                     "node_type": "teleporter",
                     "heal": false,
@@ -262,29 +239,6 @@
                             }
                         },
                         "Tile Group (POWERBEAM) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point 2": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 8700.0,
-                        "y": -5800.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_AccessPoint_3",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to Navigation Room Southeast": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9287,7 +9241,7 @@
                                 ]
                             }
                         },
-                        "Event - Morph Tunnel Blob (db_dside_mg_003)": {
+                        "Event - Morph Tunnel Blob": {
                             "type": "template",
                             "data": "Shoot Beam"
                         },
@@ -9404,7 +9358,7 @@
                         }
                     }
                 },
-                "Event - Morph Tunnel Blob (db_dside_mg_003)": {
+                "Event - Morph Tunnel Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -9462,29 +9416,6 @@
                             }
                         },
                         "Tile Group (WEIGHT) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -15000.0,
-                        "y": 5000.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_AccessPoint_3_B",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to Navigation Room Northwest": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9609,7 +9540,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "s020_magma:default:db_dside_mg_002b_000",
+                                "name": "s020_magma:default:db_dside_mg_003",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -9741,7 +9672,7 @@
                         }
                     }
                 },
-                "Event - Lower-left Tunnel Blob (db_dside_mg_003)": {
+                "Event - Lower-left Tunnel Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -9789,7 +9720,7 @@
                         }
                     }
                 },
-                "Event - Green Teleport Grapple Block (grapplepulloff1x2_001)": {
+                "Event - Green Teleport Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -9837,7 +9768,7 @@
                     "keep_name_when_vanilla": true,
                     "editable": true,
                     "connections": {
-                        "Event - Green Teleport Grapple Block (grapplepulloff1x2_001)": {
+                        "Event - Green Teleport Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -10148,7 +10079,7 @@
                     "description": "",
                     "extra": {},
                     "connections": {
-                        "Event - Lower-left Tunnel Blob (db_dside_mg_003)": {
+                        "Event - Lower-left Tunnel Blob": {
                             "type": "template",
                             "data": "Shoot Beam"
                         },
@@ -10390,6 +10321,13 @@
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Tile Group (POWERBEAM) 1": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         },
                         "Dock to collision_camera_027 (C)": {
@@ -13004,7 +12942,7 @@
             }
         },
         "Green EMMI Fight": {
-            "default_node": "Start Point 2",
+            "default_node": "Start Point",
             "valid_starting_location": true,
             "extra": {
                 "total_boundings": {
@@ -13164,30 +13102,7 @@
                         }
                     }
                 },
-                "Start Point 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -7000.0,
-                        "y": 5400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_Checkpoint_CentralUnit",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to Central Unit Room": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point 2": {
+                "Start Point": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -13434,7 +13349,7 @@
             }
         },
         "Central Unit Room": {
-            "default_node": "Start Point 2",
+            "default_node": "Start Point",
             "valid_starting_location": true,
             "extra": {
                 "total_boundings": {
@@ -13464,30 +13379,7 @@
                 "asset_id": "collision_camera_037"
             },
             "nodes": {
-                "Start Point 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -8650.0,
-                        "y": 5550.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "centralunitmagmacontroller",
-                        "start_point_actor_def": "actordef:actors/props/centralunitmagmacontroller/charclasses/centralunitmagmacontroller.bmsad"
-                    },
-                    "connections": {
-                        "Door to Green EMMI Fight": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point 2": {
+                "Start Point": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -13588,21 +13480,6 @@
                 "asset_id": "collision_camera_038"
             },
             "nodes": {
-                "Start Point 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 1425.0,
-                        "y": 5250.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "shootactivatormag01",
-                        "start_point_actor_def": "actordef:actors/props/shootactivatormag01/charclasses/shootactivatormag01.bmsad"
-                    },
-                    "connections": {}
-                },
                 "Start Point 2": {
                     "node_type": "generic",
                     "heal": false,
@@ -14099,7 +13976,7 @@
                         "node_name": "Dock to Speedboost Maze before Transport to Dairon (Bottom)"
                     },
                     "dock_type": "other",
-                    "dock_weakness": "Not Determined",
+                    "dock_weakness": "Open Passage",
                     "connections": {
                         "Dock to collision_camera_035 (C)": {
                             "type": "template",
@@ -14185,29 +14062,6 @@
                     },
                     "dock_type": "door",
                     "dock_weakness": "Power Beam Door",
-                    "connections": {
-                        "Elevator to Dairon - Transport to Cataris": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -2500.0,
-                        "y": 7800.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_Checkpoint_WideBeam",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
                     "connections": {
                         "Elevator to Dairon - Transport to Cataris": {
                             "type": "and",
@@ -17943,6 +17797,15 @@
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Tile Group (BOMB) 2": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Tile Group (POWERBEAM) 2": {

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -44,12 +44,6 @@ Extra - asset_id: collision_camera_000
   > Dock to collision_camera_007 (C)
       Trivial
 
-> Start Point 1; Heals? False
-  * Extra - start_point_actor_name: StartPoint0
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Elevator to Artaria - Transport to Cataris
-      Trivial
-
 > Elevator to Artaria - Transport to Cataris; Heals? False; Spawn Point
   * Teleporter to Artaria - Transport to Cataris
   * Extra - actor_name: LE_Elevator_FromCave
@@ -61,12 +55,6 @@ Extra - asset_id: collision_camera_000
   > Door to collision_camera_006 (C)
       Trivial
   > Tile Group (POWERBEAM) 2
-      Trivial
-
-> Start Point 2; Heals? False
-  * Extra - start_point_actor_name: SP_AccessPoint_3
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Navigation Room Southeast
       Trivial
 
 > Tile Group (POWERBEAM) 1; Heals? False
@@ -1186,7 +1174,7 @@ Extra - asset_id: collision_camera_019
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:db_hdoor_mg_002b_000
   * Extra - right_shield_def: actordef:actors/props/db_hdoor_mg_002b/charclasses/db_hdoor_mg_002b.bmsad
   > Top Ledge
-      After Cataris - db_hdoor_mg_002
+      After Cataris - Ghavoran Teleporter Upper-right Tunnel Blob
 
 > Event - First Tunnel Blob (breakablemag004); Heals? False
   * Event Cataris - breakablemag004
@@ -1248,13 +1236,13 @@ Extra - asset_id: collision_camera_019
           Varia Suit or Heat Damage ≥ 20
 
 > Event - Door Blob (db_hdoor_mg_002); Heals? False
-  * Event Cataris - db_hdoor_mg_002
+  * Event Cataris - Ghavoran Teleporter Upper-right Tunnel Blob
   > Top Ledge
       Trivial
 
 > Top Ledge; Heals? False
   > Door to collision_camera_052 (C)
-      After Cataris - db_hdoor_mg_002
+      After Cataris - Ghavoran Teleporter Upper-right Tunnel Blob
   > Left Platform
       Varia Suit or Heat Damage ≥ 10
   > Event - Door Blob (db_hdoor_mg_002)
@@ -1768,12 +1756,12 @@ Extra - asset_id: collision_camera_025
   * Extra - right_shield_def: None
   > Door to Navigation Room Northwest
       Spider Magnet or Space Jump
-  > Event - Morph Tunnel Blob (db_dside_mg_003)
+  > Event - Morph Tunnel Blob
       Shoot Beam
   > Tile Group (BOMB)
       Trivial
   > Dock to Teleport to Ghavoran
-      After Cataris - db_dside_mg_003
+      After Cataris - Ghavoran Teleporter Lower-left Tunnel Blob
 
 > Door to Navigation Room Northwest; Heals? False
   * Power Beam Door to Navigation Room Northwest/Door to Teleport to Artaria (Red)
@@ -1804,8 +1792,8 @@ Extra - asset_id: collision_camera_025
   > Door to collision_camera_043 (C)
       Morph Ball
 
-> Event - Morph Tunnel Blob (db_dside_mg_003); Heals? False
-  * Event Cataris - db_dside_mg_003
+> Event - Morph Tunnel Blob; Heals? False
+  * Event Cataris - Ghavoran Teleporter Lower-left Tunnel Blob
   * Extra - actor_name: db_dside_mg_002b_000
   * Extra - actor_def: actordef:actors/props/db_dside_mg_002b/charclasses/db_dside_mg_002b.bmsad
   > Door to collision_camera_064 (C)
@@ -1822,12 +1810,6 @@ Extra - asset_id: collision_camera_025
   > Tile Group (BOMB)
       Morph Ball
   > Tile Group (WEIGHT) 2
-      Trivial
-
-> Start Point; Heals? False
-  * Extra - start_point_actor_name: SP_AccessPoint_3_B
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Navigation Room Northwest
       Trivial
 
 > Tile Group (BOMB); Heals? False
@@ -1862,7 +1844,7 @@ Extra - asset_id: collision_camera_025
 > Dock to Teleport to Ghavoran; Heals? False
   * Slide Tunnel to Teleport to Ghavoran/Dock to Teleport to Artaria (Red)
   > Door to collision_camera_064 (C)
-      After Cataris - db_dside_mg_002b_000
+      After Cataris - Ghavoran Teleporter Lower-left Tunnel Blob
 
 ----------------
 Teleport to Ghavoran
@@ -1886,8 +1868,8 @@ Extra - asset_id: collision_camera_026
   > Tile Group (SPEEDBOOST)
       Gravity Suit
 
-> Event - Lower-left Tunnel Blob (db_dside_mg_003); Heals? False
-  * Event Cataris - db_dside_mg_003
+> Event - Lower-left Tunnel Blob; Heals? False
+  * Event Cataris - Ghavoran Teleporter Lower-left Tunnel Blob
   * Extra - actor_name: db_dside_mg_003
   * Extra - actor_def: actordef:actors/props/db_dside_mg_002/charclasses/db_dside_mg_002.bmsad
   > Lower Center
@@ -1900,8 +1882,8 @@ Extra - asset_id: collision_camera_026
   > Top room
       Trivial
 
-> Event - Green Teleport Grapple Block (grapplepulloff1x2_001); Heals? False
-  * Event Cataris - grapplepulloff1x2_001
+> Event - Green Teleport Grapple Block; Heals? False
+  * Event Cataris - Green Teleport Grapple Block
   * Extra - actor_name: grapplepulloff1x2_001
   * Extra - actor_def: actordef:actors/props/grapplepulloff1x2/charclasses/grapplepulloff1x2.bmsad
   > Teleporter to Ghavoran - Teleport to Cataris
@@ -1915,7 +1897,7 @@ Extra - asset_id: collision_camera_026
   * Extra - target_spawn_point: teleporter_magma_000_platform
   * Extra - start_point_actor_name: teleporter_forest_000_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad
-  > Event - Green Teleport Grapple Block (grapplepulloff1x2_001)
+  > Event - Green Teleport Grapple Block
       All of the following:
           Grapple Beam
           Varia Suit or Heat Damage ≥ 20
@@ -1925,7 +1907,7 @@ Extra - asset_id: collision_camera_026
           Varia Suit or Heat Damage ≥ 20
   > Top room
       All of the following:
-          Morph Ball and After Cataris - grapplepulloff1x2_001
+          Morph Ball and After Cataris - Green Teleport Grapple Block
           Varia Suit or Heat Damage ≥ 50
 
 > Tile Group (POWERBEAM) 1; Heals? False
@@ -1971,7 +1953,7 @@ Extra - asset_id: collision_camera_026
       Trivial
 
 > Lower Center; Heals? False
-  > Event - Lower-left Tunnel Blob (db_dside_mg_003)
+  > Event - Lower-left Tunnel Blob
       Shoot Beam
   > Tile Group (SPEEDBOOST)
       Gravity Suit
@@ -1983,7 +1965,7 @@ Extra - asset_id: collision_camera_026
           Grapple Beam or Infinite Bomb Jump (Beginner) or Use Spin Boost
   > Dock to Teleport to Artaria (Red)
       All of the following:
-          After Cataris - db_dside_mg_003
+          After Cataris - Ghavoran Teleporter Lower-left Tunnel Blob
           Varia Suit or Heat Damage ≥ 100
 
 > Top room; Heals? False
@@ -1995,8 +1977,10 @@ Extra - asset_id: collision_camera_026
       Shoot Beam
   > Teleporter to Ghavoran - Teleport to Cataris
       All of the following:
-          After Cataris - grapplepulloff1x2_001 and Can Slide
+          After Cataris - Green Teleport Grapple Block and Can Slide
           Varia Suit or Heat Damage ≥ 20
+  > Tile Group (POWERBEAM) 1
+      Trivial
   > Dock to collision_camera_027 (C)
       All of the following:
           After Cataris - db_dside_mg_002
@@ -2006,7 +1990,7 @@ Extra - asset_id: collision_camera_026
   * Slide Tunnel to Teleport to Artaria (Red)/Dock to Teleport to Ghavoran
   > Lower Center
       All of the following:
-          After Cataris - db_dside_mg_003
+          After Cataris - Ghavoran Teleporter Lower-left Tunnel Blob
           Varia Suit or Heat Damage ≥ 100
 
 > Dock to collision_camera_027 (C); Heals? False
@@ -2566,13 +2550,7 @@ Extra - asset_id: collision_camera_036
   > Door to Central Unit Room
       Trivial
 
-> Start Point 1; Heals? False
-  * Extra - start_point_actor_name: SP_Checkpoint_CentralUnit
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Central Unit Room
-      Trivial
-
-> Start Point 2; Heals? False; Spawn Point
+> Start Point; Heals? False; Spawn Point
   * Extra - start_point_actor_name: SP_Checkpoint_MorphBall
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Dock to collision_camera_028 (C)
@@ -2622,13 +2600,7 @@ Central Unit Room
 Extra - total_boundings: {'x1': -9700.0, 'x2': -7600.0, 'y1': 5100.0, 'y2': 6242.0}
 Extra - polygon: [[-7600.0, 6242.0], [-9700.0, 6242.0], [-9700.0, 5100.0], [-7600.0, 5100.0]]
 Extra - asset_id: collision_camera_037
-> Start Point 1; Heals? False
-  * Extra - start_point_actor_name: centralunitmagmacontroller
-  * Extra - start_point_actor_def: actordef:actors/props/centralunitmagmacontroller/charclasses/centralunitmagmacontroller.bmsad
-  > Door to Green EMMI Fight
-      Trivial
-
-> Start Point 2; Heals? False; Spawn Point
+> Start Point; Heals? False; Spawn Point
   * Extra - start_point_actor_name: SP_Checkpoint_EmmyMagmaPhase2
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to Green EMMI Fight
@@ -2650,10 +2622,6 @@ collision_camera_038 (C)
 Extra - total_boundings: {'x1': -700.0, 'x2': 4500.0, 'y1': 4400.0, 'y2': 5875.0}
 Extra - polygon: [[4500.0, 5875.0], [-700.0, 5875.0], [-700.0, 4400.0], [4500.0, 4400.0]]
 Extra - asset_id: collision_camera_038
-> Start Point 1; Heals? False
-  * Extra - start_point_actor_name: shootactivatormag01
-  * Extra - start_point_actor_def: actordef:actors/props/shootactivatormag01/charclasses/shootactivatormag01.bmsad
-
 > Start Point 2; Heals? False; Spawn Point
   * Extra - start_point_actor_name: SP_Checkpoint_PistonLeft
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2754,7 +2722,7 @@ Extra - asset_id: collision_camera_040
       Trivial
 
 > Dock to collision_camera_042 (C) (Bottom); Heals? False
-  * Not Determined to collision_camera_042 (C)/Dock to Speedboost Maze before Transport to Dairon (Bottom)
+  * Open Passage to collision_camera_042 (C)/Dock to Speedboost Maze before Transport to Dairon (Bottom)
   > Dock to collision_camera_035 (C)
       Can Slide
 
@@ -2777,12 +2745,6 @@ Extra - asset_id: collision_camera_041
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Elevator to Dairon - Transport to Cataris
-      Trivial
-
-> Start Point; Heals? False
-  * Extra - start_point_actor_name: SP_Checkpoint_WideBeam
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Elevator to Dairon - Transport to Cataris
       Trivial
 
@@ -3503,6 +3465,8 @@ Extra - asset_id: collision_camera_048
       All of the following:
           After Cataris - Heated Wide Beam Block
           Varia Suit or Heat Damage ≥ 50
+  > Tile Group (BOMB) 2
+      Morph Ball
   > Tile Group (POWERBEAM) 2
       Varia Suit or Heat Damage ≥ 50
   > Event - Wide Beam Block
@@ -3737,14 +3701,14 @@ Extra - asset_id: collision_camera_052
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:db_hdoor_mg_002b_000
   * Extra - right_shield_def: actordef:actors/props/db_hdoor_mg_002b/charclasses/db_hdoor_mg_002b.bmsad
   > Dock to Green EMMI Introduction
-      After Cataris - db_hdoor_mg_002
+      After Cataris - Ghavoran Teleporter Upper-right Tunnel Blob
 
 > Dock to Green EMMI Introduction; Heals? False
   * EMMI Door to Green EMMI Introduction/Dock to collision_camera_052 (C)
   * Extra - actor_name: dooremmy_003
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to collision_camera_019 (C)
-      After Cataris - db_hdoor_mg_002
+      After Cataris - Ghavoran Teleporter Upper-right Tunnel Blob
   > Door to Teleport to Dairon
       Trivial
   > Event - Breakable (db_hdoor_mg_002)
@@ -3777,7 +3741,7 @@ Extra - asset_id: collision_camera_052
       Trivial
 
 > Event - Breakable (db_hdoor_mg_002); Heals? False
-  * Event Cataris - db_hdoor_mg_002
+  * Event Cataris - Ghavoran Teleporter Upper-right Tunnel Blob
   * Extra - actor_name: db_hdoor_mg_002
   * Extra - actor_def: actordef:actors/props/db_hdoor_mg_002/charclasses/db_hdoor_mg_002.bmsad
   > Dock to Green EMMI Introduction

--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -1266,7 +1266,7 @@
             }
         },
         "Dairon Hub East": {
-            "default_node": "Start Point 2",
+            "default_node": "Start Point",
             "valid_starting_location": true,
             "extra": {
                 "total_boundings": {
@@ -1542,30 +1542,7 @@
                         }
                     }
                 },
-                "Start Point 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 6600.0,
-                        "y": 1200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_Checkpoint_Blackout",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to collision_camera_009 (D)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point 2": {
+                "Start Point": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -2633,29 +2610,6 @@
                     "event_name": "s030_baselab:default:db_dif_b1_001",
                     "connections": {
                         "Bottom-Left Corner": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 1600.0,
-                        "y": 1400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_Checkpoint_AfterDiffusion",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Teleporter to Cataris - Teleport to Dairon": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7602,29 +7556,6 @@
                         }
                     }
                 },
-                "Start Point": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 2300.0,
-                        "y": 7100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_Checkpoint_AfterProfessor",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to Navigation Room North (Upper)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Event - Push Wide Beam Block": {
                     "node_type": "event",
                     "heal": false,
@@ -9816,6 +9747,15 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Freezer Center": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Gravity",
+                                "amount": 1,
+                                "negate": false
+                            }
                         }
                     }
                 },
@@ -10300,6 +10240,41 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tile Group (SPEEDBOOST) 3": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Gravity",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Tile Group (SPEEDBOOST) 4": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -13478,7 +13453,7 @@
             }
         },
         "Central Unit Room": {
-            "default_node": "Start Point 2",
+            "default_node": "Start Point",
             "valid_starting_location": true,
             "extra": {
                 "total_boundings": {
@@ -13508,30 +13483,7 @@
                 "asset_id": "collision_camera_038"
             },
             "nodes": {
-                "Start Point 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -11850.0,
-                        "y": -4950.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "centralunitmagmacontroller",
-                        "start_point_actor_def": "actordef:actors/props/centralunitmagmacontroller/charclasses/centralunitmagmacontroller.bmsad"
-                    },
-                    "connections": {
-                        "Door to Yellow EMMI Fight": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point 2": {
+                "Start Point": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -14455,29 +14407,6 @@
                         }
                     }
                 },
-                "Start Point": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 23600.0,
-                        "y": 6000.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "StartPoint0",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to Teleport to Artaria": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Elevator to Cataris - Transport to Dairon": {
                     "node_type": "teleporter",
                     "heal": false,
@@ -14734,29 +14663,6 @@
                     },
                     "keep_name_when_vanilla": true,
                     "editable": true,
-                    "connections": {
-                        "Door to collision_camera_041 (D)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -19750.0,
-                        "y": -9000.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_Checkpoint_AfterAqua",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
                     "connections": {
                         "Door to collision_camera_041 (D)": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -346,13 +346,7 @@ Extra - asset_id: collision_camera_004
   > Dock to collision_camera_002 (D) (Lower)
       Trivial
 
-> Start Point 1; Heals? False
-  * Extra - start_point_actor_name: SP_Checkpoint_Blackout
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to collision_camera_009 (D)
-      Trivial
-
-> Start Point 2; Heals? False; Spawn Point
+> Start Point; Heals? False; Spawn Point
   * Extra - start_point_actor_name: SP_Checkpoint_EmmyBaseLab
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Dock to Yellow EMMI Introduction
@@ -629,12 +623,6 @@ Extra - asset_id: collision_camera_008
   * Extra - actor_name: db_dif_b1_001
   * Extra - actor_def: actordef:actors/props/db_dif_b1_001/charclasses/db_dif_b1_001.bmsad
   > Bottom-Left Corner
-      Trivial
-
-> Start Point; Heals? False
-  * Extra - start_point_actor_name: SP_Checkpoint_AfterDiffusion
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Teleporter to Cataris - Teleport to Dairon
       Trivial
 
 > Teleporter to Cataris - Teleport to Dairon; Heals? False; Spawn Point
@@ -1626,12 +1614,6 @@ Extra - asset_id: collision_camera_019
   > Door to Navigation Room North (Upper)
       Trivial
 
-> Start Point; Heals? False
-  * Extra - start_point_actor_name: SP_Checkpoint_AfterProfessor
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Navigation Room North (Upper)
-      Trivial
-
 > Event - Push Wide Beam Block; Heals? False
   * Event Dairon - Wide Beam Block Ferenia Elevator
   > Door to Navigation Room North (Lower)
@@ -2110,6 +2092,8 @@ Extra - asset_id: collision_camera_025
   * Extra - tile_types: ('SPEEDBOOST',)
   > Tile Group (SCREWATTACK)
       Trivial
+  > Freezer Center
+      Gravity Suit
 
 > Tile Group (SPEEDBOOST) 4; Heals? False
   * Configurable Node
@@ -2172,6 +2156,10 @@ Extra - asset_id: collision_camera_025
           Morph Ball and After Dairon - db_dif_b1_001
           Gravity Suit or Cold Damage ≥ 200
           Speed Booster or Walljump (Beginner) or Simple IBJ or Use Spin Boost
+  > Tile Group (SPEEDBOOST) 3
+      Gravity Suit
+  > Tile Group (SPEEDBOOST) 4
+      Gravity Suit and Space Jump
   > Event - Hidden Blob through wall (db_reg_b1_001)
       Wave Beam
 
@@ -2865,13 +2853,7 @@ Central Unit Room
 Extra - total_boundings: {'x1': -12900.0, 'x2': -10800.0, 'y1': -5400.0, 'y2': -4258.0}
 Extra - polygon: [[-10800.0, -4258.0], [-12900.0, -4258.0], [-12900.0, -5400.0], [-10800.0, -5400.0]]
 Extra - asset_id: collision_camera_038
-> Start Point 1; Heals? False
-  * Extra - start_point_actor_name: centralunitmagmacontroller
-  * Extra - start_point_actor_def: actordef:actors/props/centralunitmagmacontroller/charclasses/centralunitmagmacontroller.bmsad
-  > Door to Yellow EMMI Fight
-      Trivial
-
-> Start Point 2; Heals? False; Spawn Point
+> Start Point; Heals? False; Spawn Point
   * Extra - start_point_actor_name: SP_Checkpoint_EmmyLabPhase2
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to Yellow EMMI Fight
@@ -3091,12 +3073,6 @@ Extra - asset_id: collision_camera_043
   > Elevator to Cataris - Transport to Dairon
       Trivial
 
-> Start Point; Heals? False
-  * Extra - start_point_actor_name: StartPoint0
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Teleport to Artaria
-      Trivial
-
 > Elevator to Cataris - Transport to Dairon; Heals? False; Spawn Point
   * Teleporter to Cataris - Transport to Dairon
   * Extra - actor_name: wagontrain_magma_000
@@ -3170,12 +3146,6 @@ Extra - asset_id: collision_camera_045
   * Extra - target_spawn_point: wagontrain_baselab_001_platform
   * Extra - start_point_actor_name: wagontrain_aqua_001_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_train/charclasses/weightactivatedplatform_train.bmsad
-  > Door to collision_camera_041 (D)
-      Trivial
-
-> Start Point; Heals? False
-  * Extra - start_point_actor_name: SP_Checkpoint_AfterAqua
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to collision_camera_041 (D)
       Trivial
 

--- a/randovania/games/dread/json_data/Ferenia.json
+++ b/randovania/games/dread/json_data/Ferenia.json
@@ -73,29 +73,6 @@
                         }
                     }
                 },
-                "Start Point": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3200.0,
-                        "y": -7500.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "StartPoint0",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to collision_camera_002 (F)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Elevator to Dairon - East Transport to Ferenia": {
                     "node_type": "teleporter",
                     "heal": false,
@@ -1132,7 +1109,7 @@
             }
         },
         "Quiet Robe Room": {
-            "default_node": "Start Point 2",
+            "default_node": "Start Point",
             "valid_starting_location": true,
             "extra": {
                 "total_boundings": {
@@ -1196,30 +1173,7 @@
                         }
                     }
                 },
-                "Start Point 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -10800.0,
-                        "y": -7150.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_Checkpoint_ChozoRobotSanc",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to collision_camera_004 (F)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point 2": {
+                "Start Point": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -1715,29 +1669,6 @@
                         }
                     }
                 },
-                "Start Point 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -11050.916015625,
-                        "y": -3100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_Checkpoint_EmmySanc",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Dock to Purple EMMI Introduction": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Teleporter to Burenia - Teleport to Ferenia": {
                     "node_type": "teleporter",
                     "heal": false,
@@ -1763,29 +1694,6 @@
                     "editable": true,
                     "connections": {
                         "Dock to collision_camera_011 (F) (Lower)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point 2": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -11100.0,
-                        "y": -200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_Checkpoint_TwoChozoRobots_BottomLeft",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to Twin Robot Arena": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3472,6 +3380,13 @@
                                     }
                                 ]
                             }
+                        },
+                        "Start Point 2": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -3550,7 +3465,7 @@
                     "dock_type": "door",
                     "dock_weakness": "Access Closed",
                     "connections": {
-                        "Pickup (itemsphere_spacejump)": {
+                        "Start Point 1": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3620,7 +3535,7 @@
                     "pickup_index": 119,
                     "major_location": true,
                     "connections": {
-                        "Door from collision_camera_015 (F)": {
+                        "Start Point 1": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3777,6 +3692,13 @@
                     },
                     "connections": {
                         "Door from collision_camera_015 (F)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Pickup (itemsphere_spacejump)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5968,6 +5890,13 @@
                             }
                         },
                         "Start Point 1": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Start Point 2": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -15,12 +15,6 @@ Extra - asset_id: collision_camera_000
   > Elevator to Dairon - East Transport to Ferenia
       Trivial
 
-> Start Point; Heals? False
-  * Extra - start_point_actor_name: StartPoint0
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to collision_camera_002 (F)
-      Trivial
-
 > Elevator to Dairon - East Transport to Ferenia; Heals? False; Spawn Point
   * Teleporter to Dairon - East Transport to Ferenia
   * Extra - actor_name: elevator_baselab_000
@@ -234,13 +228,7 @@ Extra - asset_id: collision_camera_005
   > Event - Quiet Robe
       Trivial
 
-> Start Point 1; Heals? False
-  * Extra - start_point_actor_name: SP_Checkpoint_ChozoRobotSanc
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to collision_camera_004 (F)
-      Trivial
-
-> Start Point 2; Heals? False; Spawn Point
+> Start Point; Heals? False; Spawn Point
   * Extra - start_point_actor_name: SP_Checkpoint_Dead_ChozoRobotSoldier
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to collision_camera_004 (F)
@@ -369,12 +357,6 @@ Extra - asset_id: collision_camera_007
   > Door to Cold Room (Small)
       Trivial
 
-> Start Point 1; Heals? False
-  * Extra - start_point_actor_name: SP_Checkpoint_EmmySanc
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Dock to Purple EMMI Introduction
-      Trivial
-
 > Teleporter to Burenia - Teleport to Ferenia; Heals? False; Spawn Point
   * Teleporter to Burenia - Teleport to Ferenia
   * Extra - actor_name: teleporter_000
@@ -384,12 +366,6 @@ Extra - asset_id: collision_camera_007
   * Extra - start_point_actor_name: teleporter_000_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad
   > Dock to collision_camera_011 (F) (Lower)
-      Trivial
-
-> Start Point 2; Heals? False
-  * Extra - start_point_actor_name: SP_Checkpoint_TwoChozoRobots_BottomLeft
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Twin Robot Arena
       Trivial
 
 > Dock to collision_camera_011 (F) (Lower); Heals? False
@@ -755,6 +731,8 @@ Extra - asset_id: collision_camera_012
   * Extra - right_shield_def: None
   > Door to collision_camera_015 (F) (Bottom)
       Space Jump or Infinite Bomb Jump (Beginner)
+  > Start Point 2
+      Trivial
 
 > Door to collision_camera_015 (F) (Bottom); Heals? False
   * Power Beam Door to collision_camera_015 (F)/Door to Space Jump Room (Bottom)
@@ -777,7 +755,7 @@ Extra - asset_id: collision_camera_012
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorshieldmissile_000
   * Extra - right_shield_def: actordef:actors/props/doorshieldmissile/charclasses/doorshieldmissile.bmsad
-  > Pickup (itemsphere_spacejump)
+  > Start Point 1
       Trivial
   > Underwater Bottom
       Can Slide
@@ -799,7 +777,7 @@ Extra - asset_id: collision_camera_012
   * Pickup 119; Major Location? True
   * Extra - actor_name: itemsphere_spacejump
   * Extra - actor_def: actordef:actors/items/itemsphere_spacejump/charclasses/itemsphere_spacejump.bmsad
-  > Door from collision_camera_015 (F)
+  > Start Point 1
       Trivial
 
 > Pickup (item_missiletank_002); Heals? False
@@ -840,6 +818,8 @@ Extra - asset_id: collision_camera_012
   * Extra - start_point_actor_name: SP_Checkpoint_SpaceJump
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door from collision_camera_015 (F)
+      Trivial
+  > Pickup (itemsphere_spacejump)
       Trivial
 
 > Start Point 2; Heals? False; Spawn Point
@@ -1309,6 +1289,8 @@ Extra - asset_id: collision_camera_017
   > Door to collision_camera_015 (F)
       Trivial
   > Start Point 1
+      Trivial
+  > Start Point 2
       Trivial
 
 > Door to collision_camera_015 (F); Heals? False

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -4,8 +4,8 @@
         "asset_id": "maps/levels/c10_samus/s050_forest/s050_forest.brfld",
         "map_min_x": 28,
         "map_max_x": 46,
-        "map_min_y": 25,
-        "map_max_y": 26
+        "map_min_y": 24,
+        "map_max_y": 66
     },
     "areas": {
         "Transport to Burenia": {
@@ -106,29 +106,6 @@
                             }
                         },
                         "Elevator to Burenia - Transport to Ghavoran": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Start Point": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -9000.0,
-                        "y": -5650.0,
-                        "z": -0.00024399999529123306
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "StartPoint0",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Door to Right Entrance": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1893,6 +1870,13 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Start Point 1": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -3228,7 +3212,7 @@
                         "y": -5900.0,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "Normally a Power Beam Door, but listed as a missile door for helping logic.\n\n",
                     "extra": {
                         "actor_name": "doorpowerpower_007",
                         "actor_def": "actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad",
@@ -3243,9 +3227,9 @@
                         "node_name": "Door to Super Missile Room (Missile Lock)"
                     },
                     "dock_type": "door",
-                    "dock_weakness": "Power Beam Door",
+                    "dock_weakness": "Missile Door",
                     "connections": {
-                        "Pickup (itemsphere_supermissile)": {
+                        "Start Point": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3270,7 +3254,7 @@
                     "pickup_index": 100,
                     "major_location": true,
                     "connections": {
-                        "Door to collision_camera_009 (G) (Missile Lock)": {
+                        "Start Point": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3294,6 +3278,13 @@
                     },
                     "connections": {
                         "Door to collision_camera_009 (G) (Missile Lock)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Pickup (itemsphere_supermissile)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5202,7 +5193,7 @@
             }
         },
         "Blue EMMI Fight": {
-            "default_node": "Room Center (Start Point 2)",
+            "default_node": "Room Center",
             "valid_starting_location": true,
             "extra": {
                 "total_boundings": {
@@ -5292,7 +5283,7 @@
                                 ]
                             }
                         },
-                        "Room Center (Start Point 2)": {
+                        "Room Center": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5326,7 +5317,7 @@
                     "dock_type": "door",
                     "dock_weakness": "Power Beam Door",
                     "connections": {
-                        "Room Center (Start Point 2)": {
+                        "Room Center": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5386,7 +5377,7 @@
                                 ]
                             }
                         },
-                        "Room Center (Start Point 2)": {
+                        "Room Center": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5429,30 +5420,7 @@
                         }
                     }
                 },
-                "Start Point 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -6500.0,
-                        "y": 4300.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_Checkpoint_CentralUnit",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Dock to Central Unit Room": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Room Center (Start Point 2)": {
+                "Room Center": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -5536,7 +5504,7 @@
                                 ]
                             }
                         },
-                        "Room Center (Start Point 2)": {
+                        "Room Center": {
                             "type": "template",
                             "data": "Can Slide"
                         }
@@ -5555,7 +5523,7 @@
                     "pickup_index": 146,
                     "major_location": true,
                     "connections": {
-                        "Room Center (Start Point 2)": {
+                        "Room Center": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8787,6 +8755,13 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Tile Group (WEIGHT) 2": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -9848,7 +9823,7 @@
                         "y": -3000.0,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "Normally a power beam door, but listed as supers to prevent logic issues with\nblast shields\n\n",
                     "extra": {
                         "actor_name": "doorpowerpower_005",
                         "actor_def": "actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad",
@@ -9863,7 +9838,7 @@
                         "node_name": "Door to collision_camera_029 (G)"
                     },
                     "dock_type": "door",
-                    "dock_weakness": "Power Beam Door",
+                    "dock_weakness": "Super Missile Door",
                     "connections": {
                         "Center Platform": {
                             "type": "or",
@@ -12490,7 +12465,15 @@
                     },
                     "dock_type": "door",
                     "dock_weakness": "Access Closed",
-                    "connections": {}
+                    "connections": {
+                        "Start Point": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 },
                 "Pickup (item_missiletank_006)": {
                     "node_type": "pickup",

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -28,12 +28,6 @@ Extra - asset_id: collision_camera_000
   > Elevator to Burenia - Transport to Ghavoran
       Trivial
 
-> Start Point; Heals? False
-  * Extra - start_point_actor_name: StartPoint0
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Right Entrance
-      Trivial
-
 > Elevator to Burenia - Transport to Ghavoran; Heals? False; Spawn Point
   * Teleporter to Burenia - Transport to Ghavoran
   * Extra - actor_name: elevator_aqua_000
@@ -379,6 +373,8 @@ Extra - asset_id: collision_camera_005
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to collision_camera_006 (G)
       Trivial
+  > Start Point 1
+      Trivial
 
 > Door to collision_camera_006 (G); Heals? False
   * Power Beam Door to collision_camera_006 (G)/Door to collision_camera_005 (G)
@@ -678,27 +674,32 @@ Extra - asset_id: collision_camera_010
               Flash Shift and Walljump (Beginner)
 
 > Door to collision_camera_009 (G) (Missile Lock); Heals? False
-  * Power Beam Door to collision_camera_009 (G)/Door to Super Missile Room (Missile Lock)
+  * Missile Door to collision_camera_009 (G)/Door to Super Missile Room (Missile Lock)
+  * Normally a Power Beam Door, but listed as a missile door for helping logic.
+
+
   * Extra - actor_name: doorpowerpower_007
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorshieldmissile_000
   * Extra - right_shield_def: actordef:actors/props/doorshieldmissile/charclasses/doorshieldmissile.bmsad
-  > Pickup (itemsphere_supermissile)
+  > Start Point
       Trivial
 
 > Pickup (itemsphere_supermissile); Heals? False
   * Pickup 100; Major Location? True
   * Extra - actor_name: itemsphere_supermissile
   * Extra - actor_def: actordef:actors/items/itemsphere_supermissile/charclasses/itemsphere_supermissile.bmsad
-  > Door to collision_camera_009 (G) (Missile Lock)
+  > Start Point
       Trivial
 
 > Start Point; Heals? False; Spawn Point
   * Extra - start_point_actor_name: SP_Checkpoint_SuperMissiles
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to collision_camera_009 (G) (Missile Lock)
+      Trivial
+  > Pickup (itemsphere_supermissile)
       Trivial
 
 > Dock to collision_camera_009 (G); Heals? False
@@ -1114,7 +1115,7 @@ Extra - asset_id: collision_camera_019
   * Extra - right_shield_def: None
   > Door to collision_camera_016 (G)
       Flash Shift or Spider Magnet or Space Jump
-  > Room Center (Start Point 2)
+  > Room Center
       Trivial
 
 > Door to collision_camera_020 (G) (doorpowerpower_011); Heals? False
@@ -1125,7 +1126,7 @@ Extra - asset_id: collision_camera_019
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Room Center (Start Point 2)
+  > Room Center
       Trivial
 
 > Door to collision_camera_016 (G); Heals? False
@@ -1138,7 +1139,7 @@ Extra - asset_id: collision_camera_019
   * Extra - right_shield_def: None
   > Door to collision_camera_020 (G) (doorpowerpower_010)
       Flash Shift or Space Jump
-  > Room Center (Start Point 2)
+  > Room Center
       Trivial
 
 > Dock to collision_camera_016 (G); Heals? False
@@ -1152,13 +1153,7 @@ Extra - asset_id: collision_camera_019
   > Dock to Central Unit Room
       Trivial
 
-> Start Point 1; Heals? False
-  * Extra - start_point_actor_name: SP_Checkpoint_CentralUnit
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Dock to Central Unit Room
-      Trivial
-
-> Room Center (Start Point 2); Heals? False; Spawn Point
+> Room Center; Heals? False; Spawn Point
   * Extra - start_point_actor_name: SP_Checkpoint_IceMissiles
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to collision_camera_020 (G) (doorpowerpower_011)
@@ -1172,12 +1167,12 @@ Extra - asset_id: collision_camera_019
   * EMMI Door to Central Unit Room/Dock to Blue EMMI Fight
   > Dock to collision_camera_016 (G)
       Space Jump or Speed Booster or Simple IBJ
-  > Room Center (Start Point 2)
+  > Room Center
       Can Slide
 
 > Pickup (Ice Missiles); Heals? False
   * Pickup 146; Major Location? True
-  > Room Center (Start Point 2)
+  > Room Center
       Trivial
 
 ----------------
@@ -1914,6 +1909,8 @@ Extra - asset_id: collision_camera_025_B
       Morph Ball
   > Tile Group (WEIGHT) 1
       Trivial
+  > Tile Group (WEIGHT) 2
+      Trivial
 
 > Pickup (item_missiletank_007); Heals? False
   * Pickup 107; Major Location? False
@@ -2119,7 +2116,11 @@ Extra - total_boundings: {'x1': -1000.0, 'x2': 4100.0, 'y1': -3700.0, 'y2': -180
 Extra - polygon: [[4100.0, -1800.0], [-1000.0, -1800.0], [-1000.0, -3500.0], [-800.0, -3500.0], [-100.0, -3700.0], [4100.0, -3700.0]]
 Extra - asset_id: collision_camera_029
 > Door to collision_camera_007 (G); Heals? False
-  * Power Beam Door to collision_camera_007 (G)/Door to collision_camera_029 (G)
+  * Super Missile Door to collision_camera_007 (G)/Door to collision_camera_029 (G)
+  * Normally a power beam door, but listed as supers to prevent logic issues with
+blast shields
+
+
   * Extra - actor_name: doorpowerpower_005
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorshieldsupermissile_001
@@ -2725,6 +2726,8 @@ Extra - asset_id: collision_camera_039
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  > Start Point
+      Trivial
 
 > Pickup (item_missiletank_006); Heals? False
   * Pickup 106; Major Location? False

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -377,11 +377,11 @@
                 "extra": {}
             },
             "s020_magma:default:db_hdoor_mg_002": {
-                "long_name": "Cataris - db_hdoor_mg_002",
+                "long_name": "Cataris - Ghavoran Teleporter Upper-right Tunnel Blob",
                 "extra": {}
             },
             "s020_magma:default:db_dside_mg_003": {
-                "long_name": "Cataris - db_dside_mg_003",
+                "long_name": "Cataris - Ghavoran Teleporter Lower-left Tunnel Blob",
                 "extra": {}
             },
             "s020_magma:default:db_dside_mg_002": {
@@ -613,7 +613,7 @@
                 "extra": {}
             },
             "s020_magma:default:grapplepulloff1x2_001": {
-                "long_name": "Cataris - grapplepulloff1x2_001",
+                "long_name": "Cataris - Green Teleport Grapple Block",
                 "extra": {}
             },
             "s030_baselab:default:grapplepulloff1x2_007": {


### PR DESCRIPTION
I've deleted a bunch of unused Start Point nodes, added a few missing connections and changed some missile/super doors to be matching on both sides.

There's a special case in the blast shield logic that if both sides of a door are the same shield, then it handles opening from the back. Pretty much a kludge until I can get the correct way working, though I think I'll just patch the game to be that way.