### PR TITLE
Minor logic fixes and renaming after darkszero's fun test stream

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -6698,7 +6698,7 @@
                         }
                     }
                 },
-                "Pickup (Item_MissileTank002)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -6825,7 +6825,7 @@
                                 "items": []
                             }
                         },
-                        "Pickup (Item_MissileTank002)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -12686,7 +12686,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_000)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -12766,7 +12766,7 @@
                     "dock_type": "door",
                     "dock_weakness": "Sensor Lock Door",
                     "connections": {
-                        "Pickup (item_missiletank_000)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14011,7 +14011,7 @@
                         }
                     }
                 },
-                "Pickup (Item_MissileTank003)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -14097,7 +14097,7 @@
                     "dock_type": "door",
                     "dock_weakness": "Power Beam Door",
                     "connections": {
-                        "Pickup (Item_MissileTank003)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -16291,7 +16291,7 @@
                     "dock_type": "door",
                     "dock_weakness": "Power Beam Door",
                     "connections": {
-                        "Pickup (Item_MissileTank006)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -16304,7 +16304,7 @@
                         }
                     }
                 },
-                "Pickup (Item_MissileTank006)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -19248,7 +19248,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_006)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -19365,7 +19365,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_006)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -1521,7 +1521,7 @@ Extra - asset_id: collision_camera_015
   > Event - EMMI Magnet Platform Lowered
       Spider Magnet
 
-> Pickup (Item_MissileTank002); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 5; Major Location? False
   * Extra - actor_name: Item_MissileTank002
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -1560,7 +1560,7 @@ Extra - asset_id: collision_camera_015
   * Extra - right_shield_def: None
   > Door to collision_camera_017 (A) (1)
       Trivial
-  > Pickup (Item_MissileTank002)
+  > Pickup (Missile Tank)
       Grapple Beam
   > Door to First EMMI Chase
       After Artaria - EMMI Spinner Rotated
@@ -2842,7 +2842,7 @@ Extra - asset_id: collision_camera_050
   > Start Point
       Trivial
 
-> Pickup (item_missiletank_000); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 6; Major Location? False
   * Extra - actor_name: item_missiletank_000
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -2864,7 +2864,7 @@ Extra - asset_id: collision_camera_050
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Pickup (item_missiletank_000)
+  > Pickup (Missile Tank)
       Trivial
   > Start Point
       Trivial
@@ -3152,7 +3152,7 @@ Extra - asset_id: collision_camera_056
   > Tower Middle
       Trivial
 
-> Pickup (Item_MissileTank003); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 7; Major Location? False
   * Extra - actor_name: Item_MissileTank003
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -3176,7 +3176,7 @@ Extra - asset_id: collision_camera_056
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Pickup (Item_MissileTank003)
+  > Pickup (Missile Tank)
       Trivial
   > Tower Middle
       Trivial
@@ -3680,12 +3680,12 @@ Extra - asset_id: collision_camera_067
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Pickup (Item_MissileTank006)
+  > Pickup (Missile Tank)
       Trivial
   > Tile Group (MISSILE)
       Can Slide
 
-> Pickup (Item_MissileTank006); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 10; Major Location? False
   * Extra - actor_name: Item_MissileTank006
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -4304,7 +4304,7 @@ Extra - asset_id: collision_camera_080
   > Elevator to Burenia - Transport to Artaria
       Trivial
 
-> Pickup (item_missiletank_006); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 32; Major Location? False
   * Extra - actor_name: item_missiletank_006
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -4341,7 +4341,7 @@ Extra - asset_id: collision_camera_080
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SCREWATTACK',)
-  > Pickup (item_missiletank_006)
+  > Pickup (Missile Tank)
       Trivial
   > Tile Group (SCREWATTACK) 2
       Trivial

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -351,7 +351,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_006)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -419,7 +419,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_006)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -855,7 +855,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_001)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -882,7 +882,7 @@
                         }
                     }
                 },
-                "Pickup (item_energyfragment_000)": {
+                "Pickup (Energy Fragment)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -1132,7 +1132,7 @@
                     "description": "",
                     "extra": {},
                     "connections": {
-                        "Pickup (item_missiletank_001)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1302,7 +1302,7 @@
                                 ]
                             }
                         },
-                        "Pickup (item_energyfragment_000)": {
+                        "Pickup (Energy Fragment)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -2937,11 +2937,11 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_000)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
-                        "x": 849.7320556640625,
+                        "x": 849.73,
                         "y": 8520.0,
                         "z": 0.0
                     },
@@ -3258,7 +3258,7 @@
                     "description": "",
                     "extra": {},
                     "connections": {
-                        "Pickup (item_missiletank_000)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3647,7 +3647,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletankplus_000)": {
+                "Pickup (Missile+ Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -3868,7 +3868,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletankplus_000)": {
+                        "Pickup (Missile+ Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -4588,7 +4588,7 @@
                         }
                     }
                 },
-                "Pickup (item_energytank_000)": {
+                "Pickup (Energy Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -4639,7 +4639,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_005)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -4764,7 +4764,7 @@
                                 "negate": false
                             }
                         },
-                        "Pickup (item_missiletank_005)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -4892,7 +4892,7 @@
                                 "items": []
                             }
                         },
-                        "Pickup (item_energytank_000)": {
+                        "Pickup (Energy Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5121,7 +5121,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletankplus_001)": {
+                "Pickup (Missile+ Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -5213,7 +5213,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_007)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -5280,7 +5280,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_007)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5780,7 +5780,7 @@
                                 ]
                             }
                         },
-                        "Pickup (item_missiletankplus_001)": {
+                        "Pickup (Missile+ Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7435,7 +7435,7 @@
                                 "items": []
                             }
                         },
-                        "Pickup (item_missiletank)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7479,7 +7479,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -7589,7 +7589,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank)": {
+                        "Pickup (Missile Tank)": {
                             "type": "template",
                             "data": "Can Slide Underwater"
                         },
@@ -7703,7 +7703,7 @@
                                 "items": []
                             }
                         },
-                        "Pickup (powerup_ghostaura)": {
+                        "Pickup (Flash Shift)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7712,12 +7712,12 @@
                         }
                     }
                 },
-                "Pickup (powerup_ghostaura)": {
+                "Pickup (Flash Shift)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
-                        "x": 354.7911376953125,
-                        "y": -1137.9896240234375,
+                        "x": 354.79,
+                        "y": -1137.99,
                         "z": 0.0
                     },
                     "description": "",
@@ -10014,7 +10014,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletankplus)": {
+                "Pickup (Missile+ Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -10039,7 +10039,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_004)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -10628,7 +10628,7 @@
                                 "items": []
                             }
                         },
-                        "Pickup (item_missiletankplus)": {
+                        "Pickup (Missile+ Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -10756,7 +10756,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_004)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11564,7 +11564,7 @@
                         }
                     }
                 },
-                "Pickup (item_powerbombtank_000)": {
+                "Pickup (Power Bomb Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -11732,7 +11732,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_powerbombtank_000)": {
+                        "Pickup (Power Bomb Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -12121,7 +12121,7 @@
                     "dock_type": "door",
                     "dock_weakness": "Power Beam Door",
                     "connections": {
-                        "Pickup (item_energytank)": {
+                        "Pickup (Energy Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12222,7 +12222,7 @@
                         }
                     }
                 },
-                "Pickup (item_energytank)": {
+                "Pickup (Energy Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -80,7 +80,7 @@ Extra - asset_id: collision_camera_001
   > Door to Navigation Room North
       After Quiet Robe and Can Slide
 
-> Pickup (item_missiletank_006); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 92; Major Location? False
   * Extra - actor_name: item_missiletank_006
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -99,7 +99,7 @@ Extra - asset_id: collision_camera_001
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('MISSILE',)
-  > Pickup (item_missiletank_006)
+  > Pickup (Missile Tank)
       Morph Ball
   > Dock to Transport to Ghavoran
       Trivial
@@ -176,14 +176,14 @@ Extra - asset_id: collision_camera_002
   > Water Bottom
       After Burenia - db_reg_aq_007
 
-> Pickup (item_missiletank_001); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 81; Major Location? False
   * Extra - actor_name: item_missiletank_001
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Bottom-left Corner
       After Burenia - db_reg_aq_002
 
-> Pickup (item_energyfragment_000); Heals? False
+> Pickup (Energy Fragment); Heals? False
   * Pickup 90; Major Location? True
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
@@ -252,7 +252,7 @@ Extra - asset_id: collision_camera_002
       Trivial
 
 > Bottom-left Corner; Heals? False
-  > Pickup (item_missiletank_001)
+  > Pickup (Missile Tank)
       All of the following:
           After Burenia - db_reg_aq_002
           Any of the following:
@@ -272,7 +272,7 @@ Extra - asset_id: collision_camera_002
           Any of the following:
               Grapple Beam or Spider Magnet or Space Jump
               Walljump (Beginner) and Use Spin Boost
-  > Pickup (item_energyfragment_000)
+  > Pickup (Energy Fragment)
       Flash Shift or Speed Booster
   > Tile Group (SPEEDBOOST)
       Speed Booster
@@ -592,7 +592,7 @@ Extra - asset_id: collision_camera_007
   > Dock to collision_camera_005 (B) (Lower)
       Trivial
 
-> Pickup (item_missiletank_000); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 80; Major Location? False
   * Extra - actor_name: item_missiletank_000
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -649,7 +649,7 @@ Extra - asset_id: collision_camera_007
       Morph Ball
 
 > Water Bottom; Heals? False
-  > Pickup (item_missiletank_000)
+  > Pickup (Missile Tank)
       All of the following:
           Morph Ball
           Gravity Suit or Water Bomb Jump (Beginner)
@@ -721,7 +721,7 @@ Extra - asset_id: collision_camera_008
   > Tile Group (MISSILE)
       Flash Shift or Space Jump
 
-> Pickup (item_missiletankplus_000); Heals? False
+> Pickup (Missile+ Tank); Heals? False
   * Pickup 91; Major Location? False
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
@@ -787,7 +787,7 @@ Extra - asset_id: collision_camera_008
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('WEIGHT',)
-  > Pickup (item_missiletankplus_000)
+  > Pickup (Missile+ Tank)
       Morph Ball
 
 > Tile Group (MISSILE); Heals? False
@@ -953,7 +953,7 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
   > Dock to Main Hub Tower Middle (Right)
       Trivial
 
-> Pickup (item_energytank_000); Heals? False
+> Pickup (Energy Tank); Heals? False
   * Pickup 82; Major Location? False
   * Extra - actor_name: item_energytank_000
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
@@ -962,7 +962,7 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
   > Upper Left Magnet Wall
       Flash Shift and Morph Ball
 
-> Pickup (item_missiletank_005); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 84; Major Location? False
   * Extra - actor_name: item_missiletank_005
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -998,7 +998,7 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
   * Extra - tile_types: ('POWERBEAM',)
   > Door to Teleport to Ferenia
       Morph Ball
-  > Pickup (item_missiletank_005)
+  > Pickup (Missile Tank)
       Morph Ball
 
 > Upper Left Magnet Wall; Heals? False
@@ -1010,7 +1010,7 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
           Spider Magnet or Space Jump or Walljump (Beginner) or Simple IBJ
   > Door to Save Station Middle
       Trivial
-  > Pickup (item_energytank_000)
+  > Pickup (Energy Tank)
       All of the following:
           Flash Shift and Morph Ball
           Grapple Beam or Spider Magnet or Walljump (Beginner)
@@ -1048,7 +1048,7 @@ Extra - asset_id: collision_camera_010
   > Event - Lower Magnet Wall
       Spider Magnet and Horizontal Water Movement
 
-> Pickup (item_missiletankplus_001); Heals? False
+> Pickup (Missile+ Tank); Heals? False
   * Pickup 89; Major Location? False
   * Extra - actor_name: item_missiletankplus_001
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
@@ -1070,7 +1070,7 @@ Extra - asset_id: collision_camera_010
   > Dock to Main Hub Tower Top (Right)
       Trivial
 
-> Pickup (item_missiletank_007); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 94; Major Location? False
   * Extra - actor_name: item_missiletank_007
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -1090,7 +1090,7 @@ Extra - asset_id: collision_camera_010
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (item_missiletank_007)
+  > Pickup (Missile Tank)
       Trivial
   > Giant Water Bottom
       Trivial
@@ -1142,7 +1142,7 @@ Extra - asset_id: collision_camera_010
           Gravity Suit or Water Bomb Jump (Beginner)
   > Door from Teleport to Ghavoran (Charge)
       Space Jump and After Burenia - Hub Magnet Wall
-  > Pickup (item_missiletankplus_001)
+  > Pickup (Missile+ Tank)
       Trivial
   > Giant Water Bottom
       Trivial
@@ -1444,12 +1444,12 @@ Extra - asset_id: collision_camera_013
   * Extra - right_shield_def: None
   > Door to Main Hub Tower Middle
       Trivial
-  > Pickup (item_missiletank)
+  > Pickup (Missile Tank)
       All of the following:
           Gravity Suit and Morph Ball
           Simple IBJ or Use Spin Boost
 
-> Pickup (item_missiletank); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 77; Major Location? False
   * Extra - actor_name: item_missiletank
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -1483,7 +1483,7 @@ Extra - asset_id: collision_camera_013
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Pickup (item_missiletank)
+  > Pickup (Missile Tank)
       Can Slide Underwater
   > Tile Group (BOMB) 1
       Morph Ball
@@ -1515,10 +1515,10 @@ Extra - asset_id: collision_camera_014
   * Extra - right_shield_def: None
   > Door to Main Hub Tower Top
       Trivial
-  > Pickup (powerup_ghostaura)
+  > Pickup (Flash Shift)
       Trivial
 
-> Pickup (powerup_ghostaura); Heals? False
+> Pickup (Flash Shift); Heals? False
   * Pickup 78; Major Location? True
   * Extra - actor_name: powerup_ghostaura
   * Extra - actor_def: actordef:actors/items/powerup_ghostaura/charclasses/powerup_ghostaura.bmsad
@@ -2010,14 +2010,14 @@ Extra - asset_id: collision_camera_021
   > Dock to Ammo Recharge Room (Open Passage)
       After Burenia - Destroy Gravity Suit Floor
 
-> Pickup (item_missiletankplus); Heals? False
+> Pickup (Missile+ Tank); Heals? False
   * Pickup 88; Major Location? False
   * Extra - actor_name: item_missiletankplus
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
   > Tile Group (SCREWATTACK) 2
       Trivial
 
-> Pickup (item_missiletank_004); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 93; Major Location? False
   * Extra - actor_name: item_missiletank_004
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -2163,7 +2163,7 @@ Extra - asset_id: collision_camera_021
   * Extra - tile_types: ('SCREWATTACK',)
   > Door to Navigation Room South
       Trivial
-  > Pickup (item_missiletankplus)
+  > Pickup (Missile+ Tank)
       Trivial
   > Tile Group (POWERBEAM) 1
       Simple IBJ or Use Spin Boost
@@ -2196,7 +2196,7 @@ Extra - asset_id: collision_camera_021
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('MISSILE',)
-  > Pickup (item_missiletank_004)
+  > Pickup (Missile Tank)
       Trivial
   > Door to Teleport to Ghavoran
       Trivial
@@ -2362,7 +2362,7 @@ the blast shield issue.
   > Start Point
       Trivial
 
-> Pickup (item_powerbombtank_000); Heals? False
+> Pickup (Power Bomb Tank); Heals? False
   * Pickup 85; Major Location? False
   * Extra - actor_name: item_powerbombtank_000
   * Extra - actor_def: actordef:actors/items/item_powerbombtank/charclasses/item_powerbombtank.bmsad
@@ -2403,7 +2403,7 @@ the blast shield issue.
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (item_powerbombtank_000)
+  > Pickup (Power Bomb Tank)
       Morph Ball
   > Tile Group (POWERBOMB)
       Morph Ball
@@ -2477,7 +2477,7 @@ Extra - asset_id: collision_camera_025
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Pickup (item_energytank)
+  > Pickup (Energy Tank)
       All of the following:
           After Burenia - Storm Missile Gate for Etank
           Any of the following:
@@ -2490,7 +2490,7 @@ Extra - asset_id: collision_camera_025
   > Event - Storm Missile Gate
       Activate Storm Missile Locks
 
-> Pickup (item_energytank); Heals? False
+> Pickup (Energy Tank); Heals? False
   * Pickup 95; Major Location? False
   * Extra - actor_name: item_energytank
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -158,7 +158,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -359,7 +359,7 @@
                                 ]
                             }
                         },
-                        "Pickup (item_missiletank)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1579,7 +1579,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_008)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -1707,7 +1707,7 @@
                     "description": "",
                     "extra": {},
                     "connections": {
-                        "Pickup (item_missiletank_008)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -3102,6 +3102,41 @@
                                     }
                                 ]
                             }
+                        },
+                        "Event - Activate Magnet Walls with Wave": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Wave",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisMoveMagnetWallsButton",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Knowledge",
+                                            "amount": 3,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -3362,6 +3397,27 @@
                             }
                         }
                     }
+                },
+                "Event - Activate Magnet Walls with Wave": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 12177.53,
+                        "y": 2126.03,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "extra": {},
+                    "event_name": "CatarisMoveMagnetWallsButton",
+                    "connections": {
+                        "Door to collision_camera_013 (C)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -3482,7 +3538,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_009)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -3509,7 +3565,7 @@
                         }
                     }
                 },
-                "Pickup (item_powerbombtank_000)": {
+                "Pickup (Power Bomb Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -3621,7 +3677,7 @@
                     "dock_type": "door",
                     "dock_weakness": "Grapple Beam Door",
                     "connections": {
-                        "Pickup (item_powerbombtank_000)": {
+                        "Pickup (Power Bomb Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4406,7 +4462,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_009)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -8190,7 +8246,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_001)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -8336,7 +8392,7 @@
                     "dock_type": "other",
                     "dock_weakness": "Morph Ball Tunnel",
                     "connections": {
-                        "Pickup (item_missiletank_001)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -10275,7 +10331,7 @@
                                 "items": []
                             }
                         },
-                        "Pickup (item_missiletankplus_000)": {
+                        "Pickup (Missile+ Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -10436,7 +10492,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletankplus_000)": {
+                "Pickup (Missile+ Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -10689,7 +10745,7 @@
                 "asset_id": "collision_camera_026"
             },
             "nodes": {
-                "Pickup (item_missiletank_005)": {
+                "Pickup (Missile Tank - Top)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -10767,7 +10823,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_006)": {
+                "Pickup (Missile Tank - Bottom)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -11126,7 +11182,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_006)": {
+                        "Pickup (Missile Tank - Bottom)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -11437,7 +11493,7 @@
                     "description": "",
                     "extra": {},
                     "connections": {
-                        "Pickup (item_missiletank_005)": {
+                        "Pickup (Missile Tank - Top)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12138,7 +12194,7 @@
                             "type": "template",
                             "data": "Can Slide"
                         },
-                        "Pickup (item_missiletank_004)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12243,7 +12299,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_004)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -12437,7 +12493,7 @@
                 "asset_id": "collision_camera_029"
             },
             "nodes": {
-                "Pickup (item_powerbombtank_002)": {
+                "Pickup (Power Bomb Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -12614,7 +12670,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_powerbombtank_002)": {
+                        "Pickup (Power Bomb Tank)": {
                             "type": "template",
                             "data": "Ballspark"
                         },
@@ -14200,7 +14256,7 @@
                     "destination": {
                         "world_name": "Cataris",
                         "area_name": "Green EMMI Fight",
-                        "node_name": "Dock to collision_camera_035 (C)"
+                        "node_name": "Door from collision_camera_035 (C)"
                     },
                     "dock_type": "door",
                     "dock_weakness": "Wide Beam Door",
@@ -14281,7 +14337,7 @@
                 "asset_id": "collision_camera_036"
             },
             "nodes": {
-                "Dock to collision_camera_035 (C)": {
+                "Door from collision_camera_035 (C)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -14289,7 +14345,7 @@
                         "y": 3600.0,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "Door opens up after Green EMMI is defeated\n\n",
                     "extra": {
                         "actor_name": "doorpowerpower_030",
                         "actor_def": "actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad",
@@ -14303,8 +14359,8 @@
                         "area_name": "collision_camera_035 (C)",
                         "node_name": "Door to Green EMMI Fight"
                     },
-                    "dock_type": "other",
-                    "dock_weakness": "Not Determined",
+                    "dock_type": "door",
+                    "dock_weakness": "Access Closed",
                     "connections": {
                         "Dock to collision_camera_028 (C)": {
                             "type": "and",
@@ -14452,7 +14508,7 @@
                     "dock_type": "other",
                     "dock_weakness": "Cataris EMMI Tunnel",
                     "connections": {
-                        "Dock to collision_camera_035 (C)": {
+                        "Door from collision_camera_035 (C)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14472,7 +14528,7 @@
                     "description": "",
                     "extra": {},
                     "connections": {
-                        "Dock to collision_camera_035 (C)": {
+                        "Door from collision_camera_035 (C)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14529,7 +14585,7 @@
                     "dock_type": "door",
                     "dock_weakness": "Access Open",
                     "connections": {
-                        "Dock to collision_camera_035 (C)": {
+                        "Door from collision_camera_035 (C)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -14624,7 +14680,7 @@
                     "extra": {},
                     "event_name": "s020_magma:default:breakablemag008",
                     "connections": {
-                        "Dock to collision_camera_035 (C)": {
+                        "Door from collision_camera_035 (C)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -15191,7 +15247,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_000)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -15265,7 +15321,7 @@
                             "type": "template",
                             "data": "Shoot Beam"
                         },
-                        "Pickup (item_missiletank_000)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -15629,7 +15685,7 @@
                         }
                     }
                 },
-                "Pickup (item_energyfragment_001)": {
+                "Pickup (Energy Fragment)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -15654,7 +15710,7 @@
                         }
                     }
                 },
-                "Pickup (item_energytank_000)": {
+                "Pickup (Energy Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -15749,7 +15805,7 @@
                     "dock_type": "other",
                     "dock_weakness": "Slide Tunnel",
                     "connections": {
-                        "Pickup (item_energyfragment_001)": {
+                        "Pickup (Energy Fragment)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -15967,7 +16023,7 @@
                                 "negate": true
                             }
                         },
-                        "Pickup (item_energytank_000)": {
+                        "Pickup (Energy Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -16697,7 +16753,7 @@
                     "dock_type": "door",
                     "dock_weakness": "Access Closed",
                     "connections": {
-                        "Pickup (itemsphere_diffusionbeam)": {
+                        "Pickup (Diffusion Beam)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -16815,7 +16871,7 @@
                         }
                     }
                 },
-                "Pickup (itemsphere_diffusionbeam)": {
+                "Pickup (Diffusion Beam)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -16876,7 +16932,7 @@
                         }
                     }
                 },
-                "Pickup (item_powerbombtank_001)": {
+                "Pickup (Power Bomb Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -17610,7 +17666,7 @@
                     "description": "",
                     "extra": {},
                     "connections": {
-                        "Pickup (item_powerbombtank_001)": {
+                        "Pickup (Power Bomb Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -17753,7 +17809,7 @@
                     "dock_type": "door",
                     "dock_weakness": "Charge Beam Door",
                     "connections": {
-                        "Pickup (item_missiletank_010)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -17818,7 +17874,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_010)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -17945,7 +18001,7 @@
                     "description": "",
                     "extra": {},
                     "connections": {
-                        "Pickup (item_missiletank_010)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -18501,7 +18557,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_007)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -18664,7 +18720,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_007)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -19764,7 +19820,7 @@
                     "dock_type": "door",
                     "dock_weakness": "Charge Beam Door",
                     "connections": {
-                        "Pickup (item_missiletank_002)": {
+                        "Pickup (Missile Tank)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -19867,7 +19923,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_002)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -20027,7 +20083,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_003)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -21158,7 +21214,7 @@
                     "description": "",
                     "extra": {},
                     "connections": {
-                        "Pickup (item_missiletank_003)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -21943,7 +21999,7 @@
                         }
                     }
                 },
-                "Pickup (item_energyfragment_000)": {
+                "Pickup (Energy Fragment)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -22084,7 +22140,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_energyfragment_000)": {
+                        "Pickup (Energy Fragment)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -22866,7 +22922,7 @@
                 "asset_id": "collision_camera_055"
             },
             "nodes": {
-                "Pickup (item_missiletank_011)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -22949,7 +23005,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_011)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -23542,7 +23598,7 @@
                 "asset_id": "collision_camera_061"
             },
             "nodes": {
-                "Pickup (item_missiletank_012)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -23784,7 +23840,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_012)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -30,7 +30,7 @@ Extra - asset_id: collision_camera_000
   > Mid-Level
       Simple IBJ or Use Spin Boost
 
-> Pickup (item_missiletank); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 36; Major Location? False
   * Extra - actor_name: item_missiletank
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -83,7 +83,7 @@ Extra - asset_id: collision_camera_000
   * Morph Ball Tunnel to collision_camera_007 (C)/Dock to Transport to Artaria
   > Door to Navigation Room Southeast
       Morph Ball and After Cataris - breakablemag002
-  > Pickup (item_missiletank)
+  > Pickup (Missile Tank)
       Trivial
   > Event - Missile Tank Blob (breakablemag002)
       Shoot Beam
@@ -384,7 +384,7 @@ Extra - asset_id: collision_camera_009
   > Dock to collision_camera_001 (C)
       After Cataris - breakablemag003 and Can Slide
 
-> Pickup (item_missiletank_008); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 37; Major Location? False
   * Extra - actor_name: item_missiletank_008
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -421,7 +421,7 @@ Extra - asset_id: collision_camera_009
       Trivial
 
 > Pickup Corner; Heals? False
-  > Pickup (item_missiletank_008)
+  > Pickup (Missile Tank)
       Morph Ball
   > Tile Group (SCREWATTACK) 1
       Trivial
@@ -662,6 +662,8 @@ Extra - asset_id: collision_camera_014
           All of the following:
               Spider Magnet
               Grapple Beam or After Cataris - Move Magnet Walls Button
+  > Event - Activate Magnet Walls with Wave
+      Wave Beam and Before Cataris - Move Magnet Walls Button and Knowledge (Advanced)
 
 > Door to collision_camera_045 (C); Heals? False
   * Power Beam Door to collision_camera_045 (C)/Door to Moving Magnet Walls (Tall)
@@ -728,6 +730,11 @@ Extra - asset_id: collision_camera_014
   > Door to Teleport to Artaria (Blue)
       Trivial
 
+> Event - Activate Magnet Walls with Wave; Heals? False
+  * Event Cataris - Move Magnet Walls Button
+  > Door to collision_camera_013 (C)
+      Trivial
+
 ----------------
 Teleport to Artaria (Blue)
 (Valid Starting Location)
@@ -747,14 +754,14 @@ Extra - asset_id: collision_camera_015
           Morph Ball
           Gravity Suit or Lava Damage ≥ 1000
 
-> Pickup (item_missiletank_009); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 45; Major Location? False
   * Extra - actor_name: item_missiletank_009
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Tile Group (BOMB) 3
       Morph Ball
 
-> Pickup (item_powerbombtank_000); Heals? False
+> Pickup (Power Bomb Tank); Heals? False
   * Pickup 48; Major Location? False
   * Extra - actor_name: item_powerbombtank_000
   * Extra - actor_def: actordef:actors/items/item_powerbombtank/charclasses/item_powerbombtank.bmsad
@@ -773,7 +780,7 @@ Extra - asset_id: collision_camera_015
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Pickup (item_powerbombtank_000)
+  > Pickup (Power Bomb Tank)
       All of the following:
           Morph Ball and After Cataris - Lower Power Bomb Tank Ceiling
           Any of the following:
@@ -896,7 +903,7 @@ Extra - asset_id: collision_camera_015
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Pickup (item_missiletank_009)
+  > Pickup (Missile Tank)
       Morph Ball
   > Tile Group (BOMB) 2
       All of the following:
@@ -1507,7 +1514,7 @@ Extra - asset_id: collision_camera_021
   > Event - Open Passage Blob (breakablemag013)
       Shoot Beam
 
-> Pickup (item_missiletank_001); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 38; Major Location? False
   * Extra - actor_name: item_missiletank_001
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -1530,7 +1537,7 @@ Extra - asset_id: collision_camera_021
 
 > Dock to collision_camera_019 (C) (Tunnel); Heals? False
   * Morph Ball Tunnel to collision_camera_019 (C)/Dock to collision_camera_021 (C) (Tunnel)
-  > Pickup (item_missiletank_001)
+  > Pickup (Missile Tank)
       Morph Ball
 
 ----------------
@@ -1865,7 +1872,7 @@ Extra - asset_id: collision_camera_025
   * Extra - right_shield_def: None
   > Door to Save Station West
       Trivial
-  > Pickup (item_missiletankplus_000)
+  > Pickup (Missile+ Tank)
       Morph Ball
   > Tile Group (BOMB)
       Morph Ball
@@ -1909,7 +1916,7 @@ Extra - asset_id: collision_camera_025
   > Door to collision_camera_043 (C)
       Trivial
 
-> Pickup (item_missiletankplus_000); Heals? False
+> Pickup (Missile+ Tank); Heals? False
   * Pickup 50; Major Location? False
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
@@ -1976,7 +1983,7 @@ Teleport to Ghavoran
 Extra - total_boundings: {'x1': -16500.0, 'x2': -12400.0, 'y1': 1200.0, 'y2': 4700.0}
 Extra - polygon: [[-12400.0, 4700.0], [-16000.0, 4700.0], [-16500.0, 4100.0], [-16500.0, 1200.0], [-12400.0, 1200.0]]
 Extra - asset_id: collision_camera_026
-> Pickup (item_missiletank_005); Heals? False
+> Pickup (Missile Tank - Top); Heals? False
   * Pickup 41; Major Location? False
   * Extra - actor_name: item_missiletank_005
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -1987,7 +1994,7 @@ Extra - asset_id: collision_camera_026
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
 
-> Pickup (item_missiletank_006); Heals? False
+> Pickup (Missile Tank - Bottom); Heals? False
   * Pickup 53; Major Location? False
   * Extra - actor_name: item_missiletank_006
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -2057,7 +2064,7 @@ Extra - asset_id: collision_camera_026
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (item_missiletank_006)
+  > Pickup (Missile Tank - Bottom)
       Gravity Suit
   > Lower Center
       Trivial
@@ -2105,7 +2112,7 @@ Extra - asset_id: collision_camera_026
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
 > Top room; Heals? False
-  > Pickup (item_missiletank_005)
+  > Pickup (Missile Tank - Top)
       All of the following:
           Morph Ball and Varia Suit and Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
           Simple IBJ or Use Spin Boost
@@ -2218,7 +2225,7 @@ Extra - asset_id: collision_camera_028
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to collision_camera_029 (C)
       Can Slide
-  > Pickup (item_missiletank_004)
+  > Pickup (Missile Tank)
       Trivial
 
 > Dock to Long Mouth Statue Room (dooremmy_009); Heals? False
@@ -2239,7 +2246,7 @@ Extra - asset_id: collision_camera_028
   > Upper Ledge
       Grapple Beam or Spider Magnet or Space Jump or Simple IBJ
 
-> Pickup (item_missiletank_004); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 40; Major Location? False
   * Extra - actor_name: item_missiletank_004
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -2276,7 +2283,7 @@ collision_camera_029 (C)
 Extra - total_boundings: {'x1': -7650.0, 'x2': -4600.0, 'y1': 1000.0, 'y2': 3100.0}
 Extra - polygon: [[-4600.0, 3100.0], [-7650.0, 3100.0], [-7650.0, 1000.0], [-4600.0, 1000.0]]
 Extra - asset_id: collision_camera_029
-> Pickup (item_powerbombtank_002); Heals? False
+> Pickup (Power Bomb Tank); Heals? False
   * Pickup 33; Major Location? False
   * Extra - actor_name: item_powerbombtank_002
   * Extra - actor_def: actordef:actors/items/item_powerbombtank/charclasses/item_powerbombtank.bmsad
@@ -2328,7 +2335,7 @@ Extra - asset_id: collision_camera_029
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBOMB',)
-  > Pickup (item_powerbombtank_002)
+  > Pickup (Power Bomb Tank)
       Ballspark
   > Tunnel Center
       Morph Ball
@@ -2642,7 +2649,7 @@ Extra - asset_id: collision_camera_035
       Trivial
 
 > Door to Green EMMI Fight; Heals? False
-  * Wide Beam Door to Green EMMI Fight/Dock to collision_camera_035 (C)
+  * Wide Beam Door to Green EMMI Fight/Door from collision_camera_035 (C)
   * Extra - actor_name: doorpowerpower_030
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2665,8 +2672,11 @@ Green EMMI Fight
 Extra - total_boundings: {'x1': -7650.0, 'x2': -2600.0, 'y1': 3000.0, 'y2': 6500.0}
 Extra - polygon: [[-2600.0, 6500.0], [-7650.0, 6500.0], [-7650.0, 3000.0], [-2600.0, 3000.0]]
 Extra - asset_id: collision_camera_036
-> Dock to collision_camera_035 (C); Heals? False
-  * Not Determined to collision_camera_035 (C)/Door to Green EMMI Fight
+> Door from collision_camera_035 (C); Heals? False
+  * Access Closed to collision_camera_035 (C)/Door to Green EMMI Fight
+  * Door opens up after Green EMMI is defeated
+
+
   * Extra - actor_name: doorpowerpower_030
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2702,11 +2712,11 @@ Extra - asset_id: collision_camera_036
 
 > Dock to collision_camera_028 (C); Heals? False
   * Cataris EMMI Tunnel to collision_camera_028 (C)/Dock to Green EMMI Fight
-  > Dock to collision_camera_035 (C)
+  > Door from collision_camera_035 (C)
       Trivial
 
 > Upper-right Corner; Heals? False
-  > Dock to collision_camera_035 (C)
+  > Door from collision_camera_035 (C)
       Trivial
   > Event - Top Blob (breakablemag007)
       Shoot Beam
@@ -2715,7 +2725,7 @@ Extra - asset_id: collision_camera_036
 
 > Door to Central Unit Room; Heals? False
   * Access Open to Central Unit Room/Door to Green EMMI Fight
-  > Dock to collision_camera_035 (C)
+  > Door from collision_camera_035 (C)
       Any of the following:
           Morph Ball
           After Cataris - breakablemag008 and Can Slide
@@ -2730,7 +2740,7 @@ Extra - asset_id: collision_camera_036
 
 > Event - Central Unit Blob through wall; Heals? False
   * Event Cataris - breakablemag008
-  > Dock to collision_camera_035 (C)
+  > Door from collision_camera_035 (C)
       Trivial
 
 > Pickup (Morph Ball); Heals? False
@@ -2842,7 +2852,7 @@ Extra - asset_id: collision_camera_040
   > Event - Push Wide Beam Block
       Push Wide Beam Block
 
-> Pickup (item_missiletank_000); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 54; Major Location? False
   * Extra - actor_name: item_missiletank_000
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -2866,7 +2876,7 @@ Extra - asset_id: collision_camera_040
   * Extra - tile_types: ('SPEEDBOOST',)
   > Dock to collision_camera_042 (C) (Top)
       Shoot Beam
-  > Pickup (item_missiletank_000)
+  > Pickup (Missile Tank)
       Trivial
 
 > Dock to collision_camera_042 (C) (Bottom); Heals? False
@@ -2953,14 +2963,14 @@ Extra - asset_id: collision_camera_042
   > Event - Thermal Device 1
       Trivial
 
-> Pickup (item_energyfragment_001); Heals? False
+> Pickup (Energy Fragment); Heals? False
   * Pickup 42; Major Location? True
   * Extra - actor_name: item_energyfragment_001
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Dock to collision_camera_038 (C) (Top)
       Trivial
 
-> Pickup (item_energytank_000); Heals? False
+> Pickup (Energy Tank); Heals? False
   * Pickup 49; Major Location? False
   * Extra - actor_name: item_energytank_000
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
@@ -2987,7 +2997,7 @@ Extra - asset_id: collision_camera_042
 
 > Dock to collision_camera_038 (C) (Top); Heals? False
   * Slide Tunnel to collision_camera_038 (C)/Dock to collision_camera_042 (C) (Top)
-  > Pickup (item_energyfragment_001)
+  > Pickup (Energy Fragment)
       Trivial
 
 > Dock to collision_camera_038 (C) (Bottom); Heals? False
@@ -3020,7 +3030,7 @@ Extra - asset_id: collision_camera_042
 > Past Magnet Floor; Heals? False
   > Door to Lone Recharge Room
       Before Cataris - deviceheat_002
-  > Pickup (item_energytank_000)
+  > Pickup (Energy Tank)
       Trivial
   > Dock to collision_camera_018 (C)
       After Cataris - Thermal Magnet Platform Lowered
@@ -3128,7 +3138,7 @@ Extra - asset_id: collision_camera_044
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorshieldmissile
   * Extra - right_shield_def: actordef:actors/props/doorshieldmissile/charclasses/doorshieldmissile.bmsad
-  > Pickup (itemsphere_diffusionbeam)
+  > Pickup (Diffusion Beam)
       Any of the following:
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
@@ -3141,7 +3151,7 @@ Extra - asset_id: collision_camera_044
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
 
-> Pickup (itemsphere_diffusionbeam); Heals? False
+> Pickup (Diffusion Beam); Heals? False
   * Pickup 35; Major Location? True
   * Extra - actor_name: itemsphere_diffusionbeam
   * Extra - actor_def: actordef:actors/items/itemsphere_diffusionbeam/charclasses/itemsphere_diffusionbeam.bmsad
@@ -3150,7 +3160,7 @@ Extra - asset_id: collision_camera_044
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
 
-> Pickup (item_powerbombtank_001); Heals? False
+> Pickup (Power Bomb Tank); Heals? False
   * Pickup 51; Major Location? False
   * Extra - actor_name: item_powerbombtank_001
   * Extra - actor_def: actordef:actors/items/item_powerbombtank/charclasses/item_powerbombtank.bmsad
@@ -3304,7 +3314,7 @@ Extra - asset_id: collision_camera_044
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
 > Alcove; Heals? False
-  > Pickup (item_powerbombtank_001)
+  > Pickup (Power Bomb Tank)
       Morph Ball and After Cataris - grapplepulloff1x2
   > Event - PB Tank Grapple Block (grapplepulloff1x2)
       Grapple Beam
@@ -3337,7 +3347,7 @@ Extra - asset_id: collision_camera_045
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Pickup (item_missiletank_010)
+  > Pickup (Missile Tank)
       Morph Ball
   > Tile Group (POWERBEAM)
       Trivial
@@ -3357,7 +3367,7 @@ Extra - asset_id: collision_camera_045
   > Dock to Teleport to Artaria (Blue)
       After Cataris - db_dside_mg_004
 
-> Pickup (item_missiletank_010); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 46; Major Location? False
   * Extra - actor_name: item_missiletank_010
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -3390,7 +3400,7 @@ Extra - asset_id: collision_camera_045
       After Cataris - db_dside_mg_004
 
 > Pickup Corner; Heals? False
-  > Pickup (item_missiletank_010)
+  > Pickup (Missile Tank)
       Trivial
   > Tile Group (POWERBEAM)
       Trivial
@@ -3514,7 +3524,7 @@ Extra - asset_id: collision_camera_048
   > Left Floor
       After Cataris - db_hdoor_mg_001
 
-> Pickup (item_missiletank_007); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 43; Major Location? False
   * Extra - actor_name: item_missiletank_007
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -3544,7 +3554,7 @@ Extra - asset_id: collision_camera_048
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
-  > Pickup (item_missiletank_007)
+  > Pickup (Missile Tank)
       Morph Ball
   > Tile Group (BOMB) 1
       Any of the following:
@@ -3700,7 +3710,7 @@ Extra - asset_id: collision_camera_049
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Pickup (item_missiletank_002)
+  > Pickup (Missile Tank)
       Any of the following:
           Gravity Suit and Speed Booster
           All of the following:
@@ -3709,7 +3719,7 @@ Extra - asset_id: collision_camera_049
                   Heat/Cold Runs (Intermediate) and Heat Damage ≥ 200
               Simple IBJ or Use Spin Boost
 
-> Pickup (item_missiletank_002); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 52; Major Location? False
   * Extra - actor_name: item_missiletank_002
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -3735,7 +3745,7 @@ Extra - asset_id: collision_camera_051
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
 
-> Pickup (item_missiletank_003); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 39; Major Location? False
   * Extra - actor_name: item_missiletank_003
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -3893,7 +3903,7 @@ Extra - asset_id: collision_camera_051
       Trivial
 
 > Ledge above Teleport; Heals? False
-  > Pickup (item_missiletank_003)
+  > Pickup (Missile Tank)
       All of the following:
           Morph Ball
           Any of the following:
@@ -4026,7 +4036,7 @@ Extra - asset_id: collision_camera_053
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 10
 
-> Pickup (item_energyfragment_000); Heals? False
+> Pickup (Energy Fragment); Heals? False
   * Pickup 44; Major Location? True
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
@@ -4057,7 +4067,7 @@ Extra - asset_id: collision_camera_053
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (item_energyfragment_000)
+  > Pickup (Energy Fragment)
       All of the following:
           Gravity Suit and Morph Ball
           Space Jump or Speed Booster
@@ -4171,7 +4181,7 @@ collision_camera_055 (C)
 Extra - total_boundings: {'x1': 4400.0, 'x2': 8200.0, 'y1': 1700.0, 'y2': 2842.0}
 Extra - polygon: [[8200.0, 2842.0], [4400.0, 2842.0], [4400.0, 1700.0], [8200.0, 1700.0]]
 Extra - asset_id: collision_camera_055
-> Pickup (item_missiletank_011); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 47; Major Location? False
   * Extra - actor_name: item_missiletank_011
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -4194,7 +4204,7 @@ Extra - asset_id: collision_camera_055
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('MISSILE',)
-  > Pickup (item_missiletank_011)
+  > Pickup (Missile Tank)
       Morph Ball
   > Main Room
       Trivial
@@ -4310,7 +4320,7 @@ Kraid Eyedoor Room
 Extra - total_boundings: {'x1': -12500.0, 'x2': -10400.0, 'y1': -4400.0, 'y2': -2400.0}
 Extra - polygon: [[-10400.0, -2400.0], [-12500.0, -2400.0], [-12500.0, -4400.0], [-10400.0, -4400.0]]
 Extra - asset_id: collision_camera_061
-> Pickup (item_missiletank_012); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 34; Major Location? False
   * Extra - actor_name: item_missiletank_012
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -4358,7 +4368,7 @@ Extra - asset_id: collision_camera_061
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Pickup (item_missiletank_012)
+  > Pickup (Missile Tank)
       Morph Ball
   > Safe Ledge
       All of the following:

--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -14550,7 +14550,7 @@
                         }
                     }
                 },
-                "Pickup (item_energyfragment_003)": {
+                "Pickup (Energy Fragment)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -14667,7 +14667,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_energyfragment_003)": {
+                        "Pickup (Energy Fragment)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -3002,7 +3002,7 @@ Extra - asset_id: collision_camera_040
   > Door to Central Unit Room
       Morph Ball
 
-> Pickup (item_energyfragment_003); Heals? False
+> Pickup (Energy Fragment); Heals? False
   * Pickup 72; Major Location? True
   * Extra - actor_name: item_energyfragment_003
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
@@ -3036,7 +3036,7 @@ Extra - asset_id: collision_camera_040
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (item_energyfragment_003)
+  > Pickup (Energy Fragment)
       Morph Ball
   > Door to collision_camera_037 (D) (doorframe_000)
       Trivial

--- a/randovania/games/dread/json_data/Elun.json
+++ b/randovania/games/dread/json_data/Elun.json
@@ -1086,26 +1086,12 @@
                     "dock_type": "other",
                     "dock_weakness": "Blocked Passage",
                     "connections": {
-                        "Door to Plasma Beam Room (Upper)": {
+                        "Event - Release X": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s060_quarantine:default:db_reg_qt_001",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
-                        },
-                        "Event - Elun - Ammo Recharge Room Blob": {
-                            "type": "template",
-                            "data": "Shoot Beam"
                         }
                     }
                 },
@@ -1169,6 +1155,60 @@
                                         }
                                     }
                                 ]
+                            }
+                        }
+                    }
+                },
+                "Alcove": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 1975.9073143495252,
+                        "y": -1890.089335566723,
+                        "z": 0
+                    },
+                    "description": "",
+                    "extra": {},
+                    "connections": {
+                        "Door to Plasma Beam Room (Upper)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "s060_quarantine:default:db_reg_qt_001",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Event - Elun - Ammo Recharge Room Blob": {
+                            "type": "template",
+                            "data": "Shoot Beam"
+                        },
+                        "Dock from Purple Drapes": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Release X": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 1871.16,
+                        "y": -2099.58,
+                        "z": 0.0
+                    },
+                    "description": "TODO: Verify exiting this morph ball launcher releases the X\n\n",
+                    "extra": {},
+                    "event_name": "ElunReleaseX",
+                    "connections": {
+                        "Alcove": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -2918,23 +2958,6 @@
                             }
                         }
                     }
-                },
-                "Tile Group ()": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 9200.0,
-                        "y": 700.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "actor_name": "breakabletilegroup_026",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": []
-                    },
-                    "connections": {}
                 },
                 "Dock to Horizontal Bomb Maze (Upper)": {
                     "node_type": "dock",

--- a/randovania/games/dread/json_data/Elun.txt
+++ b/randovania/games/dread/json_data/Elun.txt
@@ -256,10 +256,8 @@ Extra - asset_id: collision_camera_003
 
 > Dock from Purple Drapes; Heals? False
   * Blocked Passage to Purple Drapes/Dock to Ammo Refill Room
-  > Door to Plasma Beam Room (Upper)
-      After Elun - Ammo Recharge Room Blob
-  > Event - Elun - Ammo Recharge Room Blob
-      Shoot Beam
+  > Event - Release X
+      Trivial
 
 > Dock to Bottom Morph Launcher; Heals? False
   * Morph Ball Launcher to Bottom Morph Launcher/Dock to Ammo Refill Room
@@ -270,6 +268,22 @@ Extra - asset_id: collision_camera_003
   * Morph Ball Tunnel to Horizontal Bomb Maze/Dock to Ammo Refill Room
   > Tile Group (BOMB) 2
       Morph Ball
+
+> Alcove; Heals? False
+  > Door to Plasma Beam Room (Upper)
+      After Elun - Ammo Recharge Room Blob
+  > Event - Elun - Ammo Recharge Room Blob
+      Shoot Beam
+  > Dock from Purple Drapes
+      Trivial
+
+> Event - Release X; Heals? False
+  * Event Elun - Release X Parasites
+  * TODO: Verify exiting this morph ball launcher releases the X
+
+
+  > Alcove
+      Trivial
 
 ----------------
 Chozo Soldier Arena
@@ -661,13 +675,6 @@ Extra - asset_id: collision_camera_009
       Morph Ball
   > Grapple Block Alcove
       Morph Ball
-
-> Tile Group (); Heals? False
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_026
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ()
 
 > Dock to Horizontal Bomb Maze (Upper); Heals? False
   * Morph Ball Tunnel to Horizontal Bomb Maze/Dock to Vertical Bomb Maze (Upper)

--- a/randovania/games/dread/json_data/Ferenia.json
+++ b/randovania/games/dread/json_data/Ferenia.json
@@ -354,7 +354,7 @@
                         }
                     }
                 },
-                "Pickup (item_energyfragment_002)": {
+                "Pickup (Energy Fragment)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -491,7 +491,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_energyfragment_002)": {
+                        "Pickup (Energy Fragment)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -1357,7 +1357,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletankplus_001)": {
+                "Pickup (Missile+ Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -1427,7 +1427,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletankplus_001)": {
+                        "Pickup (Missile+ Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1972,7 +1972,7 @@
                         }
                     }
                 },
-                "Pickup (item_energyfragment_000)": {
+                "Pickup (Energy Fragment)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -2173,7 +2173,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_energyfragment_000)": {
+                        "Pickup (Energy Fragment)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -3044,7 +3044,7 @@
                 "asset_id": "collision_camera_011"
             },
             "nodes": {
-                "Pickup (item_missiletank_001)": {
+                "Pickup (Missile Tank - Left)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -3080,7 +3080,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_005)": {
+                "Pickup (Missile Tank - Right)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -3152,7 +3152,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_001)": {
+                        "Pickup (Missile Tank - Left)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -3265,7 +3265,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_005)": {
+                        "Pickup (Missile Tank - Right)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -3638,7 +3638,7 @@
                         }
                     }
                 },
-                "Pickup (itemsphere_spacejump)": {
+                "Pickup (Space Jump)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -3663,7 +3663,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_002)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -3699,7 +3699,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletankplus_000)": {
+                "Pickup (Missile+ Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -3817,7 +3817,7 @@
                                 "items": []
                             }
                         },
-                        "Pickup (itemsphere_spacejump)": {
+                        "Pickup (Space Jump)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3923,7 +3923,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletankplus_000)": {
+                        "Pickup (Missile+ Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4160,7 +4160,7 @@
                                 "items": []
                             }
                         },
-                        "Pickup (item_missiletank_002)": {
+                        "Pickup (Missile Tank)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -4924,7 +4924,7 @@
                 "asset_id": "collision_camera_013"
             },
             "nodes": {
-                "Pickup (item_missiletank_000)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -5010,7 +5010,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_000)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6072,7 +6072,7 @@
                         }
                     }
                 },
-                "Pickup (item_powerbombtank_001)": {
+                "Pickup (Power Bomb Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -6207,7 +6207,7 @@
                                 "items": []
                             }
                         },
-                        "Pickup (item_powerbombtank_001)": {
+                        "Pickup (Power Bomb Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -8135,7 +8135,7 @@
                 "asset_id": "collision_camera_020"
             },
             "nodes": {
-                "Pickup (item_energyfragment_001)": {
+                "Pickup (Energy Fragment)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -8180,7 +8180,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_energyfragment_001)": {
+                        "Pickup (Energy Fragment)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -9459,7 +9459,7 @@
                         }
                     }
                 },
-                "Pickup (item_energyfragment)": {
+                "Pickup (Energy Fragment)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -9504,7 +9504,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_energyfragment)": {
+                        "Pickup (Energy Fragment)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -9666,7 +9666,7 @@
                 "asset_id": "collision_camera_026"
             },
             "nodes": {
-                "Pickup (item_missiletank_004)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -9768,7 +9768,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_004)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -10807,7 +10807,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_003)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -11497,7 +11497,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_003)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -14316,7 +14316,7 @@
                         }
                     }
                 },
-                "Pickup (item_powerbombtank_000)": {
+                "Pickup (Power Bomb Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -14384,7 +14384,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_powerbombtank_000)": {
+                        "Pickup (Power Bomb Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -71,7 +71,7 @@ Extra - asset_id: collision_camera_002
           Morph Ball
           Grapple Beam or Simple IBJ or Use Spin Boost
 
-> Pickup (item_energyfragment_002); Heals? False
+> Pickup (Energy Fragment); Heals? False
   * Pickup 123; Major Location? True
   * Extra - actor_name: item_energyfragment_002
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
@@ -113,7 +113,7 @@ Extra - asset_id: collision_camera_002
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Pickup (item_energyfragment_002)
+  > Pickup (Energy Fragment)
       Morph Ball
   > Right Alcove
       Morph Ball
@@ -272,7 +272,7 @@ Extra - asset_id: collision_camera_006
           Morph Ball
           Simple IBJ or Use Spin Boost
 
-> Pickup (item_missiletankplus_001); Heals? False
+> Pickup (Missile+ Tank); Heals? False
   * Pickup 128; Major Location? False
   * Extra - actor_name: item_missiletankplus_001
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
@@ -293,7 +293,7 @@ Extra - asset_id: collision_camera_006
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (item_missiletankplus_001)
+  > Pickup (Missile+ Tank)
       Trivial
   > Tile Group (WEIGHT)
       Trivial
@@ -428,7 +428,7 @@ Extra - asset_id: collision_camera_009
   > Tile Group (POWERBEAM) 3
       Simple IBJ or Use Spin Boost
 
-> Pickup (item_energyfragment_000); Heals? False
+> Pickup (Energy Fragment); Heals? False
   * Pickup 131; Major Location? True
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
@@ -488,7 +488,7 @@ Extra - asset_id: collision_camera_009
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (item_energyfragment_000)
+  > Pickup (Energy Fragment)
       Morph Ball
   > Tile Group (SPEEDBOOST) 2
       Trivial
@@ -632,7 +632,7 @@ collision_camera_011 (F)
 Extra - total_boundings: {'x1': -16500.0, 'x2': -13400.0, 'y1': -1000.0, 'y2': 800.0}
 Extra - polygon: [[-13400.0, 800.0], [-16500.0, 800.0], [-16500.0, -1000.0], [-13400.0, -1000.0]]
 Extra - asset_id: collision_camera_011
-> Pickup (item_missiletank_001); Heals? False
+> Pickup (Missile Tank - Left); Heals? False
   * Pickup 120; Major Location? False
   * Extra - actor_name: item_missiletank_001
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -641,7 +641,7 @@ Extra - asset_id: collision_camera_011
   > Tile Group (BOMB)
       Morph Ball
 
-> Pickup (item_missiletank_005); Heals? False
+> Pickup (Missile Tank - Right); Heals? False
   * Pickup 132; Major Location? False
   * Extra - actor_name: item_missiletank_005
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -662,7 +662,7 @@ Extra - asset_id: collision_camera_011
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Pickup (item_missiletank_001)
+  > Pickup (Missile Tank - Left)
       Morph Ball
   > Tile Group (WEIGHT) 2
       Trivial
@@ -694,7 +694,7 @@ Extra - asset_id: collision_camera_011
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
-  > Pickup (item_missiletank_005)
+  > Pickup (Missile Tank - Right)
       Morph Ball
   > Tile Group (BOMB POWERBOMB)
       Morph Ball
@@ -785,14 +785,14 @@ Extra - asset_id: collision_camera_012
   > Tile Group (POWERBEAM) 2
       Trivial
 
-> Pickup (itemsphere_spacejump); Heals? False
+> Pickup (Space Jump); Heals? False
   * Pickup 119; Major Location? True
   * Extra - actor_name: itemsphere_spacejump
   * Extra - actor_def: actordef:actors/items/itemsphere_spacejump/charclasses/itemsphere_spacejump.bmsad
   > Start Point 1
       Trivial
 
-> Pickup (item_missiletank_002); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 129; Major Location? False
   * Extra - actor_name: item_missiletank_002
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -801,7 +801,7 @@ Extra - asset_id: collision_camera_012
   > Tile Group (BOMB) 2
       Morph Ball
 
-> Pickup (item_missiletankplus_000); Heals? False
+> Pickup (Missile+ Tank); Heals? False
   * Pickup 130; Major Location? False
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
@@ -831,7 +831,7 @@ Extra - asset_id: collision_camera_012
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door from collision_camera_015 (F)
       Trivial
-  > Pickup (itemsphere_spacejump)
+  > Pickup (Space Jump)
       Trivial
 
 > Start Point 2; Heals? False; Spawn Point
@@ -862,7 +862,7 @@ Extra - asset_id: collision_camera_012
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (item_missiletankplus_000)
+  > Pickup (Missile+ Tank)
       Trivial
   > Tile Group (BOMB) 1
       Trivial
@@ -916,7 +916,7 @@ Extra - asset_id: collision_camera_012
   * Extra - tile_types: ('BOMB',)
   > Door to Navigation Room
       Trivial
-  > Pickup (item_missiletank_002)
+  > Pickup (Missile Tank)
       Space Jump or Speed Booster or Infinite Bomb Jump (Intermediate)
 
 > Tile Group (BOMB) 3; Heals? False
@@ -1029,7 +1029,7 @@ collision_camera_013 (F)
 Extra - total_boundings: {'x1': -18500.0, 'x2': -16400.0, 'y1': 1500.0, 'y2': 3200.0}
 Extra - polygon: [[-16400.0, 3200.0], [-18500.0, 3200.0], [-18500.0, 1500.0], [-16400.0, 1500.0]]
 Extra - asset_id: collision_camera_013
-> Pickup (item_missiletank_000); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 121; Major Location? False
   * Extra - actor_name: item_missiletank_000
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -1048,7 +1048,7 @@ Extra - asset_id: collision_camera_013
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('WEIGHT',)
-  > Pickup (item_missiletank_000)
+  > Pickup (Missile Tank)
       All of the following:
           Morph Ball and After Ferenia - db_reg_b2_004
           Any of the following:
@@ -1320,7 +1320,7 @@ Extra - asset_id: collision_camera_017
   > Tile Group (POWERBOMB)
       Trivial
 
-> Pickup (item_powerbombtank_001); Heals? False
+> Pickup (Power Bomb Tank); Heals? False
   * Pickup 126; Major Location? False
   * Extra - actor_name: item_powerbombtank_001
   * Extra - actor_def: actordef:actors/items/item_powerbombtank/charclasses/item_powerbombtank.bmsad
@@ -1357,7 +1357,7 @@ Extra - asset_id: collision_camera_017
   * Extra - tile_types: ('POWERBOMB',)
   > Door to collision_camera_015 (F)
       Trivial
-  > Pickup (item_powerbombtank_001)
+  > Pickup (Power Bomb Tank)
       Morph Ball
 
 ----------------
@@ -1684,7 +1684,7 @@ collision_camera_020 (F)
 Extra - total_boundings: {'x1': -2500.0, 'x2': -400.0, 'y1': 1800.0, 'y2': 2900.0}
 Extra - polygon: [[-400.0, 2900.0], [-2500.0, 2900.0], [-2500.0, 1800.0], [-400.0, 1800.0]]
 Extra - asset_id: collision_camera_020
-> Pickup (item_energyfragment_001); Heals? False
+> Pickup (Energy Fragment); Heals? False
   * Pickup 124; Major Location? True
   * Extra - actor_name: item_energyfragment_001
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
@@ -1697,7 +1697,7 @@ Extra - asset_id: collision_camera_020
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Pickup (item_energyfragment_001)
+  > Pickup (Energy Fragment)
       Morph Ball
   > Tile Group (SCREWATTACK)
       Trivial
@@ -1983,7 +1983,7 @@ Extra - asset_id: collision_camera_025
   > Tile Group (WEIGHT)
       Morph Ball
 
-> Pickup (item_energyfragment); Heals? False
+> Pickup (Energy Fragment); Heals? False
   * Pickup 133; Major Location? True
   * Extra - actor_name: item_energyfragment
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
@@ -1996,7 +1996,7 @@ Extra - asset_id: collision_camera_025
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Pickup (item_energyfragment)
+  > Pickup (Energy Fragment)
       Morph Ball
   > Dock to Escue Eyedoor Room
       Morph Ball
@@ -2034,7 +2034,7 @@ Escue Eyedoor Room
 Extra - total_boundings: {'x1': 9500.0, 'x2': 12700.0, 'y1': -3802.5, 'y2': -400.0}
 Extra - polygon: [[12700.0, -400.0], [9500.0, -400.0], [9500.0, -3802.5], [12700.0, -3802.5]]
 Extra - asset_id: collision_camera_026
-> Pickup (item_missiletank_004); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 122; Major Location? False
   * Extra - actor_name: item_missiletank_004
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -2064,7 +2064,7 @@ Extra - asset_id: collision_camera_026
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('MISSILE',)
-  > Pickup (item_missiletank_004)
+  > Pickup (Missile Tank)
       Morph Ball
   > Tile Group (POWERBEAM) 1
       Trivial
@@ -2298,7 +2298,7 @@ Extra - asset_id: collision_camera_030
           Gravity Suit
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
 
-> Pickup (item_missiletank_003); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 125; Major Location? False
   * Extra - actor_name: item_missiletank_003
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -2408,7 +2408,7 @@ Extra - asset_id: collision_camera_030
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('MISSILE',)
-  > Pickup (item_missiletank_003)
+  > Pickup (Missile Tank)
       Morph Ball
   > Tile Group (SPEEDBOOST)
       Any of the following:
@@ -2965,7 +2965,7 @@ Extra - asset_id: collision_camera_040
   > Dock to collision_camera_001 (F)
       Morph Ball and After Ferenia - Central Unit
 
-> Pickup (item_powerbombtank_000); Heals? False
+> Pickup (Power Bomb Tank); Heals? False
   * Pickup 127; Major Location? False
   * Extra - actor_name: item_powerbombtank_000
   * Extra - actor_def: actordef:actors/items/item_powerbombtank/charclasses/item_powerbombtank.bmsad
@@ -2984,7 +2984,7 @@ Extra - asset_id: collision_camera_040
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBOMB',)
-  > Pickup (item_powerbombtank_000)
+  > Pickup (Power Bomb Tank)
       Morph Ball
   > Central Platform
       Trivial

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -371,7 +371,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_000)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -616,7 +616,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_000)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -1100,7 +1100,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_003)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -1371,7 +1371,7 @@
                                 "items": []
                             }
                         },
-                        "Pickup (item_missiletank_003)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2473,7 +2473,7 @@
                                 "items": []
                             }
                         },
-                        "Pickup (item_missiletank_001)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2526,7 +2526,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_001)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -2867,7 +2867,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletankplus_000)": {
+                "Pickup (Missile+ Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -2941,7 +2941,7 @@
                     "dock_type": "other",
                     "dock_weakness": "Morph Ball Tunnel",
                     "connections": {
-                        "Pickup (item_missiletankplus_000)": {
+                        "Pickup (Missile+ Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -3238,13 +3238,13 @@
                         }
                     }
                 },
-                "Pickup (itemsphere_supermissile)": {
+                "Pickup (Super Missile)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
-                        "x": -4540.00048828125,
+                        "x": -4540.0,
                         "y": -5590.0,
-                        "z": 0.0012209999840706587
+                        "z": 0.0
                     },
                     "description": "",
                     "extra": {
@@ -3284,7 +3284,7 @@
                                 "items": []
                             }
                         },
-                        "Pickup (itemsphere_supermissile)": {
+                        "Pickup (Super Missile)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5703,12 +5703,29 @@
                     "dock_weakness": "EMMI Door",
                     "connections": {
                         "Door to Blue EMMI Fight (doorpowerpower_011)": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "GhavoranCU",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -5773,8 +5790,25 @@
                     "dock_weakness": "Power Beam Door",
                     "connections": {
                         "Dock to Spin Boost Tower (dooremmy_007)": {
-                            "type": "template",
-                            "data": "Can Slide"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "GhavoranCU",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Door to Blue EMMI Fight (doorpowerpower_010)": {
                             "type": "and",
@@ -5958,7 +5992,7 @@
                         }
                     }
                 },
-                "Pickup (item_powerbombtank_000)": {
+                "Pickup (Power Bomb Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -6083,7 +6117,7 @@
                         }
                     }
                 },
-                "Pickup (item_energyfragment_000)": {
+                "Pickup (Energy Fragment)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -6110,7 +6144,7 @@
                         }
                     }
                 },
-                "Pickup (item_energytank_000)": {
+                "Pickup (Energy Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -6202,7 +6236,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_energyfragment_000)": {
+                        "Pickup (Energy Fragment)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -6357,7 +6391,7 @@
                                 "negate": false
                             }
                         },
-                        "Pickup (item_energytank_000)": {
+                        "Pickup (Energy Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6422,7 +6456,7 @@
                                 ]
                             }
                         },
-                        "Pickup (item_powerbombtank_000)": {
+                        "Pickup (Power Bomb Tank)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -7111,7 +7145,7 @@
                         }
                     }
                 },
-                "Pickup (item_energyfragment)": {
+                "Pickup (Energy Fragment)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -7138,7 +7172,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -7210,7 +7244,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank)": {
+                        "Pickup (Missile Tank)": {
                             "type": "template",
                             "data": "Ballspark"
                         },
@@ -7285,7 +7319,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_energyfragment)": {
+                        "Pickup (Energy Fragment)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8156,7 +8190,7 @@
                                 "negate": false
                             }
                         },
-                        "Pickup (item_missiletank_004)": {
+                        "Pickup (Missile Tank)": {
                             "type": "template",
                             "data": "Lay Cross Comb"
                         }
@@ -8191,7 +8225,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_004)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -8770,7 +8804,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_007)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -8953,7 +8987,7 @@
                     "dock_type": "other",
                     "dock_weakness": "Open Passage",
                     "connections": {
-                        "Pickup (item_missiletank_007)": {
+                        "Pickup (Missile Tank)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -9065,35 +9099,12 @@
                     "dock_weakness": "Power Beam Door",
                     "connections": {}
                 },
-                "Start Point": {
+                "Before Golzuna": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 8800.0,
-                        "y": 5231.7578125,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "start_point_actor_name": "SP_Checkpoint_LineBomb",
-                        "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
-                    },
-                    "connections": {
-                        "Event - Golzuna": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT)": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 9600.0,
-                        "y": 6000.0,
+                        "x": 9500.0,
+                        "y": 5500.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -9456,7 +9467,7 @@
                     "heal": false,
                     "coordinates": {
                         "x": 9240.53,
-                        "y": 5300.33,
+                        "y": 5500.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -9490,6 +9501,64 @@
                     },
                     "pickup_index": 145,
                     "major_location": true,
+                    "connections": {
+                        "Door to Cross Bomb Tutorial": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Tile Group (WEIGHT)": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 9600.0,
+                        "y": 6000.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "extra": {
+                        "actor_name": "breakabletilegroup_011",
+                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
+                        "actor_layer": "breakables",
+                        "tile_types": [
+                            "WEIGHT"
+                        ]
+                    },
+                    "connections": {
+                        "Door to Cross Bomb Tutorial": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "ElunReleaseX",
+                                "amount": 1,
+                                "negate": true
+                            }
+                        },
+                        "Before Golzuna": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "ElunReleaseX",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        }
+                    }
+                },
+                "Start Point": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 8670.921985815603,
+                        "y": 5366.378691544769,
+                        "z": 0
+                    },
+                    "description": "",
+                    "extra": {},
                     "connections": {
                         "Door to Cross Bomb Tutorial": {
                             "type": "and",
@@ -9626,7 +9695,7 @@
                 "asset_id": "collision_camera_028"
             },
             "nodes": {
-                "Pickup (item_missiletank_002)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -9702,7 +9771,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_002)": {
+                        "Pickup (Missile Tank)": {
                             "type": "template",
                             "data": "Lay Cross Comb"
                         }
@@ -9939,7 +10008,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_009)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -9989,7 +10058,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_009)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11256,7 +11325,7 @@
                 "asset_id": "collision_camera_033"
             },
             "nodes": {
-                "Pickup (item_missiletank_005)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -11417,7 +11486,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_005)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12486,7 +12555,7 @@
                         }
                     }
                 },
-                "Pickup (item_missiletank_006)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
@@ -12620,7 +12689,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_006)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12651,7 +12720,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (item_missiletank_006)": {
+                        "Pickup (Missile Tank)": {
                             "type": "template",
                             "data": "Can Slide"
                         },

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -84,7 +84,7 @@ Extra - asset_id: collision_camera_001
           Morph Ball and After Ghavoran - grapplepulloff1x2_000
           Grapple Beam or Spider Magnet or Simple IBJ or Use Spin Boost
 
-> Pickup (item_missiletank_000); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 97; Major Location? False
   * Extra - actor_name: item_missiletank_000
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -130,7 +130,7 @@ Extra - asset_id: collision_camera_001
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('MISSILE',)
-  > Pickup (item_missiletank_000)
+  > Pickup (Missile Tank)
       Morph Ball
   > Door to Transport to Burenia
       Trivial
@@ -224,7 +224,7 @@ Extra - asset_id: collision_camera_003
   > Floating Platform
       Grapple Beam or Simple IBJ or Use Spin Boost
 
-> Pickup (item_missiletank_003); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 108; Major Location? False
   * Extra - actor_name: item_missiletank_003
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -290,7 +290,7 @@ Extra - asset_id: collision_camera_003
 > Ledge Grab; Heals? False
   > Door to Transport to Burenia
       Trivial
-  > Pickup (item_missiletank_003)
+  > Pickup (Missile Tank)
       All of the following:
           Morph Ball
           Flash Shift or Grapple Beam or Speed Booster
@@ -527,14 +527,14 @@ Extra - asset_id: collision_camera_008
   * Extra - right_shield_def: None
   > Door to Transport to Dairon
       Trivial
-  > Pickup (item_missiletank_001)
+  > Pickup (Missile Tank)
       Morph Ball and After Ghavoran - grapplepulloff1x2_002
   > Event - Breakable (grapplepulloff1x2_002)
       Grapple Beam
   > Dock to collision_camera_009 (G)
       Simple IBJ or Use Spin Boost
 
-> Pickup (item_missiletank_001); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 99; Major Location? False
   * Extra - actor_name: item_missiletank_001
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -600,7 +600,7 @@ Extra - asset_id: collision_camera_009
               Grapple Beam
               Flash Shift or Walljump (Beginner)
 
-> Pickup (item_missiletankplus_000); Heals? False
+> Pickup (Missile+ Tank); Heals? False
   * Pickup 102; Major Location? False
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
@@ -620,7 +620,7 @@ Extra - asset_id: collision_camera_009
 
 > Dock to Super Missile Room; Heals? False
   * Morph Ball Tunnel to Super Missile Room/Dock to collision_camera_009 (G)
-  > Pickup (item_missiletankplus_000)
+  > Pickup (Missile+ Tank)
       Morph Ball
 
 > Dock to Spider Magnet Elevator; Heals? False
@@ -687,7 +687,7 @@ Extra - asset_id: collision_camera_010
   > Start Point
       Trivial
 
-> Pickup (itemsphere_supermissile); Heals? False
+> Pickup (Super Missile); Heals? False
   * Pickup 100; Major Location? True
   * Extra - actor_name: itemsphere_supermissile
   * Extra - actor_def: actordef:actors/items/itemsphere_supermissile/charclasses/itemsphere_supermissile.bmsad
@@ -699,7 +699,7 @@ Extra - asset_id: collision_camera_010
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to collision_camera_009 (G) (Missile Lock)
       Trivial
-  > Pickup (itemsphere_supermissile)
+  > Pickup (Super Missile)
       Trivial
 
 > Dock to collision_camera_009 (G); Heals? False
@@ -1211,7 +1211,7 @@ Extra - asset_id: collision_camera_020
   * Extra - actor_name: dooremmy_007
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to Blue EMMI Fight (doorpowerpower_011)
-      Morph Ball
+      Morph Ball and After Ghavoran - Central Unit
 
 > Door to Blue EMMI Fight (doorpowerpower_010); Heals? False
   * Power Beam Door to Blue EMMI Fight/Door to collision_camera_020 (G) (doorpowerpower_010)
@@ -1233,7 +1233,7 @@ Extra - asset_id: collision_camera_020
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Dock to Spin Boost Tower (dooremmy_007)
-      Can Slide
+      After Ghavoran - Central Unit and Can Slide
   > Door to Blue EMMI Fight (doorpowerpower_010)
       Trivial
 
@@ -1274,7 +1274,7 @@ Extra - asset_id: collision_camera_021
   > Energy Part Platform
       Flash Shift or Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
 
-> Pickup (item_powerbombtank_000); Heals? False
+> Pickup (Power Bomb Tank); Heals? False
   * Pickup 96; Major Location? False
   * Extra - actor_name: item_powerbombtank_000
   * Extra - actor_def: actordef:actors/items/item_powerbombtank/charclasses/item_powerbombtank.bmsad
@@ -1303,14 +1303,14 @@ Extra - asset_id: collision_camera_021
   > Event - Ammo Recharge Enky (Below)
       Destroy Enky
 
-> Pickup (item_energyfragment_000); Heals? False
+> Pickup (Energy Fragment); Heals? False
   * Pickup 105; Major Location? True
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Tile Group (MISSILE)
       Morph Ball
 
-> Pickup (item_energytank_000); Heals? False
+> Pickup (Energy Tank); Heals? False
   * Pickup 109; Major Location? False
   * Extra - actor_name: item_energytank_000
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
@@ -1338,7 +1338,7 @@ Extra - asset_id: collision_camera_021
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('MISSILE',)
-  > Pickup (item_energyfragment_000)
+  > Pickup (Energy Fragment)
       Morph Ball
   > Energy Part Platform
       Trivial
@@ -1361,7 +1361,7 @@ Extra - asset_id: collision_camera_021
 > E-Tank Alcove; Heals? False
   > Dock to collision_camera_020 (G) (dooremmy_007)
       After Ghavoran - Ammo Recharge Enky Above
-  > Pickup (item_energytank_000)
+  > Pickup (Energy Tank)
       Trivial
   > Ledge Below PB Tank
       Walljump (Beginner) or Simple IBJ or Use Spin Boost
@@ -1371,7 +1371,7 @@ Extra - asset_id: collision_camera_021
 > Ledge Below PB Tank; Heals? False
   > Door to Above Pulse Radar
       Simple IBJ or Use Spin Boost
-  > Pickup (item_powerbombtank_000)
+  > Pickup (Power Bomb Tank)
       Infinite Bomb Jump (Intermediate) or Use Spin Boost
   > E-Tank Alcove
       Trivial
@@ -1527,14 +1527,14 @@ Extra - asset_id: collision_camera_024
   > Door to Save Station East
       Trivial
 
-> Pickup (item_energyfragment); Heals? False
+> Pickup (Energy Fragment); Heals? False
   * Pickup 112; Major Location? True
   * Extra - actor_name: item_energyfragment
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Tile Group (SPEEDBOOST) 1
       Morph Ball
 
-> Pickup (item_missiletank); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 113; Major Location? False
   * Extra - actor_name: item_missiletank
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -1555,7 +1555,7 @@ Extra - asset_id: collision_camera_024
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Pickup (item_missiletank)
+  > Pickup (Missile Tank)
       Ballspark
   > Tile Group (BOMB) 3
       Morph Ball
@@ -1579,7 +1579,7 @@ Extra - asset_id: collision_camera_024
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (item_energyfragment)
+  > Pickup (Energy Fragment)
       All of the following:
           Morph Ball
           Space Jump or Simple IBJ
@@ -1794,7 +1794,7 @@ Extra - asset_id: collision_camera_024
       Morph Ball
   > Tile Group (SCREWATTACK)
       Morph Ball
-  > Pickup (item_missiletank_004)
+  > Pickup (Missile Tank)
       Lay Cross Comb
 
 > Dock to collision_camera_031 (G) (Top); Heals? False
@@ -1802,7 +1802,7 @@ Extra - asset_id: collision_camera_024
   > Door to collision_camera_025_B (G)
       Morph Ball
 
-> Pickup (item_missiletank_004); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 103; Major Location? False
   * Extra - actor_name: item_missiletank_004
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -1916,7 +1916,7 @@ Extra - asset_id: collision_camera_025_B
   > Tile Group (WEIGHT) 2
       Trivial
 
-> Pickup (item_missiletank_007); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 107; Major Location? False
   * Extra - actor_name: item_missiletank_007
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -1946,7 +1946,7 @@ Extra - asset_id: collision_camera_025_B
 
 > Dock to Teleport to Burenia; Heals? False
   * Open Passage to Teleport to Burenia/Dock to collision_camera_025_B (G)
-  > Pickup (item_missiletank_007)
+  > Pickup (Missile Tank)
       Morph Ball
 
 > Event - Ferenia Transport Enky Left; Heals? False
@@ -1974,13 +1974,7 @@ Extra - asset_id: collision_camera_026
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
 
-> Start Point; Heals? False; Spawn Point
-  * Extra - start_point_actor_name: SP_Checkpoint_LineBomb
-  * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Event - Golzuna
-      Trivial
-
-> Tile Group (WEIGHT); Heals? False
+> Before Golzuna; Heals? False
   * Extra - actor_name: breakabletilegroup_011
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
@@ -2049,6 +2043,20 @@ Extra - asset_id: collision_camera_026
   > Door to Cross Bomb Tutorial
       Trivial
 
+> Tile Group (WEIGHT); Heals? False
+  * Extra - actor_name: breakabletilegroup_011
+  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
+  * Extra - actor_layer: breakables
+  * Extra - tile_types: ('WEIGHT',)
+  > Door to Cross Bomb Tutorial
+      Before Elun - Release X Parasites
+  > Before Golzuna
+      After Elun - Release X Parasites
+
+> Start Point; Heals? False; Spawn Point
+  > Door to Cross Bomb Tutorial
+      Trivial
+
 ----------------
 Transport to Ferenia
 Extra - total_boundings: {'x1': 10000.0, 'x2': 19100.0, 'y1': 2200.0, 'y2': 4100.0}
@@ -2075,7 +2083,7 @@ collision_camera_028 (G)
 Extra - total_boundings: {'x1': -3000.0, 'x2': -900.0, 'y1': -1100.0, 'y2': 42.0}
 Extra - polygon: [[-900.0, 42.0], [-3000.0, 42.0], [-3000.0, -1100.0], [-900.0, -1100.0]]
 Extra - asset_id: collision_camera_028
-> Pickup (item_missiletank_002); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 101; Major Location? False
   * Extra - actor_name: item_missiletank_002
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -2098,7 +2106,7 @@ Extra - asset_id: collision_camera_028
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Pickup (item_missiletank_002)
+  > Pickup (Missile Tank)
       Lay Cross Comb
 
 > Tile Group (BOMB) 2; Heals? False
@@ -2150,7 +2158,7 @@ blast shields
   > Center Platform
       Trivial
 
-> Pickup (item_missiletank_009); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 111; Major Location? False
   * Extra - actor_name: item_missiletank_009
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -2165,7 +2173,7 @@ blast shields
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (item_missiletank_009)
+  > Pickup (Missile Tank)
       Trivial
 
 > Center Platform; Heals? False
@@ -2433,7 +2441,7 @@ Cross Bomb Tutorial
 Extra - total_boundings: {'x1': 10000.0, 'x2': 12100.0, 'y1': 5200.0, 'y2': 7300.0}
 Extra - polygon: [[12100.0, 7300.0], [10000.0, 7300.0], [10000.0, 5200.0], [12100.0, 5200.0]]
 Extra - asset_id: collision_camera_033
-> Pickup (item_missiletank_005); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 98; Major Location? False
   * Extra - actor_name: item_missiletank_005
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -2483,7 +2491,7 @@ Extra - asset_id: collision_camera_033
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Pickup (item_missiletank_005)
+  > Pickup (Missile Tank)
       Trivial
   > Door from Golzuna Arena
       Morph Ball
@@ -2738,7 +2746,7 @@ Extra - asset_id: collision_camera_039
   > Start Point
       Trivial
 
-> Pickup (item_missiletank_006); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Pickup 106; Major Location? False
   * Extra - actor_name: item_missiletank_006
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
@@ -2780,7 +2788,7 @@ Extra - asset_id: collision_camera_039
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
-  > Pickup (item_missiletank_006)
+  > Pickup (Missile Tank)
       Trivial
   > Tile Group (POWERBEAM) 3
       Can Slide
@@ -2791,7 +2799,7 @@ Extra - asset_id: collision_camera_039
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
-  > Pickup (item_missiletank_006)
+  > Pickup (Missile Tank)
       Can Slide
   > Door from Teleport to Cataris
       Morph Ball

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -913,6 +913,10 @@
             "DaironGrappleBlockElevatorFerenia": {
                 "long_name": "Dairon - Pull Grapple Block below Ferenia Elevator",
                 "extra": {}
+            },
+            "ElunReleaseX": {
+                "long_name": "Elun - Release X Parasites",
+                "extra": {}
             }
         },
         "tricks": {
@@ -1932,8 +1936,37 @@
                         "lock_type": 3,
                         "extra": {},
                         "requirement": {
-                            "type": "template",
-                            "data": "Shoot Charge Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Charge Beam"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Power Bomb"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     },
                     "Wide Beam Door": {

--- a/randovania/games/dread/json_data/header.txt
+++ b/randovania/games/dread/json_data/header.txt
@@ -112,7 +112,9 @@ Dock Weaknesses
       Shoot Beam
 
   * Charge Beam Door; Lock type: FRONT_BLAST_BACK_IMPOSSIBLE
-      Shoot Charge Beam
+      Any of the following:
+          Shoot Charge Beam
+          Knowledge (Advanced) and Lay Power Bomb
 
   * Wide Beam Door; Lock type: FRONT_BLAST_BACK_IMPOSSIBLE
       Shoot Wide Beam


### PR DESCRIPTION
Rename pickups to be more readable.
Logically allow charge beam doors to be opened by PBs.
Minor logic fixes.