### PR TITLE
Dread: Fix missing connections in transport area

### DIFF
--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -4221,7 +4221,7 @@
                     },
                     "event_name": "s030_baselab:default:grapplepulloff1x2_006",
                     "connections": {
-                        "Elevator to Artaria - Transport to Dairon": {
+                        "Full samus control": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4273,7 +4273,7 @@
                                         "data": {
                                             "type": "damage",
                                             "name": "Heat",
-                                            "amount": 300,
+                                            "amount": 299,
                                             "negate": false
                                         }
                                     }
@@ -4510,7 +4510,7 @@
                     "dock_type": "tunnel",
                     "dock_weakness": "Morph Ball Launcher",
                     "connections": {
-                        "Elevator to Artaria - Transport to Dairon": {
+                        "Full samus control": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4599,7 +4599,7 @@
                                                     "data": {
                                                         "type": "damage",
                                                         "name": "Heat",
-                                                        "amount": 50,
+                                                        "amount": 100,
                                                         "negate": false
                                                     }
                                                 }

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -885,7 +885,7 @@ Extra - asset_id: collision_camera_011
   * Event Dairon - grapplepulloff1x2_006
   * Extra - actor_name: grapplepulloff1x2_006
   * Extra - actor_def: actordef:actors/props/grapplepulloff1x2/charclasses/grapplepulloff1x2.bmsad
-  > Elevator to Artaria - Transport to Dairon
+  > Full samus control
       Trivial
 
 > Elevator to Artaria - Transport to Dairon; Heals? False; Spawn Point
@@ -899,7 +899,7 @@ Extra - asset_id: collision_camera_011
   > Full samus control
       Any of the following:
           # Loading time in Heat Room
-          Varia Suit or Heat Damage ≥ 300
+          Varia Suit or Heat Damage ≥ 299
 
 > Tile Group (POWERBEAM); Heals? False
   * Configurable Node
@@ -936,7 +936,7 @@ Extra - asset_id: collision_camera_011
 
 > Tunnel to Hub Access; Heals? False
   * Morph Ball Launcher to Hub Access/Dock from Transport to Artaria
-  > Elevator to Artaria - Transport to Dairon
+  > Full samus control
       All of the following:
           After Dairon - grapplepulloff1x2_006
           Varia Suit or Heat Damage ≥ 50
@@ -945,7 +945,7 @@ Extra - asset_id: collision_camera_011
   > Event - Pull Grapple Block (grapplepulloff1x2_006)
       All of the following:
           Grapple Beam
-          Varia Suit or Heat Damage ≥ 50
+          Varia Suit or Heat Damage ≥ 100
   > Elevator to Artaria - Transport to Dairon
       Varia Suit or Heat Damage ≥ 100
   > Tile Group (POWERBEAM)


### PR DESCRIPTION
Heat damage change is somewhat arbitrary, but the missing connections are fixes.