### PR TITLE
Added Event to Unlock David Jaffe Room

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -8474,7 +8474,7 @@
                 "asset_id": "collision_camera_021"
             },
             "nodes": {
-                "Door from Navigation Station North": {
+                "Door to Navigation Station North": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8497,7 +8497,7 @@
                         "node_name": "Door to David Jaffe Room"
                     },
                     "dock_type": "door",
-                    "dock_weakness": "Access Closed",
+                    "dock_weakness": "Access Open",
                     "connections": {
                         "Start Point": {
                             "type": "and",
@@ -8578,11 +8578,13 @@
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
                     "connections": {
-                        "Door from Navigation Station North": {
-                            "type": "and",
+                        "Door to Navigation Station North": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "events",
+                                "name": "AccessClosedDavidJaffe",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Door to Thermal Door Tutorial": {
@@ -16684,7 +16686,7 @@
                     "destination": {
                         "world_name": "Artaria",
                         "area_name": "David Jaffe Room",
-                        "node_name": "Door from Navigation Station North"
+                        "node_name": "Door to Navigation Station North"
                     },
                     "dock_type": "door",
                     "dock_weakness": "Charge Beam Door",
@@ -16694,6 +16696,39 @@
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        },
+                        "Event - Unlock David Jaffe Room": {
+                            "type": "or",
+                            "data": {
+                                "comment": "Temporary requirement until dock works properly",
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Charge Beam"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Power Bomb"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -16841,6 +16876,27 @@
                             }
                         },
                         "Door to Arbitrary Enky Room (Thermal)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Unlock David Jaffe Room": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 12850.0,
+                        "y": 3200.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "extra": {},
+                    "event_name": "AccessClosedDavidJaffe",
+                    "connections": {
+                        "Door to David Jaffe Room": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -1922,8 +1922,8 @@ David Jaffe Room
 Extra - total_boundings: {'x1': 12800.0, 'x2': 15900.0, 'y1': 3000.0, 'y2': 4600.0}
 Extra - polygon: [[15900.0, 4600.0], [12800.0, 4600.0], [12800.0, 3000.0], [15900.0, 3000.0]]
 Extra - asset_id: collision_camera_021
-> Door from Navigation Station North; Heals? False
-  * Access Closed to Navigation Station North/Door to David Jaffe Room
+> Door to Navigation Station North; Heals? False
+  * Access Open to Navigation Station North/Door to David Jaffe Room
   * Extra - actor_name: Door029 (CG-CL,OP)
   * Extra - actor_def: actordef:actors/props/doorchargeclosed/charclasses/doorchargeclosed.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1954,8 +1954,8 @@ Extra - asset_id: collision_camera_021
 > Start Point; Heals? False; Spawn Point
   * Extra - start_point_actor_name: SP_Checkpoint_AccessPoint_2B
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door from Navigation Station North
-      Trivial
+  > Door to Navigation Station North
+      After Artaria - Unlock David Jaffe Room
   > Door to Thermal Door Tutorial
       Trivial
   > Pickup (Missile Tank)
@@ -3691,7 +3691,7 @@ Extra - total_boundings: {'x1': 10800.0, 'x2': 12900.0, 'y1': 2500.0, 'y2': 3642
 Extra - polygon: [[12900.0, 3642.0], [10800.0, 3642.0], [10800.0, 2500.0], [12900.0, 2500.0]]
 Extra - asset_id: collision_camera_065
 > Door to David Jaffe Room; Heals? False
-  * Charge Beam Door to David Jaffe Room/Door from Navigation Station North
+  * Charge Beam Door to David Jaffe Room/Door to Navigation Station North
   * Extra - actor_name: Door029 (CG-CL,OP)
   * Extra - actor_def: actordef:actors/props/doorchargeclosed/charclasses/doorchargeclosed.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -3700,6 +3700,11 @@ Extra - asset_id: collision_camera_065
   * Extra - right_shield_def: None
   > Navigation Room
       Trivial
+  > Event - Unlock David Jaffe Room
+      Any of the following:
+          # Temporary requirement until dock works properly
+          Shoot Charge Beam
+          Knowledge (Beginner) and Lay Power Bomb
 
 > Door to Invisible Corpius Room; Heals? False
   * Power Beam Door to Invisible Corpius Room/Door to Navigation Station North
@@ -3748,6 +3753,11 @@ Extra - asset_id: collision_camera_065
   > Door to Arbitrary Enky Room (Upper)
       Trivial
   > Door to Arbitrary Enky Room (Thermal)
+      Trivial
+
+> Event - Unlock David Jaffe Room; Heals? False
+  * Event Artaria - Unlock David Jaffe Room
+  > Door to David Jaffe Room
       Trivial
 
 ----------------

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -658,8 +658,16 @@
                 "long_name": "Ghavoran - grapplepulloff1x2_000",
                 "extra": {}
             },
+            "s050_forest:default:grapplepulloff1x2_001": {
+                "long_name": "Ghavoran - grapplepulloff1x2_001",
+                "extra": {}
+            },
             "s050_forest:default:grapplepulloff1x2_002": {
                 "long_name": "Ghavoran - grapplepulloff1x2_002",
+                "extra": {}
+            },
+            "s050_forest:default:grapplepulloff1x2_003": {
+                "long_name": "Ghavoran - grapplepulloff1x2_003",
                 "extra": {}
             },
             "s060_quarantine:default:grapplepulloff1x2_000": {
@@ -918,6 +926,10 @@
                 "long_name": "Elun - Release X Parasites",
                 "extra": {}
             },
+            "AccessClosedDavidJaffe": {
+                "long_name": "Artaria - Unlock David Jaffe Room",
+                "extra": {}
+            },
             "DaironTeleportToArtariaSpeedBlocksDestroyed": {
                 "long_name": "Dairon - Teleport To Artaria Speed Blocks Destroyed",
                 "extra": {}
@@ -996,6 +1008,11 @@
             },
             "RGrapple": {
                 "long_name": "Reverse Grapple Block",
+                "description": "",
+                "extra": {}
+            },
+            "DBoost": {
+                "long_name": "Damage Boost",
                 "description": "",
                 "extra": {}
             }

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -658,16 +658,8 @@
                 "long_name": "Ghavoran - grapplepulloff1x2_000",
                 "extra": {}
             },
-            "s050_forest:default:grapplepulloff1x2_001": {
-                "long_name": "Ghavoran - grapplepulloff1x2_001",
-                "extra": {}
-            },
             "s050_forest:default:grapplepulloff1x2_002": {
                 "long_name": "Ghavoran - grapplepulloff1x2_002",
-                "extra": {}
-            },
-            "s050_forest:default:grapplepulloff1x2_003": {
-                "long_name": "Ghavoran - grapplepulloff1x2_003",
                 "extra": {}
             },
             "s060_quarantine:default:grapplepulloff1x2_000": {


### PR DESCRIPTION
- Added Event - Unlock David Jaffe Room to Navigation Station North so that going through is not a dangerous action
- Start Point in David Jaffe Room requires the event to go to Door to Navigation Station North