### PR TITLE
"Add manual action" in tracker with Area Picker dialog

### DIFF
--- a/randovania/gui/lib/area_picker.py
+++ b/randovania/gui/lib/area_picker.py
@@ -1,0 +1,81 @@
+from typing import Callable, Optional
+from randovania.game_description import default_database
+from randovania.game_description.world.area import Area
+from randovania.game_description.world.area_identifier import AreaIdentifier
+from randovania.game_description.world.world import World
+from randovania.games.game import RandovaniaGame
+from randovania.game_description.world.node import Node, NodeIdentifier
+from randovania.gui.generated.area_picker_dialog_ui import Ui_AreaPickerDialog
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt
+
+def get_node(parent: QtWidgets.QWidget, game: RandovaniaGame, filter: Optional[Callable[[Node], bool]]=None) -> Optional[NodeIdentifier]:
+    dialog = AreaPickerDialog(parent, game, filter)
+    result = dialog.exec()
+    if result == QtWidgets.QDialog.DialogCode.Accepted:
+        return NodeIdentifier(AreaIdentifier(dialog.current_world.name, dialog.current_area.name), dialog.current_node.name)
+    else:
+        return None
+
+class AreaPickerDialog(QtWidgets.QDialog, Ui_AreaPickerDialog):
+    _world_list: list[World]
+    _form: QtWidgets.QFormLayout
+    world_combo_box: QtWidgets.QComboBox
+    area_combo_box: QtWidgets.QComboBox
+    node_combo_box: QtWidgets.QComboBox
+    confirm_buttons: QtWidgets.QDialogButtonBox
+    current_world: World
+    current_area: Area
+    current_node: Node
+    filter: Optional[Callable[[Node], bool]]
+
+    def __init__(self, parent: QtWidgets.QWidget, game: RandovaniaGame, filter: Optional[Callable[[Node], bool]]=None):
+        super().__init__(parent)
+        self.setupUi(self)
+        self._world_list = default_database.game_description_for(game).world_list.worlds
+        for world in self._world_list:
+            item = QtWidgets.QListWidgetItem(world.name)
+            item.setData(Qt.UserRole, world)
+            self.worldList.addItem(item)
+        self.worldList.currentItemChanged.connect(self._update_areas)
+        self.areaList.currentItemChanged.connect(self._update_nodes)
+        self.nodeList.currentItemChanged.connect(self._node_selected)
+        self.confirmButtonBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(False)
+
+    def _update_areas(self, world: QtWidgets.QListWidgetItem, previous: QtWidgets.QListWidgetItem):
+        self.areaList.clear()
+        self.nodeList.clear()
+        self.current_world = None if not world else world.data(Qt.UserRole)
+        if not world:
+            self.areaList.setDisabled(True)
+            self.nodeList.setDisabled(True)
+            return
+        area_list = world.data(Qt.UserRole).areas
+        area_list.sort(key=lambda area: area.name)
+        self.areaList.clear()
+        self.areaList.setDisabled(not area_list)
+        for area in area_list:
+            item = QtWidgets.QListWidgetItem(area.name)
+            item.setData(Qt.UserRole, area)
+            self.areaList.addItem(item)
+
+    def _update_nodes(self, area: QtWidgets.QListWidgetItem, previous: QtWidgets.QListWidgetItem):
+        self.nodeList.clear()
+        self.current_area = None if not area else area.data(Qt.UserRole)
+        if not area:
+            self.nodeList.setDisabled(True)
+            return
+        node_list = [node for node in area.data(Qt.UserRole).nodes if not node.is_resource_node]
+        node_list.sort(key=lambda node: node.name)
+        self.nodeList.setDisabled(not node_list)
+        for node in node_list:
+            item = QtWidgets.QListWidgetItem(node.name)
+            item.setData(Qt.UserRole, node)
+            self.nodeList.addItem(item)
+
+    def _node_selected(self, node: QtWidgets.QListWidgetItem, previous: QtWidgets.QListWidgetItem):
+        self._enable_confirm(node is not None)
+        self.current_node = None if not node else node.data(Qt.UserRole)
+
+    def _enable_confirm(self, enable: bool):
+        self.confirmButtonBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(enable)

--- a/randovania/gui/lib/area_picker.py
+++ b/randovania/gui/lib/area_picker.py
@@ -1,16 +1,17 @@
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 from randovania.game_description import default_database
 from randovania.game_description.world.area import Area
 from randovania.game_description.world.area_identifier import AreaIdentifier
 from randovania.game_description.world.world import World
+from randovania.game_description.world.world_list import WorldList
 from randovania.games.game import RandovaniaGame
-from randovania.game_description.world.node import DockNode, EventNode, Node, NodeIdentifier, PickupNode
+from randovania.game_description.world.node import DockNode, EventNode, GenericNode, Node, NodeIdentifier, PickupNode, ResourceNode
 from randovania.gui.generated.area_picker_dialog_ui import Ui_AreaPickerDialog
-from PySide6 import QtWidgets
+from PySide6 import QtWidgets, QtGui, QtCore
 from PySide6.QtCore import Qt
 
 def get_node(parent: QtWidgets.QWidget, game: RandovaniaGame, filter: Optional[Callable[[Node], bool]]=None) -> Optional[NodeIdentifier]:
-    dialog = AreaPickerDialog(parent, game, filter)
+    dialog = AreaPickerDialog(parent, game)
     result = dialog.exec()
     if result == QtWidgets.QDialog.DialogCode.Accepted:
         return NodeIdentifier(AreaIdentifier(dialog.current_world.name, dialog.current_area.name), dialog.current_node.name)
@@ -18,8 +19,12 @@ def get_node(parent: QtWidgets.QWidget, game: RandovaniaGame, filter: Optional[C
         return None
 
 class AreaPickerDialog(QtWidgets.QDialog, Ui_AreaPickerDialog):
-    _world_list: list[World]
-    _form: QtWidgets.QFormLayout
+    _model: QtCore.QAbstractItemModel
+    _world_list: WorldList
+    _empty_index: QtCore.QModelIndex
+    worldList: QtWidgets.QListView
+    areaList: QtWidgets.QListView
+    nodeList: QtWidgets.QListView
     world_combo_box: QtWidgets.QComboBox
     area_combo_box: QtWidgets.QComboBox
     node_combo_box: QtWidgets.QComboBox
@@ -27,71 +32,148 @@ class AreaPickerDialog(QtWidgets.QDialog, Ui_AreaPickerDialog):
     current_world: Optional[World]
     current_area: Optional[Area]
     current_node: Optional[Node]
-    filter: Optional[Callable[[Node], bool]]
 
-    def __init__(self, parent: QtWidgets.QWidget, game: RandovaniaGame, filter: Optional[Callable[[Node], bool]]=None):
+    def __init__(self, parent: QtWidgets.QWidget, game: RandovaniaGame):
         super().__init__(parent)
         self.setupUi(self)
-        self._world_list = default_database.game_description_for(game).world_list.worlds
-        for world in self._world_list:
-            item = QtWidgets.QListWidgetItem(world.name)
-            item.setData(Qt.UserRole, world)
-            self.worldList.addItem(item)
+        self._world_list = default_database.game_description_for(game).world_list
+        self._build_model()
         self.current_world = None
         self.current_area = None
         self.current_node = None
-        self.worldList.currentItemChanged.connect(self._update_areas)
-        self.areaList.currentItemChanged.connect(self._update_nodes)
-        self.nodeList.currentItemChanged.connect(self._node_selected)
-        self.nodeList.itemDoubleClicked.connect(lambda _: self.accept())
-        self.locationsCheckBox.stateChanged.connect(self._checkbox_changed)
-        self.pickupsCheckBox.stateChanged.connect(self._checkbox_changed)
-        self.eventsCheckBox.stateChanged.connect(self._checkbox_changed)
+        self.worldList.selectionModel().currentChanged.connect(self._update_areas)
+        self.areaList.selectionModel().currentChanged.connect(self._update_nodes)
+        self.nodeList.selectionModel().currentChanged.connect(self._node_selected)
+        self.nodeList.doubleClicked.connect(self._confirm_selection)
+        self.searchLineEdit.textEdited.connect(self._update_search)
+        self.searchLineEdit.returnPressed.connect(self._confirm_selection)
         self.confirmButtonBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(False)
+        self.searchLineEdit.setFocus()
 
-    def _update_areas(self, world: QtWidgets.QListWidgetItem, previous: QtWidgets.QListWidgetItem):
-        self.areaList.clear()
-        self.nodeList.clear()
-        self.current_world = None if not world else world.data(Qt.UserRole)
-        if not world:
-            self.areaList.setDisabled(True)
-            self.nodeList.setDisabled(True)
-            return
-        area_list = world.data(Qt.UserRole).areas
-        area_list.sort(key=lambda area: area.name)
-        self.areaList.clear()
-        self.areaList.setDisabled(not area_list)
-        for area in area_list:
-            item = QtWidgets.QListWidgetItem(area.name)
-            item.setData(Qt.UserRole, area)
-            self.areaList.addItem(item)
+    def _build_model(self):
+        model = QtGui.QStandardItemModel()
+        top_level = QtGui.QStandardItem()
+        for world in self._world_list.worlds:
+            world_item = QtGui.QStandardItem(world.name)
+            world_item.setData(world, Qt.UserRole)
+            for area in world.areas:
+                area_item = QtGui.QStandardItem(area.name)
+                area_item.setData(area, Qt.UserRole)
+                for node in area.nodes:
+                    node_item = QtGui.QStandardItem(node.name)
+                    node_item.setData(node, Qt.UserRole)
+                    area_item.appendRow(node_item)
+                world_item.appendRow(area_item)
+            top_level.appendRow(world_item)
+        model.appendRow(top_level)
+        model.sort(0)
+        proxy_model = AreaPickerFilterProxyModel(self)
+        proxy_model.setSourceModel(model)
+        self._model = proxy_model
+        self.worldList.setModel(proxy_model)
+        self.areaList.setModel(proxy_model)
+        self.nodeList.setModel(proxy_model)
+        self._empty_index = self.worldList.rootIndex()
+        self.worldList.setRootIndex(proxy_model.index(0, 0))
+        self.areaList.setEnabled(False)
+        self.nodeList.setEnabled(False)
 
-    def _update_nodes(self, area: QtWidgets.QListWidgetItem, previous: QtWidgets.QListWidgetItem=None):
-        self.nodeList.clear()
-        self.current_area = None if not area else area.data(Qt.UserRole)
-        if not area:
-            self.nodeList.setDisabled(True)
-            return
-        node_list = [node for node in area.data(Qt.UserRole).nodes]
-        if not self.locationsCheckBox.isChecked():
-            node_list = [node for node in node_list if not isinstance(node, DockNode)]
-        if not self.pickupsCheckBox.isChecked():
-            node_list = [node for node in node_list if not isinstance(node, PickupNode)]
-        if not self.eventsCheckBox.isChecked():
-            node_list = [node for node in node_list if not isinstance(node, EventNode)]
-        node_list.sort(key=lambda node: node.name)
-        self.nodeList.setDisabled(not node_list)
-        for node in node_list:
-            item = QtWidgets.QListWidgetItem(node.name)
-            item.setData(Qt.UserRole, node)
-            self.nodeList.addItem(item)
+    def validate_root_indexes(self):
+        self.worldList.setRootIndex(self._model.index(0, 0))
+        self._validate_selection(self.areaList, self.areaList.rootIndex())
+        self._validate_selection(self.nodeList, self.nodeList.rootIndex())
 
-    def _node_selected(self, node: QtWidgets.QListWidgetItem, previous: QtWidgets.QListWidgetItem):
-        self._enable_confirm(node is not None)
-        self.current_node = None if not node else node.data(Qt.UserRole)
+    def _validate_selection(self, list: QtWidgets.QListView, root_index: QtCore.QModelIndex):
+        valid = root_index.isValid()
+        list.setRootIndex(root_index if valid else self._empty_index)
+        list.setEnabled(valid)
+        if not valid:
+            self._enable_confirm(False)
+
+    def _confirm_selection(self):
+        if self.current_node is not None:
+            self.accept()
+
+    def _update_areas(self, world: QtCore.QModelIndex):
+        self.current_world = world.data(Qt.UserRole)
+        self._validate_selection(self.areaList, world)
+        self.areaList.selectionModel().clear()
+
+    def _update_nodes(self, area: QtCore.QModelIndex):
+        self.current_area = area.data(Qt.UserRole)
+        self._validate_selection(self.nodeList, area)
+        self.nodeList.selectionModel().clear()
+
+    def _node_selected(self, node: QtCore.QModelIndex):
+        self._enable_confirm(node.isValid())
+        self.current_node = node.data(Qt.UserRole)
 
     def _enable_confirm(self, enable: bool):
         self.confirmButtonBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(enable)
+
+    def _update_search(self, text: str):
+        if not text:
+            return
+        text = text.lower()
+        root: QtCore.QModelIndex = self.worldList.rootIndex()
+        i = 0
+        while self._model.hasIndex(i, 0, root):
+            world_index = self._model.index(i, 0, root)
+            j = 0
+            while self._model.hasIndex(j, 0, world_index):
+                area_index = self._model.index(j, 0, world_index)
+                if area_index.data(Qt.UserRole).name.lower().startswith(text):
+                    self.worldList.selectionModel().setCurrentIndex(world_index, QtCore.QItemSelectionModel.SelectCurrent)
+                    self.areaList.selectionModel().setCurrentIndex(area_index, QtCore.QItemSelectionModel.SelectCurrent)
+                    self.nodeList.selectionModel().setCurrentIndex(self._model.index(0, 0, area_index), QtCore.QItemSelectionModel.SelectCurrent)
+                    return
+                j += 1
+            i += 1
+
+
+class AreaPickerFilterProxyModel(QtCore.QSortFilterProxyModel):
+    _show_locations: bool
+    _show_pickups: bool
+    _show_events: bool
+
+    def __init__(self, parent: AreaPickerDialog):
+        super().__init__(parent)
+        self._show_locations = parent.locationsCheckBox.isChecked()
+        self._show_pickups = parent.pickupsCheckBox.isChecked()
+        self._show_events = parent.eventsCheckBox.isChecked()
+        parent.locationsCheckBox.stateChanged.connect(self._set_show_locations)
+        parent.pickupsCheckBox.stateChanged.connect(self._set_show_pickups)
+        parent.eventsCheckBox.stateChanged.connect(self._set_show_events)
+        # Lets us filter nodes only; worlds/areas with visible nodes will appear
+        self.setRecursiveFilteringEnabled(True)
+        self._default_filters = [
+            self._filter_location,
+            self._filter_pickup,
+            self._filter_event
+        ]
     
-    def _checkbox_changed(self):
-        self._update_nodes(self.areaList.currentItem())
+    def _set_show_locations(self, state):
+        self._show_locations = state == Qt.Checked
+        self.invalidateFilter()
+    def _set_show_pickups(self, state):
+        self._show_pickups = state == Qt.Checked
+        self.invalidateFilter()
+    def _set_show_events(self, state):
+        self._show_events = state == Qt.Checked
+        self.invalidateFilter()
+
+    def _filter_location(self, node: Node) -> bool:
+        return self._show_locations and (isinstance(node, DockNode) or isinstance(node, GenericNode))
+    def _filter_pickup(self, node: Node) -> bool:
+        return self._show_pickups and isinstance(node, PickupNode)
+    def _filter_event(self, node: Node) -> bool:
+        return self._show_events and isinstance(node, EventNode)
+
+    def filterAcceptsRow(self, source_row: int, source_parent: Union[QtCore.QModelIndex, QtCore.QPersistentModelIndex]) -> bool:
+        source_index = self.sourceModel().index(source_row, 0, source_parent)
+        data = source_index.data(Qt.UserRole)
+        return any([filter(data) for filter in self._default_filters])
+
+    def invalidateFilter(self):
+        super().invalidateFilter()
+        self.parent().validate_root_indexes()

--- a/randovania/gui/lib/area_picker.py
+++ b/randovania/gui/lib/area_picker.py
@@ -11,6 +11,14 @@ from PySide6 import QtWidgets, QtGui, QtCore
 from PySide6.QtCore import Qt
 
 def get_node(parent: QtWidgets.QWidget, game: RandovaniaGame, valid_areas: list[AreaIdentifier] = None) -> Optional[NodeIdentifier]:
+    """
+    Opens a modal dialog for the user to pick a specific node.
+
+    :param parent: the parent widget that spawns the dialog
+    :param game: the game whose nodes will be used
+    :param valid_areas: limit the areas shown in the dialog to the areas in this list
+    :return: a NodeIdentifier of the selected node, or None if the dialog was canceled
+    """
     dialog = AreaPickerDialog(parent, game, valid_areas)
     result = dialog.exec()
     if result == QtWidgets.QDialog.DialogCode.Accepted:
@@ -19,6 +27,14 @@ def get_node(parent: QtWidgets.QWidget, game: RandovaniaGame, valid_areas: list[
         return None
 
 def get_area(parent: QtWidgets.QWidget, game: RandovaniaGame, valid_areas: list[AreaIdentifier] = None) -> Optional[NodeIdentifier]:
+    """
+    Opens a modal dialog for the user to pick a specific area.
+
+    :param parent: the parent widget that spawns the dialog
+    :param game: the game whose areas will be used
+    :param valid_areas: limit the areas shown in the dialog to the areas in this list
+    :return: an AreaIdentifier of the selected area, or None if the dialog was canceled
+    """
     dialog = AreaPickerDialog(parent, game, valid_areas, False)
     result = dialog.exec()
     if result == QtWidgets.QDialog.DialogCode.Accepted:

--- a/randovania/gui/lib/area_picker.py
+++ b/randovania/gui/lib/area_picker.py
@@ -4,7 +4,7 @@ from randovania.game_description.world.area import Area
 from randovania.game_description.world.area_identifier import AreaIdentifier
 from randovania.game_description.world.world import World
 from randovania.games.game import RandovaniaGame
-from randovania.game_description.world.node import Node, NodeIdentifier
+from randovania.game_description.world.node import DockNode, EventNode, Node, NodeIdentifier, PickupNode
 from randovania.gui.generated.area_picker_dialog_ui import Ui_AreaPickerDialog
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt
@@ -24,9 +24,9 @@ class AreaPickerDialog(QtWidgets.QDialog, Ui_AreaPickerDialog):
     area_combo_box: QtWidgets.QComboBox
     node_combo_box: QtWidgets.QComboBox
     confirm_buttons: QtWidgets.QDialogButtonBox
-    current_world: World
-    current_area: Area
-    current_node: Node
+    current_world: Optional[World]
+    current_area: Optional[Area]
+    current_node: Optional[Node]
     filter: Optional[Callable[[Node], bool]]
 
     def __init__(self, parent: QtWidgets.QWidget, game: RandovaniaGame, filter: Optional[Callable[[Node], bool]]=None):
@@ -37,9 +37,16 @@ class AreaPickerDialog(QtWidgets.QDialog, Ui_AreaPickerDialog):
             item = QtWidgets.QListWidgetItem(world.name)
             item.setData(Qt.UserRole, world)
             self.worldList.addItem(item)
+        self.current_world = None
+        self.current_area = None
+        self.current_node = None
         self.worldList.currentItemChanged.connect(self._update_areas)
         self.areaList.currentItemChanged.connect(self._update_nodes)
         self.nodeList.currentItemChanged.connect(self._node_selected)
+        self.nodeList.itemDoubleClicked.connect(lambda _: self.accept())
+        self.locationsCheckBox.stateChanged.connect(self._checkbox_changed)
+        self.pickupsCheckBox.stateChanged.connect(self._checkbox_changed)
+        self.eventsCheckBox.stateChanged.connect(self._checkbox_changed)
         self.confirmButtonBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(False)
 
     def _update_areas(self, world: QtWidgets.QListWidgetItem, previous: QtWidgets.QListWidgetItem):
@@ -59,13 +66,19 @@ class AreaPickerDialog(QtWidgets.QDialog, Ui_AreaPickerDialog):
             item.setData(Qt.UserRole, area)
             self.areaList.addItem(item)
 
-    def _update_nodes(self, area: QtWidgets.QListWidgetItem, previous: QtWidgets.QListWidgetItem):
+    def _update_nodes(self, area: QtWidgets.QListWidgetItem, previous: QtWidgets.QListWidgetItem=None):
         self.nodeList.clear()
         self.current_area = None if not area else area.data(Qt.UserRole)
         if not area:
             self.nodeList.setDisabled(True)
             return
-        node_list = [node for node in area.data(Qt.UserRole).nodes if not node.is_resource_node]
+        node_list = [node for node in area.data(Qt.UserRole).nodes]
+        if not self.locationsCheckBox.isChecked():
+            node_list = [node for node in node_list if not isinstance(node, DockNode)]
+        if not self.pickupsCheckBox.isChecked():
+            node_list = [node for node in node_list if not isinstance(node, PickupNode)]
+        if not self.eventsCheckBox.isChecked():
+            node_list = [node for node in node_list if not isinstance(node, EventNode)]
         node_list.sort(key=lambda node: node.name)
         self.nodeList.setDisabled(not node_list)
         for node in node_list:
@@ -79,3 +92,6 @@ class AreaPickerDialog(QtWidgets.QDialog, Ui_AreaPickerDialog):
 
     def _enable_confirm(self, enable: bool):
         self.confirmButtonBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(enable)
+    
+    def _checkbox_changed(self):
+        self._update_nodes(self.areaList.currentItem())

--- a/randovania/gui/lib/area_picker.py
+++ b/randovania/gui/lib/area_picker.py
@@ -10,7 +10,7 @@ from randovania.gui.generated.area_picker_dialog_ui import Ui_AreaPickerDialog
 from PySide6 import QtWidgets, QtGui, QtCore
 from PySide6.QtCore import Qt
 
-def get_node(header_text: str, parent: QtWidgets.QWidget, game: RandovaniaGame, valid_areas: list[AreaIdentifier] = None) -> Optional[NodeIdentifier]:
+def get_node(header_text: str, parent: QtWidgets.QWidget, game: RandovaniaGame, title_text: str = None, valid_areas: list[AreaIdentifier] = None) -> Optional[NodeIdentifier]:
     """
     Opens a modal dialog for the user to pick a specific node.
 
@@ -20,10 +20,10 @@ def get_node(header_text: str, parent: QtWidgets.QWidget, game: RandovaniaGame, 
     :param valid_areas: limit the areas shown in the dialog to the areas in this list
     :return: a NodeIdentifier of the selected node, or None if the dialog was canceled
     """
-    accepted, world, area, node = _get_item(header_text, parent, game, valid_areas, True, "Select Node")
+    accepted, world, area, node = _get_item(header_text, parent, game, valid_areas, True, title_text if title_text else "Select Node")
     return None if not accepted else NodeIdentifier(AreaIdentifier(world.name, area.name), node.name)
 
-def get_area(header_text: str, parent: QtWidgets.QWidget, game: RandovaniaGame, valid_areas: list[AreaIdentifier] = None) -> Optional[NodeIdentifier]:
+def get_area(header_text: str, parent: QtWidgets.QWidget, game: RandovaniaGame, title_text: str = None, valid_areas: list[AreaIdentifier] = None) -> Optional[NodeIdentifier]:
     """
     Opens a modal dialog for the user to pick a specific area.
 
@@ -33,7 +33,7 @@ def get_area(header_text: str, parent: QtWidgets.QWidget, game: RandovaniaGame, 
     :param valid_areas: limit the areas shown in the dialog to the areas in this list
     :return: an AreaIdentifier of the selected area, or None if the dialog was canceled
     """
-    accepted, world, area, _ = _get_item(header_text, parent, game, valid_areas, False, "Select Area")
+    accepted, world, area, _ = _get_item(header_text, parent, game, valid_areas, False, title_text if title_text else "Select Area")
     return None if not accepted else AreaIdentifier(world.name, area.name)
 
 def _get_item(header_text: str, parent: QtWidgets.QWidget, game: RandovaniaGame, valid_areas: list[AreaIdentifier] = None, pick_node = True, window_title: str = None) -> tuple[bool, Optional[World], Optional[Area], Optional[Node]]:

--- a/randovania/gui/tracker_window.py
+++ b/randovania/gui/tracker_window.py
@@ -17,6 +17,7 @@ from matplotlib.axes import Axes
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure
+from randovania import game_description
 
 from randovania.game_description.game_description import GameDescription
 from randovania.game_description.requirements import RequirementAnd, ResourceRequirement, Requirement
@@ -35,6 +36,7 @@ from randovania.games.prime2.layout.translator_configuration import LayoutTransl
 from randovania.generator import generator
 from randovania.gui.dialog.scroll_label_dialog import ScrollLabelDialog
 from randovania.gui.generated.tracker_window_ui import Ui_TrackerWindow
+from randovania.gui.lib import area_picker
 from randovania.gui.lib.common_qt_lib import set_default_window_icon
 from randovania.gui.lib.scroll_protected import ScrollProtectedSpinBox
 from randovania.layout.base.base_configuration import BaseConfiguration
@@ -328,14 +330,11 @@ class TrackerWindow(QMainWindow, Ui_TrackerWindow):
 
     def _force_location(self):
         world_list = self.game_description.world_list
-        area_locations = location_list.area_locations_with_filter(self.game_description.game, lambda area: True)
-        location_names = [world_list.area_name(world_list.area_by_area_location(it))
-                            for it in area_locations]
-        selected_name = QtWidgets.QInputDialog.getItem(self, "Force New Location", "Select your current room",
-                                                        location_names, 0, False)
-        area_location = area_locations[location_names.index(selected_name[0])]
-        node = world_list.resolve_teleporter_connection(area_location)
-        self._add_new_action(node)
+        print(world_list._nodes_to_area)
+        node_id = area_picker.get_node(self, self.game_description.game)
+        if node_id is not None:
+            node = world_list.node_by_identifier(node_id)
+            self._add_new_action(node)
 
     def _on_tree_node_double_clicked(self, item: QTreeWidgetItem, _):
         node: Optional[Node] = getattr(item, "node", None)

--- a/randovania/gui/tracker_window.py
+++ b/randovania/gui/tracker_window.py
@@ -330,7 +330,6 @@ class TrackerWindow(QMainWindow, Ui_TrackerWindow):
 
     def _force_location(self):
         world_list = self.game_description.world_list
-        print(world_list._nodes_to_area)
         node_id = area_picker.get_node(self, self.game_description.game)
         if node_id is not None:
             node = world_list.node_by_identifier(node_id)

--- a/randovania/gui/tracker_window.py
+++ b/randovania/gui/tracker_window.py
@@ -157,7 +157,7 @@ class TrackerWindow(QMainWindow, Ui_TrackerWindow):
         self.resource_filter_check.stateChanged.connect(self.update_locations_tree_for_reachable_nodes)
         self.hide_collected_resources_check.stateChanged.connect(self.update_locations_tree_for_reachable_nodes)
         self.undo_last_action_button.clicked.connect(self._undo_last_action)
-        self.force_location_button.clicked.connect(self._force_location)
+        self.force_location_button.clicked.connect(self._add_manual_action)
 
         self.configuration_label.setText("Trick Level: {}; Starts with:\n{}".format(
             self.preset.configuration.trick_level.pretty_description,
@@ -328,9 +328,9 @@ class TrackerWindow(QMainWindow, Ui_TrackerWindow):
         self.actions_list.takeItem(len(self._actions))
         self._refresh_for_new_action()
 
-    def _force_location(self):
+    def _add_manual_action(self):
         world_list = self.game_description.world_list
-        node_id = area_picker.get_node(self, self.game_description.game, self.game_configuration.starting_location.locations)
+        node_id = area_picker.get_node("Select the action you'd like to add.", self, self.game_description.game, "Add Manual Action")
         if node_id is not None:
             node = world_list.node_by_identifier(node_id)
             self._add_new_action(node)

--- a/randovania/gui/tracker_window.py
+++ b/randovania/gui/tracker_window.py
@@ -330,7 +330,7 @@ class TrackerWindow(QMainWindow, Ui_TrackerWindow):
 
     def _force_location(self):
         world_list = self.game_description.world_list
-        node_id = area_picker.get_node(self, self.game_description.game)
+        node_id = area_picker.get_node(self, self.game_description.game, self.game_configuration.starting_location.locations)
         if node_id is not None:
             node = world_list.node_by_identifier(node_id)
             self._add_new_action(node)

--- a/randovania/gui/ui_files/area_picker_dialog.ui
+++ b/randovania/gui/ui_files/area_picker_dialog.ui
@@ -46,19 +46,27 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="3">
-    <widget class="QDialogButtonBox" name="confirmButtonBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="0" column="2">
+    <widget class="QLabel" name="nodeLabel">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+      </font>
      </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+     <property name="text">
+      <string>Node</string>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="worldLabel">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>World</string>
      </property>
     </widget>
    </item>
@@ -75,18 +83,6 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="worldLabel">
-     <property name="font">
-      <font>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>World</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="1">
     <widget class="QLabel" name="areaLabel">
      <property name="font">
@@ -99,17 +95,58 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
-    <widget class="QLabel" name="nodeLabel">
-     <property name="font">
-      <font>
-       <bold>true</bold>
-      </font>
+   <item row="3" column="2">
+    <widget class="QDialogButtonBox" name="confirmButtonBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="text">
-      <string>Node</string>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
+   </item>
+   <item row="2" column="0" rowspan="3" colspan="2">
+    <layout class="QHBoxLayout" name="nodeFiltersLayout">
+     <property name="rightMargin">
+      <number>208</number>
+     </property>
+     <item>
+      <widget class="QCheckBox" name="locationsCheckBox">
+       <property name="text">
+        <string>Locations</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="pickupsCheckBox">
+       <property name="text">
+        <string>Pickups</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="eventsCheckBox">
+       <property name="text">
+        <string>Events</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/randovania/gui/ui_files/area_picker_dialog.ui
+++ b/randovania/gui/ui_files/area_picker_dialog.ui
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AreaPickerDialog</class>
+ <widget class="QDialog" name="AreaPickerDialog">
+  <property name="windowModality">
+   <enum>Qt::ApplicationModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>740</width>
+    <height>450</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Area Picker</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="2">
+    <widget class="QListWidget" name="nodeList">
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QListWidget" name="worldList">
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="confirmButtonBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QListWidget" name="areaList">
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="worldLabel">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>World</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLabel" name="areaLabel">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Area</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLabel" name="nodeLabel">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Node</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>confirmButtonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>AreaPickerDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>confirmButtonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>AreaPickerDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/randovania/gui/ui_files/area_picker_dialog.ui
+++ b/randovania/gui/ui_files/area_picker_dialog.ui
@@ -9,9 +9,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>805</width>
+    <width>815</width>
     <height>450</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Area Picker</string>
@@ -58,9 +64,6 @@
    </item>
    <item row="2" column="0" rowspan="3" colspan="3">
     <layout class="QHBoxLayout" name="nodeFiltersLayout">
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
      <item>
       <widget class="QLabel" name="searchLabel">
        <property name="sizePolicy">
@@ -189,11 +192,11 @@
         <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
+        <enum>QSizePolicy::MinimumExpanding</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>200</width>
+         <width>20</width>
          <height>20</height>
         </size>
        </property>
@@ -209,7 +212,7 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>0</width>
+         <width>180</width>
          <height>0</height>
         </size>
        </property>
@@ -225,6 +228,18 @@
    </item>
    <item row="1" column="0">
     <widget class="QListView" name="worldList">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>250</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="horizontalScrollBarPolicy">
       <enum>Qt::ScrollBarAlwaysOff</enum>
      </property>
@@ -235,6 +250,18 @@
    </item>
    <item row="1" column="1">
     <widget class="QListView" name="areaList">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>250</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="horizontalScrollBarPolicy">
       <enum>Qt::ScrollBarAlwaysOff</enum>
      </property>
@@ -245,6 +272,18 @@
    </item>
    <item row="1" column="2">
     <widget class="QListView" name="nodeList">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>250</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="horizontalScrollBarPolicy">
       <enum>Qt::ScrollBarAlwaysOff</enum>
      </property>

--- a/randovania/gui/ui_files/area_picker_dialog.ui
+++ b/randovania/gui/ui_files/area_picker_dialog.ui
@@ -231,9 +231,6 @@
      <property name="showDropIndicator" stdset="0">
       <bool>false</bool>
      </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
     </widget>
    </item>
    <item row="1" column="1">
@@ -244,9 +241,6 @@
      <property name="showDropIndicator" stdset="0">
       <bool>false</bool>
      </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
     </widget>
    </item>
    <item row="1" column="2">
@@ -256,9 +250,6 @@
      </property>
      <property name="showDropIndicator" stdset="0">
       <bool>false</bool>
-     </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/randovania/gui/ui_files/area_picker_dialog.ui
+++ b/randovania/gui/ui_files/area_picker_dialog.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>740</width>
+    <width>805</width>
     <height>450</height>
    </rect>
   </property>
@@ -20,32 +20,6 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="2">
-    <widget class="QListWidget" name="nodeList">
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
-     </property>
-     <property name="showDropIndicator" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QListWidget" name="worldList">
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
-     </property>
-     <property name="showDropIndicator" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="2">
     <widget class="QLabel" name="nodeLabel">
      <property name="font">
@@ -70,19 +44,6 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QListWidget" name="areaList">
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
-     </property>
-     <property name="showDropIndicator" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="1">
     <widget class="QLabel" name="areaLabel">
      <property name="font">
@@ -95,29 +56,93 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
-    <widget class="QDialogButtonBox" name="confirmButtonBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" rowspan="3" colspan="2">
+   <item row="2" column="0" rowspan="3" colspan="3">
     <layout class="QHBoxLayout" name="nodeFiltersLayout">
      <property name="rightMargin">
-      <number>208</number>
+      <number>0</number>
      </property>
      <item>
+      <widget class="QLabel" name="searchLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Find Area</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="searchLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>140</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="filterLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Show Nodes</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QCheckBox" name="locationsCheckBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Locations</string>
        </property>
@@ -128,6 +153,12 @@
      </item>
      <item>
       <widget class="QCheckBox" name="pickupsCheckBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Pickups</string>
        </property>
@@ -138,6 +169,12 @@
      </item>
      <item>
       <widget class="QCheckBox" name="eventsCheckBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Events</string>
        </property>
@@ -146,7 +183,84 @@
        </property>
       </widget>
      </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>200</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="confirmButtonBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
     </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QListView" name="worldList">
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QListView" name="areaList">
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QListView" name="nodeList">
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/randovania/gui/ui_files/area_picker_dialog.ui
+++ b/randovania/gui/ui_files/area_picker_dialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>815</width>
-    <height>450</height>
+    <width>816</width>
+    <height>524</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -26,7 +26,29 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="2">
+   <item row="4" column="1">
+    <widget class="QListView" name="areaList">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>250</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
     <widget class="QLabel" name="nodeLabel">
      <property name="font">
       <font>
@@ -38,31 +60,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="worldLabel">
-     <property name="font">
-      <font>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>World</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLabel" name="areaLabel">
-     <property name="font">
-      <font>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Area</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" rowspan="3" colspan="3">
+   <item row="5" column="0" rowspan="3" colspan="3">
     <layout class="QHBoxLayout" name="nodeFiltersLayout">
      <item>
       <widget class="QLabel" name="searchLabel">
@@ -226,7 +224,72 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="0">
+   <item row="3" column="0">
+    <widget class="QLabel" name="worldLabel">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>World</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="areaLabel">
+     <property name="font">
+      <font>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Area</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QListView" name="nodeList">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>250</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="3">
+    <widget class="QLabel" name="headerLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Please select a node to continue.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignHCenter|Qt::AlignTop</set>
+     </property>
+     <property name="margin">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
     <widget class="QListView" name="worldList">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
@@ -248,47 +311,10 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QListView" name="areaList">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>250</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
-     </property>
-     <property name="showDropIndicator" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QListView" name="nodeList">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>250</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
-     </property>
-     <property name="showDropIndicator" stdset="0">
-      <bool>false</bool>
+   <item row="2" column="0" colspan="3">
+    <widget class="Line" name="headerLine">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>

--- a/randovania/gui/ui_files/tracker_window.ui
+++ b/randovania/gui/ui_files/tracker_window.ui
@@ -96,8 +96,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>333</width>
-             <height>402</height>
+             <width>324</width>
+             <height>392</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="pickup_box_layout">
@@ -207,8 +207,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>333</width>
-             <height>402</height>
+             <width>324</width>
+             <height>392</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="elevators_scroll_layout">
@@ -263,8 +263,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>331</width>
-             <height>400</height>
+             <width>322</width>
+             <height>390</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="translator_gate_scroll_layout">
@@ -291,7 +291,7 @@
     <item row="2" column="1" colspan="2">
      <widget class="QTabWidget" name="map_tab_widget">
       <property name="currentIndex">
-       <number>0</number>
+       <number>3</number>
       </property>
       <widget class="QWidget" name="tab_text_map">
        <attribute name="title">
@@ -333,13 +333,6 @@
            <string>Current location:</string>
           </property>
          </widget>
-        </item>
-        <item>
-          <widget class="QPushButton" name="force_location_button">
-            <property name="text">
-              <string>Force new location</string>
-            </property>
-          </widget>
         </item>
         <item>
          <widget class="QTreeWidget" name="possible_locations_tree">
@@ -419,27 +412,11 @@
        <attribute name="title">
         <string>Actions</string>
        </attribute>
-       <layout class="QVBoxLayout" name="tab_actions_layout">
-        <property name="leftMargin">
-         <number>4</number>
-        </property>
-        <property name="topMargin">
-         <number>4</number>
-        </property>
-        <property name="rightMargin">
-         <number>4</number>
-        </property>
-        <property name="bottomMargin">
-         <number>4</number>
-        </property>
-        <item>
-         <widget class="QPushButton" name="undo_last_action_button">
-          <property name="text">
-           <string>Undo last action</string>
-          </property>
-         </widget>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="3" column="0" colspan="2">
+         <widget class="QListWidget" name="actions_list"/>
         </item>
-        <item>
+        <item row="2" column="0" colspan="2">
          <widget class="QLabel" name="actions_title_label">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -447,16 +424,41 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="font">
+           <font>
+            <bold>true</bold>
+           </font>
+          </property>
           <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;History of all actions that have been performed.&lt;/p&gt;&lt;p&gt;Press &amp;quot;Undo last action&amp;quot; to remove the last action from the list.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>Action History</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
           </property>
           <property name="wordWrap">
            <bool>true</bool>
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QListWidget" name="actions_list"/>
+        <item row="1" column="1">
+         <widget class="QPushButton" name="undo_last_action_button">
+          <property name="toolTip">
+           <string>Remove the last action from the list.</string>
+          </property>
+          <property name="text">
+           <string>Undo last action</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QPushButton" name="force_location_button">
+          <property name="toolTip">
+           <string>Let the tracker know you've gotten to a location, event, or item, even if it's not showing up in the Text Map.</string>
+          </property>
+          <property name="text">
+           <string>Add manual action</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>
@@ -470,7 +472,7 @@
      <x>0</x>
      <y>0</y>
      <width>1040</width>
-     <height>22</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_tracker">

--- a/randovania/gui/ui_files/tracker_window.ui
+++ b/randovania/gui/ui_files/tracker_window.ui
@@ -335,6 +335,13 @@
          </widget>
         </item>
         <item>
+          <widget class="QPushButton" name="force_location_button">
+            <property name="text">
+              <string>Force new location</string>
+            </property>
+          </widget>
+        </item>
+        <item>
          <widget class="QTreeWidget" name="possible_locations_tree">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Ignored" vsizetype="Expanding">


### PR DESCRIPTION
## Add Manual Action
![2022-02-28_05-11-14](https://user-images.githubusercontent.com/7810794/155981388-63f3ae61-638c-49e6-9185-7ebddd26f9c6.png)

- An "Add manual action" button is added next to "Undo last action". This allows the player to manually add an action that is not exposed in the Map Tracker due to it being "illogical" in the current settings—for example, if out-of-logic tricks are performed.
- The text instructions were moved to tooltips that appear when hovering over each button, which explains each of their functions.

## Area Picker
![2022-02-28_05-15-31](https://user-images.githubusercontent.com/7810794/155981960-91e44bd6-0882-4522-a148-909c20ad7eac.png)

The Area Picker dialog widget is a general-purpose dialog that prompts the user to select a node or an area (via `get_node()` or `get_area()`), which gets returned as a `NodeIdentifier` or `AreaIdentifier`. Similarly to `QInputDialog`, there is no boilerplate to create/connect the dialog. It also accepts a `valid_areas` list which will show only those areas in the dialog.