### PR TITLE
Ensure Hanubia is reachable only by Golzuna or SSC

### DIFF
--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -9384,7 +9384,24 @@
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
-                    "connections": {}
+                    "connections": {
+                        "Before Golzuna": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "ElunReleaseX",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Start Point": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 },
                 "Before Golzuna": {
                     "node_type": "generic",
@@ -9818,15 +9835,6 @@
                         ]
                     },
                     "connections": {
-                        "Door to Cross Bomb Tutorial": {
-                            "type": "resource",
-                            "data": {
-                                "type": "events",
-                                "name": "ElunReleaseX",
-                                "amount": 1,
-                                "negate": true
-                            }
-                        },
                         "Before Golzuna": {
                             "type": "resource",
                             "data": {
@@ -9850,6 +9858,44 @@
                     "extra": {},
                     "connections": {
                         "Door to Cross Bomb Tutorial": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Dock from Above Golzuna": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 8073.47,
+                        "y": 6064.85,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "extra": {},
+                    "dock_type": "other",
+                    "default_connection": {
+                        "world_name": "Ghavoran",
+                        "area_name": "Above Golzuna",
+                        "node_name": "Dock to Golzuna Arena"
+                    },
+                    "default_dock_weakness": "Blocked Passage",
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {
+                        "Before Golzuna": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "ElunReleaseX",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Start Point": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12541,6 +12587,27 @@
                                 "amount": 1,
                                 "negate": false
                             }
+                        },
+                        "Dock to Golzuna Arena": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can SSC"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "SSC",
+                                            "amount": 4,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -12610,6 +12677,27 @@
                             }
                         }
                     }
+                },
+                "Dock to Golzuna Arena": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 8073.47,
+                        "y": 6064.85,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "extra": {},
+                    "dock_type": "other",
+                    "default_connection": {
+                        "world_name": "Ghavoran",
+                        "area_name": "Golzuna Arena",
+                        "node_name": "Dock from Above Golzuna"
+                    },
+                    "default_dock_weakness": "Open Passage",
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {}
                 }
             }
         },

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -9874,7 +9874,7 @@
                         "y": 6064.85,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "This dock is only used with the SSC.\n\n",
                     "extra": {},
                     "dock_type": "other",
                     "default_connection": {
@@ -12686,7 +12686,7 @@
                         "y": 6064.85,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "This dock is only used with the SSC.\n\n",
                     "extra": {},
                     "dock_type": "other",
                     "default_connection": {

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -2065,6 +2065,9 @@ Extra - asset_id: collision_camera_026
 
 > Dock from Above Golzuna; Heals? False
   * Blocked Passage to Above Golzuna/Dock to Golzuna Arena
+  * This dock is only used with the SSC.
+
+
   > Before Golzuna
       After Elun - Release X Parasites
   > Start Point
@@ -2687,6 +2690,9 @@ Extra - asset_id: collision_camera_036
 
 > Dock to Golzuna Arena; Heals? False
   * Open Passage to Golzuna Arena/Dock from Above Golzuna
+  * This dock is only used with the SSC.
+
+
 
 ----------------
 Transport to Elun

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -1977,6 +1977,10 @@ Extra - asset_id: collision_camera_026
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  > Before Golzuna
+      After Elun - Release X Parasites
+  > Start Point
+      Trivial
 
 > Before Golzuna; Heals? False
   * Extra - actor_name: breakabletilegroup_011
@@ -2052,13 +2056,18 @@ Extra - asset_id: collision_camera_026
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('WEIGHT',)
-  > Door to Cross Bomb Tutorial
-      Before Elun - Release X Parasites
   > Before Golzuna
       After Elun - Release X Parasites
 
 > Start Point; Heals? False; Spawn Point
   > Door to Cross Bomb Tutorial
+      Trivial
+
+> Dock from Above Golzuna; Heals? False
+  * Blocked Passage to Above Golzuna/Dock to Golzuna Arena
+  > Before Golzuna
+      After Elun - Release X Parasites
+  > Start Point
       Trivial
 
 ----------------
@@ -2657,6 +2666,8 @@ Extra - asset_id: collision_camera_036
       Trivial
   > Tunnel to Golzuna Arena
       Morph Ball
+  > Dock to Golzuna Arena
+      Shinesink Clip (Expert) and Can SSC
 
 > Door from Cross Bomb Tutorial; Heals? False
   * Access Closed to Cross Bomb Tutorial/Door to Above Golzuna
@@ -2673,6 +2684,9 @@ Extra - asset_id: collision_camera_036
   * Morph Ball Tunnel to Golzuna Arena/Tunnel to Above Golzuna
   > Door to Golzuna Tower
       Morph Ball
+
+> Dock to Golzuna Arena; Heals? False
+  * Open Passage to Golzuna Arena/Dock from Above Golzuna
 
 ----------------
 Transport to Elun


### PR DESCRIPTION
- Added "Dock to Golzuna Arena" in "Above Golzuna" for the SSC
- Added "Dock from Above Golzuna" in "Golzuna Arena" for the SSC
- Removed "Tile (WEIGHT)" connection to "Door to Cross Bomb Tutorial"