### PR TITLE
Correct logic for the PB Tank in Grav Suit Room

### DIFF
--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -12003,7 +12003,7 @@
                     "pickup_index": 85,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
+                        "Tile Group (POWERBOMB)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -12139,44 +12139,6 @@
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 3600.0,
-                        "y": -12300.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "extra": {
-                        "actor_name": "breakabletilegroup_010",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Power Bomb Tank)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Tile Group (POWERBOMB)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
                 "Tunnel to Gravity Suit Room Access (Upper)": {
                     "node_type": "dock",
                     "heal": false,
@@ -12277,9 +12239,26 @@
                         ]
                     },
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "template",
-                            "data": "Ballspark"
+                        "Pickup (Power Bomb Tank)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    }
+                                ]
+                            }
                         },
                         "Tunnel to Gravity Suit Room Access (Lower)": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -2403,7 +2403,7 @@ the blast shield issue.
   * Pickup 85; Major Location? False
   * Extra - actor_name: item_powerbombtank_000
   * Extra - actor_def: actordef:actors/items/item_powerbombtank/charclasses/item_powerbombtank.bmsad
-  > Tile Group (SPEEDBOOST)
+  > Tile Group (POWERBOMB)
       Morph Ball
 
 > Door to Gravity Suit Tower (Lower); Heals? False
@@ -2434,17 +2434,6 @@ the blast shield issue.
   > Pickup (Gravity Suit)
       Trivial
 
-> Tile Group (SPEEDBOOST); Heals? False
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_010
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Power Bomb Tank)
-      Morph Ball
-  > Tile Group (POWERBOMB)
-      Morph Ball
-
 > Tunnel to Gravity Suit Room Access (Upper); Heals? False
   * Morph Ball Tunnel to Gravity Suit Room Access/Tunnel to Gravity Suit Room (Upper)
   > Door to Gravity Suit Tower (Lower)
@@ -2462,8 +2451,8 @@ the blast shield issue.
   * Extra - actor_name: breakabletilegroup_036
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - tile_types: ('POWERBOMB',)
-  > Tile Group (SPEEDBOOST)
-      Ballspark
+  > Pickup (Power Bomb Tank)
+      Gravity Suit and Ballspark
   > Tunnel to Gravity Suit Room Access (Lower)
       All of the following:
           Morph Ball


### PR DESCRIPTION
- Removes the node for Tile Group (SPEEDBOOST) as it is unnecessary
- Adds Gravity Suit to the ballspark requirement to get the PB Tank