### PR TITLE
Adjust logic involving the Pulse Radar Enky

### DIFF
--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -7226,18 +7226,22 @@
                                                         "amount": 2,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "ElunReleaseX",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "IBJ",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Simple IBJ"
                                     }
                                 ]
                             }
@@ -7282,15 +7286,10 @@
                                                     "data": {
                                                         "comment": null,
                                                         "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Spin",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
+															{
+																"type": "template",
+																"data": "Use Spin Boost"
+															},
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
@@ -7305,7 +7304,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "Walljump",
-                                                                    "amount": 3,
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -7313,29 +7312,12 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Speed",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Movement",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 },
                                                 {
@@ -7544,8 +7526,63 @@
                     "major_location": false,
                     "connections": {
                         "Door to Save Station East": {
-                            "type": "template",
-                            "data": "Ballspark"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Ballspark"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "GhavoranPulseRadarEnky",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Cross Comb"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Bomb",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Tile Group (WEIGHT) 3": {
                             "type": "resource",
@@ -7577,8 +7614,37 @@
                     },
                     "connections": {
                         "Pickup (Missile Tank)": {
-                            "type": "template",
-                            "data": "Ballspark"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Ballspark"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "GhavoranPulseRadarEnky",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    }
+                                ]
+                            }
                         },
                         "Tile Group (BOMB) 3": {
                             "type": "resource",
@@ -11298,12 +11364,29 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "GhavoranPulseRadarEnky",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -7286,10 +7286,10 @@
                                                     "data": {
                                                         "comment": null,
                                                         "items": [
-															{
-																"type": "template",
-																"data": "Use Spin Boost"
-															},
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -1505,17 +1505,16 @@ Extra - asset_id: collision_camera_024
   * Extra - right_shield_def: None
   > Door to Above Golzuna
       Any of the following:
-          Space Jump or Speed Booster or Infinite Bomb Jump (Beginner)
-          Ice Missile and Movement (Intermediate) and Use Spin Boost
+          Space Jump or Speed Booster or Simple IBJ
+          Ice Missile and After Elun - Release X Parasites and Movement (Intermediate) and Use Spin Boost
   > Door to Energy Recharge Station
       Trivial
   > Pickup (Missile Tank)
       All of the following:
           Morph Ball
           Any of the following:
-              Space Jump or Simple IBJ
-              Flash Shift and Spin Boost and Walljump (Advanced)
-              Speed Booster and Movement (Intermediate)
+              Space Jump or Simple IBJ or Speed Booster
+              Flash Shift and Use Spin Boost and Walljump (Beginner)
   > Tile Group (SPEEDBOOST) 2
       Speed Booster
 
@@ -1575,7 +1574,9 @@ Extra - asset_id: collision_camera_024
   * Extra - actor_name: item_missiletank
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Door to Save Station East
-      Ballspark
+      Any of the following:
+          After Ghavoran - Pulse Radar Enky and Ballspark
+          Bomb and Movement (Expert) and Lay Cross Comb
   > Tile Group (WEIGHT) 3
       Morph Ball
 
@@ -1586,7 +1587,9 @@ Extra - asset_id: collision_camera_024
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
   > Pickup (Missile Tank)
-      Ballspark
+      Any of the following:
+          Lay Cross Comb
+          After Ghavoran - Pulse Radar Enky and Ballspark
   > Tile Group (BOMB) 3
       Morph Ball
   > Tile Group (POWERBEAM) 3
@@ -2364,7 +2367,8 @@ Extra - asset_id: collision_camera_031
       Trivial
   > Dock to Teleport to Burenia
       Any of the following:
-          Space Jump or Speed Booster
+          Space Jump
+          Speed Booster and After Ghavoran - Pulse Radar Enky
           All of the following:
               Gravity Suit
               Flash Shift or Simple IBJ or Use Spin Boost

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -1513,8 +1513,8 @@ Extra - asset_id: collision_camera_024
       All of the following:
           Morph Ball
           Any of the following:
-              Space Jump or Simple IBJ or Speed Booster
-              Flash Shift and Use Spin Boost and Walljump (Beginner)
+              Space Jump or Speed Booster or Simple IBJ
+              Flash Shift and Walljump (Beginner) and Use Spin Boost
   > Tile Group (SPEEDBOOST) 2
       Speed Booster
 
@@ -2368,10 +2368,10 @@ Extra - asset_id: collision_camera_031
   > Dock to Teleport to Burenia
       Any of the following:
           Space Jump
-          Speed Booster and After Ghavoran - Pulse Radar Enky
           All of the following:
               Gravity Suit
               Flash Shift or Simple IBJ or Use Spin Boost
+          Speed Booster and After Ghavoran - Pulse Radar Enky
 
 > Top Room; Heals? False
   > Life Recharge


### PR DESCRIPTION
- Added the event for destroying the enky to the ballspark requirement to get the missile tank and through the tunnel in Golzuna Tower
- Added expert movement trick for getting through the tunnel with just both bomb types
- Adjusted some logic for reaching the missile tank from the other side
- Added the event for destroying the enky to the speed booster requirement to reach Teleport to Burenia in Energy Recharge Station