### PR TITLE
Fix logic for Hot Cataris Shortcut

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -20132,19 +20132,6 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Magnet",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
                                                     "type": "template",
                                                     "data": "Use Spin Boost"
                                                 },
@@ -20157,22 +20144,43 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
-                                                                    "name": "Grapple",
+                                                                    "name": "Flash",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "or",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "Flash",
-                                                                    "amount": 1,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Grapple",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Walljump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
                                                 }
                                             ]
                                         }
@@ -20181,12 +20189,21 @@
                             }
                         },
                         "Door to Transport to Cataris": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "and",
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
@@ -20194,109 +20211,32 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Morph",
+                                                        "name": "Varia",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "or",
+                                                    "type": "and",
                                                     "data": {
                                                         "comment": null,
                                                         "items": [
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "Varia",
-                                                                    "amount": 1,
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Heat",
-                                                                                "amount": 100,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Suitless",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Magnet",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": "Spider magnet is super slow. Slow enough to warrant havin a separate heate damage value vs. taking this path with morph ball",
-                                                        "items": [
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "Varia",
-                                                                    "amount": 1,
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 100,
                                                                     "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Heat",
-                                                                                "amount": 200,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Suitless",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -20360,6 +20300,15 @@
                                                     "data": {
                                                         "type": "items",
                                                         "name": "Flash",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Magnet",
                                                         "amount": 1,
                                                         "negate": false
                                                     }

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -4400,21 +4400,16 @@ Extra - asset_id: collision_camera_078
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
           Any of the following:
-              Spider Magnet or Use Spin Boost
-              Flash Shift and Grapple Beam
+              Simple IBJ or Use Spin Boost
+              All of the following:
+                  Flash Shift
+                  Grapple Beam or Walljump (Beginner)
   > Door to Transport to Cataris
-      Any of the following:
-          All of the following:
-              Morph Ball
-              Any of the following:
-                  Varia Suit
-                  Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
-          All of the following:
-              Spider Magnet
-              Any of the following:
-                  # Spider magnet is super slow. Slow enough to warrant havin a separate heate damage value vs. taking this path with morph ball
-                  Varia Suit
-                  Heat/Cold Runs (Intermediate) and Heat Damage ≥ 200
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Varia Suit
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
 > Door to Transport to Cataris; Heals? False
   * Charge Beam Door to Transport to Cataris/Door to Hot Cataris Shortcut
@@ -4426,7 +4421,7 @@ Extra - asset_id: collision_camera_078
   * Extra - right_shield_def: None
   > Pickup (Missile Tank)
       All of the following:
-          Flash Shift or Simple IBJ or Use Spin Boost
+          Flash Shift or Spider Magnet or Simple IBJ or Use Spin Boost
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50


### PR DESCRIPTION
- Removed Spider Magnet from "Door to Hot Room Hub" connection to "Pickup (Missile Tank)"
- Added Spider Magnet to "Door to Transport to Cataris" connection to "Pickup (Missile Tank)"
- Added other logic possibilities to reach "Pickup (Missile Tank)" from "Door to Hot Room Hub"