### PR TITLE
Dread: Fix Gravity Suit Tower logic bug

### DIFF
--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -11313,7 +11313,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s040_aqua:default:ev_demolition_db_003",
+                                            "name": "BureniaDestroyGravitySuitFloor",
                                             "amount": 1,
                                             "negate": false
                                         }

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -2269,7 +2269,7 @@ Extra - asset_id: collision_camera_021
       After Burenia - Destroy Gravity Suit Floor
   > Door to Navigation Station South
       All of the following:
-          Gravity Suit and After Burenia - ev_demolition_db_003
+          Gravity Suit and After Burenia - Destroy Gravity Suit Floor
           Space Jump or Speed Booster or Simple IBJ
   > Dock to Ammo Recharge South
       Any of the following:


### PR DESCRIPTION
- Changes the event in the connection of "Breakable Floor" to "Door to Navigation Station South" from destroying the third blob to pulling the grapple block