### PR TITLE
Fix Ghavoran Golzuna tower logic

### DIFF
--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -7544,8 +7544,25 @@
                     "major_location": false,
                     "connections": {
                         "Door to Save Station East": {
-                            "type": "template",
-                            "data": "Ballspark"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "GhavoranPulseRadarEnky",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Tile Group (WEIGHT) 3": {
                             "type": "resource",

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -1575,7 +1575,7 @@ Extra - asset_id: collision_camera_024
   * Extra - actor_name: item_missiletank
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Door to Save Station East
-      Ballspark
+      After Ghavoran - Pulse Radar Enky and Ballspark
   > Tile Group (WEIGHT) 3
       Morph Ball
 


### PR DESCRIPTION
A friend and I got softlocked on two different seeds because the logic expected us to be able to ballspark out of the Morph Ball maze under Pulse Radar out into the Golzuna Tower before being able to destroy the Enky in that hallway. My friend was able to do some insane cross bomb + bomb + jump combos using a turbo controller, but I didn't have regular bombs, and couldn't get out.

The connection from the missile tank in the diagonal tunnel out into the Golzuna Tower should only be marked as accessible via Ballspark if that Enky has been destroyed already (unless there's some INSANE speed strat we're both entirely unaware of)