### PR TITLE
Fixed ftp export directory creation to only have one leading slash

### DIFF
--- a/randovania/games/dread/gui/dialog/ftp_uploader.py
+++ b/randovania/games/dread/gui/dialog/ftp_uploader.py
@@ -55,7 +55,9 @@ class FtpUploader:
 
             # Create remote path
             ensure_path = ""
-            for part in self.remote_path.split("/"):
+            path_parts = self.remote_path.split("/")
+            path_parts.pop(0)
+            for part in path_parts:
                 ensure_path += f"/{part}"
                 try:
                     ftp.mkd(ensure_path)


### PR DESCRIPTION
For more sensitive ftp clients such as sys-ftpd-light, the double slash for some MKD commands caused the export to fail (best I can tell). This PR is an attempt to fix that.

As a note, I had trouble getting my locally built randovania to display export windows so I wasn't able to test it directly. I also only know python so well, so feel free to correct things or trash this entirely, this is more of a POC.


Example of error using sys-ftpd-light:
```
[2022-04-06 21:31:53,050] [WARNING] [root] __call__: Unable to create //mods: 553 Invalid argument
[2022-04-06 21:31:53,062] [WARNING] [root] __call__: Unable to create //mods/Metroid Dread: 553 Invalid argument
[2022-04-06 21:31:53,072] [WARNING] [root] __call__: Unable to create //mods/Metroid Dread/Randovania Central Dizzean Spittail: 553 Invalid argument
[2022-04-06 21:31:53,097] [ERROR] [root] export_game: Unable to export game
Traceback (most recent call last):
  File "randovania\games\dread\gui\dialog\ftp_uploader.py", line 70, in __call__
  File "ftplib.py", line 637, in mkd
  File "ftplib.py", line 286, in voidcmd
  File "ftplib.py", line 259, in voidresp
  File "ftplib.py", line 254, in getresp
ftplib.error_perm: 550 failed to create directory

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "randovania\gui\lib\game_exporter.py", line 45, in export_game
  File "randovania\gui\lib\background_task_mixin.py", line 75, in run_in_background_async
  File "randovania\gui\lib\background_task_mixin.py", line 67, in work
  File "randovania\gui\lib\game_exporter.py", line 35, in work
  File "randovania\games\dread\exporter\game_exporter.py", line 71, in export_game
  File "randovania\games\dread\gui\dialog\ftp_uploader.py", line 77, in __call__
RuntimeError: Unable to create /mods/Metroid Dread/Randovania Central Dizzean Spittail/contents
```

Example of a successful export to ftpd:
![IMG_3739](https://user-images.githubusercontent.com/3383889/162128676-7a8c0168-7842-4f03-a36e-f07a71801c86.jpg)

