### PR TITLE
Change GamePatches to hold a BaseConfiguration

### DIFF
--- a/randovania/exporter/hints/credits_spoiler.py
+++ b/randovania/exporter/hints/credits_spoiler.py
@@ -38,7 +38,7 @@ def get_locations_for_major_pickups_and_keys(
                     player_name = players_config.player_names[player_index]
 
                 results[target.pickup].append(
-                    OwnedPickupLocation(player_name, PickupLocation(patches.game_enum, pickup_index))
+                    OwnedPickupLocation(player_name, PickupLocation(patches.configuration.game, pickup_index))
                 )
 
     return results

--- a/randovania/exporter/hints/guaranteed_item_hint.py
+++ b/randovania/exporter/hints/guaranteed_item_hint.py
@@ -24,7 +24,7 @@ def find_locations_that_gives_items(
 
             for resource, quantity in resources.items():
                 if quantity > 0 and resource in result:
-                    result[resource].append((other_player, PickupLocation(patches.game_enum, pickup_index)))
+                    result[resource].append((other_player, PickupLocation(patches.configuration.game, pickup_index)))
 
     return result
 

--- a/randovania/exporter/hints/hint_exporter.py
+++ b/randovania/exporter/hints/hint_exporter.py
@@ -42,19 +42,19 @@ class HintExporter:
         else:
             assert hint.hint_type == HintType.LOCATION
 
-            player_game = all_patches[players_config.player_index].game_enum
+            configuration = all_patches[players_config.player_index].configuration
 
             pickup_target = patches.pickup_assignment.get(hint.target)
             phint = pickup_hint.create_pickup_hint(
                 patches.pickup_assignment,
-                default_database.game_description_for(player_game).world_list,
+                default_database.game_description_for(configuration.game).world_list,
                 hint.precision.item,
                 pickup_target,
                 players_config,
                 hint.precision.include_owner,
             )
             return self.namer.format_location_hint(
-                player_game,
+                configuration.game,
                 phint,
                 hint,
                 with_color,

--- a/randovania/exporter/hints/hint_formatters.py
+++ b/randovania/exporter/hints/hint_formatters.py
@@ -49,7 +49,7 @@ class TemplatedFormatter(LocationFormatter):
 
 class RelativeFormatter(LocationFormatter):
     def __init__(self, patches: GamePatches, distance_painter: Callable[[str, bool], str]):
-        self.world_list = default_database.game_description_for(patches.game_enum).world_list
+        self.world_list = default_database.game_description_for(patches.configuration.game).world_list
         self.patches = patches
         self.distance_painter = distance_painter
 

--- a/randovania/game_description/game_description.py
+++ b/randovania/game_description/game_description.py
@@ -3,7 +3,6 @@ import copy
 import dataclasses
 from typing import Iterator, FrozenSet, Dict, Optional, List
 
-from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.requirements import SatisfiableRequirements, Requirement
 from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.game_description.resources.resource_info import ResourceInfo, ResourceGainTuple, CurrentResources
@@ -109,15 +108,13 @@ class GameDescription:
         self.world_list.patch_requirements(resources, damage_multiplier, self.resource_database)
         self._dangerous_resources = None
 
-    def create_game_patches(self) -> GamePatches:
-        elevator_connection: Dict[NodeIdentifier, AreaIdentifier] = {
+    def get_default_elevator_connection(self) -> dict[NodeIdentifier, AreaIdentifier]:
+        return {
             self.world_list.identifier_for_node(node): node.default_connection
 
             for node in self.world_list.all_nodes
             if isinstance(node, TeleporterNode) and node.editable
         }
-
-        return GamePatches(None, self.game, {}, elevator_connection, {}, {}, {}, {}, self.starting_location, {})
 
     @property
     def dangerous_resources(self) -> FrozenSet[ResourceInfo]:

--- a/randovania/game_description/game_patches.py
+++ b/randovania/game_description/game_patches.py
@@ -1,20 +1,25 @@
+from __future__ import annotations
+
 import copy
 import dataclasses
+import typing
 from dataclasses import dataclass
 from typing import Tuple, Iterator, Optional
 
-from randovania.game_description.assignment import PickupAssignment, NodeConfigurationAssignment, PickupTarget
-from randovania.game_description.hint import Hint
-from randovania.game_description.requirements import Requirement
-from randovania.game_description.resources.pickup_index import PickupIndex
-from randovania.game_description.resources.resource_info import CurrentResources
 from randovania.game_description.resources.resource_type import ResourceType
 from randovania.game_description.world.area_identifier import AreaIdentifier
-from randovania.game_description.world.dock import DockWeakness
 from randovania.game_description.world.node_identifier import NodeIdentifier
-from randovania.games.game import RandovaniaGame
 
 ElevatorConnection = dict[NodeIdentifier, Optional[AreaIdentifier]]
+
+if typing.TYPE_CHECKING:
+    from randovania.game_description.assignment import PickupAssignment, NodeConfigurationAssignment, PickupTarget
+    from randovania.game_description.hint import Hint
+    from randovania.game_description.requirements import Requirement
+    from randovania.game_description.resources.pickup_index import PickupIndex
+    from randovania.game_description.resources.resource_info import CurrentResources
+    from randovania.game_description.world.dock import DockWeakness
+    from randovania.layout.base.base_configuration import BaseConfiguration
 
 
 @dataclass(frozen=True)
@@ -24,7 +29,7 @@ class GamePatches:
     * Swapping pickup locations
     """
     player_index: int
-    game_enum: RandovaniaGame
+    configuration: BaseConfiguration
     pickup_assignment: PickupAssignment
     elevator_connection: ElevatorConnection
     dock_connection: dict[NodeIdentifier, Optional[NodeIdentifier]]
@@ -34,7 +39,7 @@ class GamePatches:
     starting_location: AreaIdentifier
     hints: dict[NodeIdentifier, Hint]
 
-    def assign_new_pickups(self, assignments: Iterator[Tuple[PickupIndex, PickupTarget]]) -> "GamePatches":
+    def assign_new_pickups(self, assignments: Iterator[tuple[PickupIndex, PickupTarget]]) -> "GamePatches":
         new_pickup_assignment = copy.copy(self.pickup_assignment)
 
         for index, pickup in assignments:
@@ -44,7 +49,7 @@ class GamePatches:
         return dataclasses.replace(self, pickup_assignment=new_pickup_assignment)
 
     def assign_pickup_assignment(self, assignment: PickupAssignment) -> "GamePatches":
-        items: Iterator[Tuple[PickupIndex, PickupTarget]] = assignment.items()
+        items: Iterator[tuple[PickupIndex, PickupTarget]] = assignment.items()
         return self.assign_new_pickups(items)
 
     def assign_node_configuration(self, assignment: NodeConfigurationAssignment) -> "GamePatches":

--- a/randovania/game_description/integrity_check.py
+++ b/randovania/game_description/integrity_check.py
@@ -3,16 +3,17 @@ from typing import Iterator, Optional
 
 from randovania.game_description import derived_nodes
 from randovania.game_description.game_description import GameDescription
+from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.requirements import Requirement
 from randovania.game_description.resources.resource_info import convert_resource_gain_to_current_resources
 from randovania.game_description.world.area import Area
 from randovania.game_description.world.area_identifier import AreaIdentifier
 from randovania.game_description.world.dock import DockWeakness, DockType
-from randovania.game_description.world.node import Node, NodeContext
-from randovania.game_description.world.teleporter_node import TeleporterNode
 from randovania.game_description.world.dock_node import DockNode
 from randovania.game_description.world.event_node import EventNode
+from randovania.game_description.world.node import Node, NodeContext
 from randovania.game_description.world.pickup_node import PickupNode
+from randovania.game_description.world.teleporter_node import TeleporterNode
 from randovania.game_description.world.world import World
 
 pickup_node_re = re.compile(r"^Pickup (\d+ )?\(.*\)$")
@@ -158,7 +159,18 @@ def find_invalid_strongly_connected_components(game: GameDescription) -> Iterato
         graph.add_node(node)
 
     context = NodeContext(
-        patches=game.create_game_patches(),
+        patches=GamePatches(
+            player_index=0,
+            configuration=None,
+            pickup_assignment={},
+            elevator_connection={},
+            dock_connection={},
+            dock_weakness={},
+            configurable_nodes={},
+            starting_items={},
+            starting_location=game.starting_location,
+            hints={},
+        ),
         current_resources={},
         database=game.resource_database,
         node_provider=game.world_list,

--- a/randovania/generator/base_patches_factory.py
+++ b/randovania/generator/base_patches_factory.py
@@ -35,8 +35,8 @@ class BasePatchesFactory:
                             ) -> GamePatches:
         """
         """
-        patches = dataclasses.replace(game.create_game_patches(),
-                                      player_index=player_index)
+        patches = GamePatches(player_index, configuration, {}, game.get_default_elevator_connection(),
+                              {}, {}, {}, {}, game.starting_location, {})
 
         # Elevators
         try:
@@ -61,7 +61,7 @@ class BasePatchesFactory:
         except MissingRng as e:
             if rng_required:
                 raise e
-        
+
         return patches
 
     def add_elevator_connections_to_patches(self,

--- a/randovania/generator/old_generator_reach.py
+++ b/randovania/generator/old_generator_reach.py
@@ -86,6 +86,7 @@ class OldGeneratorReach(GeneratorReach):
                          ) -> "GeneratorReach":
 
         reach = cls(game, initial_state, graph_module.RandovaniaGraph.new())
+        game.world_list.ensure_has_node_cache()
         reach._expand_graph([GraphPath(None, initial_state.node, RequirementSet.trivial())])
         return reach
 

--- a/randovania/layout/base/base_configuration.py
+++ b/randovania/layout/base/base_configuration.py
@@ -4,7 +4,6 @@ from typing import List
 from randovania.bitpacking.bitpacking import BitPackDataclass
 from randovania.bitpacking.json_dataclass import JsonDataclass
 from randovania.bitpacking.type_enforcement import DataclassPostInitTypeCheck
-from randovania.games import default_data
 from randovania.games.game import RandovaniaGame
 from randovania.layout.base.ammo_configuration import AmmoConfiguration
 from randovania.layout.base.available_locations import AvailableLocationsConfiguration
@@ -43,10 +42,6 @@ class BaseConfiguration(BitPackDataclass, JsonDataclass, DataclassPostInitTypeCh
     @property
     def game(self):
         return self.game_enum()
-
-    @property
-    def game_data(self) -> dict:
-        return default_data.read_json_then_binary(self.game)[1]
 
     @classmethod
     def json_extra_arguments(cls):

--- a/randovania/layout/game_patches_serializer.py
+++ b/randovania/layout/game_patches_serializer.py
@@ -64,12 +64,12 @@ def serialize_single(player_index: int, num_players: int, patches: GamePatches) 
     :param patches:
     :return:
     """
-    game = default_database.game_description_for(patches.game_enum)
+    game = default_database.game_description_for(patches.configuration.game)
     world_list = game.world_list
 
     result = {
         # This field helps schema migrations, if nothing else
-        "game": patches.game_enum.value,
+        "game": patches.configuration.game.value,
         "starting_location": patches.starting_location.as_string,
         "starting_items": {
             resource_info.long_name: quantity
@@ -196,7 +196,7 @@ def decode_single(player_index: int, all_pools: Dict[int, PoolResults], game: Ga
 
     return GamePatches(
         player_index=player_index,
-        game_enum=game.game,
+        configuration=configuration,
         pickup_assignment=pickup_assignment,  # PickupAssignment
         elevator_connection=elevator_connection,  # ElevatorConnection
         dock_connection={},  # Dict[Tuple[int, int], DockConnection]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,8 +14,10 @@ from randovania.game_description.item.item_database import ItemDatabase
 from randovania.game_description.resources.pickup_entry import PickupEntry, PickupModel
 from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.games import default_data
+from randovania.games.blank.layout import BlankConfiguration
 from randovania.games.cave_story.layout.cs_configuration import CSConfiguration
 from randovania.games.game import RandovaniaGame
+from randovania.games.prime1.layout.prime_configuration import PrimeConfiguration
 from randovania.games.prime2.exporter.game_exporter import decode_randomizer_data
 from randovania.games.prime2.layout.echoes_configuration import EchoesConfiguration
 from randovania.interface_common.preset_manager import PresetManager
@@ -50,8 +52,22 @@ def blank_game_data() -> dict:
 
 
 @pytest.fixture(scope="session")
+def default_blank_configuration() -> BlankConfiguration:
+    preset = PresetManager(None).default_preset_for_game(RandovaniaGame.BLANK).get_preset()
+    assert isinstance(preset.configuration, BlankConfiguration)
+    return preset.configuration
+
+
+@pytest.fixture(scope="session")
 def blank_game_description() -> GameDescription:
     return default_database.game_description_for(RandovaniaGame.BLANK)
+
+
+@pytest.fixture()
+def blank_game_patches(empty_patches, default_blank_configuration, blank_game_description) -> GamePatches:
+    return dataclasses.replace(empty_patches, configuration=default_blank_configuration,
+                               starting_location=blank_game_description.starting_location,
+                               elevator_connection=blank_game_description.get_default_elevator_connection())
 
 
 @pytest.fixture(scope="session")
@@ -77,14 +93,28 @@ def default_echoes_preset() -> Preset:
 
 
 @pytest.fixture(scope="session")
-def default_cs_preset() -> Preset:
-    return PresetManager(None).default_preset_for_game(RandovaniaGame.CAVE_STORY).get_preset()
+def default_echoes_configuration(default_echoes_preset) -> EchoesConfiguration:
+    assert isinstance(default_echoes_preset.configuration, EchoesConfiguration)
+    return default_echoes_preset.configuration
+
+
+@pytest.fixture()
+def echoes_game_patches(empty_patches, default_echoes_configuration, echoes_game_description) -> GamePatches:
+    return dataclasses.replace(empty_patches, configuration=default_echoes_configuration,
+                               starting_location=echoes_game_description.starting_location,
+                               elevator_connection=echoes_game_description.get_default_elevator_connection())
 
 
 @pytest.fixture(scope="session")
-def default_layout_configuration(default_echoes_preset) -> EchoesConfiguration:
-    assert isinstance(default_echoes_preset.configuration, EchoesConfiguration)
-    return default_echoes_preset.configuration
+def default_prime_configuration() -> PrimeConfiguration:
+    preset = PresetManager(None).default_preset_for_game(RandovaniaGame.METROID_PRIME).get_preset()
+    assert isinstance(preset.configuration, PrimeConfiguration)
+    return preset.configuration
+
+
+@pytest.fixture(scope="session")
+def default_cs_preset() -> Preset:
+    return PresetManager(None).default_preset_for_game(RandovaniaGame.CAVE_STORY).get_preset()
 
 
 @pytest.fixture(scope="session")
@@ -193,8 +223,10 @@ def dataclass_test_lib() -> DataclassTestLib:
 
 
 @pytest.fixture()
-def empty_patches() -> GamePatches:
-    return GamePatches(0, RandovaniaGame.BLANK, {}, {}, {}, {}, {}, {}, None, {})
+def empty_patches(preset_manager) -> GamePatches:
+    configuration = preset_manager.default_preset_for_game(RandovaniaGame.BLANK).get_preset().configuration
+    return GamePatches(0, configuration, {}, {}, {}, {}, {}, {}, None, {})
+
 
 
 def pytest_addoption(parser):

--- a/test/game_description/test_integrity_check.py
+++ b/test/game_description/test_integrity_check.py
@@ -15,7 +15,7 @@ _acceptable_database_errors = {
         g, not g.data.development_state.is_stable) else [])
     for g in iterate_enum(RandovaniaGame)
 ])
-def test_find_database_errors(game_enum):
+def test_find_database_errors(game_enum: RandovaniaGame):
     # Setup
     game = default_database.game_description_for(game_enum)
 

--- a/test/games/prime/patcher_file_lib/test_sky_temple_key_hint.py
+++ b/test/games/prime/patcher_file_lib/test_sky_temple_key_hint.py
@@ -44,7 +44,8 @@ def make_useless_stk_hint(key_number: int) -> List[str]:
 
 @pytest.mark.parametrize("multiworld", [False, True])
 @pytest.mark.parametrize("hide_area", [False, True])
-def test_create_hints_all_placed(hide_area: bool, multiworld: bool, empty_patches):
+def test_create_hints_all_placed(hide_area: bool, multiworld: bool, empty_patches, default_echoes_configuration,
+                                 default_prime_configuration):
     # Setup
     echoes_game = default_database.game_description_for(RandovaniaGame.METROID_PRIME_ECHOES)
     players_config = PlayersConfiguration(0, {0: "you", 1: "them"} if multiworld else {0: "you"})
@@ -54,14 +55,14 @@ def test_create_hints_all_placed(hide_area: bool, multiworld: bool, empty_patche
          PickupTarget(pickup_creator.create_sky_temple_key(key, echoes_game.resource_database), 0))
         for key in range(5 if multiworld else 9)
     ])
-    patches = dataclasses.replace(patches, game_enum=RandovaniaGame.METROID_PRIME_ECHOES)
+    patches = dataclasses.replace(patches, configuration=default_echoes_configuration)
 
     other_patches = empty_patches.assign_new_pickups([
         (PickupIndex(17 + key),
          PickupTarget(pickup_creator.create_sky_temple_key(key, echoes_game.resource_database), 0))
         for key in range(5, 9)
     ])
-    other_patches = dataclasses.replace(other_patches, game_enum=RandovaniaGame.METROID_PRIME)
+    other_patches = dataclasses.replace(other_patches, configuration=default_prime_configuration)
     assets = [0xD97685FE, 0x32413EFD, 0xDD8355C3, 0x3F5F4EBA, 0xD09D2584,
               0x3BAA9E87, 0xD468F5B9, 0x2563AE34, 0xCAA1C50A]
 
@@ -106,16 +107,15 @@ def test_create_hints_all_placed(hide_area: bool, multiworld: bool, empty_patche
 
 @pytest.mark.parametrize("multiworld", [False, True])
 @pytest.mark.parametrize("hide_area", [False, True])
-def test_create_hints_all_starting(hide_area: bool, multiworld: bool,
-                                   empty_patches, echoes_game_description):
+def test_create_hints_all_starting(hide_area: bool, multiworld: bool, empty_patches, echoes_game_description,
+                                   default_echoes_configuration):
     # Setup
     players_config = PlayersConfiguration(0, {0: "you", 1: "them"} if multiworld else {0: "you"})
-    area_namer = {0: None, 1: None} if multiworld else {0: None}
     patches = empty_patches.assign_extra_initial_items({
         echoes_game_description.resource_database.get_item(echoes_items.SKY_TEMPLE_KEY_ITEMS[key]): 1
         for key in range(9)
     })
-    patches = dataclasses.replace(patches, game_enum=echoes_game_description.game)
+    patches = dataclasses.replace(patches, configuration=default_echoes_configuration)
     namer = EchoesHintNamer({0: patches}, players_config)
 
     expected = [

--- a/test/generator/filler/test_pickup_list.py
+++ b/test/generator/filler/test_pickup_list.py
@@ -5,14 +5,15 @@ from randovania.game_description.resources import search
 from randovania.generator.filler import pickup_list
 
 
-def test_requirement_lists_without_satisfied_resources(echoes_game_description, default_echoes_preset):
+def test_requirement_lists_without_satisfied_resources(echoes_game_description, default_echoes_preset,
+                                                       echoes_game_patches):
     # Setup
     def item(name):
         return search.find_resource_info_with_long_name(echoes_game_description.resource_database.item, name)
 
     state = echoes_game_description.game.generator.bootstrap.calculate_starting_state(
         echoes_game_description,
-        echoes_game_description.create_game_patches(),
+        echoes_game_patches,
         default_echoes_preset.configuration)
     state.resources[item("Seeker Launcher")] = 1
     state.resources[item("Space Jump Boots")] = 1

--- a/test/generator/filler/test_player_state.py
+++ b/test/generator/filler/test_player_state.py
@@ -26,8 +26,9 @@ def _default_filler_config() -> FillerConfiguration:
 
 
 @pytest.fixture(name="state_for_blank")
-def _state_for_blank(preset_manager, default_filler_config) -> player_state.PlayerState:
-    game = default_database.game_description_for(RandovaniaGame.BLANK).make_mutable_copy()
+def _state_for_blank(default_filler_config, blank_game_description, default_blank_configuration,
+                     blank_game_patches) -> player_state.PlayerState:
+    game = blank_game_description.make_mutable_copy()
     derived_nodes.create_derived_nodes(game)
 
     return player_state.PlayerState(
@@ -35,8 +36,8 @@ def _state_for_blank(preset_manager, default_filler_config) -> player_state.Play
         game=game,
         initial_state=game.game.generator.bootstrap.calculate_starting_state(
             game,
-            game.create_game_patches(),
-            preset_manager.default_preset_for_game(game.game).get_preset().configuration,
+            blank_game_patches,
+            default_blank_configuration,
         ),
         pickups_left=[],
         configuration=default_filler_config,

--- a/test/generator/filler/test_runner.py
+++ b/test/generator/filler/test_runner.py
@@ -10,8 +10,8 @@ from randovania.game_description.item.item_category import ItemCategory
 from randovania.game_description.resources.pickup_entry import PickupEntry, PickupModel
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.game_description.world.area_identifier import AreaIdentifier
-from randovania.game_description.world.node_identifier import NodeIdentifier
 from randovania.game_description.world.logbook_node import LogbookNode
+from randovania.game_description.world.node_identifier import NodeIdentifier
 from randovania.games.game import RandovaniaGame
 from randovania.games.prime2.generator.hint_distributor import EchoesHintDistributor
 from randovania.generator.filler import runner
@@ -19,7 +19,8 @@ from randovania.generator.generator import create_player_pool
 
 
 async def test_run_filler(echoes_game_description,
-                          default_layout_configuration,
+                          echoes_game_patches,
+                          default_echoes_configuration,
                           mocker,
                           ):
     # Setup
@@ -30,12 +31,11 @@ async def test_run_filler(echoes_game_description,
                         for node in echoes_game_description.world_list.all_nodes if isinstance(node, LogbookNode)]
 
     player_pools = [
-        await create_player_pool(rng, default_layout_configuration, 0, 1),
+        await create_player_pool(rng, default_echoes_configuration, 0, 1),
     ]
     initial_pickup_count = len(player_pools[0].pickups)
 
-    patches = echoes_game_description.create_game_patches()
-    patches = patches.assign_hint(
+    patches = echoes_game_patches.assign_hint(
         hint_identifiers[0],
         Hint(HintType.LOCATION, None, PickupIndex(0))
     )
@@ -64,17 +64,16 @@ async def test_run_filler(echoes_game_description,
     assert initial_pickup_count == len(remaining_items) + len(result_patches.pickup_assignment.values())
 
 
-def test_fill_unassigned_hints_empty_assignment(echoes_game_description):
+def test_fill_unassigned_hints_empty_assignment(echoes_game_description, echoes_game_patches):
     # Setup
     rng = Random(5000)
-    base_patches = echoes_game_description.create_game_patches()
     expected_logbooks = sum(1 for node in echoes_game_description.world_list.all_nodes
                             if isinstance(node, LogbookNode))
     hint_distributor = echoes_game_description.game.generator.hint_distributor
 
     # Run
     result = hint_distributor.fill_unassigned_hints(
-        base_patches,
+        echoes_game_patches,
         echoes_game_description.world_list,
         rng, {},
     )

--- a/test/generator/item_pool/test_pool_creator.py
+++ b/test/generator/item_pool/test_pool_creator.py
@@ -14,11 +14,11 @@ from randovania.generator.item_pool import pool_creator
 from randovania.layout.base.trick_level import LayoutTrickLevel
 
 
-def test_calculate_pool_item_count(default_layout_configuration):
+def test_calculate_pool_item_count(default_echoes_configuration):
     layout_configuration = dataclasses.replace(
-        default_layout_configuration,
+        default_echoes_configuration,
         major_items_configuration=dataclasses.replace(
-            default_layout_configuration.major_items_configuration,
+            default_echoes_configuration.major_items_configuration,
             minimum_random_starting_items=2,
         ),
         sky_temple_keys=LayoutSkyTempleKeyMode.ALL_BOSSES,
@@ -47,7 +47,7 @@ def test_cs_item_pool_creator(default_cs_configuration: CSConfiguration, puppies
         LayoutTrickLevel.HYPERMODE)
     default_cs_configuration = dataclasses.replace(default_cs_configuration, trick_level=tricks)
 
-    base_patches = GamePatches(0, game_description.game, {}, {}, {}, {}, {}, {}, starting_area, {})
+    base_patches = GamePatches(0, default_cs_configuration, {}, {}, {}, {}, {}, {}, starting_area, {})
     rng = Random()
 
     result = pool_creator.calculate_pool_results(

--- a/test/generator/test_generator.py
+++ b/test/generator/test_generator.py
@@ -59,12 +59,12 @@ async def test_create_patches(mock_random: MagicMock,
     )
 
 
-def test_distribute_remaining_items_no_locations_left(echoes_game_description):
+def test_distribute_remaining_items_no_locations_left(echoes_game_description, echoes_game_patches):
     # Setup
     rng = MagicMock()
     player_result = FillerPlayerResult(
         game=echoes_game_description,
-        patches=echoes_game_description.create_game_patches(),
+        patches=echoes_game_patches,
         unassigned_pickups=[MagicMock()] * 1000,
     )
     filler_results = {0: player_result}

--- a/test/generator/test_generator_reach.py
+++ b/test/generator/test_generator_reach.py
@@ -165,7 +165,7 @@ def test_database_collectable(preset_manager, game_enum, ignore_events, ignore_p
 
 
 @pytest.mark.parametrize("has_translator", [False, True])
-def test_basic_search_with_translator_gate(has_translator: bool, echoes_resource_database):
+def test_basic_search_with_translator_gate(has_translator: bool, echoes_resource_database, echoes_game_patches):
     # Setup
     scan_visor = echoes_resource_database.get_item("DarkVisor")
     nc = functools.partial(NodeIdentifier.create, "Test World", "Test Area A")
@@ -178,7 +178,7 @@ def test_basic_search_with_translator_gate(has_translator: bool, echoes_resource
 
     world_list = WorldList([
         World("Test World", [
-            Area("Test Area A", 0, True, [node_a, node_b, node_c, translator_node],
+            Area("Test Area A", None, True, [node_a, node_b, node_c, translator_node],
                  {
                      node_a: {
                          node_b: Requirement.trivial(),
@@ -203,8 +203,7 @@ def test_basic_search_with_translator_gate(has_translator: bool, echoes_resource
                            echoes_resource_database, ("default",), Requirement.impossible(),
                            None, {}, None, world_list)
 
-    patches = game.create_game_patches()
-    patches = patches.assign_node_configuration({
+    patches = echoes_game_patches.assign_node_configuration({
         translator_identif: ResourceRequirement(scan_visor, 1, False)
     })
     initial_state = State({scan_visor: 1 if has_translator else 0}, (), 99,
@@ -220,11 +219,11 @@ def test_basic_search_with_translator_gate(has_translator: bool, echoes_resource
         assert set(reach.safe_nodes) == {node_a, node_b}
 
 
-def test_reach_size_from_start_echoes(small_echoes_game_description, default_layout_configuration, mocker):
+def test_reach_size_from_start_echoes(small_echoes_game_description, default_echoes_configuration, mocker):
     # Setup
     game: GameDescription = small_echoes_game_description.make_mutable_copy()
     derived_nodes.create_derived_nodes(game)
-    derived_nodes.remove_inactive_layers(game, default_layout_configuration.active_layers())
+    derived_nodes.remove_inactive_layers(game, default_echoes_configuration.active_layers())
 
     mocker.patch("randovania.game_description.default_database.game_description_for", return_value=game)
     generator = game.game.generator
@@ -248,10 +247,10 @@ def test_reach_size_from_start_echoes(small_echoes_game_description, default_lay
         return result
 
     layout_configuration = dataclasses.replace(
-        default_layout_configuration,
+        default_echoes_configuration,
         trick_level=TrickLevelConfiguration(minimal_logic=False,
                                             specific_levels=specific_levels,
-                                            game=default_layout_configuration.game),
+                                            game=default_echoes_configuration.game),
         starting_location=StartingLocationList.with_elements(
             [game.starting_location],
             game=RandovaniaGame.METROID_PRIME_ECHOES,
@@ -261,7 +260,7 @@ def test_reach_size_from_start_echoes(small_echoes_game_description, default_lay
         layout_configuration, Random(15000),
         game,
         False, player_index=0)
-    state = generator.bootstrap.calculate_starting_state(game, patches, default_layout_configuration)
+    state = generator.bootstrap.calculate_starting_state(game, patches, default_echoes_configuration)
     state.resources[item("Combat Visor")] = 1
     state.resources[item("Amber Translator")] = 1
     state.resources[item("Scan Visor")] = 1

--- a/test/gui/test_game_details_window.py
+++ b/test/gui/test_game_details_window.py
@@ -1,4 +1,5 @@
 import collections
+import dataclasses
 
 from PySide6 import QtWidgets, QtCore
 from mock import MagicMock, AsyncMock, call, ANY
@@ -117,7 +118,7 @@ def test_update_layout_description_actual_seed(skip_qtbot, test_files_dir):
     assert pickup_details_tab.pickup_spoiler_show_all_button.text() == "Hide All"
 
 
-async def test_show_dialog_for_prime3_layout(skip_qtbot, mocker, corruption_game_description):
+async def test_show_dialog_for_prime3_layout(skip_qtbot, mocker, corruption_game_description, empty_patches):
     mock_execute_dialog = mocker.patch("randovania.gui.lib.async_dialog.execute_dialog", new_callable=AsyncMock)
     mock_clipboard: MagicMock = mocker.patch("PySide6.QtWidgets.QApplication.clipboard")
 
@@ -131,7 +132,7 @@ async def test_show_dialog_for_prime3_layout(skip_qtbot, mocker, corruption_game
     target = MagicMock()
     target.pickup.name = "Boost Ball"
 
-    patches = corruption_game_description.create_game_patches()
+    patches = dataclasses.replace(empty_patches, starting_location=corruption_game_description.starting_location)
     for i in range(100):
         patches.pickup_assignment[PickupIndex(i)] = target
 

--- a/test/gui/test_tracker_window.py
+++ b/test/gui/test_tracker_window.py
@@ -16,45 +16,45 @@ from randovania.layout.versioned_preset import VersionedPreset
                         {"elevators": TeleporterShuffleMode.ONE_WAY_ANYTHING,
                          "translator_configuration": True}],
                 name="layout_config")
-def _layout_config(request, default_layout_configuration):
+def _layout_config(request, default_echoes_configuration):
     if "translator_configuration" in request.param:
-        translator_requirement = copy.copy(default_layout_configuration.translator_configuration.translator_requirement)
+        translator_requirement = copy.copy(default_echoes_configuration.translator_configuration.translator_requirement)
         for gate in translator_requirement.keys():
             translator_requirement[gate] = LayoutTranslatorRequirement.RANDOM
             break
 
-        new_gate = dataclasses.replace(default_layout_configuration.translator_configuration,
+        new_gate = dataclasses.replace(default_echoes_configuration.translator_configuration,
                                        translator_requirement=translator_requirement)
         request.param["translator_configuration"] = new_gate
-    return dataclasses.replace(default_layout_configuration, **request.param)
+    return dataclasses.replace(default_echoes_configuration, **request.param)
 
 
-def test_load_previous_state_no_previous_layout(tmp_path: Path, default_layout_configuration):
+def test_load_previous_state_no_previous_layout(tmp_path: Path, default_echoes_configuration):
     # Run
-    result = tracker_window._load_previous_state(tmp_path, default_layout_configuration)
+    result = tracker_window._load_previous_state(tmp_path, default_echoes_configuration)
 
     # Assert
     assert result is None
 
 
-def test_load_previous_state_previous_layout_not_json(tmp_path: Path, default_layout_configuration):
+def test_load_previous_state_previous_layout_not_json(tmp_path: Path, default_echoes_configuration):
     # Setup
     tmp_path.joinpath("preset.rdvpreset").write_text("this is not a json")
 
     # Run
-    result = tracker_window._load_previous_state(tmp_path, default_layout_configuration)
+    result = tracker_window._load_previous_state(tmp_path, default_echoes_configuration)
 
     # Assert
     assert result is None
 
 
-def test_load_previous_state_previous_layout_not_layout(tmp_path: Path, default_layout_configuration):
+def test_load_previous_state_previous_layout_not_layout(tmp_path: Path, default_echoes_configuration):
     # Setup
     tmp_path.joinpath("preset.rdvpreset").write_text(json.dumps({"trick_level": "foo"}))
     tmp_path.joinpath("state.json").write_text("[]")
 
     # Run
-    result = tracker_window._load_previous_state(tmp_path, default_layout_configuration)
+    result = tracker_window._load_previous_state(tmp_path, default_echoes_configuration)
 
     # Assert
     assert result is None

--- a/test/interface_common/test_preset_editor.py
+++ b/test/interface_common/test_preset_editor.py
@@ -28,10 +28,10 @@ def _initial_layout_configuration_params(request) -> dict:
 @pytest.mark.parametrize("menu_mod", [False, True])
 def test_edit_menu_mod(editor: PresetEditor,
                        initial_layout_configuration_params: dict,
-                       default_layout_configuration,
+                       default_echoes_configuration,
                        menu_mod):
     # Setup
-    editor._configuration = dataclasses.replace(default_layout_configuration,
+    editor._configuration = dataclasses.replace(default_echoes_configuration,
                                                 **initial_layout_configuration_params)
     editor._nested_autosave_level = 1
 
@@ -40,5 +40,5 @@ def test_edit_menu_mod(editor: PresetEditor,
     editor.set_configuration_field("menu_mod", menu_mod)
 
     # Assert
-    assert editor.configuration == dataclasses.replace(default_layout_configuration,
+    assert editor.configuration == dataclasses.replace(default_echoes_configuration,
                                                        **initial_layout_configuration_params)

--- a/test/layout/test_echoes_configuration.py
+++ b/test/layout/test_echoes_configuration.py
@@ -72,8 +72,8 @@ def make_dummy(cls: Type[T]) -> T:
          },
     ],
     name="layout_config_with_data")
-def _layout_config_with_data(request, default_layout_configuration):
-    data = default_layout_configuration.as_json
+def _layout_config_with_data(request, default_echoes_configuration):
+    data = default_echoes_configuration.as_json
     for key, value in request.param.items():
         if key != "encoded":
             assert key in data

--- a/test/layout/test_preset_describer.py
+++ b/test/layout/test_preset_describer.py
@@ -4,10 +4,10 @@ from randovania.games.game import RandovaniaGame
 from randovania.games.prime2.layout.echoes_configuration import LayoutSkyTempleKeyMode
 
 
-def test_echoes_format_params(default_layout_configuration):
+def test_echoes_format_params(default_echoes_configuration):
     # Setup
     layout_configuration = dataclasses.replace(
-        default_layout_configuration,
+        default_echoes_configuration,
         sky_temple_keys=LayoutSkyTempleKeyMode.ALL_BOSSES,
     )
 

--- a/test/resolver/test_bootstrap.py
+++ b/test/resolver/test_bootstrap.py
@@ -1,3 +1,4 @@
+import dataclasses
 from unittest.mock import MagicMock
 
 import pytest
@@ -36,12 +37,15 @@ def test_misc_resources_for_configuration(echoes_resource_database,
     }
 
 
-def test_logic_bootstrap(preset_manager, game_enum):
-    game = default_database.game_description_for(game_enum)
+def test_logic_bootstrap(preset_manager, game_enum, empty_patches):
+    configuration = preset_manager.default_preset_for_game(game_enum).get_preset().configuration
+    game = default_database.game_description_for(configuration.game)
+
     new_game, state = game_enum.generator.bootstrap.logic_bootstrap(
-        preset_manager.default_preset_for_game(game_enum).get_preset().configuration,
+        configuration,
         game.make_mutable_copy(),
-        game.create_game_patches())
+        dataclasses.replace(empty_patches, configuration=configuration, starting_location=game.starting_location),
+    )
 
 
 @pytest.mark.parametrize(["expected", "suits"], [


### PR DESCRIPTION
This is in preparation to prefer getting the GameDescription from a BaseConfiguration, instead of RandovaniaGame.
It also comes with plenty of refactoring for how GamePatches are created in tests.