### PR TITLE
Pulse Radar Room logic does not work as a starting location when it contains required progression to exit

### DIFF
--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -12231,13 +12231,6 @@
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
                     "connections": {
-                        "Pickup (Pulse Radar)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Tile Group (POWERBEAM) 1": {
                             "type": "and",
                             "data": {

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -2638,8 +2638,6 @@ Extra - asset_id: collision_camera_032
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_SonarObtained
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Pickup (Pulse Radar)
-      Trivial
   > Tile Group (POWERBEAM) 1
       Trivial
 


### PR DESCRIPTION
The Pulse Radar room had a connection configured from "Start Point" to the item pickup. This led to a seed where my starting location was the Pulse Radar room, and the item that was acquired from that room was Morph Ball. I was unable to leave the room, because spawning in the room doesn't trigger the item acquisition.

Logic has been adjusted so that the only connection to the Pickup is from the Pitfall Blocks tile group.