### PR TITLE
Dread: Properly account for Access Closed doors

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -2398,7 +2398,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from White EMMI Arena": {
+                        "Door to White EMMI Arena": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2407,7 +2407,7 @@
                         }
                     }
                 },
-                "Door from White EMMI Arena": {
+                "Door to White EMMI Arena": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2433,7 +2433,7 @@
                         "area_name": "White EMMI Arena",
                         "node_name": "Door to EMMI Zone First Entrance"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -2708,7 +2708,7 @@
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
                     "connections": {
-                        "Door from White EMMI Arena": {
+                        "Door to White EMMI Arena": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3374,7 +3374,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "EMMI Zone Exit North",
-                        "node_name": "Door to Teleport to Dairon"
+                        "node_name": "Door to Teleport to Dairon (Power)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -3745,7 +3745,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "EMMI Zone Exit North",
-                        "node_name": "Dock from Teleport to Dairon"
+                        "node_name": "Door to Teleport to Dairon (Wide)"
                     },
                     "default_dock_weakness": "Wide Beam Door",
                     "override_default_open_requirement": null,
@@ -4047,7 +4047,7 @@
                 "asset_id": "collision_camera_009"
             },
             "nodes": {
-                "Door to Teleport to Dairon": {
+                "Door to Teleport to Dairon (Power)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4084,7 +4084,7 @@
                                 "items": []
                             }
                         },
-                        "Dock from Teleport to Dairon": {
+                        "Door to Teleport to Dairon (Wide)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4123,7 +4123,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Teleport to Dairon": {
+                        "Door to Teleport to Dairon (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4218,7 +4218,7 @@
                         }
                     }
                 },
-                "Dock from Teleport to Dairon": {
+                "Door to Teleport to Dairon (Wide)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4238,17 +4238,17 @@
                         "right_shield_entity": "Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorwidebeam_000",
                         "right_shield_def": "actordef:actors/props/doorwidebeam/charclasses/doorwidebeam.bmsad"
                     },
-                    "dock_type": "other",
+                    "dock_type": "door",
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Teleport to Dairon",
                         "node_name": "Door to EMMI Zone Exit North (Upper)"
                     },
-                    "default_dock_weakness": "Blocked Passage",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Teleport to Dairon": {
+                        "Door to Teleport to Dairon (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4455,7 +4455,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Door to Teleport to Dairon": {
+                        "Door to Teleport to Dairon (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8303,7 +8303,7 @@
                 "asset_id": "collision_camera_017"
             },
             "nodes": {
-                "Door to Central Unit Access": {
+                "Door to Central Unit Access (Charge)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8456,7 +8456,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "EMMI Zone First Entrance",
-                        "node_name": "Door from White EMMI Arena"
+                        "node_name": "Door to White EMMI Arena"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -8487,7 +8487,7 @@
                         }
                     }
                 },
-                "Door from Central Unit Access": {
+                "Door to Central Unit Access (Power)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8513,7 +8513,7 @@
                         "area_name": "Central Unit Access",
                         "node_name": "Door to White EMMI Arena (Bottom)"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -8563,7 +8563,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from Central Unit Access": {
+                        "Door to Central Unit Access (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8602,7 +8602,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Central Unit Access": {
+                        "Door to Central Unit Access (Charge)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8674,7 +8674,7 @@
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
                     "connections": {
-                        "Door to Central Unit Access": {
+                        "Door to Central Unit Access (Charge)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8715,7 +8715,7 @@
                                 ]
                             }
                         },
-                        "Door from Central Unit Access": {
+                        "Door to Central Unit Access (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -10772,7 +10772,7 @@
                         "area_name": "Varia Suit Tutorial North",
                         "node_name": "Door to Chain Reaction Room"
                     },
-                    "default_dock_weakness": "Power Beam Door",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -14076,7 +14076,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "White EMMI Arena",
-                        "node_name": "Door to Central Unit Access"
+                        "node_name": "Door to Central Unit Access (Charge)"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -14122,7 +14122,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "White EMMI Arena",
-                        "node_name": "Door from Central Unit Access"
+                        "node_name": "Door to Central Unit Access (Power)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -18396,7 +18396,7 @@
                 "asset_id": "collision_camera_066"
             },
             "nodes": {
-                "Door to Thermal Device": {
+                "Door to Thermal Device (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -18433,7 +18433,7 @@
                                 "items": []
                             }
                         },
-                        "Door from Thermal Device": {
+                        "Door to Thermal Device (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -18472,7 +18472,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Thermal Device": {
+                        "Door to Thermal Device (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -18481,7 +18481,7 @@
                         }
                     }
                 },
-                "Door from Thermal Device": {
+                "Door to Thermal Device (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -18507,11 +18507,11 @@
                         "area_name": "Thermal Device",
                         "node_name": "Door to Path to Thermal Device (Upper)"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Thermal Device": {
+                        "Door to Thermal Device (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -18534,7 +18534,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Door to Thermal Device": {
+                        "Door to Thermal Device (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -18600,7 +18600,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Path to Thermal Device",
-                        "node_name": "Door to Thermal Device"
+                        "node_name": "Door to Thermal Device (Lower)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -18678,7 +18678,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Path to Thermal Device",
-                        "node_name": "Door from Thermal Device"
+                        "node_name": "Door to Thermal Device (Upper)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -554,12 +554,12 @@ Extra - asset_id: collision_camera_005
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door from White EMMI Arena
+  > Door to White EMMI Arena
       Trivial
 
-> Door from White EMMI Arena; Heals? False
+> Door to White EMMI Arena; Heals? False
   * Layers: default
-  * Access Closed to White EMMI Arena/Door to EMMI Zone First Entrance
+  * Access Locked to White EMMI Arena/Door to EMMI Zone First Entrance
   * Extra - actor_name: Door018 (CG-CL,OP)
   * Extra - actor_def: actordef:actors/props/doorpowerclosed/charclasses/doorpowerclosed.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -617,7 +617,7 @@ Extra - asset_id: collision_camera_005
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_EmmyCave
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door from White EMMI Arena
+  > Door to White EMMI Arena
       Trivial
   > Door to White EMMI Introduction
       Trivial
@@ -763,7 +763,7 @@ Extra - polygon: [[8900.0, 4400.0], [5800.0, 4400.0], [5800.0, 300.0], [8900.0, 
 Extra - asset_id: collision_camera_008
 > Door to EMMI Zone Exit North (Bottom); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone Exit North/Door to Teleport to Dairon
+  * Power Beam Door to EMMI Zone Exit North/Door to Teleport to Dairon (Power)
   * Extra - actor_name: Door020 (PW-PW)
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -861,7 +861,7 @@ Extra - asset_id: collision_camera_008
 
 > Door to EMMI Zone Exit North (Upper); Heals? False
   * Layers: default
-  * Wide Beam Door to EMMI Zone Exit North/Dock from Teleport to Dairon
+  * Wide Beam Door to EMMI Zone Exit North/Door to Teleport to Dairon (Wide)
   * Extra - actor_name: Door028
   * Extra - actor_def: actordef:actors/props/doorclosedpower/charclasses/doorclosedpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -945,7 +945,7 @@ EMMI Zone Exit North
 Extra - total_boundings: {'x1': 699.9979858398438, 'x2': 5900.0, 'y1': 1800.0, 'y2': 4900.0}
 Extra - polygon: [[700.0, 4900.0], [699.9979858398438, 1800.0], [5900.0, 1800.0], [5900.0, 4900.0]]
 Extra - asset_id: collision_camera_009
-> Door to Teleport to Dairon; Heals? False
+> Door to Teleport to Dairon (Power); Heals? False
   * Layers: default
   * Power Beam Door to Teleport to Dairon/Door to EMMI Zone Exit North (Bottom)
   * Extra - actor_name: Door020 (PW-PW)
@@ -956,7 +956,7 @@ Extra - asset_id: collision_camera_009
   * Extra - right_shield_def: None
   > Door to EMMI Zone Dome
       Trivial
-  > Dock from Teleport to Dairon
+  > Door to Teleport to Dairon (Wide)
       Trivial
 
 > Door to EMMI Zone Dome; Heals? False
@@ -968,7 +968,7 @@ Extra - asset_id: collision_camera_009
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Teleport to Dairon
+  > Door to Teleport to Dairon (Power)
       Trivial
   > Tunnel to Teleport to Dairon
       Trivial
@@ -993,16 +993,16 @@ Extra - asset_id: collision_camera_009
   > Tile Group (POWERBEAM)
       Trivial
 
-> Dock from Teleport to Dairon; Heals? False
+> Door to Teleport to Dairon (Wide); Heals? False
   * Layers: default
-  * Blocked Passage to Teleport to Dairon/Door to EMMI Zone Exit North (Upper)
+  * Access Locked to Teleport to Dairon/Door to EMMI Zone Exit North (Upper)
   * Extra - actor_name: Door028
   * Extra - actor_def: actordef:actors/props/doorclosedpower/charclasses/doorclosedpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorwidebeam_000
   * Extra - right_shield_def: actordef:actors/props/doorwidebeam/charclasses/doorwidebeam.bmsad
-  > Door to Teleport to Dairon
+  > Door to Teleport to Dairon (Power)
       Trivial
 
 > Tile Group (POWERBEAM); Heals? False
@@ -1057,7 +1057,7 @@ Extra - asset_id: collision_camera_009
 
 > Start Point; Heals? False; Spawn Point
   * Layers: default
-  > Door to Teleport to Dairon
+  > Door to Teleport to Dairon (Power)
       Trivial
 
 ----------------
@@ -1890,7 +1890,7 @@ White EMMI Arena
 Extra - total_boundings: {'x1': 2700.0, 'x2': 5900.0, 'y1': -6450.0, 'y2': -1700.0}
 Extra - polygon: [[5900.0, -1700.0], [2700.0, -1700.0], [2700.0, -6450.0], [5900.0, -6450.0]]
 Extra - asset_id: collision_camera_017
-> Door to Central Unit Access; Heals? False
+> Door to Central Unit Access (Charge); Heals? False
   * Layers: default
   * Charge Beam Door to Central Unit Access/Door to White EMMI Arena (Top)
   * Extra - actor_name: Door015 (CG-CG)
@@ -1920,7 +1920,7 @@ Extra - asset_id: collision_camera_017
 
 > Door to EMMI Zone First Entrance; Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone First Entrance/Door from White EMMI Arena
+  * Power Beam Door to EMMI Zone First Entrance/Door to White EMMI Arena
   * Extra - actor_name: Door018 (CG-CL,OP)
   * Extra - actor_def: actordef:actors/props/doorpowerclosed/charclasses/doorpowerclosed.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1932,9 +1932,9 @@ Extra - asset_id: collision_camera_017
   > Door to EMMI Zone Spinner (DoorFrame_011)
       Simple IBJ or Use Spin Boost
 
-> Door from Central Unit Access; Heals? False
+> Door to Central Unit Access (Power); Heals? False
   * Layers: default
-  * Access Closed to Central Unit Access/Door to White EMMI Arena (Bottom)
+  * Access Locked to Central Unit Access/Door to White EMMI Arena (Bottom)
   * Extra - actor_name: Door059 (CL-PW)
   * Extra - actor_def: actordef:actors/props/doorclosedpower/charclasses/doorclosedpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1955,7 +1955,7 @@ Extra - asset_id: collision_camera_017
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door from Central Unit Access
+  > Door to Central Unit Access (Power)
       Trivial
 
 > Door to EMMI Zone Spinner (DoorFrame_010); Heals? False
@@ -1967,7 +1967,7 @@ Extra - asset_id: collision_camera_017
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Central Unit Access
+  > Door to Central Unit Access (Charge)
       Trivial
   > Door to EMMI Zone First Entrance
       Trivial
@@ -1988,11 +1988,11 @@ Extra - asset_id: collision_camera_017
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_MagnetGlove
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Central Unit Access
+  > Door to Central Unit Access (Charge)
       Trivial
   > Door to EMMI Zone Spinner (1)
       Grapple Beam or Spider Magnet or Simple IBJ or Use Spin Boost
-  > Door from Central Unit Access
+  > Door to Central Unit Access (Power)
       Trivial
   > Tunnel to EMMI Zone Spinner
       Trivial
@@ -2462,7 +2462,7 @@ Extra - polygon: [[-8100.0, 9200.0], [-12200.0, 9200.0], [-12200.0, 4700.0], [-8
 Extra - asset_id: collision_camera_026
 > Door to Varia Suit Tutorial North; Heals? False
   * Layers: default
-  * Power Beam Door to Varia Suit Tutorial North/Door to Chain Reaction Room
+  * Access Locked to Varia Suit Tutorial North/Door to Chain Reaction Room
   * Extra - actor_name: Door057
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -3130,7 +3130,7 @@ Extra - polygon: [[8350.0, -3600.0], [5800.0, -3600.0], [5800.0, -6450.0], [8350
 Extra - asset_id: collision_camera_049
 > Door to White EMMI Arena (Top); Heals? False
   * Layers: default
-  * Charge Beam Door to White EMMI Arena/Door to Central Unit Access
+  * Charge Beam Door to White EMMI Arena/Door to Central Unit Access (Charge)
   * Extra - actor_name: Door015 (CG-CG)
   * Extra - actor_def: actordef:actors/props/doorchargecharge/charclasses/doorchargecharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -3144,7 +3144,7 @@ Extra - asset_id: collision_camera_049
 
 > Door to White EMMI Arena (Bottom); Heals? False
   * Layers: default
-  * Power Beam Door to White EMMI Arena/Door from Central Unit Access
+  * Power Beam Door to White EMMI Arena/Door to Central Unit Access (Power)
   * Extra - actor_name: Door059 (CL-PW)
   * Extra - actor_def: actordef:actors/props/doorclosedpower/charclasses/doorclosedpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -4117,7 +4117,7 @@ Path to Thermal Device
 Extra - total_boundings: {'x1': 19800.0, 'x2': 22900.0, 'y1': 958.0, 'y2': 2100.0}
 Extra - polygon: [[22900.0, 2100.0], [19800.0, 2100.0], [19800.0, 958.0], [22900.0, 958.0]]
 Extra - asset_id: collision_camera_066
-> Door to Thermal Device; Heals? False
+> Door to Thermal Device (Lower); Heals? False
   * Layers: default
   * Power Beam Door to Thermal Device/Door to Path to Thermal Device (Lower)
   * Extra - actor_name: Door033 (PW-PW)
@@ -4128,7 +4128,7 @@ Extra - asset_id: collision_camera_066
   * Extra - right_shield_def: None
   > Door to Save Station East
       Trivial
-  > Door from Thermal Device
+  > Door to Thermal Device (Upper)
       Trivial
 
 > Door to Save Station East; Heals? False
@@ -4140,24 +4140,24 @@ Extra - asset_id: collision_camera_066
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Thermal Device
+  > Door to Thermal Device (Lower)
       Trivial
 
-> Door from Thermal Device; Heals? False
+> Door to Thermal Device (Upper); Heals? False
   * Layers: default
-  * Access Closed to Thermal Device/Door to Path to Thermal Device (Upper)
+  * Access Locked to Thermal Device/Door to Path to Thermal Device (Upper)
   * Extra - actor_name: Door046 (PW-CL,OP)
   * Extra - actor_def: actordef:actors/props/doorpowerclosed/charclasses/doorpowerclosed.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Thermal Device
+  > Door to Thermal Device (Lower)
       Trivial
 
 > Start Point; Heals? False; Spawn Point
   * Layers: default
-  > Door to Thermal Device
+  > Door to Thermal Device (Lower)
       Trivial
 
 ----------------
@@ -4168,7 +4168,7 @@ Extra - polygon: [[19900.0, 2600.0], [17800.0, 2600.0], [17800.0, 900.0], [19900
 Extra - asset_id: collision_camera_067
 > Door to Path to Thermal Device (Lower); Heals? False
   * Layers: default
-  * Power Beam Door to Path to Thermal Device/Door to Thermal Device
+  * Power Beam Door to Path to Thermal Device/Door to Thermal Device (Lower)
   * Extra - actor_name: Door033 (PW-PW)
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -4192,7 +4192,7 @@ Extra - asset_id: collision_camera_067
 
 > Door to Path to Thermal Device (Upper); Heals? False
   * Layers: default
-  * Power Beam Door to Path to Thermal Device/Door from Thermal Device
+  * Power Beam Door to Path to Thermal Device/Door to Thermal Device (Upper)
   * Extra - actor_name: Door046 (PW-CL,OP)
   * Extra - actor_def: actordef:actors/props/doorpowerclosed/charclasses/doorpowerclosed.bmsad
   * Extra - left_shield_entity: {EMPTY}

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -5468,7 +5468,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from Teleport to Ghavoran (Charge)": {
+                        "Door to Teleport to Ghavoran (Charge)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5500,7 +5500,7 @@
                         }
                     }
                 },
-                "Door from Teleport to Ghavoran (Charge)": {
+                "Door to Teleport to Ghavoran (Charge)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5526,7 +5526,7 @@
                         "area_name": "Teleport to Ghavoran",
                         "node_name": "Door to Main Hub Tower Middle (Charge)"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -5609,7 +5609,7 @@
                         }
                     }
                 },
-                "Door from Teleport to Ghavoran (Plasma)": {
+                "Door to Teleport to Ghavoran (Plasma)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5635,7 +5635,7 @@
                         "area_name": "Teleport to Ghavoran",
                         "node_name": "Door to Main Hub Tower Middle (Plasma)"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -5839,7 +5839,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from Teleport to Ghavoran (Plasma)": {
+                        "Door to Teleport to Ghavoran (Plasma)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -5938,7 +5938,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from Teleport to Ghavoran (Charge)": {
+                        "Door to Teleport to Ghavoran (Charge)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -6149,7 +6149,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Door from Teleport to Ghavoran (Plasma)": {
+                        "Door to Teleport to Ghavoran (Plasma)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6250,7 +6250,7 @@
                                 ]
                             }
                         },
-                        "Door from Teleport to Ghavoran (Charge)": {
+                        "Door to Teleport to Ghavoran (Charge)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6629,7 +6629,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Door from Teleport to Ghavoran (Charge)": {
+                        "Door to Teleport to Ghavoran (Charge)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -6771,7 +6771,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from Teleport to Ghavoran (Plasma)": {
+                        "Door to Teleport to Ghavoran (Plasma)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8616,7 +8616,7 @@
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Main Hub Tower Middle",
-                        "node_name": "Door from Teleport to Ghavoran (Charge)"
+                        "node_name": "Door to Teleport to Ghavoran (Charge)"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -8695,13 +8695,13 @@
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Main Hub Tower Middle",
-                        "node_name": "Door from Teleport to Ghavoran (Plasma)"
+                        "node_name": "Door to Teleport to Ghavoran (Plasma)"
                     },
                     "default_dock_weakness": "Plasma Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from Gravity Suit Tower": {
+                        "Door to Gravity Suit Tower": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8719,7 +8719,7 @@
                         }
                     }
                 },
-                "Door from Gravity Suit Tower": {
+                "Door to Gravity Suit Tower": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8745,7 +8745,7 @@
                         "area_name": "Gravity Suit Tower",
                         "node_name": "Door to Teleport to Ghavoran"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -8826,7 +8826,7 @@
                     "keep_name_when_vanilla": true,
                     "editable": true,
                     "connections": {
-                        "Door from Gravity Suit Tower": {
+                        "Door to Gravity Suit Tower": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8856,7 +8856,7 @@
                         ]
                     },
                     "connections": {
-                        "Door from Gravity Suit Tower": {
+                        "Door to Gravity Suit Tower": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11083,7 +11083,7 @@
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Teleport to Ghavoran",
-                        "node_name": "Door from Gravity Suit Tower"
+                        "node_name": "Door to Gravity Suit Tower"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -1137,14 +1137,14 @@ Extra - asset_id: collision_camera_010
   * Extra - left_shield_def: actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:door_shield_plasma_002
   * Extra - right_shield_def: actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad
-  > Door from Teleport to Ghavoran (Charge)
+  > Door to Teleport to Ghavoran (Charge)
       After Burenia - Hub Magnet Wall and Horizontal Water Movement
   > Missile Tank Plus Platform
       After Burenia - Hub Magnet Wall
 
-> Door from Teleport to Ghavoran (Charge); Heals? False
+> Door to Teleport to Ghavoran (Charge); Heals? False
   * Layers: default
-  * Access Closed to Teleport to Ghavoran/Door to Main Hub Tower Middle (Charge)
+  * Access Locked to Teleport to Ghavoran/Door to Main Hub Tower Middle (Charge)
   * Extra - actor_name: doorclosedcharge_002
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1166,9 +1166,9 @@ Extra - asset_id: collision_camera_010
   > Missile Tank Plus Platform
       Trivial
 
-> Door from Teleport to Ghavoran (Plasma); Heals? False
+> Door to Teleport to Ghavoran (Plasma); Heals? False
   * Layers: default
-  * Access Closed to Teleport to Ghavoran/Door to Main Hub Tower Middle (Plasma)
+  * Access Locked to Teleport to Ghavoran/Door to Main Hub Tower Middle (Plasma)
   * Extra - actor_name: doorclosedpower
   * Extra - actor_def: actordef:actors/props/doorclosedpower/charclasses/doorclosedpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1217,7 +1217,7 @@ Extra - asset_id: collision_camera_010
 > Tunnel to Teleport to Ghavoran (Upper Tunnel); Heals? False
   * Layers: default
   * Morph Ball Tunnel to Teleport to Ghavoran/Tunnel to Main Hub Tower Middle (Upper)
-  > Door from Teleport to Ghavoran (Plasma)
+  > Door to Teleport to Ghavoran (Plasma)
       Grapple Beam or Gravity Suit or Spider Magnet or Water Bomb Jump (Beginner)
   > Upper Water Ledge - Right
       Gravity Suit or Water Bomb Jump (Beginner) or Use Spin Boost
@@ -1225,7 +1225,7 @@ Extra - asset_id: collision_camera_010
 > Tunnel to Teleport to Ghavoran (Lower Tunnel); Heals? False
   * Layers: default
   * Morph Ball Tunnel to Teleport to Ghavoran/Tunnel to Main Hub Tower Middle (Lower)
-  > Door from Teleport to Ghavoran (Charge)
+  > Door to Teleport to Ghavoran (Charge)
       Gravity Suit
   > Missile Tank Plus Platform
       Horizontal Water Movement
@@ -1247,7 +1247,7 @@ Extra - asset_id: collision_camera_010
 
 > Left of Central Grapple Block; Heals? False
   * Layers: default
-  > Door from Teleport to Ghavoran (Plasma)
+  > Door to Teleport to Ghavoran (Plasma)
       Morph Ball and After Burenia - grapplepulloff1x2_005
   > Event - Pull Central Grapple Block (grapplepulloff1x2_005)
       Grapple Beam
@@ -1260,7 +1260,7 @@ Extra - asset_id: collision_camera_010
       All of the following:
           After Burenia - Hub Magnet Wall
           Gravity Suit or Water Bomb Jump (Beginner)
-  > Door from Teleport to Ghavoran (Charge)
+  > Door to Teleport to Ghavoran (Charge)
       Space Jump and After Burenia - Hub Magnet Wall
   > Pickup (Missile+ Tank)
       Trivial
@@ -1318,7 +1318,7 @@ Extra - asset_id: collision_camera_010
 
 > Falling from above; Heals? False
   * Layers: default
-  > Door from Teleport to Ghavoran (Charge)
+  > Door to Teleport to Ghavoran (Charge)
       Any of the following:
           Space Jump
           Flash Shift and Gravity Suit
@@ -1336,7 +1336,7 @@ Extra - asset_id: collision_camera_010
 > Dock to Main Hub Tower Top (Right); Heals? False
   * Layers: default
   * Open Passage to Main Hub Tower Top/Dock to Main Hub Tower Middle (Right)
-  > Door from Teleport to Ghavoran (Plasma)
+  > Door to Teleport to Ghavoran (Plasma)
       Trivial
 
 > Dock to Main Hub Tower Bottom; Heals? False
@@ -1734,7 +1734,7 @@ Extra - asset_id: collision_camera_015
 
 > Door to Main Hub Tower Middle (Charge); Heals? False
   * Layers: default
-  * Charge Beam Door to Main Hub Tower Middle/Door from Teleport to Ghavoran (Charge)
+  * Charge Beam Door to Main Hub Tower Middle/Door to Teleport to Ghavoran (Charge)
   * Extra - actor_name: doorclosedcharge_002
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1750,21 +1750,21 @@ Extra - asset_id: collision_camera_015
 
 > Door to Main Hub Tower Middle (Plasma); Heals? False
   * Layers: default
-  * Plasma Beam Door to Main Hub Tower Middle/Door from Teleport to Ghavoran (Plasma)
+  * Plasma Beam Door to Main Hub Tower Middle/Door to Teleport to Ghavoran (Plasma)
   * Extra - actor_name: doorclosedpower
   * Extra - actor_def: actordef:actors/props/doorclosedpower/charclasses/doorclosedpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:door_shield_plasma_004
   * Extra - right_shield_def: actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad
-  > Door from Gravity Suit Tower
+  > Door to Gravity Suit Tower
       Trivial
   > Event - Blob through floor (db_reg_aq_012)
       Wave Beam
 
-> Door from Gravity Suit Tower; Heals? False
+> Door to Gravity Suit Tower; Heals? False
   * Layers: default
-  * Access Closed to Gravity Suit Tower/Door to Teleport to Ghavoran
+  * Access Locked to Gravity Suit Tower/Door to Teleport to Ghavoran
   * Extra - actor_name: doorclosedcharge_001
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1795,7 +1795,7 @@ Extra - asset_id: collision_camera_015
   * Extra - target_spawn_point: teleporter_aqua_000_platform
   * Extra - start_point_actor_name: teleporter_forest_000_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad
-  > Door from Gravity Suit Tower
+  > Door to Gravity Suit Tower
       Trivial
 
 > Tile Group (BOMB); Heals? False
@@ -1805,7 +1805,7 @@ Extra - asset_id: collision_camera_015
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Door from Gravity Suit Tower
+  > Door to Gravity Suit Tower
       Trivial
   > Top of Enky Shaft
       Can Slide
@@ -2261,7 +2261,7 @@ Extra - asset_id: collision_camera_021
 
 > Door to Teleport to Ghavoran; Heals? False
   * Layers: default
-  * Charge Beam Door to Teleport to Ghavoran/Door from Gravity Suit Tower
+  * Charge Beam Door to Teleport to Ghavoran/Door to Gravity Suit Tower
   * Extra - actor_name: doorclosedcharge_001
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -2274,7 +2274,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone Tower East",
-                        "node_name": "Door to EMMI Zone Exit East"
+                        "node_name": "Door to EMMI Zone Exit East (Power)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -2380,7 +2380,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone Tower East",
-                        "node_name": "Door from EMMI Zone Exit East"
+                        "node_name": "Door to EMMI Zone Exit East (Charge)"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -3469,7 +3469,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Energy Recharge Station",
-                        "node_name": "Door from Moving Magnet Walls (Tall)"
+                        "node_name": "Door to Moving Magnet Walls (Tall) (Charge)"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -3570,7 +3570,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Energy Recharge Station",
-                        "node_name": "Door to Moving Magnet Walls (Tall)"
+                        "node_name": "Door to Moving Magnet Walls (Tall) (Cloak)"
                     },
                     "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
@@ -6785,7 +6785,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from Moving Magnet Walls (Tall)": {
+                        "Door to Moving Magnet Walls (Tall) (Charge)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6840,7 +6840,7 @@
                         }
                     }
                 },
-                "Door from Moving Magnet Walls (Tall)": {
+                "Door to Moving Magnet Walls (Tall) (Charge)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6866,7 +6866,7 @@
                         "area_name": "Moving Magnet Walls (Tall)",
                         "node_name": "Door to Energy Recharge Station (doorclosedcharge_002)"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -6909,7 +6909,7 @@
                         }
                     }
                 },
-                "Door to Moving Magnet Walls (Tall)": {
+                "Door to Moving Magnet Walls (Tall) (Cloak)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -7004,7 +7004,7 @@
                                 "items": []
                             }
                         },
-                        "Door from Moving Magnet Walls (Tall)": {
+                        "Door to Moving Magnet Walls (Tall) (Charge)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7036,7 +7036,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Moving Magnet Walls (Tall)": {
+                        "Door to Moving Magnet Walls (Tall) (Cloak)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14321,7 +14321,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone East Tower Access",
-                        "node_name": "Door to EMMI Zone Tower East (doorpowerpower_015)"
+                        "node_name": "Door to EMMI Zone Tower East (Middle)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -14336,7 +14336,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone Exit East": {
+                "Door to EMMI Zone Exit East (Power)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -14646,7 +14646,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone East Tower Access",
-                        "node_name": "Door to EMMI Zone Tower East (doorpowerpower_000)"
+                        "node_name": "Door to EMMI Zone Tower East (Top)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -14685,13 +14685,13 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone East Tower Access",
-                        "node_name": "Door from EMMI Zone Tower East"
+                        "node_name": "Door to EMMI Zone Tower East (Bottom)"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Exit East": {
+                        "Door to EMMI Zone Exit East (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14700,7 +14700,7 @@
                         }
                     }
                 },
-                "Door from EMMI Zone Exit East": {
+                "Door to EMMI Zone Exit East (Charge)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -14726,7 +14726,7 @@
                         "area_name": "EMMI Zone Exit East",
                         "node_name": "Door to EMMI Zone Tower East (doorclosedcharge_001)"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -14776,7 +14776,7 @@
                                 "items": []
                             }
                         },
-                        "Door from EMMI Zone Exit East": {
+                        "Door to EMMI Zone Exit East (Charge)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14815,7 +14815,7 @@
                                 "items": []
                             }
                         },
-                        "Door to EMMI Zone Exit East": {
+                        "Door to EMMI Zone Exit East (Power)": {
                             "type": "template",
                             "data": "Can Slide"
                         },
@@ -14883,7 +14883,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from EMMI Zone Exit East": {
+                        "Door to EMMI Zone Exit East (Charge)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -19458,7 +19458,7 @@
                 "asset_id": "collision_camera_046"
             },
             "nodes": {
-                "Door to EMMI Zone Tower East (doorpowerpower_015)": {
+                "Door to EMMI Zone Tower East (Middle)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -19495,7 +19495,7 @@
                                 "items": []
                             }
                         },
-                        "Door from EMMI Zone Tower East": {
+                        "Door to EMMI Zone Tower East (Bottom)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -19590,7 +19590,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (doorpowerpower_015)": {
+                        "Door to EMMI Zone Tower East (Middle)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -19599,7 +19599,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone Tower East (doorpowerpower_000)": {
+                "Door to EMMI Zone Tower East (Top)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -19635,7 +19635,7 @@
                         }
                     }
                 },
-                "Door from EMMI Zone Tower East": {
+                "Door to EMMI Zone Tower East (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -19661,11 +19661,11 @@
                         "area_name": "EMMI Zone Tower East",
                         "node_name": "Door to EMMI Zone East Tower Access (doorclosedcharge)"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (doorpowerpower_015)": {
+                        "Door to EMMI Zone Tower East (Middle)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -19704,7 +19704,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (doorpowerpower_000)": {
+                        "Door to EMMI Zone Tower East (Top)": {
                             "type": "template",
                             "data": "Can Slide"
                         },
@@ -19766,7 +19766,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (doorpowerpower_015)": {
+                        "Door to EMMI Zone Tower East (Middle)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -19798,7 +19798,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (doorpowerpower_015)": {
+                        "Door to EMMI Zone Tower East (Middle)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -19862,7 +19862,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (doorpowerpower_015)": {
+                        "Door to EMMI Zone Tower East (Middle)": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -524,7 +524,7 @@ Extra - polygon: [[8500.0, 1800.0], [4400.0, 1800.0], [4400.0, -1300.0], [8500.0
 Extra - asset_id: collision_camera_010
 > Door to EMMI Zone Tower East (doorpowerpower_016); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone Tower East/Door to EMMI Zone Exit East
+  * Power Beam Door to EMMI Zone Tower East/Door to EMMI Zone Exit East (Power)
   * Extra - actor_name: doorpowerpower_016
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -546,7 +546,7 @@ Extra - asset_id: collision_camera_010
 
 > Door to EMMI Zone Tower East (doorclosedcharge_001); Heals? False
   * Layers: default
-  * Charge Beam Door to EMMI Zone Tower East/Door from EMMI Zone Exit East
+  * Charge Beam Door to EMMI Zone Tower East/Door to EMMI Zone Exit East (Charge)
   * Extra - actor_name: doorclosedcharge_001
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -744,7 +744,7 @@ Extra - asset_id: collision_camera_014
 
 > Door to Energy Recharge Station (doorclosedcharge_002); Heals? False
   * Layers: default
-  * Charge Beam Door to Energy Recharge Station/Door from Moving Magnet Walls (Tall)
+  * Charge Beam Door to Energy Recharge Station/Door to Moving Magnet Walls (Tall) (Charge)
   * Extra - actor_name: doorclosedcharge_002
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -764,7 +764,7 @@ Extra - asset_id: collision_camera_014
 
 > Door to Energy Recharge Station (doorpresenceframe_000); Heals? False
   * Layers: default
-  * Access Open to Energy Recharge Station/Door to Moving Magnet Walls (Tall)
+  * Access Open to Energy Recharge Station/Door to Moving Magnet Walls (Tall) (Cloak)
   * Extra - actor_name: doorpresenceframe_000
   * Extra - actor_def: actordef:actors/props/doorpresenceframe/charclasses/doorpresenceframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1281,7 +1281,7 @@ Extra - asset_id: collision_camera_018
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door from Moving Magnet Walls (Tall)
+  > Door to Moving Magnet Walls (Tall) (Charge)
       Trivial
   > Life Recharge
       Trivial
@@ -1298,9 +1298,9 @@ Extra - asset_id: collision_camera_018
   > Tile Group (POWERBEAM)
       Trivial
 
-> Door from Moving Magnet Walls (Tall); Heals? False
+> Door to Moving Magnet Walls (Tall) (Charge); Heals? False
   * Layers: default
-  * Access Closed to Moving Magnet Walls (Tall)/Door to Energy Recharge Station (doorclosedcharge_002)
+  * Access Locked to Moving Magnet Walls (Tall)/Door to Energy Recharge Station (doorclosedcharge_002)
   * Extra - actor_name: doorclosedcharge_002
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1312,7 +1312,7 @@ Extra - asset_id: collision_camera_018
   > Tile Group (POWERBEAM)
       Spider Magnet or Infinite Bomb Jump (Beginner) or Use Spin Boost
 
-> Door to Moving Magnet Walls (Tall); Heals? False
+> Door to Moving Magnet Walls (Tall) (Cloak); Heals? False
   * Layers: default
   * Sensor Lock Door to Moving Magnet Walls (Tall)/Door to Energy Recharge Station (doorpresenceframe_000)
   * Extra - actor_name: doorpresenceframe_000
@@ -1342,13 +1342,13 @@ Extra - asset_id: collision_camera_018
   * Extra - tile_types: ('POWERBEAM',)
   > Door to Thermal Device Room North
       Trivial
-  > Door from Moving Magnet Walls (Tall)
+  > Door to Moving Magnet Walls (Tall) (Charge)
       Trivial
 
 > Dock to Thermal Device Room North; Heals? False
   * Layers: default
   * Open Passage to Thermal Device Room North/Dock to Energy Recharge Station
-  > Door to Moving Magnet Walls (Tall)
+  > Door to Moving Magnet Walls (Tall) (Cloak)
       Trivial
 
 ----------------
@@ -2678,7 +2678,7 @@ Extra - polygon: [[4500.0, 4150.0], [2400.0, 4150.0], [2400.0, -1300.0], [4500.0
 Extra - asset_id: collision_camera_032
 > Door to EMMI Zone East Tower Access (doorpowerpower_015); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone East Tower Access/Door to EMMI Zone Tower East (doorpowerpower_015)
+  * Power Beam Door to EMMI Zone East Tower Access/Door to EMMI Zone Tower East (Middle)
   * Extra - actor_name: doorpowerpower_015
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2688,7 +2688,7 @@ Extra - asset_id: collision_camera_032
   > Tunnel to EMMI Zone Exit East
       Trivial
 
-> Door to EMMI Zone Exit East; Heals? False
+> Door to EMMI Zone Exit East (Power); Heals? False
   * Layers: default
   * Power Beam Door to EMMI Zone Exit East/Door to EMMI Zone Tower East (doorpowerpower_016)
   * Extra - actor_name: doorpowerpower_016
@@ -2736,7 +2736,7 @@ Extra - asset_id: collision_camera_032
 
 > Door to EMMI Zone East Tower Access (doorpowerpower_000); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone East Tower Access/Door to EMMI Zone Tower East (doorpowerpower_000)
+  * Power Beam Door to EMMI Zone East Tower Access/Door to EMMI Zone Tower East (Top)
   * Extra - actor_name: doorpowerpower_000
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2748,19 +2748,19 @@ Extra - asset_id: collision_camera_032
 
 > Door to EMMI Zone East Tower Access (doorclosedcharge); Heals? False
   * Layers: default
-  * Charge Beam Door to EMMI Zone East Tower Access/Door from EMMI Zone Tower East
+  * Charge Beam Door to EMMI Zone East Tower Access/Door to EMMI Zone Tower East (Bottom)
   * Extra - actor_name: doorclosedcharge
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Exit East
+  > Door to EMMI Zone Exit East (Power)
       Trivial
 
-> Door from EMMI Zone Exit East; Heals? False
+> Door to EMMI Zone Exit East (Charge); Heals? False
   * Layers: default
-  * Access Closed to EMMI Zone Exit East/Door to EMMI Zone Tower East (doorclosedcharge_001)
+  * Access Locked to EMMI Zone Exit East/Door to EMMI Zone Tower East (doorclosedcharge_001)
   * Extra - actor_name: doorclosedcharge_001
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2777,7 +2777,7 @@ Extra - asset_id: collision_camera_032
   * Morph Ball Tunnel to EMMI Zone Hidden Missile Room/Tunnel to EMMI Zone Tower East
   > Dock to Hall Thermal Device Room
       Trivial
-  > Door from EMMI Zone Exit East
+  > Door to EMMI Zone Exit East (Charge)
       Trivial
 
 > Tunnel to EMMI Zone Exit East; Heals? False
@@ -2785,7 +2785,7 @@ Extra - asset_id: collision_camera_032
   * Morph Ball Tunnel to EMMI Zone Exit East/Tunnel to EMMI Zone Tower East
   > Door to EMMI Zone East Tower Access (doorpowerpower_015)
       Trivial
-  > Door to EMMI Zone Exit East
+  > Door to EMMI Zone Exit East (Power)
       Can Slide
   > Tunnel to EMMI Zone East Tower Access (1)
       Trivial
@@ -2799,7 +2799,7 @@ Extra - asset_id: collision_camera_032
 > Tunnel to EMMI Zone East Tower Access (2); Heals? False
   * Layers: default
   * Cataris EMMI Tunnel to EMMI Zone East Tower Access/Tunnel to EMMI Zone Tower East (2)
-  > Door from EMMI Zone Exit East
+  > Door to EMMI Zone Exit East (Charge)
       Trivial
 
 ----------------
@@ -3752,7 +3752,7 @@ EMMI Zone East Tower Access
 Extra - total_boundings: {'x1': -700.0, 'x2': 2500.0, 'y1': -1300.0, 'y2': 2000.0}
 Extra - polygon: [[2500.0, 2000.0], [-700.0, 2000.0], [-700.0, -1300.0], [2500.0, -1300.0]]
 Extra - asset_id: collision_camera_046
-> Door to EMMI Zone Tower East (doorpowerpower_015); Heals? False
+> Door to EMMI Zone Tower East (Middle); Heals? False
   * Layers: default
   * Power Beam Door to EMMI Zone Tower East/Door to EMMI Zone East Tower Access (doorpowerpower_015)
   * Extra - actor_name: doorpowerpower_015
@@ -3763,7 +3763,7 @@ Extra - asset_id: collision_camera_046
   * Extra - right_shield_def: None
   > Door to Green EMMI Introduction (doorchargecharge_005)
       Trivial
-  > Door from EMMI Zone Tower East
+  > Door to EMMI Zone Tower East (Bottom)
       Trivial
   > Tunnel to EMMI Zone Tower East (1)
       Trivial
@@ -3783,10 +3783,10 @@ Extra - asset_id: collision_camera_046
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Tower East (doorpowerpower_015)
+  > Door to EMMI Zone Tower East (Middle)
       Trivial
 
-> Door to EMMI Zone Tower East (doorpowerpower_000); Heals? False
+> Door to EMMI Zone Tower East (Top); Heals? False
   * Layers: default
   * Power Beam Door to EMMI Zone Tower East/Door to EMMI Zone East Tower Access (doorpowerpower_000)
   * Extra - actor_name: doorpowerpower_000
@@ -3798,16 +3798,16 @@ Extra - asset_id: collision_camera_046
   > Door to Green EMMI Introduction (doorshutter_001)
       Can Slide
 
-> Door from EMMI Zone Tower East; Heals? False
+> Door to EMMI Zone Tower East (Bottom); Heals? False
   * Layers: default
-  * Access Closed to EMMI Zone Tower East/Door to EMMI Zone East Tower Access (doorclosedcharge)
+  * Access Locked to EMMI Zone Tower East/Door to EMMI Zone East Tower Access (doorclosedcharge)
   * Extra - actor_name: doorclosedcharge
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Tower East (doorpowerpower_015)
+  > Door to EMMI Zone Tower East (Middle)
       Trivial
 
 > Door to Green EMMI Introduction (doorshutter_001); Heals? False
@@ -3819,7 +3819,7 @@ Extra - asset_id: collision_camera_046
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Tower East (doorpowerpower_000)
+  > Door to EMMI Zone Tower East (Top)
       Can Slide
   > Tunnel to Green EMMI Introduction (Upper)
       Trivial
@@ -3829,13 +3829,13 @@ Extra - asset_id: collision_camera_046
 > Tunnel to EMMI Zone Tower East (1); Heals? False
   * Layers: default
   * Morph Ball Tunnel to EMMI Zone Tower East/Tunnel to EMMI Zone East Tower Access (1)
-  > Door to EMMI Zone Tower East (doorpowerpower_015)
+  > Door to EMMI Zone Tower East (Middle)
       Trivial
 
 > Tunnel to Green EMMI Introduction (Bottom); Heals? False
   * Layers: default
   * Cataris EMMI Tunnel to Green EMMI Introduction/Tunnel to EMMI Zone East Tower Access (Bottom)
-  > Door to EMMI Zone Tower East (doorpowerpower_015)
+  > Door to EMMI Zone Tower East (Middle)
       Trivial
 
 > Tunnel to Green EMMI Introduction (Upper); Heals? False
@@ -3847,7 +3847,7 @@ Extra - asset_id: collision_camera_046
 > Tunnel to EMMI Zone Tower East (2); Heals? False
   * Layers: default
   * Cataris EMMI Tunnel to EMMI Zone Tower East/Tunnel to EMMI Zone East Tower Access (2)
-  > Door to EMMI Zone Tower East (doorpowerpower_015)
+  > Door to EMMI Zone Tower East (Middle)
       Morph Ball and After Cataris - Central Unit
   > Door to Green EMMI Introduction (doorshutter_001)
       Morph Ball and After Cataris - Central Unit

--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -4350,7 +4350,7 @@
                         }
                     }
                 },
-                "Door from Early Grapple Room": {
+                "Door to Early Grapple Room": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4376,7 +4376,7 @@
                         "area_name": "Early Grapple Room",
                         "node_name": "Door to Transport to Artaria"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -4663,7 +4663,7 @@
                         ]
                     },
                     "connections": {
-                        "Door from Early Grapple Room": {
+                        "Door to Early Grapple Room": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -4757,7 +4757,7 @@
                                 ]
                             }
                         },
-                        "Door from Early Grapple Room": {
+                        "Door to Early Grapple Room": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -4855,7 +4855,7 @@
                         ]
                     },
                     "connections": {
-                        "Door from Early Grapple Room": {
+                        "Door to Early Grapple Room": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5534,7 +5534,7 @@
                     "default_connection": {
                         "world_name": "Dairon",
                         "area_name": "Transport to Artaria",
-                        "node_name": "Door from Early Grapple Room"
+                        "node_name": "Door to Early Grapple Room"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -13939,7 +13939,7 @@
                         }
                     }
                 },
-                "Door from Ammo Recharge Station": {
+                "Door to Ammo Recharge Station": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13965,7 +13965,7 @@
                         "area_name": "Ammo Recharge Station",
                         "node_name": "Door to Storm Missile Gate Room"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -14063,7 +14063,7 @@
                                 "items": []
                             }
                         },
-                        "Door from Ammo Recharge Station": {
+                        "Door to Ammo Recharge Station": {
                             "type": "template",
                             "data": "Can Slide"
                         }
@@ -14090,7 +14090,7 @@
                         ]
                     },
                     "connections": {
-                        "Door from Ammo Recharge Station": {
+                        "Door to Ammo Recharge Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14129,7 +14129,7 @@
                         ]
                     },
                     "connections": {
-                        "Door from Ammo Recharge Station": {
+                        "Door to Ammo Recharge Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14168,7 +14168,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from Ammo Recharge Station": {
+                        "Door to Ammo Recharge Station": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -14228,7 +14228,7 @@
                     "extra": {},
                     "event_name": "DaironStormMissileGate",
                     "connections": {
-                        "Door from Ammo Recharge Station": {
+                        "Door to Ammo Recharge Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14336,7 +14336,7 @@
                     "default_connection": {
                         "world_name": "Dairon",
                         "area_name": "Storm Missile Gate Room",
-                        "node_name": "Door from Ammo Recharge Station"
+                        "node_name": "Door to Ammo Recharge Station"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -912,9 +912,9 @@ Extra - asset_id: collision_camera_011
   > Tile Group (WEIGHT) 1
       Morph Ball
 
-> Door from Early Grapple Room; Heals? False
+> Door to Early Grapple Room; Heals? False
   * Layers: default
-  * Access Closed to Early Grapple Room/Door to Transport to Artaria
+  * Access Locked to Early Grapple Room/Door to Transport to Artaria
   * Extra - actor_name: doorchargeclosed_001
   * Extra - actor_def: actordef:actors/props/doorchargeclosed/charclasses/doorchargeclosed.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -977,7 +977,7 @@ Extra - asset_id: collision_camera_011
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
-  > Door from Early Grapple Room
+  > Door to Early Grapple Room
       Varia Suit or Heat Damage ≥ 100
   > Full samus control
       Varia Suit or Heat Damage ≥ 50
@@ -986,7 +986,7 @@ Extra - asset_id: collision_camera_011
   * Layers: default
   > Pickup (Power Bomb Tank)
       Missiles ≥ 2 and Morph Ball
-  > Door from Early Grapple Room
+  > Door to Early Grapple Room
       Varia Suit or Heat Damage ≥ 50
 
 > Tile Group (WEIGHT) 1; Heals? False
@@ -1004,7 +1004,7 @@ Extra - asset_id: collision_camera_011
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('WEIGHT',)
-  > Door from Early Grapple Room
+  > Door to Early Grapple Room
       Trivial
 
 > Tunnel to Hub Access; Heals? False
@@ -1088,7 +1088,7 @@ Extra - asset_id: collision_camera_012
 
 > Door to Transport to Artaria; Heals? False
   * Layers: default
-  * Charge Beam Door to Transport to Artaria/Door from Early Grapple Room
+  * Charge Beam Door to Transport to Artaria/Door to Early Grapple Room
   * Extra - actor_name: doorchargeclosed_001
   * Extra - actor_def: actordef:actors/props/doorchargeclosed/charclasses/doorchargeclosed.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2831,9 +2831,9 @@ Extra - asset_id: collision_camera_033
   > Tile Group (BOMB)
       Trivial
 
-> Door from Ammo Recharge Station; Heals? False
+> Door to Ammo Recharge Station; Heals? False
   * Layers: default
-  * Access Closed to Ammo Recharge Station/Door to Storm Missile Gate Room
+  * Access Locked to Ammo Recharge Station/Door to Storm Missile Gate Room
   * Extra - actor_name: doorclosedcharge_000
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2868,7 +2868,7 @@ Extra - asset_id: collision_camera_033
   * Extra - tile_types: ('BOMB',)
   > Dock to Shinespark Tutorial
       Trivial
-  > Door from Ammo Recharge Station
+  > Door to Ammo Recharge Station
       Can Slide
 
 > Tile Group (SPEEDBOOST) 1; Heals? False
@@ -2878,7 +2878,7 @@ Extra - asset_id: collision_camera_033
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SPEEDBOOST',)
-  > Door from Ammo Recharge Station
+  > Door to Ammo Recharge Station
       Trivial
   > Tunnel to Ammo Recharge Station
       Morph Ball
@@ -2890,7 +2890,7 @@ Extra - asset_id: collision_camera_033
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SPEEDBOOST',)
-  > Door from Ammo Recharge Station
+  > Door to Ammo Recharge Station
       Trivial
   > Pickup (Missile+ Tank)
       Trivial
@@ -2898,7 +2898,7 @@ Extra - asset_id: collision_camera_033
 > Dock to Lake Puzzle Room; Heals? False
   * Layers: default
   * Open Passage to Lake Puzzle Room/Dock to Storm Missile Gate Room
-  > Door from Ammo Recharge Station
+  > Door to Ammo Recharge Station
       After Dairon - Storm Missile Gate
 
 > Tunnel to Ammo Recharge Station; Heals? False
@@ -2910,7 +2910,7 @@ Extra - asset_id: collision_camera_033
 > Event - Storm Missile Gate; Heals? False
   * Layers: default
   * Event Dairon - Storm Missile Gate
-  > Door from Ammo Recharge Station
+  > Door to Ammo Recharge Station
       Trivial
 
 ----------------
@@ -2930,7 +2930,7 @@ Extra - asset_id: collision_camera_034
 
 > Door to Storm Missile Gate Room; Heals? False
   * Layers: default
-  * Charge Beam Door to Storm Missile Gate Room/Door from Ammo Recharge Station
+  * Charge Beam Door to Storm Missile Gate Room/Door to Ammo Recharge Station
   * Extra - actor_name: doorclosedcharge_000
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}

--- a/randovania/games/dread/json_data/Ferenia.json
+++ b/randovania/games/dread/json_data/Ferenia.json
@@ -799,7 +799,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone Exit Middle": {
+                "Door to EMMI Zone Exit Middle (Power)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -838,7 +838,7 @@
                         }
                     }
                 },
-                "Door from EMMI Zone Exit Middle": {
+                "Door to EMMI Zone Exit Middle (Charge)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -864,11 +864,11 @@
                         "area_name": "EMMI Zone Exit Middle",
                         "node_name": "Door to EMMI Zone Exit West (doorclosedcharge_004)"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Exit Middle": {
+                        "Door to EMMI Zone Exit Middle (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -974,7 +974,7 @@
                                 ]
                             }
                         },
-                        "Door from EMMI Zone Exit Middle": {
+                        "Door to EMMI Zone Exit Middle (Charge)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -5972,7 +5972,7 @@
                 "asset_id": "collision_camera_015"
             },
             "nodes": {
-                "Door from Twin Robot Arena": {
+                "Door to Twin Robot Arena": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5998,7 +5998,7 @@
                         "area_name": "Twin Robot Arena",
                         "node_name": "Door to Space Jump Room Access"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -6169,7 +6169,7 @@
                         ]
                     },
                     "connections": {
-                        "Door from Twin Robot Arena": {
+                        "Door to Twin Robot Arena": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6206,7 +6206,7 @@
                         ]
                     },
                     "connections": {
-                        "Door from Twin Robot Arena": {
+                        "Door to Twin Robot Arena": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -6676,7 +6676,7 @@
                     "default_connection": {
                         "world_name": "Ferenia",
                         "area_name": "Space Jump Room Access",
-                        "node_name": "Door from Twin Robot Arena"
+                        "node_name": "Door to Twin Robot Arena"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -9262,7 +9262,7 @@
                     "default_connection": {
                         "world_name": "Ferenia",
                         "area_name": "EMMI Zone Exit West",
-                        "node_name": "Door to EMMI Zone Exit Middle"
+                        "node_name": "Door to EMMI Zone Exit Middle (Power)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -9434,7 +9434,7 @@
                     "default_connection": {
                         "world_name": "Ferenia",
                         "area_name": "EMMI Zone Exit West",
-                        "node_name": "Door from EMMI Zone Exit Middle"
+                        "node_name": "Door to EMMI Zone Exit Middle (Charge)"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -10233,7 +10233,7 @@
                     "default_connection": {
                         "world_name": "Ferenia",
                         "area_name": "Save Station Southeast",
-                        "node_name": "Door from Path to Escue"
+                        "node_name": "Door to Path to Escue"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -12986,7 +12986,7 @@
                     "default_connection": {
                         "world_name": "Ferenia",
                         "area_name": "EMMI Zone Exit East Access",
-                        "node_name": "Door from Wave Beam Tutorial"
+                        "node_name": "Door to Wave Beam Tutorial"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -13264,7 +13264,7 @@
                     "default_connection": {
                         "world_name": "Ferenia",
                         "area_name": "EMMI Zone Exit East Access",
-                        "node_name": "Door to EMMI Zone Exit East"
+                        "node_name": "Door to EMMI Zone Exit East (Power)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -13305,7 +13305,7 @@
                     "default_connection": {
                         "world_name": "Ferenia",
                         "area_name": "EMMI Zone Exit East Access",
-                        "node_name": "Door from EMMI Zone Exit East"
+                        "node_name": "Door to EMMI Zone Exit East (Charge)"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -13488,7 +13488,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from EMMI Zone Exit East": {
+                        "Door to EMMI Zone Exit East (Charge)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13497,7 +13497,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone Exit East": {
+                "Door to EMMI Zone Exit East (Power)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13527,7 +13527,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from EMMI Zone Exit East": {
+                        "Door to EMMI Zone Exit East (Charge)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13536,7 +13536,7 @@
                         }
                     }
                 },
-                "Door from EMMI Zone Exit East": {
+                "Door to EMMI Zone Exit East (Charge)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13562,7 +13562,7 @@
                         "area_name": "EMMI Zone Exit East",
                         "node_name": "Door to EMMI Zone Exit East Access (doorclosedcharge_001)"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -13573,14 +13573,14 @@
                                 "items": []
                             }
                         },
-                        "Door to EMMI Zone Exit East": {
+                        "Door to EMMI Zone Exit East (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Door from Wave Beam Tutorial": {
+                        "Door to Wave Beam Tutorial": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13640,7 +13640,7 @@
                         }
                     }
                 },
-                "Door from Wave Beam Tutorial": {
+                "Door to Wave Beam Tutorial": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13666,11 +13666,11 @@
                         "area_name": "Wave Beam Tutorial",
                         "node_name": "Door to EMMI Zone Exit East Access"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from EMMI Zone Exit East": {
+                        "Door to EMMI Zone Exit East (Charge)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13702,7 +13702,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from EMMI Zone Exit East": {
+                        "Door to EMMI Zone Exit East (Charge)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -15864,7 +15864,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from Path to Escue": {
+                        "Door to Path to Escue": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -15873,7 +15873,7 @@
                         }
                     }
                 },
-                "Door from Path to Escue": {
+                "Door to Path to Escue": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -15899,7 +15899,7 @@
                         "area_name": "Path to Escue",
                         "node_name": "Door to Save Station Southeast"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -15938,7 +15938,7 @@
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
                     "connections": {
-                        "Door from Path to Escue": {
+                        "Door to Path to Escue": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -154,7 +154,7 @@ Extra - asset_id: collision_camera_003
   > Center Platform
       Trivial
 
-> Door to EMMI Zone Exit Middle; Heals? False
+> Door to EMMI Zone Exit Middle (Power); Heals? False
   * Layers: default
   * Power Beam Door to EMMI Zone Exit Middle/Door to EMMI Zone Exit West (doorpowerpower_016)
   * Extra - actor_name: doorpowerpower_016
@@ -166,16 +166,16 @@ Extra - asset_id: collision_camera_003
   > Center Platform
       Trivial
 
-> Door from EMMI Zone Exit Middle; Heals? False
+> Door to EMMI Zone Exit Middle (Charge); Heals? False
   * Layers: default
-  * Access Closed to EMMI Zone Exit Middle/Door to EMMI Zone Exit West (doorclosedcharge_004)
+  * Access Locked to EMMI Zone Exit Middle/Door to EMMI Zone Exit West (doorclosedcharge_004)
   * Extra - actor_name: doorclosedcharge_004
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Exit Middle
+  > Door to EMMI Zone Exit Middle (Power)
       Trivial
   > Center Platform
       Trivial
@@ -190,7 +190,7 @@ Extra - asset_id: collision_camera_003
   * Layers: default
   > Dock to Teleport to Burenia (Cyan)
       Grapple Beam or Gravity Suit or Use Spin Boost
-  > Door from EMMI Zone Exit Middle
+  > Door to EMMI Zone Exit Middle (Charge)
       Grapple Beam or Gravity Suit or Use Spin Boost
 
 ----------------
@@ -1242,9 +1242,9 @@ Space Jump Room Access
 Extra - total_boundings: {'x1': -12500.0, 'x2': -10400.0, 'y1': 1800.0, 'y2': 5400.0}
 Extra - polygon: [[-10400.0, 5400.0], [-12500.0, 5400.0], [-12500.0, 1800.0], [-10400.0, 1800.0]]
 Extra - asset_id: collision_camera_015
-> Door from Twin Robot Arena; Heals? False
+> Door to Twin Robot Arena; Heals? False
   * Layers: default
-  * Access Closed to Twin Robot Arena/Door to Space Jump Room Access
+  * Access Locked to Twin Robot Arena/Door to Space Jump Room Access
   * Extra - actor_name: doorclosedcharge_000
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1299,7 +1299,7 @@ Extra - asset_id: collision_camera_015
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
-  > Door from Twin Robot Arena
+  > Door to Twin Robot Arena
       Trivial
   > Aiming Platform
       Trivial
@@ -1311,7 +1311,7 @@ Extra - asset_id: collision_camera_015
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
-  > Door from Twin Robot Arena
+  > Door to Twin Robot Arena
       Morph Ball
   > Door to Space Jump Room (Bottom)
       Trivial
@@ -1435,7 +1435,7 @@ Extra - asset_id: collision_camera_017
 
 > Door to Space Jump Room Access; Heals? False
   * Layers: default
-  * Charge Beam Door to Space Jump Room Access/Door from Twin Robot Arena
+  * Charge Beam Door to Space Jump Room Access/Door to Twin Robot Arena
   * Extra - actor_name: doorclosedcharge_000
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1890,7 +1890,7 @@ Extra - asset_id: collision_camera_021
 
 > Door to EMMI Zone Exit West (doorpowerpower_016); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone Exit West/Door to EMMI Zone Exit Middle
+  * Power Beam Door to EMMI Zone Exit West/Door to EMMI Zone Exit Middle (Power)
   * Extra - actor_name: doorpowerpower_016
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1916,7 +1916,7 @@ Extra - asset_id: collision_camera_021
 
 > Door to EMMI Zone Exit West (doorclosedcharge_004); Heals? False
   * Layers: default
-  * Charge Beam Door to EMMI Zone Exit West/Door from EMMI Zone Exit Middle
+  * Charge Beam Door to EMMI Zone Exit West/Door to EMMI Zone Exit Middle (Charge)
   * Extra - actor_name: doorclosedcharge_004
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2115,7 +2115,7 @@ Extra - asset_id: collision_camera_025
 
 > Door to Save Station Southeast; Heals? False
   * Layers: default
-  * Charge Beam Door to Save Station Southeast/Door from Path to Escue
+  * Charge Beam Door to Save Station Southeast/Door to Path to Escue
   * Extra - actor_name: doorclosedcharge_003
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2668,7 +2668,7 @@ Extra - asset_id: collision_camera_031
 
 > Door to EMMI Zone Exit East Access; Heals? False
   * Layers: default
-  * Charge Beam Door to EMMI Zone Exit East Access/Door from Wave Beam Tutorial
+  * Charge Beam Door to EMMI Zone Exit East Access/Door to Wave Beam Tutorial
   * Extra - actor_name: doorclosedcharge_002
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2732,7 +2732,7 @@ Extra - polygon: [[6600.0, 1800.0], [2500.0, 1800.0], [2500.0, -300.0], [6600.0,
 Extra - asset_id: collision_camera_032
 > Door to EMMI Zone Exit East Access (doorpowerpower_017); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone Exit East Access/Door to EMMI Zone Exit East
+  * Power Beam Door to EMMI Zone Exit East Access/Door to EMMI Zone Exit East (Power)
   * Extra - actor_name: doorpowerpower_017
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2744,7 +2744,7 @@ Extra - asset_id: collision_camera_032
 
 > Door to EMMI Zone Exit East Access (doorclosedcharge_001); Heals? False
   * Layers: default
-  * Charge Beam Door to EMMI Zone Exit East Access/Door from EMMI Zone Exit East
+  * Charge Beam Door to EMMI Zone Exit East Access/Door to EMMI Zone Exit East (Charge)
   * Extra - actor_name: doorclosedcharge_001
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2782,10 +2782,10 @@ Extra - asset_id: collision_camera_033
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door from EMMI Zone Exit East
+  > Door to EMMI Zone Exit East (Charge)
       Trivial
 
-> Door to EMMI Zone Exit East; Heals? False
+> Door to EMMI Zone Exit East (Power); Heals? False
   * Layers: default
   * Power Beam Door to EMMI Zone Exit East/Door to EMMI Zone Exit East Access (doorpowerpower_017)
   * Extra - actor_name: doorpowerpower_017
@@ -2794,12 +2794,12 @@ Extra - asset_id: collision_camera_033
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door from EMMI Zone Exit East
+  > Door to EMMI Zone Exit East (Charge)
       Trivial
 
-> Door from EMMI Zone Exit East; Heals? False
+> Door to EMMI Zone Exit East (Charge); Heals? False
   * Layers: default
-  * Access Closed to EMMI Zone Exit East/Door to EMMI Zone Exit East Access (doorclosedcharge_001)
+  * Access Locked to EMMI Zone Exit East/Door to EMMI Zone Exit East Access (doorclosedcharge_001)
   * Extra - actor_name: doorclosedcharge_001
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2808,31 +2808,31 @@ Extra - asset_id: collision_camera_033
   * Extra - right_shield_def: None
   > Door to EMMI Zone Exit Middle
       Trivial
-  > Door to EMMI Zone Exit East
+  > Door to EMMI Zone Exit East (Power)
       Trivial
-  > Door from Wave Beam Tutorial
+  > Door to Wave Beam Tutorial
       Trivial
   > Tunnel to Wave Beam Tutorial
       Any of the following:
           Flash Shift or Simple IBJ or Use Spin Boost
           Gravity Suit and Speed Booster
 
-> Door from Wave Beam Tutorial; Heals? False
+> Door to Wave Beam Tutorial; Heals? False
   * Layers: default
-  * Access Closed to Wave Beam Tutorial/Door to EMMI Zone Exit East Access
+  * Access Locked to Wave Beam Tutorial/Door to EMMI Zone Exit East Access
   * Extra - actor_name: doorclosedcharge_002
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door from EMMI Zone Exit East
+  > Door to EMMI Zone Exit East (Charge)
       Trivial
 
 > Tunnel to Wave Beam Tutorial; Heals? False
   * Layers: default
   * Ferenia EMMI Tunnel to Wave Beam Tutorial/Tunnel to EMMI Zone Exit East Access
-  > Door from EMMI Zone Exit East
+  > Door to EMMI Zone Exit East (Charge)
       Trivial
 
 ----------------
@@ -3274,12 +3274,12 @@ Extra - asset_id: collision_camera_041
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door from Path to Escue
+  > Door to Path to Escue
       Trivial
 
-> Door from Path to Escue; Heals? False
+> Door to Path to Escue; Heals? False
   * Layers: default
-  * Access Closed to Path to Escue/Door to Save Station Southeast
+  * Access Locked to Path to Escue/Door to Save Station Southeast
   * Extra - actor_name: doorclosedcharge_003
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -3297,6 +3297,6 @@ Extra - asset_id: collision_camera_041
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
   * Extra - start_point_actor_name: savestation_001_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad
-  > Door from Path to Escue
+  > Door to Path to Escue
       Trivial
 

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -7881,7 +7881,7 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "Above Pulse Radar",
-                        "node_name": "Door from Golzuna Tower"
+                        "node_name": "Door to Golzuna Tower"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -12581,13 +12581,13 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "Above Golzuna",
-                        "node_name": "Door from Cross Bomb Tutorial"
+                        "node_name": "Door to Cross Bomb Tutorial"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from Transport to Hanubia": {
+                        "Door to Transport to Hanubia": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12596,7 +12596,7 @@
                         }
                     }
                 },
-                "Door from Transport to Hanubia": {
+                "Door to Transport to Hanubia": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -12622,7 +12622,7 @@
                         "area_name": "Transport to Hanubia",
                         "node_name": "Door to Cross Bomb Tutorial"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -12716,7 +12716,7 @@
                         ]
                     },
                     "connections": {
-                        "Door from Transport to Hanubia": {
+                        "Door to Transport to Hanubia": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12784,7 +12784,7 @@
                         ]
                     },
                     "connections": {
-                        "Door from Transport to Hanubia": {
+                        "Door to Transport to Hanubia": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12998,7 +12998,7 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "Cross Bomb Tutorial",
-                        "node_name": "Door from Transport to Hanubia"
+                        "node_name": "Door to Transport to Hanubia"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -13438,7 +13438,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from Cross Bomb Tutorial": {
+                        "Door to Cross Bomb Tutorial": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13477,7 +13477,7 @@
                         }
                     }
                 },
-                "Door from Cross Bomb Tutorial": {
+                "Door to Cross Bomb Tutorial": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13503,7 +13503,7 @@
                         "area_name": "Cross Bomb Tutorial",
                         "node_name": "Door to Above Golzuna"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -13916,7 +13916,7 @@
                         }
                     }
                 },
-                "Door from Golzuna Tower": {
+                "Door to Golzuna Tower": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13942,7 +13942,7 @@
                         "area_name": "Golzuna Tower",
                         "node_name": "Door to Above Pulse Radar"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -14071,7 +14071,7 @@
                             "type": "template",
                             "data": "Can Slide"
                         },
-                        "Door from Golzuna Tower": {
+                        "Door to Golzuna Tower": {
                             "type": "resource",
                             "data": {
                                 "type": "items",

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -1690,7 +1690,7 @@ Extra - asset_id: collision_camera_024
 
 > Door to Above Pulse Radar; Heals? False
   * Layers: default
-  * Charge Beam Door to Above Pulse Radar/Door from Golzuna Tower
+  * Charge Beam Door to Above Pulse Radar/Door to Golzuna Tower
   * Extra - actor_name: doorclosedcharge
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2724,19 +2724,19 @@ Extra - asset_id: collision_camera_033
 
 > Door to Above Golzuna; Heals? False
   * Layers: default
-  * Power Beam Door to Above Golzuna/Door from Cross Bomb Tutorial
+  * Power Beam Door to Above Golzuna/Door to Cross Bomb Tutorial
   * Extra - actor_name: doorclosedpower_003
   * Extra - actor_def: actordef:actors/props/doorclosedpower/charclasses/doorclosedpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door from Transport to Hanubia
+  > Door to Transport to Hanubia
       Trivial
 
-> Door from Transport to Hanubia; Heals? False
+> Door to Transport to Hanubia; Heals? False
   * Layers: default
-  * Access Closed to Transport to Hanubia/Door to Cross Bomb Tutorial
+  * Access Locked to Transport to Hanubia/Door to Cross Bomb Tutorial
   * Extra - actor_name: doorclosedpower_000
   * Extra - actor_def: actordef:actors/props/doorclosedpower/charclasses/doorclosedpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2771,7 +2771,7 @@ Extra - asset_id: collision_camera_033
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Door from Transport to Hanubia
+  > Door to Transport to Hanubia
       Trivial
   > Tile Group (WEIGHT) 2
       Can Slide
@@ -2794,7 +2794,7 @@ Extra - asset_id: collision_camera_033
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SCREWATTACK',)
-  > Door from Transport to Hanubia
+  > Door to Transport to Hanubia
       Trivial
   > Tunnel to Transport to Hanubia
       Morph Ball
@@ -2841,7 +2841,7 @@ Extra - polygon: [[21100.0, 8200.0], [12000.0, 8200.0], [12000.0, 6300.0], [2110
 Extra - asset_id: collision_camera_034
 > Door to Cross Bomb Tutorial; Heals? False
   * Layers: default
-  * Power Beam Door to Cross Bomb Tutorial/Door from Transport to Hanubia
+  * Power Beam Door to Cross Bomb Tutorial/Door to Transport to Hanubia
   * Extra - actor_name: doorclosedpower_000
   * Extra - actor_def: actordef:actors/props/doorclosedpower/charclasses/doorclosedpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2930,16 +2930,16 @@ Extra - asset_id: collision_camera_036
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door from Cross Bomb Tutorial
+  > Door to Cross Bomb Tutorial
       Trivial
   > Tunnel to Golzuna Arena
       Morph Ball
   > Dock to Golzuna Arena
       Shinesink Clip (Expert) and Can SSC
 
-> Door from Cross Bomb Tutorial; Heals? False
+> Door to Cross Bomb Tutorial; Heals? False
   * Layers: default
-  * Access Closed to Cross Bomb Tutorial/Door to Above Golzuna
+  * Access Locked to Cross Bomb Tutorial/Door to Above Golzuna
   * Extra - actor_name: doorclosedpower_003
   * Extra - actor_def: actordef:actors/props/doorclosedpower/charclasses/doorclosedpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -3055,9 +3055,9 @@ Extra - asset_id: collision_camera_039
   > Tile Group (POWERBEAM) 1
       Can Slide
 
-> Door from Golzuna Tower; Heals? False
+> Door to Golzuna Tower; Heals? False
   * Layers: default
-  * Access Closed to Golzuna Tower/Door to Above Pulse Radar
+  * Access Locked to Golzuna Tower/Door to Above Pulse Radar
   * Extra - actor_name: doorclosedcharge
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -3106,7 +3106,7 @@ Extra - asset_id: collision_camera_039
   * Extra - tile_types: ('POWERBEAM',)
   > Pickup (Missile Tank)
       Can Slide
-  > Door from Golzuna Tower
+  > Door to Golzuna Tower
       Morph Ball
 
 > Tile Group (POWERBEAM) 3; Heals? False


### PR DESCRIPTION
Changes necessary Access Closed docks to Access Locked so that logic can properly account for them. Changes doors in every area except Elun, Hanubia, and Itorash.

Fixes Issue #2837 List of Access Closed Docks