### PR TITLE
Dread: redo logic for Artaria - First Tutorial

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -373,50 +373,6 @@
                         }
                     }
                 },
-                "Tile Group (POWERBEAM) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 3700.0,
-                        "y": -8100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_054",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {}
-                },
-                "Tile Group (POWERBEAM) 3": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 3200.0,
-                        "y": -8400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_055",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {}
-                },
                 "Tile Group (MISSILE) 2": {
                     "node_type": "configurable_node",
                     "heal": false,
@@ -551,25 +507,8 @@
                             }
                         },
                         "Event - First Tutorial Blob": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Wave",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Diffusion Beam"
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Shoot Diffusion or Wave"
                         },
                         "Ammo Recharge": {
                             "type": "or",
@@ -577,8 +516,71 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Slide Underwater"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Slide Underwater"
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Gravity",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Flash",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Walljump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Perform Water Bomb Jump"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Perform Water Cross Jump"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -92,22 +92,6 @@ Extra - asset_id: collision_camera_000
   > Tile Group (MISSILE) 2
       Can Slide
 
-> Tile Group (POWERBEAM) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_054
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-
-> Tile Group (POWERBEAM) 3; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_055
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-
 > Tile Group (MISSILE) 2; Heals? False
   * Layers: default
   * Configurable Node
@@ -147,10 +131,14 @@ Extra - asset_id: collision_camera_000
   > Door to Charge Tutorial
       After Artaria - First Tutorial Blob
   > Event - First Tutorial Blob
-      Wave Beam or Shoot Diffusion Beam
+      Shoot Diffusion or Wave
   > Ammo Recharge
       Any of the following:
-          Can Slide Underwater
+          All of the following:
+              Can Slide Underwater
+              Any of the following:
+                  Gravity Suit or Perform Water Bomb Jump or Perform Water Cross Jump or Use Spin Boost
+                  Flash Shift and Walljump (Beginner)
           Before Artaria - EMMI Zone Water Device and Can Slide
 
 > Tunnel to First Tutorial Access; Heals? False

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1908,6 +1908,80 @@
                         }
                     ]
                 }
+            },
+            "Perform Water Bomb Jump": {
+                "type": "and",
+                "data": {
+                    "comment": "Gain a little extra height in water without Gravity Suit by using a bomb",
+                    "items": [
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Bomb",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Gravity",
+                                "amount": 1,
+                                "negate": true
+                            }
+                        },
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "tricks",
+                                "name": "WBJ",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        }
+                    ]
+                }
+            },
+            "Perform Water Cross Jump": {
+                "type": "and",
+                "data": {
+                    "comment": "Gain a little extra height in water without Gravity Suit by using a Cross Bomb",
+                    "items": [
+                        {
+                            "type": "template",
+                            "data": "Lay Cross Comb"
+                        },
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Gravity",
+                                "amount": 1,
+                                "negate": true
+                            }
+                        },
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "tricks",
+                                "name": "WBJ",
+                                "amount": 2,
+                                "negate": false
+                            }
+                        }
+                    ]
+                }
             }
         },
         "damage_reductions": [

--- a/randovania/games/dread/json_data/header.txt
+++ b/randovania/games/dread/json_data/header.txt
@@ -103,6 +103,16 @@ Templates
 * Break/Move Grapple Block from Behind:
       Grapple Beam and Slide and Reverse Grapple Block (Beginner)
 
+* Perform Water Bomb Jump:
+      All of the following:
+          # Gain a little extra height in water without Gravity Suit by using a bomb
+          Bomb and No Gravity Suit and Morph Ball and Water Bomb Jump (Beginner)
+
+* Perform Water Cross Jump:
+      All of the following:
+          # Gain a little extra height in water without Gravity Suit by using a Cross Bomb
+          No Gravity Suit and Water Bomb Jump (Intermediate) and Lay Cross Comb
+
 ====================
 Dock Weaknesses
 


### PR DESCRIPTION
- Added extra methods of climbing to the Ammo Recharge station from "Above Breakable"
- Added templates for "Perform Water Bomb Jump" and "Perform Water Cross Jump"