### PR TITLE
Dread: Fix grapple events for Ghavoran

### DIFF
--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -286,7 +286,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s050_forest:default:grapplepulloff1x2_000",
+                                            "name": "GhavoranGrappleBox1",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -346,7 +346,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s050_forest:default:grapplepulloff1x2_000",
+                                            "name": "GhavoranGrappleBox1",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -520,7 +520,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s050_forest:default:grapplepulloff1x2_000",
+                                            "name": "GhavoranGrappleBox1",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -702,7 +702,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s050_forest:default:grapplepulloff1x2_000",
+                                            "name": "GhavoranGrappleBox1",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -728,7 +728,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s050_forest:default:grapplepulloff1x2_000",
+                                            "name": "GhavoranGrappleBox1",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -749,7 +749,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s050_forest:default:grapplepulloff1x2_000",
+                                            "name": "GhavoranGrappleBox1",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -761,7 +761,7 @@
                                 ]
                             }
                         },
-                        "Event - Pull Grapple Block (grapplepulloff1x2_000)": {
+                        "Event - Burenia Transport Grapple Block": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -772,7 +772,7 @@
                         }
                     }
                 },
-                "Event - Pull Grapple Block (grapplepulloff1x2_000)": {
+                "Event - Burenia Transport Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -785,7 +785,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "event_name": "s050_forest:default:grapplepulloff1x2_000",
+                    "event_name": "GhavoranGrappleBox1",
                     "connections": {
                         "Grapple Block Alcove": {
                             "type": "and",
@@ -9219,7 +9219,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s050_forest:default:grapplepulloff1x2_002",
+                                            "name": "GhavoranGrappleBox2",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -9355,7 +9355,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s050_forest:default:grapplepulloff1x2_002",
+                                            "name": "GhavoranGrappleBox2",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -9397,7 +9397,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s050_forest:default:grapplepulloff1x2_002",
+                                            "name": "GhavoranGrappleBox2",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -9423,7 +9423,7 @@
                                 ]
                             }
                         },
-                        "Event - Pull Grapple Block (grapplepulloff1x2_002)": {
+                        "Event - Ferenia Transport Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9466,7 +9466,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s050_forest:default:grapplepulloff1x2_002",
+                                            "name": "GhavoranGrappleBox2",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -9750,7 +9750,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s050_forest:default:grapplepulloff1x2_002",
+                                            "name": "GhavoranGrappleBox2",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -9776,7 +9776,7 @@
                                 ]
                             }
                         },
-                        "Event - Pull Grapple Block (grapplepulloff1x2_002)": {
+                        "Event - Ferenia Transport Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9819,7 +9819,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s050_forest:default:grapplepulloff1x2_002",
+                                            "name": "GhavoranGrappleBox2",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -9833,7 +9833,7 @@
                         }
                     }
                 },
-                "Event - Pull Grapple Block (grapplepulloff1x2_002)": {
+                "Event - Ferenia Transport Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -9846,7 +9846,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "event_name": "s050_forest:default:grapplepulloff1x2_002",
+                    "event_name": "GhavoranGrappleBox2",
                     "connections": {
                         "Door to Teleport to Burenia (Missile)": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -286,7 +286,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "GhavoranGrappleBox1",
+                                            "name": "GhavoranBureniaTransportGrappleBox",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -346,7 +346,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "GhavoranGrappleBox1",
+                                            "name": "GhavoranBureniaTransportGrappleBox",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -520,7 +520,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "GhavoranGrappleBox1",
+                                            "name": "GhavoranBureniaTransportGrappleBox",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -702,7 +702,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "GhavoranGrappleBox1",
+                                            "name": "GhavoranBureniaTransportGrappleBox",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -728,7 +728,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "GhavoranGrappleBox1",
+                                            "name": "GhavoranBureniaTransportGrappleBox",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -749,7 +749,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "GhavoranGrappleBox1",
+                                            "name": "GhavoranBureniaTransportGrappleBox",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -761,7 +761,7 @@
                                 ]
                             }
                         },
-                        "Event - Burenia Transport Grapple Block": {
+                        "Event - Burenia Transport Grapple Box": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -772,7 +772,7 @@
                         }
                     }
                 },
-                "Event - Burenia Transport Grapple Block": {
+                "Event - Burenia Transport Grapple Box": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -785,7 +785,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "event_name": "GhavoranGrappleBox1",
+                    "event_name": "GhavoranBureniaTransportGrappleBox",
                     "connections": {
                         "Grapple Block Alcove": {
                             "type": "and",
@@ -9219,7 +9219,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "GhavoranGrappleBox2",
+                                            "name": "GhavoranFereniaTransportGrappleBox",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -9355,7 +9355,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "GhavoranGrappleBox2",
+                                            "name": "GhavoranFereniaTransportGrappleBox",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -9397,7 +9397,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "GhavoranGrappleBox2",
+                                            "name": "GhavoranFereniaTransportGrappleBox",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -9423,7 +9423,7 @@
                                 ]
                             }
                         },
-                        "Event - Ferenia Transport Grapple Block": {
+                        "Event - Ferenia Transport Grapple Box (Front)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9466,7 +9466,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "GhavoranGrappleBox2",
+                                            "name": "GhavoranFereniaTransportGrappleBox",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -9750,7 +9750,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "GhavoranGrappleBox2",
+                                            "name": "GhavoranFereniaTransportGrappleBox",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -9776,7 +9776,41 @@
                                 ]
                             }
                         },
-                        "Event - Ferenia Transport Grapple Block": {
+                        "Event - Ferenia Transport Enky Left": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Destroy Enky"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "GhavoranFereniaTransportEnkyRight",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "GhavoranFereniaTransportGrappleBox",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Ferenia Transport Enky Right": {
+                            "type": "template",
+                            "data": "Destroy Enky"
+                        },
+                        "Event - Ferenia Transport Grapple Box (Back)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9796,48 +9830,14 @@
                                     }
                                 ]
                             }
-                        },
-                        "Event - Ferenia Transport Enky Left": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Destroy Enky"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "GhavoranFereniaTransportEnkyLeft",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "GhavoranGrappleBox2",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Event - Ferenia Transport Enky Right": {
-                            "type": "template",
-                            "data": "Destroy Enky"
                         }
                     }
                 },
-                "Event - Ferenia Transport Grapple Block": {
+                "Event - Ferenia Transport Grapple Box (Front)": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 8872.39,
+                        "x": 8672.39,
                         "y": 2593.52,
                         "z": 0.0
                     },
@@ -9846,7 +9846,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "event_name": "GhavoranGrappleBox2",
+                    "event_name": "GhavoranFereniaTransportGrappleBox",
                     "connections": {
                         "Door to Teleport to Burenia (Missile)": {
                             "type": "and",
@@ -9960,6 +9960,30 @@
                     ],
                     "extra": {},
                     "event_name": "GhavoranFereniaTransportEnkyRight",
+                    "connections": {
+                        "Dock to Transport to Ferenia": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Ferenia Transport Grapple Box (Back)": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 9072.39,
+                        "y": 2593.52,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "GhavoranFereniaTransportGrappleBox",
                     "connections": {
                         "Dock to Transport to Ferenia": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -72,7 +72,7 @@ Extra - asset_id: collision_camera_001
   > Door to Robot Fight Arena
       Trivial
   > Grapple Block Alcove
-      After Ghavoran - Burenia Transport Grapple Block and Can Slide
+      After Ghavoran - Burenia Transport Grapple Box and Can Slide
 
 > Door to Super Missile Room; Heals? False
   * Layers: default
@@ -87,7 +87,7 @@ Extra - asset_id: collision_camera_001
       Trivial
   > Grapple Block Alcove
       All of the following:
-          Morph Ball and After Ghavoran - Burenia Transport Grapple Block
+          Morph Ball and After Ghavoran - Burenia Transport Grapple Box
           Grapple Beam or Spider Magnet or Simple IBJ or Use Spin Boost
 
 > Pickup (Missile Tank); Heals? False
@@ -113,7 +113,7 @@ Extra - asset_id: collision_camera_001
           Gravity Suit or Space Jump or Speed Booster
   > Grapple Block Alcove
       All of the following:
-          Morph Ball and Before Ghavoran - Burenia Transport Grapple Block
+          Morph Ball and Before Ghavoran - Burenia Transport Grapple Box
           Any of the following:
               Spider Magnet or Space Jump
               Flash Shift and Use Spin Boost
@@ -149,17 +149,17 @@ Extra - asset_id: collision_camera_001
 > Grapple Block Alcove; Heals? False
   * Layers: default
   > Door to Spider Magnet Elevator
-      Morph Ball and After Ghavoran - Burenia Transport Grapple Block
+      Morph Ball and After Ghavoran - Burenia Transport Grapple Box
   > Door to Super Missile Room
-      After Ghavoran - Burenia Transport Grapple Block and Can Slide
+      After Ghavoran - Burenia Transport Grapple Box and Can Slide
   > Door to Transport to Burenia
-      Before Ghavoran - Burenia Transport Grapple Block and Can Slide
-  > Event - Burenia Transport Grapple Block
+      Before Ghavoran - Burenia Transport Grapple Box and Can Slide
+  > Event - Burenia Transport Grapple Box
       Grapple Beam
 
-> Event - Burenia Transport Grapple Block; Heals? False
+> Event - Burenia Transport Grapple Box; Heals? False
   * Layers: default
-  * Event Ghavoran - Burenia Transport Grapple Block
+  * Event Ghavoran - Burenia Transport Grapple Box
   > Grapple Block Alcove
       Trivial
 
@@ -2016,7 +2016,7 @@ Extra - asset_id: collision_camera_025_B
   * Extra - right_shield_def: None
   > Door to Teleport to Burenia (Missile)
       All of the following:
-          Morph Ball and Before Ghavoran - Ferenia Transport Grapple Block
+          Morph Ball and Before Ghavoran - Ferenia Transport Grapple Box
           Grapple Beam or Spider Magnet or Space Jump or Speed Booster or Walljump (Beginner) or Simple IBJ
   > Door to Teleport to Burenia (Power Beam)
       Infinite Bomb Jump (Intermediate) or Use Spin Boost
@@ -2031,19 +2031,19 @@ Extra - asset_id: collision_camera_025_B
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorshieldmissile_001
   * Extra - right_shield_def: actordef:actors/props/doorshieldmissile/charclasses/doorshieldmissile.bmsad
   > Door from Chozo Warrior Arena
-      Morph Ball and Before Ghavoran - Ferenia Transport Grapple Block
+      Morph Ball and Before Ghavoran - Ferenia Transport Grapple Box
   > Total Recharge
       Trivial
   > Tile Group (SCREWATTACK)
       Morph Ball
   > Dock to Transport to Ferenia
-      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Enky Right and After Ghavoran - Ferenia Transport Grapple Block
-  > Event - Ferenia Transport Grapple Block
+      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Enky Right and After Ghavoran - Ferenia Transport Grapple Box
+  > Event - Ferenia Transport Grapple Box (Front)
       Grapple Beam and After Ghavoran - Ferenia Transport Enky Left
   > Event - Ferenia Transport Enky Left
       Destroy Enky
   > Event - Ferenia Transport Enky Right
-      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Grapple Block and Destroy Enky
+      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Grapple Box and Destroy Enky
 
 > Door to Teleport to Burenia (Power Beam); Heals? False
   * Layers: default
@@ -2119,17 +2119,17 @@ Extra - asset_id: collision_camera_025_B
   * Layers: default
   * Open Passage to Transport to Ferenia/Dock to Total Recharge Station North
   > Door to Teleport to Burenia (Missile)
-      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Enky Right and After Ghavoran - Ferenia Transport Grapple Block
-  > Event - Ferenia Transport Grapple Block
-      After Ghavoran - Ferenia Transport Enky Right and Break/Move Grapple Block from Behind
+      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Enky Right and After Ghavoran - Ferenia Transport Grapple Box
   > Event - Ferenia Transport Enky Left
-      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Grapple Block and Destroy Enky
+      After Ghavoran - Ferenia Transport Enky Right and After Ghavoran - Ferenia Transport Grapple Box and Destroy Enky
   > Event - Ferenia Transport Enky Right
       Destroy Enky
+  > Event - Ferenia Transport Grapple Box (Back)
+      After Ghavoran - Ferenia Transport Enky Right and Break/Move Grapple Block from Behind
 
-> Event - Ferenia Transport Grapple Block; Heals? False
+> Event - Ferenia Transport Grapple Box (Front); Heals? False
   * Layers: default
-  * Event Ghavoran - Ferenia Transport Grapple Block
+  * Event Ghavoran - Ferenia Transport Grapple Box
   > Door to Teleport to Burenia (Missile)
       Trivial
 
@@ -2156,6 +2156,12 @@ Extra - asset_id: collision_camera_025_B
 > Event - Ferenia Transport Enky Right; Heals? False
   * Layers: default
   * Event Ghavoran - Ferenia Transport Enky Right
+  > Dock to Transport to Ferenia
+      Trivial
+
+> Event - Ferenia Transport Grapple Box (Back); Heals? False
+  * Layers: default
+  * Event Ghavoran - Ferenia Transport Grapple Box
   > Dock to Transport to Ferenia
       Trivial
 

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -72,7 +72,7 @@ Extra - asset_id: collision_camera_001
   > Door to Robot Fight Arena
       Trivial
   > Grapple Block Alcove
-      After Ghavoran - grapplepulloff1x2_000 and Can Slide
+      After Ghavoran - Burenia Transport Grapple Block and Can Slide
 
 > Door to Super Missile Room; Heals? False
   * Layers: default
@@ -87,7 +87,7 @@ Extra - asset_id: collision_camera_001
       Trivial
   > Grapple Block Alcove
       All of the following:
-          Morph Ball and After Ghavoran - grapplepulloff1x2_000
+          Morph Ball and After Ghavoran - Burenia Transport Grapple Block
           Grapple Beam or Spider Magnet or Simple IBJ or Use Spin Boost
 
 > Pickup (Missile Tank); Heals? False
@@ -113,7 +113,7 @@ Extra - asset_id: collision_camera_001
           Gravity Suit or Space Jump or Speed Booster
   > Grapple Block Alcove
       All of the following:
-          Morph Ball and Before Ghavoran - grapplepulloff1x2_000
+          Morph Ball and Before Ghavoran - Burenia Transport Grapple Block
           Any of the following:
               Spider Magnet or Space Jump
               Flash Shift and Use Spin Boost
@@ -149,17 +149,17 @@ Extra - asset_id: collision_camera_001
 > Grapple Block Alcove; Heals? False
   * Layers: default
   > Door to Spider Magnet Elevator
-      Morph Ball and After Ghavoran - grapplepulloff1x2_000
+      Morph Ball and After Ghavoran - Burenia Transport Grapple Block
   > Door to Super Missile Room
-      After Ghavoran - grapplepulloff1x2_000 and Can Slide
+      After Ghavoran - Burenia Transport Grapple Block and Can Slide
   > Door to Transport to Burenia
-      Before Ghavoran - grapplepulloff1x2_000 and Can Slide
-  > Event - Pull Grapple Block (grapplepulloff1x2_000)
+      Before Ghavoran - Burenia Transport Grapple Block and Can Slide
+  > Event - Burenia Transport Grapple Block
       Grapple Beam
 
-> Event - Pull Grapple Block (grapplepulloff1x2_000); Heals? False
+> Event - Burenia Transport Grapple Block; Heals? False
   * Layers: default
-  * Event Ghavoran - grapplepulloff1x2_000
+  * Event Ghavoran - Burenia Transport Grapple Block
   > Grapple Block Alcove
       Trivial
 
@@ -2016,7 +2016,7 @@ Extra - asset_id: collision_camera_025_B
   * Extra - right_shield_def: None
   > Door to Teleport to Burenia (Missile)
       All of the following:
-          Morph Ball and Before Ghavoran - grapplepulloff1x2_002
+          Morph Ball and Before Ghavoran - Ferenia Transport Grapple Block
           Grapple Beam or Spider Magnet or Space Jump or Speed Booster or Walljump (Beginner) or Simple IBJ
   > Door to Teleport to Burenia (Power Beam)
       Infinite Bomb Jump (Intermediate) or Use Spin Boost
@@ -2031,19 +2031,19 @@ Extra - asset_id: collision_camera_025_B
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorshieldmissile_001
   * Extra - right_shield_def: actordef:actors/props/doorshieldmissile/charclasses/doorshieldmissile.bmsad
   > Door from Chozo Warrior Arena
-      Morph Ball and Before Ghavoran - grapplepulloff1x2_002
+      Morph Ball and Before Ghavoran - Ferenia Transport Grapple Block
   > Total Recharge
       Trivial
   > Tile Group (SCREWATTACK)
       Morph Ball
   > Dock to Transport to Ferenia
-      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Enky Right and After Ghavoran - grapplepulloff1x2_002
-  > Event - Pull Grapple Block (grapplepulloff1x2_002)
+      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Enky Right and After Ghavoran - Ferenia Transport Grapple Block
+  > Event - Ferenia Transport Grapple Block
       Grapple Beam and After Ghavoran - Ferenia Transport Enky Left
   > Event - Ferenia Transport Enky Left
       Destroy Enky
   > Event - Ferenia Transport Enky Right
-      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - grapplepulloff1x2_002 and Destroy Enky
+      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Grapple Block and Destroy Enky
 
 > Door to Teleport to Burenia (Power Beam); Heals? False
   * Layers: default
@@ -2119,17 +2119,17 @@ Extra - asset_id: collision_camera_025_B
   * Layers: default
   * Open Passage to Transport to Ferenia/Dock to Total Recharge Station North
   > Door to Teleport to Burenia (Missile)
-      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Enky Right and After Ghavoran - grapplepulloff1x2_002
-  > Event - Pull Grapple Block (grapplepulloff1x2_002)
+      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Enky Right and After Ghavoran - Ferenia Transport Grapple Block
+  > Event - Ferenia Transport Grapple Block
       After Ghavoran - Ferenia Transport Enky Right and Break/Move Grapple Block from Behind
   > Event - Ferenia Transport Enky Left
-      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - grapplepulloff1x2_002 and Destroy Enky
+      After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Grapple Block and Destroy Enky
   > Event - Ferenia Transport Enky Right
       Destroy Enky
 
-> Event - Pull Grapple Block (grapplepulloff1x2_002); Heals? False
+> Event - Ferenia Transport Grapple Block; Heals? False
   * Layers: default
-  * Event Ghavoran - grapplepulloff1x2_002
+  * Event Ghavoran - Ferenia Transport Grapple Block
   > Door to Teleport to Burenia (Missile)
       Trivial
 

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -862,6 +862,14 @@
                 "long_name": "Ghavoran - Ferenia Transport Enky Right",
                 "extra": {}
             },
+            "GhavoranGrappleBox1": {
+                "long_name": "Ghavoran - Burenia Transport Grapple Block",
+                "extra": {}
+            },
+            "GhavoranGrappleBox2": {
+                "long_name": "Ghavoran - Ferenia Transport Grapple Block",
+                "extra": {}
+            },
             "BureniaGhavoranTeleportEnky": {
                 "long_name": "Burenia - Ghavoran Teleport Enky",
                 "extra": {}

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -850,8 +850,8 @@
                 "long_name": "Ghavoran - Ammo Recharge Enky Below",
                 "extra": {}
             },
-            "GhavoranSuperRotatableEnky": {
-                "long_name": "Ghavoran - Super Missile Rotatable Enky",
+            "GhavoranBureniaTransportGrappleBox": {
+                "long_name": "Ghavoran - Burenia Transport Grapple Box",
                 "extra": {}
             },
             "GhavoranFereniaTransportEnkyLeft": {
@@ -862,12 +862,12 @@
                 "long_name": "Ghavoran - Ferenia Transport Enky Right",
                 "extra": {}
             },
-            "GhavoranGrappleBox1": {
-                "long_name": "Ghavoran - Burenia Transport Grapple Block",
+            "GhavoranFereniaTransportGrappleBox": {
+                "long_name": "Ghavoran - Ferenia Transport Grapple Box",
                 "extra": {}
             },
-            "GhavoranGrappleBox2": {
-                "long_name": "Ghavoran - Ferenia Transport Grapple Block",
+            "GhavoranSuperRotatableEnky": {
+                "long_name": "Ghavoran - Super Missile Rotatable Enky",
                 "extra": {}
             },
             "BureniaGhavoranTeleportEnky": {


### PR DESCRIPTION
The grapple blocks in Ghavoran were sharing events in pairs, causing some seeds to be incompletable due to triggering the other one in the pair first.

- Adds two new events: Burenia Transport Grapple Box and Ferenia Transport Grapple Box
- The former is in Right Entrance and the latter is in Total Recharge Station North, with both a front and a back to allow for pseudoing it
- Spin Boost Tower and Dairon Transport Access are unchanged