### PR TITLE
Dread: Redo logic for Melee Tutorial Room

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -1171,7 +1171,7 @@
                 "asset_id": "collision_camera_003"
             },
             "nodes": {
-                "Door from Proto EMMI Introduction": {
+                "Door to Proto EMMI Introduction (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1197,7 +1197,7 @@
                         "area_name": "Proto EMMI Introduction",
                         "node_name": "Door to Melee Tutorial Room (Lower)"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -1353,6 +1353,15 @@
                                     {
                                         "type": "template",
                                         "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -1398,7 +1407,7 @@
                         }
                     }
                 },
-                "Door to Proto EMMI Introduction": {
+                "Door to Proto EMMI Introduction (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1456,7 +1465,7 @@
                     "pickup_index": 31,
                     "major_location": false,
                     "connections": {
-                        "Door to Proto EMMI Introduction": {
+                        "Door to Proto EMMI Introduction (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1613,7 +1622,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from Proto EMMI Introduction": {
+                        "Door to Proto EMMI Introduction (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1707,7 +1716,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Door from Proto EMMI Introduction": {
+                        "Door to Proto EMMI Introduction (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1776,17 +1785,8 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Wave",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "template",
-                                        "data": "Shoot Diffusion Beam"
+                                        "data": "Shoot Diffusion or Wave"
                                     },
                                     {
                                         "type": "resource",
@@ -1826,8 +1826,13 @@
                             }
                         },
                         "Tile Group (BOMB)": {
-                            "type": "template",
-                            "data": "Can Slide"
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
+                            }
                         },
                         "Tunnel to Melee Tutorial West": {
                             "type": "and",
@@ -7972,7 +7977,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Melee Tutorial Room",
-                        "node_name": "Door from Proto EMMI Introduction"
+                        "node_name": "Door to Proto EMMI Introduction (Lower)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -8011,7 +8016,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Melee Tutorial Room",
-                        "node_name": "Door to Proto EMMI Introduction"
+                        "node_name": "Door to Proto EMMI Introduction (Upper)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -272,9 +272,9 @@ Melee Tutorial Room
 Extra - total_boundings: {'x1': 10800.0, 'x2': 14900.0, 'y1': -8500.0, 'y2': -1200.0}
 Extra - polygon: [[14900.0, -1200.0], [12800.0, -1200.0], [12800.0, -2000.0], [10800.0, -2000.0], [10800.0, -8500.0], [13800.0, -8500.0], [13800.0, -7000.0], [14900.0, -4100.0]]
 Extra - asset_id: collision_camera_003
-> Door from Proto EMMI Introduction; Heals? False
+> Door to Proto EMMI Introduction (Lower); Heals? False
   * Layers: default
-  * Access Closed to Proto EMMI Introduction/Door to Melee Tutorial Room (Lower)
+  * Access Locked to Proto EMMI Introduction/Door to Melee Tutorial Room (Lower)
   * Extra - actor_name: Door010 (CL-PW,OP)
   * Extra - actor_def: actordef:actors/props/doorclosedpower/charclasses/doorclosedpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -318,7 +318,7 @@ Extra - asset_id: collision_camera_003
   * Extra - actor_name: DoorEmmy11
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to Early Cloak Room
-      Walljump (Beginner) or Simple IBJ or Use Spin Boost
+      Speed Booster or Walljump (Beginner) or Simple IBJ or Use Spin Boost
   > Tile Group (BOMB)
       Morph Ball
 
@@ -330,7 +330,7 @@ Extra - asset_id: collision_camera_003
   > Near Missile Tank 1
       Morph Ball
 
-> Door to Proto EMMI Introduction; Heals? False
+> Door to Proto EMMI Introduction (Upper); Heals? False
   * Layers: default
   * Power Beam Door to Proto EMMI Introduction/Door to Melee Tutorial Room (Upper)
   * Extra - actor_name: Door055 (PW-PW)
@@ -347,7 +347,7 @@ Extra - asset_id: collision_camera_003
   * Pickup 31; Major Location? False
   * Extra - actor_name: item_missiletank_005
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Door to Proto EMMI Introduction
+  > Door to Proto EMMI Introduction (Upper)
       Trivial
   > East of Blob
       Trivial
@@ -384,7 +384,7 @@ Extra - asset_id: collision_camera_003
 > Tunnel to Melee Tutorial West; Heals? False
   * Layers: default
   * Slide Tunnel to Melee Tutorial West/Tunnel to Melee Tutorial Room
-  > Door from Proto EMMI Introduction
+  > Door to Proto EMMI Introduction (Lower)
       Trivial
   > Near Missile Tank 1
       Any of the following:
@@ -399,7 +399,7 @@ Extra - asset_id: collision_camera_003
 
 > West of Blob; Heals? False; Spawn Point
   * Layers: default
-  > Door from Proto EMMI Introduction
+  > Door to Proto EMMI Introduction (Lower)
       Trivial
   > Door to Save Station South
       After Artaria - Proto EMMI Blob
@@ -408,14 +408,14 @@ Extra - asset_id: collision_camera_003
   > East of Blob
       Morph Ball and After Artaria - Proto EMMI Blob
   > Event - Proto EMMI Blob (West Side)
-      Wave Beam or Pseudo-Wave Beam (Beginner) or Shoot Diffusion Beam
+      Pseudo-Wave Beam (Beginner) or Shoot Diffusion or Wave
 
 > Near Missile Tank 1; Heals? False
   * Layers: default
   > Pickup (Missile Tank 1)
       Morph Ball
   > Tile Group (BOMB)
-      Can Slide
+      Morph Ball
   > Tunnel to Melee Tutorial West
       Trivial
 
@@ -1804,7 +1804,7 @@ Extra - polygon: [[17800.0, -1200.0], [14800.0, -1200.0], [14800.0, -3700.0], [1
 Extra - asset_id: collision_camera_016
 > Door to Melee Tutorial Room (Lower); Heals? False
   * Layers: default
-  * Power Beam Door to Melee Tutorial Room/Door from Proto EMMI Introduction
+  * Power Beam Door to Melee Tutorial Room/Door to Proto EMMI Introduction (Lower)
   * Extra - actor_name: Door010 (CL-PW,OP)
   * Extra - actor_def: actordef:actors/props/doorclosedpower/charclasses/doorclosedpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1816,7 +1816,7 @@ Extra - asset_id: collision_camera_016
 
 > Door to Melee Tutorial Room (Upper); Heals? False
   * Layers: default
-  * Power Beam Door to Melee Tutorial Room/Door to Proto EMMI Introduction
+  * Power Beam Door to Melee Tutorial Room/Door to Proto EMMI Introduction (Upper)
   * Extra - actor_name: Door055 (PW-PW)
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}


### PR DESCRIPTION
Changes a few things and adds a Speed option to going from EMMI Zone Entrance Hallway to Early Cloak Room. Unchanged for the most part.