### PR TITLE
Warn when loading a game that wasn't created on the current patch, and don't save over it

### DIFF
--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -328,6 +328,7 @@ class DreadPatchDataFactory(BasePatchDataFactory):
             ],
             "hints": self._encode_hints(),
             "text_patches": self._static_text_changes(),
+            "shareable_hash": self.description.shareable_hash,
             "cosmetic_patches": self._cosmetic_patch_data(),
             "immediate_energy_parts": self.configuration.immediate_energy_parts,
             "game_patches": {

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -245,6 +245,15 @@ class DreadPatchDataFactory(BasePatchDataFactory):
             full_hash
         ])
 
+        # Warning message for continuing a non-rando game file
+        text["GUI_WARNING_NOT_RANDO_GAME_1"] = "|".join([
+            r"{c1}Warning!{c0}",
+            "You have continued a game that was not started with the current Randovania patches enabled."
+        ])
+        text["GUI_WARNING_NOT_RANDO_GAME_2"] = "|".join([
+            "You must start a New Game when using Randovania. Some parts of this file may not work correctly."
+        ])
+
         return text
     
     def _cosmetic_patch_data(self) -> dict:


### PR DESCRIPTION
This is a companion PR to randovania/open-dread-rando#84. The full description of the changes are in that PR; this PR provides the necessary data patches that the patcher needs for this change.