### PR TITLE
Dread: Redo logic for Proto EMMI Introduction

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -1550,7 +1550,15 @@
                             "type": "and",
                             "data": {
                                 "comment": "Connection required to make things easier on the generator",
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Connection required to make things easier on the generator",
+                                            "items": []
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "West of Blob": {

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -1015,6 +1015,27 @@
                                     {
                                         "type": "template",
                                         "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Slide"
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -1528,7 +1549,7 @@
                         "Pickup (Missile Tank 2)": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "Connection required to make things easier on the generator",
                                 "items": []
                             }
                         },
@@ -8046,7 +8067,7 @@
                         "Tile Group (BOMB)": {
                             "type": "and",
                             "data": {
-                                "comment": "TODO: Check if it's viable to get this with ice missiles?",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
@@ -8074,6 +8095,36 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Ice Missile"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "ElunReleaseX",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -8167,33 +8218,101 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Space",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Tile Group (BOMB)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Flash",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Space",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Spin",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Flash",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Spin",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Speed",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Simple IBJ"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -239,7 +239,9 @@ Extra - asset_id: collision_camera_002
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to Navigation Station South
-      Simple IBJ or Use Spin Boost
+      Any of the following:
+          Simple IBJ or Use Spin Boost
+          Speed Booster and Can Slide
   > Tunnel to Melee Tutorial Room
       Trivial
 
@@ -1827,9 +1829,10 @@ Extra - asset_id: collision_camera_016
       After Artaria - Proto Central Unit or Can Slide
   > Tile Group (BOMB)
       All of the following:
-          # TODO: Check if it's viable to get this with ice missiles?
           Morph Ball
-          Flash Shift or Use Spin Boost
+          Any of the following:
+              Flash Shift or Use Spin Boost
+              After Elun - Release X Parasites and Movement (Beginner) and Shoot Ice Missile
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -1851,9 +1854,14 @@ Extra - asset_id: collision_camera_016
   > Door to Melee Tutorial Room (Lower)
       After Artaria - Proto Central Unit
   > Door to Melee Tutorial Room (Upper)
-      Space Jump and After Artaria - Proto Central Unit
-  > Tile Group (BOMB)
-      Flash Shift and Simple IBJ
+      All of the following:
+          After Artaria - Proto Central Unit
+          Any of the following:
+              Space Jump
+              Spin Boost and Walljump (Beginner)
+              All of the following:
+                  Flash Shift or Spin Boost
+                  Speed Booster or Simple IBJ
 
 > Tile Group (BOMB); Heals? False
   * Layers: default


### PR DESCRIPTION
- Changes up some logic for Artaria - Proto EMMI Introduction, including the Ice Missile method for reaching the item
- Adds a comment to "East of Blob" > "Pickup (Missile) 2" in Melee Tutorial Room explaining why the pickup is required
- Adds speed option to go from "Door to Charge Tutorial" > "Door to Navigation Station South" in Melee Tutorial West