### PR TITLE
Dread: Remove all Speed Booster Tile Groups + some extra

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -4217,11 +4217,13 @@
                                 "items": []
                             }
                         },
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "and",
+                        "Tunnel to Teleport to Dairon": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -4330,80 +4332,6 @@
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 2200.0,
-                        "y": 4000.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_039",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tunnel to Teleport to Dairon": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 1400.0,
-                        "y": 4000.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_040",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Dock to Shinespark Tower to Grapple": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Tunnel to Teleport to Dairon": {
                     "node_type": "dock",
                     "heal": false,
@@ -4434,11 +4362,13 @@
                                 "items": []
                             }
                         },
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "and",
+                        "Dock to Shinespark Tower to Grapple": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -4576,32 +4506,6 @@
                             "data": {
                                 "comment": null,
                                 "items": []
-                            }
-                        },
-                        "Tunnel to EMMI Zone Exit Northwest": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Knowledge",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
                             }
                         }
                     }
@@ -5033,30 +4937,8 @@
                             }
                         },
                         "Tunnel to EMMI Zone Exit Northwest": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Space",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Ballspark"
                         }
                     }
                 },
@@ -14910,95 +14792,46 @@
                     "pickup_index": 21,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (POWERBEAM)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -5293.451920598092,
-                        "y": 1047.125547821603,
-                        "z": 0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_060",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
                         "Tunnel to EMMI Zone Hub": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -6000.0,
-                        "y": 1300.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_061",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Missile Tank)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Tile Group (POWERBEAM)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Bomb"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "PBAmmo",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Diffusion or Wave"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -15026,14 +14859,9 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (POWERBEAM)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
+                        "Pickup (Missile Tank)": {
+                            "type": "template",
+                            "data": "Ballspark"
                         }
                     }
                 },
@@ -24114,36 +23942,6 @@
                 "asset_id": "collision_camera_083"
             },
             "nodes": {
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -14900.0,
-                        "y": -7300.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_013",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Dock to Speed Hallway": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Dock to Speed Hallway": {
                     "node_type": "dock",
                     "heal": false,
@@ -24167,11 +23965,13 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
+                        "Start Point": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -24190,11 +23990,13 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
+                        "Dock to Speed Hallway": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -24432,7 +24234,7 @@
                     "pickup_index": 15,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 1": {
+                        "Dock to Speed Booster Bonus Room": {
                             "type": "template",
                             "data": "Can Slide"
                         }
@@ -24496,10 +24298,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Red Chozo Arena": {
-                            "type": "template",
-                            "data": "Can Slide"
-                        },
                         "Tile Group (MISSILE)": {
                             "type": "and",
                             "data": {
@@ -24507,12 +24305,9 @@
                                 "items": []
                             }
                         },
-                        "Tile Group (SPEEDBOOST) 5": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                        "Dock to Speed Booster Bonus Room": {
+                            "type": "template",
+                            "data": "Can Slide"
                         }
                     }
                 },
@@ -24547,24 +24342,6 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Pickup (Energy Part)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Door to Cold Introduction": {
-                            "type": "template",
-                            "data": "Can Slide"
-                        },
-                        "Tile Group (SPEEDBOOST) 3": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 4": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -24608,195 +24385,25 @@
                                 "items": []
                             }
                         },
-                        "Tile Group (SPEEDBOOST) 3": {
-                            "type": "and",
+                        "Dock to Speed Booster Bonus Room": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -10300.0,
-                        "y": -7100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_009",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Missile+ Tank)": {
-                            "type": "template",
-                            "data": "Can Slide"
-                        },
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -11400.0,
-                        "y": -7100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_010",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 4": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 3": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -13300.0,
-                        "y": -7600.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_011",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Red Chozo Arena": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (MISSILE)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 4": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -12800.0,
-                        "y": -7100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_012",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Red Chozo Arena": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 5": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -9700.0,
-                        "y": -8700.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_041",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Cold Introduction": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tunnel to Cold Introduction": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -24824,11 +24431,78 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Pickup (Missile+ Tank)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Door to Cold Introduction": {
+                            "type": "template",
+                            "data": "Can Slide"
+                        },
                         "Door to Red Chozo Arena": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        },
+                        "Tile Group (MISSILE)": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tunnel to Cold Introduction": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -24856,14 +24530,9 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 5": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
+                        "Door to Cold Introduction": {
+                            "type": "template",
+                            "data": "Ballspark"
                         }
                     }
                 },

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -972,8 +972,8 @@ Extra - asset_id: collision_camera_009
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Tile Group (POWERBEAM)
       Trivial
-  > Tile Group (SPEEDBOOST) 2
-      Trivial
+  > Tunnel to Teleport to Dairon
+      Speed Booster
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -1007,37 +1007,13 @@ Extra - asset_id: collision_camera_009
   > Pickup (Missile Tank)
       Trivial
 
-> Tile Group (SPEEDBOOST) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_039
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Tile Group (SPEEDBOOST) 2
-      Trivial
-  > Tunnel to Teleport to Dairon
-      Trivial
-
-> Tile Group (SPEEDBOOST) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_040
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Dock to Shinespark Tower to Grapple
-      Trivial
-  > Tile Group (SPEEDBOOST) 1
-      Trivial
-
 > Tunnel to Teleport to Dairon; Heals? False
   * Layers: default
   * Slide Tunnel to Teleport to Dairon/Tunnel to EMMI Zone Exit North
   > Door to EMMI Zone Dome
       Trivial
-  > Tile Group (SPEEDBOOST) 1
-      Trivial
+  > Dock to Shinespark Tower to Grapple
+      Speed Booster
 
 > Tunnel to EMMI Zone Dome; Heals? False
   * Layers: default
@@ -1066,8 +1042,6 @@ Extra - asset_id: collision_camera_010
   * Extra - right_shield_def: actordef:actors/props/doorwavebeam/charclasses/doorwavebeam.bmsad
   > Door to EMMI Zone Exit Southwest (DoorFrame_004)
       Trivial
-  > Tunnel to EMMI Zone Exit Northwest
-      Morph Ball and Knowledge (Beginner)
 
 > Door to EMMI Zone Exit Southwest (DoorFrame_004); Heals? False
   * Layers: default
@@ -1157,7 +1131,7 @@ Extra - asset_id: collision_camera_010
               Grapple Beam or Space Jump
               Spider Magnet and Use Spin Boost
   > Tunnel to EMMI Zone Exit Northwest
-      Space Jump or Speed Booster
+      Ballspark
 
 > Event - Water Device; Heals? False
   * Layers: default
@@ -3302,38 +3276,16 @@ Extra - asset_id: collision_camera_051
   * Pickup 21; Major Location? False
   * Extra - actor_name: item_missiletank_004
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Tile Group (SPEEDBOOST)
-      Morph Ball
-
-> Tile Group (POWERBEAM); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_060
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-  > Tile Group (SPEEDBOOST)
-      Morph Ball
   > Tunnel to EMMI Zone Hub
-      Morph Ball
-
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_061
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Missile Tank)
-      Morph Ball
-  > Tile Group (POWERBEAM)
-      Morph Ball
+      All of the following:
+          Morph Ball
+          Power Bombs or Lay Bomb or Shoot Diffusion or Wave
 
 > Tunnel to EMMI Zone Hub; Heals? False
   * Layers: default
   * Morph Ball Tunnel to EMMI Zone Hub/Tunnel to EMMI Zone Exit Northwest
-  > Tile Group (POWERBEAM)
-      Morph Ball
+  > Pickup (Missile Tank)
+      Ballspark
 
 > Tunnel to Teleport to Cataris; Heals? False
   * Layers: default
@@ -5341,26 +5293,16 @@ Speed Booster Bonus Room
 Extra - total_boundings: {'x1': -16900.0, 'x2': -14800.0, 'y1': -7500.0, 'y2': -6358.0}
 Extra - polygon: [[-14800.0, -6358.0], [-16900.0, -6358.0], [-16900.0, -7500.0], [-14800.0, -7500.0]]
 Extra - asset_id: collision_camera_083
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_013
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Dock to Speed Hallway
-      Trivial
-
 > Dock to Speed Hallway; Heals? False
   * Layers: default
   * Open Passage to Speed Hallway/Dock to Speed Booster Bonus Room
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Start Point
+      Speed Booster
 
 > Start Point; Heals? False; Spawn Point
   * Layers: default
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Dock to Speed Hallway
+      Speed Booster
 
 ----------------
 Shortcut to Screw Attack
@@ -5414,7 +5356,7 @@ Extra - asset_id: collision_camera_086
   * Pickup 15; Major Location? False
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
-  > Tile Group (SPEEDBOOST) 1
+  > Dock to Speed Booster Bonus Room
       Can Slide
 
 > Pickup (Energy Part); Heals? False
@@ -5434,12 +5376,10 @@ Extra - asset_id: collision_camera_086
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Red Chozo Arena
-      Can Slide
   > Tile Group (MISSILE)
       Trivial
-  > Tile Group (SPEEDBOOST) 5
-      Trivial
+  > Dock to Speed Booster Bonus Room
+      Can Slide
 
 > Door to Red Chozo Arena; Heals? False
   * Layers: default
@@ -5451,12 +5391,6 @@ Extra - asset_id: collision_camera_086
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Pickup (Energy Part)
-      Trivial
-  > Door to Cold Introduction
-      Can Slide
-  > Tile Group (SPEEDBOOST) 3
-      Trivial
-  > Tile Group (SPEEDBOOST) 4
       Trivial
   > Dock to Speed Booster Bonus Room
       Trivial
@@ -5470,80 +5404,28 @@ Extra - asset_id: collision_camera_086
   * Extra - tile_types: ('MISSILE',)
   > Door to Cold Introduction
       Trivial
-  > Tile Group (SPEEDBOOST) 3
-      Trivial
-
-> Tile Group (SPEEDBOOST) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_009
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Missile+ Tank)
-      Can Slide
-  > Tile Group (SPEEDBOOST) 2
-      Trivial
-
-> Tile Group (SPEEDBOOST) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_010
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Tile Group (SPEEDBOOST) 1
-      Trivial
-  > Tile Group (SPEEDBOOST) 4
-      Trivial
-
-> Tile Group (SPEEDBOOST) 3; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_011
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to Red Chozo Arena
-      Trivial
-  > Tile Group (MISSILE)
-      Trivial
-
-> Tile Group (SPEEDBOOST) 4; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_012
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to Red Chozo Arena
-      Trivial
-  > Tile Group (SPEEDBOOST) 2
-      Trivial
-
-> Tile Group (SPEEDBOOST) 5; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_041
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to Cold Introduction
-      Trivial
-  > Tunnel to Cold Introduction
-      Morph Ball
+  > Dock to Speed Booster Bonus Room
+      Speed Booster or Can Slide
 
 > Dock to Speed Booster Bonus Room; Heals? False
   * Layers: default
   * Open Passage to Speed Booster Bonus Room/Dock to Speed Hallway
+  > Pickup (Missile+ Tank)
+      Speed Booster and Can Slide
+  > Door to Cold Introduction
+      Can Slide
   > Door to Red Chozo Arena
       Trivial
+  > Tile Group (MISSILE)
+      Speed Booster or Can Slide
+  > Tunnel to Cold Introduction
+      Speed Booster and Can Slide
 
 > Tunnel to Cold Introduction; Heals? False
   * Layers: default
   * Morph Ball Tunnel to Cold Introduction/Tunnel to Speed Hallway
-  > Tile Group (SPEEDBOOST) 5
-      Morph Ball
+  > Door to Cold Introduction
+      Ballspark
 
 > Start Point; Heals? False; Spawn Point
   * Layers: default

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -8531,11 +8531,30 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
+                        "Door to Early Gravity Speedboost Room 1 (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "BureniaEarlyGravEPart",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Top of Enky Shaft": {
@@ -8583,11 +8602,30 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
+                        "Door to Early Gravity Speedboost Room 1 (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "BureniaEarlyGravEPart",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -8866,43 +8904,6 @@
                         "Top of Enky Shaft": {
                             "type": "template",
                             "data": "Can Slide"
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 1100.0,
-                        "y": -4900.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_017",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Early Gravity Speedboost Room 1 (Upper)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Door to Early Gravity Speedboost Room 1 (Lower)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
                         }
                     }
                 },
@@ -9654,6 +9655,13 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Event - Early Gravity Energy Part": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -9749,43 +9757,6 @@
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 3100.0,
-                        "y": -8200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_013",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (POWERBEAM) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Dock to Early Gravity Speedboost Room 2 (Lower)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Tile Group (POWERBEAM) 1": {
                     "node_type": "configurable_node",
                     "heal": false,
@@ -9814,7 +9785,7 @@
                                 "items": []
                             }
                         },
-                        "Tile Group (SPEEDBOOST)": {
+                        "Dock to Early Gravity Speedboost Room 2 (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -10166,11 +10137,13 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
+                        "Tile Group (POWERBEAM) 1": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -10208,6 +10181,30 @@
                             }
                         }
                     }
+                },
+                "Event - Early Gravity Energy Part": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 3400.0,
+                        "y": -5200.0,
+                        "z": 0.0
+                    },
+                    "description": "Event added to account for door rando as it would otherwise be impossible to\nuse the speed blocks just outside\n\n",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "BureniaEarlyGravEPart",
+                    "connections": {
+                        "Door to Teleport to Ghavoran (Upper)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -10242,70 +10239,6 @@
                 "asset_id": "collision_camera_019"
             },
             "nodes": {
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 1700.0,
-                        "y": -8200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_012",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Dock to Early Gravity Speedboost Room 1 (Lower)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Slope Top": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Walljump",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
                 "Dock to Early Gravity Speedboost Room 1 (Upper)": {
                     "node_type": "dock",
                     "heal": false,
@@ -10393,11 +10326,42 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
+                        "Slope Top": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spin Boost"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Walljump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -10503,13 +10467,6 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Dock to Early Gravity Speedboost Room 1 (Upper)": {
                             "type": "or",
                             "data": {
@@ -10589,6 +10546,15 @@
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Dock to Early Gravity Speedboost Room 1 (Lower)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Water Pit": {

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -1713,8 +1713,8 @@ Extra - asset_id: collision_camera_015
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Door to Early Gravity Speedboost Room 1 (Lower)
+      Speed Booster and After Burenia - Early Gravity Energy Part
   > Top of Enky Shaft
       After Burenia - Ghavoran Teleport Enky
   > Event - Destroy all Enkys
@@ -1729,8 +1729,8 @@ Extra - asset_id: collision_camera_015
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Door to Early Gravity Speedboost Room 1 (Upper)
+      Speed Booster and After Burenia - Early Gravity Energy Part
 
 > Door to Main Hub Tower Middle (Charge); Heals? False
   * Layers: default
@@ -1809,18 +1809,6 @@ Extra - asset_id: collision_camera_015
       Trivial
   > Top of Enky Shaft
       Can Slide
-
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_017
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to Early Gravity Speedboost Room 1 (Upper)
-      Trivial
-  > Door to Early Gravity Speedboost Room 1 (Lower)
-      Trivial
 
 > Top of Enky Shaft; Heals? False
   * Layers: default
@@ -2004,6 +1992,8 @@ Extra - asset_id: collision_camera_018
   * Extra - right_shield_def: None
   > Pickup (Energy Part)
       Trivial
+  > Event - Early Gravity Energy Part
+      Trivial
 
 > Door to Teleport to Ghavoran (Lower); Heals? False
   * Layers: default
@@ -2033,18 +2023,6 @@ Extra - asset_id: collision_camera_018
   > Tile Group (POWERBEAM) 1
       Trivial
 
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_013
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Tile Group (POWERBEAM) 1
-      Trivial
-  > Dock to Early Gravity Speedboost Room 2 (Lower)
-      Trivial
-
 > Tile Group (POWERBEAM) 1; Heals? False
   * Layers: default
   * Configurable Node
@@ -2054,7 +2032,7 @@ Extra - asset_id: collision_camera_018
   * Extra - tile_types: ('POWERBEAM',)
   > Pickup (Missile+ Tank)
       Trivial
-  > Tile Group (SPEEDBOOST)
+  > Dock to Early Gravity Speedboost Room 2 (Lower)
       Trivial
   > Tunnel to Gravity Suit Tower
       Morph Ball
@@ -2103,8 +2081,8 @@ Extra - asset_id: collision_camera_018
 > Dock to Early Gravity Speedboost Room 2 (Lower); Heals? False
   * Layers: default
   * Open Passage to Early Gravity Speedboost Room 2/Dock to Early Gravity Speedboost Room 1 (Lower)
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Tile Group (POWERBEAM) 1
+      Speed Booster
 
 > Tunnel to Gravity Suit Tower; Heals? False
   * Layers: default
@@ -2112,23 +2090,21 @@ Extra - asset_id: collision_camera_018
   > Tile Group (POWERBEAM) 1
       Morph Ball
 
+> Event - Early Gravity Energy Part; Heals? False
+  * Layers: default
+  * Event Burenia - Early Gravity Energy Part
+  * Event added to account for door rando as it would otherwise be impossible to
+use the speed blocks just outside
+
+
+  > Door to Teleport to Ghavoran (Upper)
+      Trivial
+
 ----------------
 Early Gravity Speedboost Room 2
 Extra - total_boundings: {'x1': -700.0, 'x2': 2100.0, 'y1': -8300.0, 'y2': -6000.0}
 Extra - polygon: [[2100.0, -6000.0], [-700.0, -6000.0], [-700.0, -8300.0], [2100.0, -8300.0]]
 Extra - asset_id: collision_camera_019
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_012
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Dock to Early Gravity Speedboost Room 1 (Lower)
-      Trivial
-  > Slope Top
-      Speed Booster or Walljump (Beginner) or Simple IBJ or Use Spin Boost
-
 > Dock to Early Gravity Speedboost Room 1 (Upper); Heals? False
   * Layers: default
   * Open Passage to Early Gravity Speedboost Room 1/Dock to Early Gravity Speedboost Room 2 (Upper)
@@ -2140,8 +2116,8 @@ Extra - asset_id: collision_camera_019
 > Dock to Early Gravity Speedboost Room 1 (Lower); Heals? False
   * Layers: default
   * Open Passage to Early Gravity Speedboost Room 1/Dock to Early Gravity Speedboost Room 2 (Lower)
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Slope Top
+      Speed Booster or Walljump (Beginner) or Lay Cross Comb or Simple IBJ or Use Spin Boost
 
 > Water Pit; Heals? False
   * Layers: default
@@ -2156,14 +2132,14 @@ Extra - asset_id: collision_camera_019
 
 > Slope Top; Heals? False
   * Layers: default
-  > Tile Group (SPEEDBOOST)
-      Trivial
   > Dock to Early Gravity Speedboost Room 1 (Upper)
       Any of the following:
           Space Jump
           All of the following:
               Spider Magnet or Walljump (Beginner)
               Flash Shift or Grapple Beam or Use Spin Boost
+  > Dock to Early Gravity Speedboost Room 1 (Lower)
+      Speed Booster
   > Water Pit
       Trivial
 

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -11611,13 +11611,11 @@
                     "pickup_index": 53,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "resource",
+                        "Lower Center": {
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Gravity",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -11951,45 +11949,6 @@
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -13000.0,
-                        "y": 1300.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_069",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Missile Tank - Bottom)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Gravity",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Lower Center": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Tile Group (POWERBEAM) 2": {
                     "node_type": "configurable_node",
                     "heal": false,
@@ -12011,6 +11970,36 @@
                         ]
                     },
                     "connections": {
+                        "Pickup (Missile Tank - Bottom)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Lower Center": {
                             "type": "and",
                             "data": {
@@ -12127,15 +12116,6 @@
                         "Event - Lower-left Tunnel Blob": {
                             "type": "template",
                             "data": "Shoot Beam"
-                        },
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Gravity",
-                                "amount": 1,
-                                "negate": false
-                            }
                         },
                         "Tile Group (POWERBEAM) 2": {
                             "type": "resource",
@@ -23591,30 +23571,13 @@
                     "pickup_index": 44,
                     "major_location": true,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "and",
+                        "Dock to Underlava Puzzle Room 1": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -23642,148 +23605,6 @@
                             "data": {
                                 "comment": null,
                                 "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3800.0,
-                        "y": -6500.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_000",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "resource",
-                            "data": {
-                                "type": "events",
-                                "name": "s020_magma:default:grapplepulloff1x2_000",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Dock to Underlava Puzzle Room 1": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "damage",
-                                            "name": "Lava",
-                                            "amount": 400,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3800.0,
-                        "y": -6300.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_001",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Energy Part)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Space",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "resource",
-                            "data": {
-                                "type": "events",
-                                "name": "s020_magma:default:grapplepulloff1x2_000",
-                                "amount": 1,
-                                "negate": false
                             }
                         }
                     }
@@ -24279,8 +24100,8 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "or",
+                        "Pickup (Energy Part)": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -24294,12 +24115,67 @@
                                         }
                                     },
                                     {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    },
+                                    {
                                         "type": "resource",
                                         "data": {
-                                            "type": "damage",
-                                            "name": "Lava",
-                                            "amount": 400,
+                                            "type": "events",
+                                            "name": "s020_magma:default:grapplepulloff1x2_000",
+                                            "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Flash",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Speedbooster",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -24340,81 +24216,6 @@
                 "asset_id": "collision_camera_054"
             },
             "nodes": {
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -4800.0,
-                        "y": -6500.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_024",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Dock to Underlava Puzzle Room 2": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "damage",
-                                            "name": "Lava",
-                                            "amount": 400,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Dock to Teleport to Dairon": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "damage",
-                                            "name": "Lava",
-                                            "amount": 400,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
                 "Dock to Underlava Puzzle Room 2": {
                     "node_type": "dock",
                     "heal": false,
@@ -24438,30 +24239,13 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "or",
+                        "Dock to Teleport to Dairon": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "damage",
-                                            "name": "Lava",
-                                            "amount": 400,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "type": "items",
+                                "name": "Gravity",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -24489,8 +24273,8 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "or",
+                        "Dock to Underlava Puzzle Room 2": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -24504,13 +24288,8 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "damage",
-                                            "name": "Lava",
-                                            "amount": 400,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Ballspark"
                                     }
                                 ]
                             }

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -2185,8 +2185,8 @@ Extra - asset_id: collision_camera_026
   * Pickup 53; Major Location? False
   * Extra - actor_name: item_missiletank_006
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Tile Group (SPEEDBOOST)
-      Gravity Suit
+  > Lower Center
+      Trivial
 
 > Event - Lower-left Tunnel Blob; Heals? False
   * Layers: default
@@ -2250,18 +2250,6 @@ Extra - asset_id: collision_camera_026
   > Top room
       Trivial
 
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_069
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Missile Tank - Bottom)
-      Gravity Suit
-  > Lower Center
-      Trivial
-
 > Tile Group (POWERBEAM) 2; Heals? False
   * Layers: default
   * Configurable Node
@@ -2269,6 +2257,8 @@ Extra - asset_id: collision_camera_026
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
+  > Pickup (Missile Tank - Bottom)
+      Gravity Suit and Speed Booster and Can Slide
   > Lower Center
       Trivial
 
@@ -2292,8 +2282,6 @@ Extra - asset_id: collision_camera_026
   * Layers: default
   > Event - Lower-left Tunnel Blob
       Shoot Beam
-  > Tile Group (SPEEDBOOST)
-      Gravity Suit
   > Tile Group (POWERBEAM) 2
       Gravity Suit
   > Tile Group (POWERBEAM) 3
@@ -4424,8 +4412,8 @@ Extra - asset_id: collision_camera_053
   * Pickup 44; Major Location? True
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
-  > Tile Group (SPEEDBOOST) 2
-      Gravity Suit and Morph Ball
+  > Dock to Underlava Puzzle Room 1
+      Morph Ball
 
 > Event - Lava Grapple Block (grapplepulloff1x2_000); Heals? False
   * Layers: default
@@ -4434,32 +4422,6 @@ Extra - asset_id: collision_camera_053
   * Extra - actor_def: actordef:actors/props/grapplepulloff1x2/charclasses/grapplepulloff1x2.bmsad
   > Below Lava
       Trivial
-
-> Tile Group (SPEEDBOOST) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_000
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Tile Group (SPEEDBOOST) 2
-      After Cataris - grapplepulloff1x2_000
-  > Dock to Underlava Puzzle Room 1
-      Gravity Suit or Lava Damage ≥ 400
-
-> Tile Group (SPEEDBOOST) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_001
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Energy Part)
-      All of the following:
-          Gravity Suit and Morph Ball
-          Space Jump or Speed Booster
-  > Tile Group (SPEEDBOOST) 1
-      After Cataris - grapplepulloff1x2_000
 
 > Tile Group (POWERBEAM) 1; Heals? False
   * Layers: default
@@ -4542,37 +4504,29 @@ Extra - asset_id: collision_camera_053
 > Dock to Underlava Puzzle Room 1; Heals? False
   * Layers: default
   * Open Passage to Underlava Puzzle Room 1/Dock to Underlava Puzzle Room 2
-  > Tile Group (SPEEDBOOST) 1
-      Gravity Suit or Lava Damage ≥ 400
+  > Pickup (Energy Part)
+      All of the following:
+          Gravity Suit and After Cataris - grapplepulloff1x2_000 and Ballspark
+          Any of the following:
+              Flash Shift or Simple IBJ or Use Spin Boost
+              Speedbooster Conservation (Intermediate) and Walljump (Beginner)
 
 ----------------
 Underlava Puzzle Room 1
 Extra - total_boundings: {'x1': -6700.0, 'x2': -4600.0, 'y1': -6600.0, 'y2': -5458.0}
 Extra - polygon: [[-4600.0, -5458.0], [-6700.0, -5458.0], [-6700.0, -6600.0], [-4600.0, -6600.0]]
 Extra - asset_id: collision_camera_054
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_024
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Dock to Underlava Puzzle Room 2
-      Gravity Suit or Lava Damage ≥ 400
-  > Dock to Teleport to Dairon
-      Gravity Suit or Lava Damage ≥ 400
-
 > Dock to Underlava Puzzle Room 2; Heals? False
   * Layers: default
   * Open Passage to Underlava Puzzle Room 2/Dock to Underlava Puzzle Room 1
-  > Tile Group (SPEEDBOOST)
-      Gravity Suit or Lava Damage ≥ 400
+  > Dock to Teleport to Dairon
+      Gravity Suit
 
 > Dock to Teleport to Dairon; Heals? False
   * Layers: default
   * Open Passage to Teleport to Dairon/Dock to Underlava Puzzle Room 1
-  > Tile Group (SPEEDBOOST)
-      Gravity Suit or Lava Damage ≥ 400
+  > Dock to Underlava Puzzle Room 2
+      Gravity Suit and Ballspark
 
 ----------------
 EMMI Zone Hidden Missile Room

--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -439,6 +439,15 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Event - Speed Booster blocks Destroyed": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
+                            }
                         }
                     }
                 },
@@ -652,6 +661,15 @@
                                 "items": []
                             }
                         },
+                        "Wide Beam Block - Adjacent": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "DaironTeleportToArtariaSpeedBlocksDestroyed",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
                         "Top Floor": {
                             "type": "and",
                             "data": {
@@ -662,23 +680,6 @@
                                         "data": {
                                             "type": "events",
                                             "name": "DaironTeleportToArtariaSpeedBlocksDestroyed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Event - Speed Booster blocks Destroyed": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -1918,14 +1919,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from Yellow EMMI Introduction": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST)": {
+                        "Door to Yellow EMMI Introduction": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1960,16 +1954,18 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
+                        "Dock to Hub Access": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "events",
+                                "name": "DaironEMMIExitEastSpeedBlocks",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
                 },
-                "Door from Yellow EMMI Introduction": {
+                "Door to Yellow EMMI Introduction": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1995,7 +1991,7 @@
                         "area_name": "Yellow EMMI Introduction",
                         "node_name": "Door to EMMI Zone Exit East"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -2005,37 +2001,42 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Dock to East Transport to Ferenia": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "DaironEMMIExitEastSpeedBlocks",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Event - Speed Blocks Destroyed": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
+                            }
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
+                "Event - Speed Blocks Destroyed": {
+                    "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 11600.0,
-                        "y": 5800.0,
+                        "x": 11750.0,
+                        "y": 5900.0,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "Event added because a speed cannot be bulit in the transport to Ferenia,\ntherefore leading to death upon entry\n\n",
                     "layers": [
                         "default"
                     ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_025",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
+                    "extra": {},
+                    "event_name": "DaironEMMIExitEastSpeedBlocks",
                     "connections": {
-                        "Dock to Hub Access": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Dock to East Transport to Ferenia": {
                             "type": "and",
                             "data": {
@@ -5138,30 +5139,11 @@
                     "pickup_index": 55,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 2": {
+                        "Lava Floor with Gravity Suit": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }
@@ -5876,156 +5858,6 @@
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 10900.0,
-                        "y": -2200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_064",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Lava Floor with Gravity Suit": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 11600.0,
-                        "y": -2200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_065",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Missile Tank Speedboost)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
                 "Ledge before Slide Jump": {
                     "node_type": "generic",
                     "heal": false,
@@ -6356,6 +6188,27 @@
                     ],
                     "extra": {},
                     "connections": {
+                        "Pickup (Missile Tank Speedboost)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    }
+                                ]
+                            }
+                        },
                         "Door to Early Grapple Access": {
                             "type": "and",
                             "data": {
@@ -6436,32 +6289,6 @@
                                 "name": "Gravity",
                                 "amount": 1,
                                 "negate": false
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
                             }
                         },
                         "Ledge before Slide Jump": {
@@ -7132,18 +6959,121 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "and",
+                        "Dock to Storm Missile Gate Room": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
-                        "Tile Group (SPEEDBOOST) 3": {
-                            "type": "and",
+                        "Door to EMMI Zone Exit North": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Magnet",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Spin",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Tile Group (POWERBEAM) 2": {
@@ -7181,11 +7111,13 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "and",
+                        "Door to EMMI Zone Exit North": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -7227,11 +7159,20 @@
                                 "items": []
                             }
                         },
-                        "Tile Group (SPEEDBOOST) 4": {
+                        "Dock to Energy Recharge Station Middle": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        },
+                        "Pickup (Energy Tank)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Tile Group (POWERBEAM) 2": {
@@ -7262,7 +7203,7 @@
                     "pickup_index": 71,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 5": {
+                        "Dock to Energy Recharge Station Middle": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7302,191 +7243,6 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Dock to Test Chamber Access": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (POWERBEAM) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3700.0,
-                        "y": 1200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_074",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (SPEEDBOOST) 3": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (POWERBEAM) 4": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3900.0,
-                        "y": -1800.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_019",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Dock to Storm Missile Gate Room": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3900.0,
-                        "y": -400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_020",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Dock to Energy Recharge Station Middle": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 3": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3900.0,
-                        "y": 500.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_021",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Dock to Energy Recharge Station Middle": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (POWERBEAM) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 4": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3900.0,
-                        "y": 2900.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_022",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to EMMI Zone Exit North": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 5": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7564,109 +7320,6 @@
                                         "data": "Simple IBJ"
                                     }
                                 ]
-                            }
-                        }
-                    }
-                },
-                "Tile Group (POWERBEAM) 3": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -6900.0,
-                        "y": 1800.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_038",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {}
-                },
-                "Tile Group (SPEEDBOOST) 5": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -4000.0,
-                        "y": 2200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_039",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Energy Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 4": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (POWERBEAM) 4": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (POWERBEAM) 4": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3900.0,
-                        "y": 1600.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_067",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (POWERBEAM) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 5": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }
@@ -7755,11 +7408,13 @@
                                 "items": []
                             }
                         },
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
+                        "Dock to Yellow EMMI Introduction": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Lower-Right Corner": {
@@ -8089,43 +7744,6 @@
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 900.0,
-                        "y": 4800.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_023",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Dock to West Transport to Ferenia": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Dock to Yellow EMMI Introduction": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Dock to Yellow EMMI Introduction": {
                     "node_type": "dock",
                     "heal": false,
@@ -8149,11 +7767,13 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
+                        "Dock to West Transport to Ferenia": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -8347,6 +7967,27 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Dock to EMMI Zone Exit North": {
+                            "type": "and",
+                            "data": {
+                                "comment": "Connection present due to possible door and block rando shenanigans",
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "DaironCU",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -8374,7 +8015,7 @@
                     "default_connection": {
                         "world_name": "Dairon",
                         "area_name": "EMMI Zone Exit East",
-                        "node_name": "Door from Yellow EMMI Introduction"
+                        "node_name": "Door to Yellow EMMI Introduction"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -8406,20 +8047,139 @@
                                 ]
                             }
                         },
-                        "Tile Group (SPEEDBOOST)": {
+                        "Dock to EMMI Zone Exit North": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Temporary until door rando is accounted for",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Charge",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Lay Power Bomb"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Knowledge",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Lower-Left Area": {
-                            "type": "resource",
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "Flash",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Flash",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spin Boost"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Temporary until door rando is accounted for",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Charge",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Lay Power Bomb"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Knowledge",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -8450,43 +8210,6 @@
                                 "name": "Morph",
                                 "amount": 1,
                                 "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 3200.0,
-                        "y": 4800.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_024",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to EMMI Zone Exit East": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Dock to EMMI Zone Exit North": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }
@@ -8618,6 +8341,15 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Door to EMMI Zone Exit East": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
                         "Pickup (Energy Part)": {
                             "type": "and",
                             "data": {
@@ -8639,11 +8371,13 @@
                                 ]
                             }
                         },
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
+                        "Lower-Left Area": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -8684,9 +8418,9 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 1459.4594594594596,
-                        "y": 4404.72972972973,
-                        "z": 0
+                        "x": 1460.0,
+                        "y": 3950.0,
+                        "z": 0.0
                     },
                     "description": "",
                     "layers": [
@@ -8695,10 +8429,29 @@
                     "extra": {},
                     "connections": {
                         "Door to EMMI Zone Exit East": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "DaironCU",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "DaironYellowEMMIChase",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Tile Group (POWERBEAM) 1": {
@@ -8708,7 +8461,83 @@
                                 "items": []
                             }
                         },
+                        "Dock to EMMI Zone Exit North": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "DaironYellowEMMIChase",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "DaironCU",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Tunnel to EMMI Zone Exit North": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Event - Yellow EMMI Chase": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "DaironCU",
+                                "amount": 1,
+                                "negate": true
+                            }
+                        }
+                    }
+                },
+                "Event - Yellow EMMI Chase": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 1460.0,
+                        "y": 4400.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "DaironYellowEMMIChase",
+                    "connections": {
+                        "Door to EMMI Zone Exit East": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9837,12 +9666,29 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Bomb Room": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:powergenerator_002",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Center": {
@@ -10454,70 +10300,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Power Switch 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s030_baselab:default:db_dif_b1_002",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Can Slide"
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 200,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
                         "Freezer Center": {
                             "type": "or",
                             "data": {
@@ -10556,6 +10338,15 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:powergenerator_002",
+                                            "amount": 1,
+                                            "negate": true
                                         }
                                     }
                                 ]
@@ -10614,6 +10405,15 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
                                                 }
                                             ]
                                         }
@@ -10622,12 +10422,101 @@
                             }
                         },
                         "Event - Right Blob from above (db_reg_b1_002)": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Wave",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Wave",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Diffusion Beam"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Pseudo",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 50,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -10701,6 +10590,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:powergenerator_002",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
                                     }
                                 ]
                             }
@@ -10758,6 +10656,15 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
                                                 }
                                             ]
                                         }
@@ -10797,7 +10704,76 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 4": {
+                        "Door to Energy Recharge Station West (doorpowerpower_030)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 120,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Freezer Center": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -10812,6 +10788,15 @@
                                         }
                                     },
                                     {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:powergenerator_002",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
                                         "type": "and",
                                         "data": {
                                             "comment": null,
@@ -10819,18 +10804,18 @@
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "damage",
-                                                        "name": "Cold",
-                                                        "amount": 20,
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
+                                                        "amount": 2,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Suitless",
-                                                        "amount": 2,
+                                                        "type": "damage",
+                                                        "name": "Cold",
+                                                        "amount": 30,
                                                         "negate": false
                                                     }
                                                 }
@@ -10873,40 +10858,78 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Pickup (Missile Tank - Upper)": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "damage",
-                                                        "name": "Cold",
-                                                        "amount": 20,
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:db_reg_b1_001",
+                                                        "amount": 1,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Slide"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 30,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Suitless",
-                                                        "amount": 2,
-                                                        "negate": false
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
                                                     }
                                                 }
                                             ]
@@ -10927,6 +10950,58 @@
                                     {
                                         "type": "template",
                                         "data": "Lay Bomb"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 30,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -10983,6 +11058,15 @@
                                                                 }
                                                             }
                                                         ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
                                                     }
                                                 }
                                             ]
@@ -11074,6 +11158,15 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
                                                 }
                                             ]
                                         }
@@ -11141,6 +11234,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:powergenerator_002",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
                                     }
                                 ]
                             }
@@ -11201,390 +11303,6 @@
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -12900.0,
-                        "y": 2000.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_015",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Bottom-Left Corner": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -13500.0,
-                        "y": 2600.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_016",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (SCREWATTACK)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Space",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Walljump",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 100,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Tile Group (WEIGHT)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 50,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Bottom-Left Corner": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 3": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -13100.0,
-                        "y": 4200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_017",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (SCREWATTACK)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Freezer Center": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Gravity",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 4": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -13100.0,
-                        "y": 7100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_018",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Energy Recharge Station West (doorpowerpower_028)": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "damage",
-                                                        "name": "Cold",
-                                                        "amount": 20,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Suitless",
-                                                        "amount": 2,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Door to Energy Recharge Station West (doorpowerpower_030)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s030_baselab:default:db_dif_b1_001",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 100,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
                 "Tile Group (SCREWATTACK)": {
                     "node_type": "configurable_node",
                     "heal": false,
@@ -11606,7 +11324,76 @@
                         ]
                     },
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 2": {
+                        "Tile Group (WEIGHT)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 70,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Freezer Center": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -11621,19 +11408,19 @@
                                         }
                                     },
                                     {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:powergenerator_002",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
                                         "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "damage",
-                                                        "name": "Cold",
-                                                        "amount": 10,
-                                                        "negate": false
-                                                    }
-                                                },
                                                 {
                                                     "type": "resource",
                                                     "data": {
@@ -11642,27 +11429,20 @@
                                                         "amount": 2,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Cold",
+                                                        "amount": 30,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
                                     }
                                 ]
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 3": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (WEIGHT)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
                             }
                         }
                     }
@@ -11688,8 +11468,8 @@
                         ]
                     },
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "or",
+                        "Bottom-Left Corner": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -11697,32 +11477,58 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "Gravity",
+                                            "name": "Speed",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "damage",
-                                                        "name": "Cold",
-                                                        "amount": 50,
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 50,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Suitless",
-                                                        "amount": 2,
-                                                        "negate": false
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
                                                     }
                                                 }
                                             ]
@@ -11800,6 +11606,15 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
                                                 }
                                             ]
                                         }
@@ -11807,11 +11622,167 @@
                                 ]
                             }
                         },
-                        "Tile Group (SPEEDBOOST) 2": {
+                        "Tile Group (SCREWATTACK)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 100,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Space",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tile Group (WEIGHT)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 70,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -11898,6 +11869,15 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
                                                 }
                                             ]
                                         }
@@ -11947,15 +11927,66 @@
                         "Door to Power Switch 2": {
                             "type": "or",
                             "data": {
-                                "comment": "TODO: Implement logic for un-frozen freezer, which adds a few extra requirements for jumping around the pond",
+                                "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Gravity",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Cold",
+                                                                                "amount": 200,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -11966,19 +11997,239 @@
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "damage",
-                                                        "name": "Cold",
-                                                        "amount": 200,
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Space",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Magnet",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Grapple",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Gravity",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "or",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Spin",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Walljump",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Simple IBJ"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Flash",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Walljump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Door to Energy Recharge Station West (doorpowerpower_028)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Suitless",
-                                                        "amount": 2,
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 200,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Space",
+                                                        "amount": 1,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -12049,6 +12300,15 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
                                                 }
                                             ]
                                         }
@@ -12090,16 +12350,7 @@
                                 ]
                             }
                         },
-                        "Tile Group (SPEEDBOOST) 3": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Gravity",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 4": {
+                        "Tile Group (SCREWATTACK)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12108,18 +12359,61 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "Gravity",
+                                            "name": "Speed",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Space",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 50,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -12150,6 +12444,75 @@
                     ],
                     "extra": {},
                     "connections": {
+                        "Door to Map Station": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:db_reg_b1_002",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 30,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Door to Power Switch 2": {
                             "type": "and",
                             "data": {
@@ -12198,6 +12561,15 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
                                                 }
                                             ]
                                         }
@@ -12206,8 +12578,68 @@
                             }
                         },
                         "Event - Right Blob from right (db_reg_b1_002)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 30,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -12945,14 +13377,9 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
+                        "Dock to EMMI Zone Exit Northwest": {
+                            "type": "template",
+                            "data": "Ballspark"
                         }
                     }
                 },
@@ -13037,40 +13464,6 @@
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -10100.0,
-                        "y": 0.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_014",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to EMMI Zone Exit Northwest": {
-                            "type": "template",
-                            "data": "Can Slide"
-                        },
-                        "Dock to EMMI Zone Exit Northwest": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Dock to EMMI Zone Exit Northwest": {
                     "node_type": "dock",
                     "heal": false,
@@ -13094,12 +13487,9 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                        "Door to EMMI Zone Exit Northwest": {
+                            "type": "template",
+                            "data": "Can Slide"
                         }
                     }
                 },
@@ -13969,6 +14359,49 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Pickup (Missile+ Tank)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Speedbooster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Tile Group (BOMB)": {
                             "type": "resource",
                             "data": {
@@ -13976,20 +14409,6 @@
                                 "name": "Morph",
                                 "amount": 1,
                                 "negate": false
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         },
                         "Dock to Lake Puzzle Room": {
@@ -14026,7 +14445,7 @@
                     "pickup_index": 68,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 2": {
+                        "Door to Ammo Recharge Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14066,81 +14485,26 @@
                         "Door to Ammo Recharge Station": {
                             "type": "template",
                             "data": "Can Slide"
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -8100.0,
-                        "y": -5100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_012",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Ammo Recharge Station": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
                         },
                         "Tunnel to Ammo Recharge Station": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -8900.0,
-                        "y": -3000.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_013",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Ammo Recharge Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Pickup (Missile+ Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Speedbooster",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -14202,13 +14566,25 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "resource",
+                        "Door to Ammo Recharge Station": {
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    }
+                                ]
                             }
                         }
                     }
@@ -14309,6 +14685,10 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Tunnel to Storm Missile Gate Room": {
+                            "type": "template",
+                            "data": "Ballspark"
                         }
                     }
                 },
@@ -14348,15 +14728,6 @@
                                 "comment": null,
                                 "items": []
                             }
-                        },
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
                         }
                     }
                 },
@@ -14388,47 +14759,6 @@
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -7500.0,
-                        "y": -5100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_011",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Storm Missile Gate Room": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Tunnel to Storm Missile Gate Room": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
                 "Tunnel to Storm Missile Gate Room": {
                     "node_type": "dock",
                     "heal": false,
@@ -14452,14 +14782,9 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
+                        "Door to Storm Missile Gate Room": {
+                            "type": "template",
+                            "data": "Ballspark"
                         }
                     }
                 }
@@ -15133,11 +15458,13 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "and",
+                        "Upper Area": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -15343,85 +15670,13 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -8400.0,
-                        "y": -6200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_002",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Dock to Ammo Recharge Station": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Upper Area": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -12400.0,
-                        "y": -6100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_010",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Central Unit Access (doorframe_000)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Upper Area": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -15440,6 +15695,15 @@
                     ],
                     "extra": {},
                     "connections": {
+                        "Dock to Ammo Recharge Station": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
                         "Door to Central Unit Access (doorchargecharge_000)": {
                             "type": "and",
                             "data": {
@@ -15447,18 +15711,13 @@
                                 "items": []
                             }
                         },
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "and",
+                        "Door to Central Unit Access (doorframe_000)": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Submerged Area": {
@@ -15619,7 +15878,38 @@
                     "default_dock_weakness": "Dairon EMMI Tunnel",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
-                    "connections": {}
+                    "connections": {
+                        "Upper Area": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Bomb",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Movement",
+                                            "amount": 5,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -15954,13 +16244,81 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Central Unit": {
+                        "Upper Area": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
                                 "name": "Morph",
                                 "amount": 1,
                                 "negate": false
+                            }
+                        },
+                        "Tunnel to EMMI Zone Exit South": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Slide",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Slide",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Flash",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -15984,13 +16342,11 @@
                     "pickup_index": 72,
                     "major_location": true,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "resource",
+                        "Door to EMMI Zone Exit South (doorframe_000)": {
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -16025,16 +16381,22 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
+                        "Pickup (Energy Part)": {
+                            "type": "template",
+                            "data": "Ballspark"
+                        },
+                        "Upper Area": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
                 },
-                "Start Point 1": {
+                "Upper Area": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -16050,7 +16412,64 @@
                         "start_point_actor_name": "SP_Checkpoint_SpeedBooster",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "connections": {}
+                    "connections": {
+                        "Door to EMMI Zone Exit South (doorchargecharge_000)": {
+                            "type": "template",
+                            "data": "Can Slide"
+                        },
+                        "Door to EMMI Zone Exit South (doorframe_000)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Door to Central Unit": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spin Boost"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Pickup (Speed Booster)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "DaironCU",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        }
+                    }
                 },
                 "Start Point 2": {
                     "node_type": "generic",
@@ -16070,45 +16489,6 @@
                     },
                     "connections": {
                         "Door to Central Unit": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -13300.0,
-                        "y": -6100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_009",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Energy Part)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Door to EMMI Zone Exit South (doorframe_000)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -16140,24 +16520,11 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Exit South (doorchargecharge_000)": {
-                            "type": "template",
-                            "data": "Can Slide"
-                        },
-                        "Tile Group (SPEEDBOOST)": {
+                        "Upper Area": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
-                            }
-                        },
-                        "Pickup (Speed Booster)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "events",
-                                "name": "DaironCU",
-                                "amount": 1,
-                                "negate": false
                             }
                         },
                         "Tunnel to EMMI Zone Exit Southwest": {
@@ -16191,8 +16558,8 @@
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
-                        "x": -14000.0,
-                        "y": -4700.0,
+                        "x": -15000.0,
+                        "y": -5800.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -16208,7 +16575,7 @@
                     "pickup_index": 147,
                     "major_location": true,
                     "connections": {
-                        "Door to Central Unit": {
+                        "Upper Area": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -16509,10 +16876,6 @@
                                 "comment": null,
                                 "items": []
                             }
-                        },
-                        "Dock to Transport to Ghavoran": {
-                            "type": "template",
-                            "data": "Can Slide"
                         }
                     }
                 },
@@ -16564,11 +16927,17 @@
                     },
                     "connections": {
                         "Door to Freezer (doorpowerpower_030)": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "events",
+                                "name": "s030_baselab:default:powergenerator_002",
+                                "amount": 1,
+                                "negate": false
                             }
+                        },
+                        "Dock to Transport to Ghavoran": {
+                            "type": "template",
+                            "data": "Can Slide"
                         }
                     }
                 },
@@ -16649,6 +17018,15 @@
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Life Recharge": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -92,6 +92,8 @@ Extra - asset_id: collision_camera_001
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_energy/charclasses/weightactivatedplatform_energy.bmsad
   > Door to Save Station East
       Trivial
+  > Event - Speed Booster blocks Destroyed
+      Speed Booster
 
 > Teleporter to Artaria - Teleport to Dairon; Heals? False; Spawn Point
   * Layers: default
@@ -140,10 +142,10 @@ Extra - asset_id: collision_camera_001
       Trivial
   > Tile Group (POWERBEAM)
       Trivial
+  > Wide Beam Block - Adjacent
+      After Dairon - Teleport To Artaria Speed Blocks Destroyed
   > Top Floor
       After Dairon - Teleport To Artaria Speed Blocks Destroyed
-  > Event - Speed Booster blocks Destroyed
-      Speed Booster
 
 > Top Floor; Heals? False
   * Layers: default
@@ -403,9 +405,7 @@ Extra - asset_id: collision_camera_005
   * EMMI Door to Hub Access/Dock to EMMI Zone Exit East
   * Extra - actor_name: dooremmy_001
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Door from Yellow EMMI Introduction
-      Trivial
-  > Tile Group (SPEEDBOOST)
+  > Door to Yellow EMMI Introduction
       Trivial
 
 > Dock to East Transport to Ferenia; Heals? False
@@ -413,12 +413,12 @@ Extra - asset_id: collision_camera_005
   * EMMI Door to East Transport to Ferenia/Dock to EMMI Zone Exit East
   * Extra - actor_name: dooremmy_002
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Dock to Hub Access
+      After Dairon - EMMI Zone Exit East Speed Blocks Destroyed
 
-> Door from Yellow EMMI Introduction; Heals? False
+> Door to Yellow EMMI Introduction; Heals? False
   * Layers: default
-  * Access Closed to Yellow EMMI Introduction/Door to EMMI Zone Exit East
+  * Access Locked to Yellow EMMI Introduction/Door to EMMI Zone Exit East
   * Extra - actor_name: doorchargeclosed_000
   * Extra - actor_def: actordef:actors/props/doorchargeclosed/charclasses/doorchargeclosed.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -427,16 +427,18 @@ Extra - asset_id: collision_camera_005
   * Extra - right_shield_def: None
   > Dock to Hub Access
       Trivial
+  > Dock to East Transport to Ferenia
+      After Dairon - EMMI Zone Exit East Speed Blocks Destroyed
+  > Event - Speed Blocks Destroyed
+      Speed Booster
 
-> Tile Group (SPEEDBOOST); Heals? False
+> Event - Speed Blocks Destroyed; Heals? False
   * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_025
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Dock to Hub Access
-      Trivial
+  * Event Dairon - EMMI Zone Exit East Speed Blocks Destroyed
+  * Event added because a speed cannot be bulit in the transport to Ferenia,
+therefore leading to death upon entry
+
+
   > Dock to East Transport to Ferenia
       Trivial
 
@@ -1040,8 +1042,8 @@ Extra - asset_id: collision_camera_012
   * Pickup 55; Major Location? False
   * Extra - actor_name: item_missiletank_004
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Tile Group (SPEEDBOOST) 2
-      Gravity Suit and Morph Ball
+  > Lava Floor with Gravity Suit
+      Trivial
 
 > Door to Early Grapple Access; Heals? False
   * Layers: default
@@ -1145,30 +1147,6 @@ Extra - asset_id: collision_camera_012
   > Lava Floor with Gravity Suit
       Gravity Suit
 
-> Tile Group (SPEEDBOOST) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_064
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Tile Group (SPEEDBOOST) 2
-      Gravity Suit and Speed Booster
-  > Lava Floor with Gravity Suit
-      Gravity Suit and Speed Booster
-
-> Tile Group (SPEEDBOOST) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_065
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Missile Tank Speedboost)
-      Gravity Suit and Morph Ball
-  > Tile Group (SPEEDBOOST) 1
-      Gravity Suit and Speed Booster
-
 > Ledge before Slide Jump; Heals? False
   * Layers: default
   > Door to Transport to Artaria
@@ -1202,6 +1180,8 @@ Extra - asset_id: collision_camera_012
 
 > Lava Floor with Gravity Suit; Heals? False
   * Layers: default
+  > Pickup (Missile Tank Speedboost)
+      Gravity Suit and Ballspark
   > Door to Early Grapple Access
       Gravity Suit and Morph Ball
   > Door to Transport to Artaria
@@ -1210,8 +1190,6 @@ Extra - asset_id: collision_camera_012
           Space Jump or Simple IBJ
   > Tile Group (POWERBEAM)
       Gravity Suit
-  > Tile Group (SPEEDBOOST) 1
-      Gravity Suit and Speed Booster
   > Ledge before Slide Jump
       Gravity Suit and Speed Booster
 
@@ -1356,10 +1334,15 @@ Extra - asset_id: collision_camera_016
   * EMMI Door to Energy Recharge Station Middle/Dock to Shinespark Tutorial
   * Extra - actor_name: dooremmy_006
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Tile Group (SPEEDBOOST) 2
-      Trivial
-  > Tile Group (SPEEDBOOST) 3
-      Trivial
+  > Dock to Storm Missile Gate Room
+      Speed Booster
+  > Door to EMMI Zone Exit North
+      Any of the following:
+          Spider Magnet or Space Jump or Speed Booster or Simple IBJ
+          Spin Boost and Walljump (Beginner)
+          All of the following:
+              Grapple Beam
+              Movement (Intermediate) or Walljump (Beginner)
   > Tile Group (POWERBEAM) 2
       Trivial
 
@@ -1368,8 +1351,8 @@ Extra - asset_id: collision_camera_016
   * EMMI Door to Storm Missile Gate Room/Dock to Shinespark Tutorial
   * Extra - actor_name: dooremmy_007
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Tile Group (SPEEDBOOST) 1
-      Trivial
+  > Door to EMMI Zone Exit North
+      Speed Booster
 
 > Door to EMMI Zone Exit North; Heals? False
   * Layers: default
@@ -1382,8 +1365,10 @@ Extra - asset_id: collision_camera_016
   * Extra - right_shield_def: None
   > Dock to Test Chamber Access
       Trivial
-  > Tile Group (SPEEDBOOST) 4
+  > Dock to Energy Recharge Station Middle
       Trivial
+  > Pickup (Energy Tank)
+      Speed Booster
   > Tile Group (POWERBEAM) 2
       Trivial
 
@@ -1392,7 +1377,7 @@ Extra - asset_id: collision_camera_016
   * Pickup 71; Major Location? False
   * Extra - actor_name: item_energytank
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
-  > Tile Group (SPEEDBOOST) 5
+  > Dock to Energy Recharge Station Middle
       Trivial
 
 > Door to EMMI Zone Exit Northwest; Heals? False
@@ -1407,66 +1392,6 @@ Extra - asset_id: collision_camera_016
   > Dock to Test Chamber Access
       Trivial
 
-> Tile Group (POWERBEAM) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_074
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-  > Tile Group (SPEEDBOOST) 3
-      Trivial
-  > Tile Group (POWERBEAM) 4
-      Trivial
-
-> Tile Group (SPEEDBOOST) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_019
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Dock to Storm Missile Gate Room
-      Trivial
-  > Tile Group (SPEEDBOOST) 2
-      Trivial
-
-> Tile Group (SPEEDBOOST) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_020
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Dock to Energy Recharge Station Middle
-      Trivial
-  > Tile Group (SPEEDBOOST) 1
-      Trivial
-
-> Tile Group (SPEEDBOOST) 3; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_021
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Dock to Energy Recharge Station Middle
-      Trivial
-  > Tile Group (POWERBEAM) 1
-      Trivial
-
-> Tile Group (SPEEDBOOST) 4; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_022
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to EMMI Zone Exit North
-      Trivial
-  > Tile Group (SPEEDBOOST) 5
-      Trivial
-
 > Tile Group (POWERBEAM) 2; Heals? False
   * Layers: default
   * Configurable Node
@@ -1478,40 +1403,6 @@ Extra - asset_id: collision_camera_016
       Trivial
   > Door to EMMI Zone Exit North
       Grapple Beam or Spider Magnet or Walljump (Beginner) or Simple IBJ or Use Spin Boost
-
-> Tile Group (POWERBEAM) 3; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_038
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-
-> Tile Group (SPEEDBOOST) 5; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_039
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Energy Tank)
-      Trivial
-  > Tile Group (SPEEDBOOST) 4
-      Trivial
-  > Tile Group (POWERBEAM) 4
-      Trivial
-
-> Tile Group (POWERBEAM) 4; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_067
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-  > Tile Group (POWERBEAM) 1
-      Trivial
-  > Tile Group (SPEEDBOOST) 5
-      Trivial
 
 ----------------
 EMMI Zone Exit North
@@ -1531,8 +1422,8 @@ Extra - asset_id: collision_camera_017
       Shoot Diffusion or Wave
   > Tile Group (POWERBOMB) 1
       Trivial
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Dock to Yellow EMMI Introduction
+      Speed Booster
   > Lower-Right Corner
       After Dairon - db_dif_b1_002
 
@@ -1607,23 +1498,11 @@ Extra - asset_id: collision_camera_017
   > Pickup (Power Bomb Tank)
       Morph Ball
 
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_023
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Dock to West Transport to Ferenia
-      Trivial
-  > Dock to Yellow EMMI Introduction
-      Trivial
-
 > Dock to Yellow EMMI Introduction; Heals? False
   * Layers: default
   * Open Passage to Yellow EMMI Introduction/Dock to EMMI Zone Exit North
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Dock to West Transport to Ferenia
+      Speed Booster
 
 > Tunnel to Yellow EMMI Introduction; Heals? False
   * Layers: default
@@ -1658,10 +1537,14 @@ Extra - asset_id: collision_camera_018
       Morph Ball and After Dairon - Central Unit
   > Tile Group (POWERBEAM) 2
       Trivial
+  > Dock to EMMI Zone Exit North
+      All of the following:
+          # Connection present due to possible door and block rando shenanigans
+          After Dairon - Central Unit and Ballspark
 
 > Door to EMMI Zone Exit East; Heals? False
   * Layers: default
-  * Charge Beam Door to EMMI Zone Exit East/Door from Yellow EMMI Introduction
+  * Charge Beam Door to EMMI Zone Exit East/Door to Yellow EMMI Introduction
   * Extra - actor_name: doorchargeclosed_000
   * Extra - actor_def: actordef:actors/props/doorchargeclosed/charclasses/doorchargeclosed.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1670,10 +1553,22 @@ Extra - asset_id: collision_camera_018
   * Extra - right_shield_def: None
   > Dock to Big Hub
       Morph Ball and After Dairon - Central Unit
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Dock to EMMI Zone Exit North
+      All of the following:
+          Speed Booster
+          Any of the following:
+              # Temporary until door rando is accounted for
+              Charge Beam
+              Knowledge (Beginner) and Lay Power Bomb
   > Lower-Left Area
-      Flash Shift
+      Any of the following:
+          Flash Shift or Lay Cross Comb or Use Spin Boost
+          All of the following:
+              # Temporary until door rando is accounted for
+              Speed Booster
+              Any of the following:
+                  Charge Beam
+                  Knowledge (Beginner) and Lay Power Bomb
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
@@ -1682,18 +1577,6 @@ Extra - asset_id: collision_camera_018
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Tile Group (WEIGHT)
       Morph Ball
-
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_024
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to EMMI Zone Exit East
-      Trivial
-  > Dock to EMMI Zone Exit North
-      Trivial
 
 > Tile Group (POWERBEAM) 1; Heals? False
   * Layers: default
@@ -1731,10 +1614,12 @@ Extra - asset_id: collision_camera_018
 > Dock to EMMI Zone Exit North; Heals? False
   * Layers: default
   * Open Passage to EMMI Zone Exit North/Dock to Yellow EMMI Introduction
+  > Door to EMMI Zone Exit East
+      Speed Booster
   > Pickup (Energy Part)
       Missiles and Lay Bomb
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Lower-Left Area
+      Speed Booster
 
 > Tunnel to EMMI Zone Exit North; Heals? False
   * Layers: default
@@ -1745,10 +1630,22 @@ Extra - asset_id: collision_camera_018
 > Lower-Left Area; Heals? False
   * Layers: default
   > Door to EMMI Zone Exit East
-      Trivial
+      After Dairon - Central Unit or After Dairon - Yellow EMMI Chase
   > Tile Group (POWERBEAM) 1
       Trivial
+  > Dock to EMMI Zone Exit North
+      All of the following:
+          Speed Booster
+          After Dairon - Central Unit or After Dairon - Yellow EMMI Chase
   > Tunnel to EMMI Zone Exit North
+      Trivial
+  > Event - Yellow EMMI Chase
+      Before Dairon - Central Unit
+
+> Event - Yellow EMMI Chase; Heals? False
+  * Layers: default
+  * Event Dairon - Yellow EMMI Chase
+  > Door to EMMI Zone Exit East
       Trivial
 
 ----------------
@@ -2041,7 +1938,7 @@ Extra - asset_id: collision_camera_022
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to Bomb Room
-      Morph Ball
+      Morph Ball and After Dairon - powergenerator_002
   > Center
       Trivial
 
@@ -2181,24 +2078,24 @@ Extra - asset_id: collision_camera_025
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Power Switch 2
-      All of the following:
-          After Dairon - db_dif_b1_002 and Can Slide
-          Any of the following:
-              Gravity Suit
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
   > Freezer Center
       Any of the following:
-          Gravity Suit
+          Gravity Suit or Before Dairon - powergenerator_002
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
   > Beside the Blob
       All of the following:
           After Dairon - db_reg_b1_002
           Any of the following:
-              Gravity Suit
+              Gravity Suit or Before Dairon - powergenerator_002
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
   > Event - Right Blob from above (db_reg_b1_002)
-      Wave Beam
+      All of the following:
+          Any of the following:
+              Wave Beam
+              Pseudo-Wave Beam (Beginner) and Shoot Diffusion Beam
+          Any of the following:
+              Gravity Suit or Before Dairon - powergenerator_002
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
 
 > Door to Power Switch 2; Heals? False
   * Layers: default
@@ -2211,13 +2108,13 @@ Extra - asset_id: collision_camera_025
   * Extra - right_shield_def: None
   > Freezer Center
       Any of the following:
-          Gravity Suit
+          Gravity Suit or Before Dairon - powergenerator_002
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
   > Beside the Blob
       All of the following:
           Morph Ball
           Any of the following:
-              Gravity Suit
+              Gravity Suit or Before Dairon - powergenerator_002
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
 
 > Door to Energy Recharge Station West (doorpowerpower_028); Heals? False
@@ -2229,10 +2126,16 @@ Extra - asset_id: collision_camera_025
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Tile Group (SPEEDBOOST) 4
+  > Door to Energy Recharge Station West (doorpowerpower_030)
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Gravity Suit or Before Dairon - powergenerator_002
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 120
+  > Freezer Center
       Any of the following:
-          Gravity Suit
-          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 20
+          Gravity Suit or Before Dairon - powergenerator_002
+          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
 
 > Door to Energy Recharge Station West (doorpowerpower_030); Heals? False
   * Layers: default
@@ -2244,16 +2147,20 @@ Extra - asset_id: collision_camera_025
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Pickup (Missile Tank - Upper)
-      Any of the following:
-          Gravity Suit
-          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 20
+      All of the following:
+          After Dairon - Freezer Hidden Left Blob or Can Slide
+          Any of the following:
+              Gravity Suit or Before Dairon - powergenerator_002
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
   > Event - Hidden Blob from left (db_reg_b1_001)
-      Lay Bomb or Shoot Beam
+      Any of the following:
+          Gravity Suit or Before Dairon - powergenerator_002 or Lay Bomb or Shoot Beam
+          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
   > Freezer Center
       All of the following:
           Morph Ball and After Dairon - Freezer Hidden Left Blob
           Any of the following:
-              Gravity Suit
+              Gravity Suit or Before Dairon - powergenerator_002
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
 
 > Pickup (Missile Tank - Lower); Heals? False
@@ -2265,7 +2172,7 @@ Extra - asset_id: collision_camera_025
       All of the following:
           Morph Ball
           Any of the following:
-              Gravity Suit
+              Gravity Suit or Before Dairon - powergenerator_002
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
 
 > Pickup (Missile Tank - Upper); Heals? False
@@ -2275,7 +2182,7 @@ Extra - asset_id: collision_camera_025
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Door to Energy Recharge Station West (doorpowerpower_030)
       Any of the following:
-          Gravity Suit
+          Gravity Suit or Before Dairon - powergenerator_002
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 20
 
 > Event - Hidden Blob from left (db_reg_b1_001); Heals? False
@@ -2294,68 +2201,6 @@ Extra - asset_id: collision_camera_025
   > Beside the Blob
       Trivial
 
-> Tile Group (SPEEDBOOST) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_015
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Bottom-Left Corner
-      Trivial
-
-> Tile Group (SPEEDBOOST) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_016
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Tile Group (SCREWATTACK)
-      All of the following:
-          Space Jump or Speed Booster or Walljump (Beginner) or Simple IBJ
-          Any of the following:
-              Gravity Suit
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
-  > Tile Group (WEIGHT)
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Gravity Suit
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
-  > Bottom-Left Corner
-      Trivial
-
-> Tile Group (SPEEDBOOST) 3; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_017
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Tile Group (SCREWATTACK)
-      Trivial
-  > Freezer Center
-      Gravity Suit
-
-> Tile Group (SPEEDBOOST) 4; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_018
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to Energy Recharge Station West (doorpowerpower_028)
-      Any of the following:
-          Gravity Suit
-          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 20
-  > Door to Energy Recharge Station West (doorpowerpower_030)
-      All of the following:
-          Morph Ball and After Dairon - db_dif_b1_001
-          Any of the following:
-              Gravity Suit
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
-
 > Tile Group (SCREWATTACK); Heals? False
   * Layers: default
   * Configurable Node
@@ -2363,14 +2208,16 @@ Extra - asset_id: collision_camera_025
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SCREWATTACK',)
-  > Tile Group (SPEEDBOOST) 2
-      Any of the following:
-          Gravity Suit
-          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 10
-  > Tile Group (SPEEDBOOST) 3
-      Trivial
   > Tile Group (WEIGHT)
-      Morph Ball
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Gravity Suit or Before Dairon - powergenerator_002
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 70
+  > Freezer Center
+      Any of the following:
+          Gravity Suit or Before Dairon - powergenerator_002
+          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
 
 > Tile Group (WEIGHT); Heals? False
   * Layers: default
@@ -2378,10 +2225,12 @@ Extra - asset_id: collision_camera_025
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('WEIGHT',)
-  > Tile Group (SPEEDBOOST) 1
-      Any of the following:
-          Gravity Suit
-          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
+  > Bottom-Left Corner
+      All of the following:
+          Speed Booster
+          Any of the following:
+              Gravity Suit or Before Dairon - powergenerator_002
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
 
 > Bottom-Left Corner; Heals? False
   * Layers: default
@@ -2389,10 +2238,21 @@ Extra - asset_id: collision_camera_025
       All of the following:
           Morph Ball
           Any of the following:
-              Gravity Suit
+              Gravity Suit or Before Dairon - powergenerator_002
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
-  > Tile Group (SPEEDBOOST) 2
-      Trivial
+  > Tile Group (SCREWATTACK)
+      All of the following:
+          Speed Booster
+          Any of the following:
+              Gravity Suit or Before Dairon - powergenerator_002
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
+          Space Jump or Walljump (Beginner) or Simple IBJ
+  > Tile Group (WEIGHT)
+      All of the following:
+          Ballspark
+          Any of the following:
+              Gravity Suit or Before Dairon - powergenerator_002
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 70
 
 > Event - Hidden Blob through wall (db_reg_b1_001); Heals? False
   * Layers: default
@@ -2405,38 +2265,69 @@ Extra - asset_id: collision_camera_025
   > Door to Map Station
       All of the following:
           Any of the following:
-              Gravity Suit
+              Gravity Suit or Before Dairon - powergenerator_002
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 150
           Space Jump or Speed Booster or Walljump (Beginner) or Simple IBJ
   > Door to Power Switch 2
       Any of the following:
-          # TODO: Implement logic for un-frozen freezer, which adds a few extra requirements for jumping around the pond
-          Gravity Suit
-          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
+          All of the following:
+              After Dairon - powergenerator_002
+              Any of the following:
+                  Gravity Suit
+                  Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
+          All of the following:
+              Before Dairon - powergenerator_002
+              Any of the following:
+                  Grapple Beam or Spider Magnet or Space Jump or Speed Booster
+                  All of the following:
+                      Gravity Suit
+                      Spin Boost or Walljump (Beginner) or Simple IBJ
+                  Flash Shift and Walljump (Beginner)
+  > Door to Energy Recharge Station West (doorpowerpower_028)
+      All of the following:
+          Speed Booster
+          Any of the following:
+              Gravity Suit or Before Dairon - powergenerator_002
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
+          Any of the following:
+              Space Jump
+              Movement (Intermediate) and Walljump (Beginner)
   > Door to Energy Recharge Station West (doorpowerpower_030)
       All of the following:
           Morph Ball and After Dairon - Freezer Hidden Left Blob
           Any of the following:
-              Gravity Suit
+              Gravity Suit or Before Dairon - powergenerator_002
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
           Speed Booster or Walljump (Beginner) or Simple IBJ or Use Spin Boost
-  > Tile Group (SPEEDBOOST) 3
-      Gravity Suit
-  > Tile Group (SPEEDBOOST) 4
-      Gravity Suit and Space Jump
+  > Tile Group (SCREWATTACK)
+      All of the following:
+          Speed Booster
+          Any of the following:
+              Gravity Suit or Before Dairon - powergenerator_002
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
   > Event - Hidden Blob through wall (db_reg_b1_001)
       Wave Beam
 
 > Beside the Blob; Heals? False
   * Layers: default
+  > Door to Map Station
+      All of the following:
+          After Dairon - db_reg_b1_002
+          Any of the following:
+              Gravity Suit or Before Dairon - powergenerator_002
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
   > Door to Power Switch 2
       All of the following:
           Can Slide
           Any of the following:
-              Gravity Suit
+              Gravity Suit or Before Dairon - powergenerator_002
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
   > Event - Right Blob from right (db_reg_b1_002)
-      Shoot Beam
+      All of the following:
+          Shoot Beam
+          Any of the following:
+              Gravity Suit or Before Dairon - powergenerator_002
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
 
 > Event - Right Blob from above (db_reg_b1_002); Heals? False
   * Layers: default
@@ -2593,8 +2484,8 @@ Extra - asset_id: collision_camera_029
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Tile Group (SPEEDBOOST)
-      Morph Ball
+  > Dock to EMMI Zone Exit Northwest
+      Ballspark
 
 > Dock to Hidden Grapple Shortcut Room; Heals? False
   * Layers: default
@@ -2618,23 +2509,11 @@ Extra - asset_id: collision_camera_029
   > Dock to Hidden Grapple Shortcut Room
       Trivial
 
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_014
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to EMMI Zone Exit Northwest
-      Can Slide
-  > Dock to EMMI Zone Exit Northwest
-      Trivial
-
 > Dock to EMMI Zone Exit Northwest; Heals? False
   * Layers: default
   * Open Passage to EMMI Zone Exit Northwest/Dock to EMMI Zone Exit West
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Door to EMMI Zone Exit Northwest
+      Can Slide
 
 > Tunnel to EMMI Zone Exit Northwest; Heals? False
   * Layers: default
@@ -2840,12 +2719,12 @@ Extra - asset_id: collision_camera_033
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  > Pickup (Missile+ Tank)
+      All of the following:
+          Speed Booster
+          Speedbooster Conservation (Beginner) or Walljump (Beginner)
   > Tile Group (BOMB)
       Morph Ball
-  > Tile Group (SPEEDBOOST) 1
-      Trivial
-  > Tile Group (SPEEDBOOST) 2
-      Trivial
   > Dock to Lake Puzzle Room
       After Dairon - Storm Missile Gate
   > Event - Storm Missile Gate
@@ -2856,7 +2735,7 @@ Extra - asset_id: collision_camera_033
   * Pickup 68; Major Location? False
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
-  > Tile Group (SPEEDBOOST) 2
+  > Door to Ammo Recharge Station
       Trivial
 
 > Tile Group (BOMB); Heals? False
@@ -2870,30 +2749,8 @@ Extra - asset_id: collision_camera_033
       Trivial
   > Door to Ammo Recharge Station
       Can Slide
-
-> Tile Group (SPEEDBOOST) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_012
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to Ammo Recharge Station
-      Trivial
   > Tunnel to Ammo Recharge Station
-      Morph Ball
-
-> Tile Group (SPEEDBOOST) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_013
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to Ammo Recharge Station
-      Trivial
-  > Pickup (Missile+ Tank)
-      Trivial
+      Speedbooster Conservation (Intermediate) and Ballspark
 
 > Dock to Lake Puzzle Room; Heals? False
   * Layers: default
@@ -2904,8 +2761,8 @@ Extra - asset_id: collision_camera_033
 > Tunnel to Ammo Recharge Station; Heals? False
   * Layers: default
   * Morph Ball Tunnel to Ammo Recharge Station/Tunnel to Storm Missile Gate Room
-  > Tile Group (SPEEDBOOST) 1
-      Morph Ball
+  > Door to Ammo Recharge Station
+      Speed Booster and Can Slide
 
 > Event - Storm Missile Gate; Heals? False
   * Layers: default
@@ -2927,6 +2784,8 @@ Extra - asset_id: collision_camera_034
       Trivial
   > Ammo Recharge
       Trivial
+  > Tunnel to Storm Missile Gate Room
+      Ballspark
 
 > Door to Storm Missile Gate Room; Heals? False
   * Layers: default
@@ -2939,8 +2798,6 @@ Extra - asset_id: collision_camera_034
   * Extra - right_shield_def: None
   > Dock to EMMI Zone Exit South
       Trivial
-  > Tile Group (SPEEDBOOST)
-      Morph Ball
 
 > Ammo Recharge; Heals? False; Spawn Point
   * Layers: default
@@ -2951,23 +2808,11 @@ Extra - asset_id: collision_camera_034
   > Dock to EMMI Zone Exit South
       Trivial
 
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_011
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to Storm Missile Gate Room
-      Morph Ball
-  > Tunnel to Storm Missile Gate Room
-      Morph Ball
-
 > Tunnel to Storm Missile Gate Room; Heals? False
   * Layers: default
   * Morph Ball Tunnel to Storm Missile Gate Room/Tunnel to Ammo Recharge Station
-  > Tile Group (SPEEDBOOST)
-      Morph Ball
+  > Door to Storm Missile Gate Room
+      Ballspark
 
 ----------------
 Lake Puzzle Room
@@ -3080,8 +2925,8 @@ Extra - asset_id: collision_camera_037
   * EMMI Door to Ammo Recharge Station/Dock to EMMI Zone Exit South
   * Extra - actor_name: dooremmy_011
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Tile Group (SPEEDBOOST) 1
-      Trivial
+  > Upper Area
+      Speed Booster
 
 > Dock to Burenia Lower Transport Access; Heals? False
   * Layers: default
@@ -3118,41 +2963,17 @@ Extra - asset_id: collision_camera_037
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Tile Group (SPEEDBOOST) 2
-      Trivial
-
-> Tile Group (SPEEDBOOST) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_002
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Dock to Ammo Recharge Station
-      Trivial
   > Upper Area
-      Trivial
-
-> Tile Group (SPEEDBOOST) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_010
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to Central Unit Access (doorframe_000)
-      Trivial
-  > Upper Area
-      Trivial
+      Speed Booster
 
 > Upper Area; Heals? False
   * Layers: default
+  > Dock to Ammo Recharge Station
+      Speed Booster
   > Door to Central Unit Access (doorchargecharge_000)
       Trivial
-  > Tile Group (SPEEDBOOST) 1
-      Trivial
-  > Tile Group (SPEEDBOOST) 2
-      Trivial
+  > Door to Central Unit Access (doorframe_000)
+      Speed Booster
   > Submerged Area
       Trivial
   > Tunnel to Central Unit Access
@@ -3170,6 +2991,8 @@ Extra - asset_id: collision_camera_037
 > Tunnel to Central Unit Access; Heals? False
   * Layers: default
   * Dairon EMMI Tunnel to Central Unit Access/Tunnel to EMMI Zone Exit South
+  > Upper Area
+      Bomb and Movement (Hypermode) and Lay Cross Comb
 
 ----------------
 Central Unit
@@ -3238,16 +3061,22 @@ Extra - asset_id: collision_camera_040
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Central Unit
+  > Upper Area
       Morph Ball
+  > Tunnel to EMMI Zone Exit South
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Flash Shift or Simple IBJ or Use Spin Boost
+              Slide and Slide Jump (Beginner)
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
   * Pickup 72; Major Location? True
   * Extra - actor_name: item_energyfragment_003
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
-  > Tile Group (SPEEDBOOST)
-      Morph Ball
+  > Door to EMMI Zone Exit South (doorframe_000)
+      Trivial
 
 > Door to EMMI Zone Exit South (doorframe_000); Heals? False
   * Layers: default
@@ -3258,13 +3087,23 @@ Extra - asset_id: collision_camera_040
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Pickup (Energy Part)
+      Ballspark
+  > Upper Area
+      Speed Booster
 
-> Start Point 1; Heals? False
+> Upper Area; Heals? False
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_SpeedBooster
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
+  > Door to EMMI Zone Exit South (doorchargecharge_000)
+      Can Slide
+  > Door to EMMI Zone Exit South (doorframe_000)
+      Speed Booster
+  > Door to Central Unit
+      Morph Ball or Speed Booster or Simple IBJ or Use Spin Boost
+  > Pickup (Speed Booster)
+      After Dairon - Central Unit
 
 > Start Point 2; Heals? False; Spawn Point
   * Layers: default
@@ -3273,27 +3112,11 @@ Extra - asset_id: collision_camera_040
   > Door to Central Unit
       Trivial
 
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_009
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Energy Part)
-      Morph Ball
-  > Door to EMMI Zone Exit South (doorframe_000)
-      Trivial
-
 > Door to Central Unit; Heals? False
   * Layers: default
   * Access Open to Central Unit/Door to Central Unit Access
-  > Door to EMMI Zone Exit South (doorchargecharge_000)
-      Can Slide
-  > Tile Group (SPEEDBOOST)
+  > Upper Area
       Trivial
-  > Pickup (Speed Booster)
-      After Dairon - Central Unit
   > Tunnel to EMMI Zone Exit Southwest
       Speed Booster or Simple IBJ or Use Spin Boost
 
@@ -3304,7 +3127,7 @@ Extra - asset_id: collision_camera_040
   * Extra - actor_def: actors/characters/emmylab/charclasses/emmylab.bmsad
   * Extra - string_key: GUI_ITEM_ACQUIRED_SPEED_BOOSTER
   * Extra - callback_function: OnEmmyBaseLabDead
-  > Door to Central Unit
+  > Upper Area
       Trivial
 
 > Tunnel to EMMI Zone Exit South; Heals? False
@@ -3374,8 +3197,6 @@ Extra - asset_id: collision_camera_042
   * Extra - right_shield_def: None
   > Life Recharge
       Trivial
-  > Dock to Transport to Ghavoran
-      Can Slide
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
@@ -3392,7 +3213,9 @@ Extra - asset_id: collision_camera_042
   * Extra - start_point_actor_name: energyrecharge_001_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_energy/charclasses/weightactivatedplatform_energy.bmsad
   > Door to Freezer (doorpowerpower_030)
-      Trivial
+      After Dairon - powergenerator_002
+  > Dock to Transport to Ghavoran
+      Can Slide
 
 > Tile Group (WEIGHT); Heals? False
   * Layers: default
@@ -3408,6 +3231,8 @@ Extra - asset_id: collision_camera_042
   * Open Passage to Transport to Ghavoran/Dock to Energy Recharge Station West
   > Door to Freezer (doorpowerpower_030)
       Morph Ball and After Dairon - powergenerator_002
+  > Life Recharge
+      Morph Ball
 
 ----------------
 Transport to Cataris

--- a/randovania/games/dread/json_data/Elun.json
+++ b/randovania/games/dread/json_data/Elun.json
@@ -2361,11 +2361,20 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (POWERBEAM)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
                                     {
                                         "type": "template",
                                         "data": "Can Slide"
@@ -2373,7 +2382,7 @@
                                 ]
                             }
                         },
-                        "Tile Group (SPEEDBOOST)": {
+                        "Tile Group (POWERBEAM)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2423,7 +2432,7 @@
                     "pickup_index": 117,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
+                        "Tile Group (POWERBEAM)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2454,30 +2463,8 @@
                     },
                     "connections": {
                         "Door to Gyroscope Room": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Ballspark"
                         },
                         "Tunnel to Bottom Morph Launcher": {
                             "type": "and",
@@ -2494,43 +2481,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 5813.398692810458,
-                        "y": -1692.5925925925926,
-                        "z": 0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_004",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Missile Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (POWERBEAM)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }

--- a/randovania/games/dread/json_data/Elun.txt
+++ b/randovania/games/dread/json_data/Elun.txt
@@ -561,9 +561,9 @@ Extra - asset_id: collision_camera_008
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  > Pickup (Missile Tank)
+      Speed Booster and Can Slide
   > Tile Group (POWERBEAM)
-      Can Slide
-  > Tile Group (SPEEDBOOST)
       Can Slide
   > Tunnel to Vertical Bomb Maze
       Morph Ball
@@ -573,7 +573,7 @@ Extra - asset_id: collision_camera_008
   * Pickup 117; Major Location? False
   * Extra - actor_name: item_missiletank_002
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Tile Group (SPEEDBOOST)
+  > Tile Group (POWERBEAM)
       Trivial
 
 > Tile Group (POWERBEAM); Heals? False
@@ -584,21 +584,9 @@ Extra - asset_id: collision_camera_008
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
   > Door to Gyroscope Room
-      Morph Ball and Speed Booster
+      Ballspark
   > Tunnel to Bottom Morph Launcher
       Morph Ball
-
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_004
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Missile Tank)
-      Trivial
-  > Tile Group (POWERBEAM)
-      Trivial
 
 > Tunnel to Vertical Bomb Maze; Heals? False
   * Layers: default

--- a/randovania/games/dread/json_data/Ferenia.json
+++ b/randovania/games/dread/json_data/Ferenia.json
@@ -1501,7 +1501,14 @@
                     "pickup_index": 128,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
+                        "Tile Group (WEIGHT)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Tile Group (POWERBEAM)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1540,50 +1547,6 @@
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -13000.0,
-                        "y": -4900.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_049",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Missile+ Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (WEIGHT)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (POWERBEAM)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Tile Group (POWERBEAM)": {
                     "node_type": "configurable_node",
                     "heal": false,
@@ -1614,14 +1577,87 @@
                                 "negate": false
                             }
                         },
-                        "Tile Group (WEIGHT)": {
+                        "Pickup (Missile+ Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "These methods are temporary until door rando is supported",
+                                            "items": [
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Gravity",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Cold",
+                                                                                "amount": 30,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         },
-                        "Tile Group (SPEEDBOOST)": {
+                        "Tile Group (WEIGHT)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2179,13 +2215,11 @@
                     "pickup_index": 131,
                     "major_location": true,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "resource",
+                        "Ledge above Slope": {
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -2361,110 +2395,6 @@
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -17800.0,
-                        "y": -1400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_045",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Energy Part)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -17800.0,
-                        "y": -2400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_046",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Space",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "IBJ",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Ledge above Slope": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Tile Group (POWERBEAM) 4": {
                     "node_type": "configurable_node",
                     "heal": false,
@@ -2590,32 +2520,53 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "or",
+                        "Pickup (Energy Part)": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Flash",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "template",
-                                        "data": "Use Spin Boost"
+                                        "data": "Ballspark"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s070_basesanc:default:db_reg_b2_003",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Speedbooster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Flash",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -3977,12 +3928,9 @@
                                 "items": []
                             }
                         },
-                        "Tile Group (POWERBEAM) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                        "Tile Group (WEIGHT) 2": {
+                            "type": "template",
+                            "data": "Can Slide"
                         }
                     }
                 },
@@ -4073,11 +4021,41 @@
                     "pickup_index": 130,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
+                        "Tile Group (WEIGHT) 2": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Slide"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Power Bomb"
+                                    }
+                                ]
                             }
                         }
                     }
@@ -4280,92 +4258,35 @@
                                 "comment": null,
                                 "items": []
                             }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -14900.0,
-                        "y": 5400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_024",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
+                        },
                         "Pickup (Missile+ Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (BOMB) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (POWERBEAM) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -15600.0,
-                        "y": 4700.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_025",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (WEIGHT) 2": {
-                            "type": "template",
-                            "data": "Can Slide"
-                        },
-                        "Tile Group (BOMB) 1": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Tile Group (POWERBEAM) 2": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    },
+                                    {
+                                        "type": "or",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Bomb"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "PBAmmo",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -4385,137 +4306,11 @@
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "Tile Group (BOMB) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -14900.0,
-                        "y": 4800.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_026",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "BOMB"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (WEIGHT) 2": {
-                            "type": "template",
-                            "data": "Can Slide"
-                        },
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Space",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
-                                    }
-                                ]
-                            }
-                        },
-                        "Tile Group (POWERBEAM) 1": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (POWERBEAM) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -14200.0,
-                        "y": 4700.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_027",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (WEIGHT) 2": {
-                            "type": "template",
-                            "data": "Can Slide"
-                        },
-                        "Tile Group (POWERBEAM) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Cross Comb"
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can Slide"
                                                 }
                                             ]
                                         }
@@ -7330,14 +7125,19 @@
                                 ]
                             }
                         },
-                        "Tile Group (SPEEDBOOST) 1": {
+                        "Tile Group (POWERBEAM)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Slide"
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     },
                                     {
                                         "type": "or",
@@ -7361,20 +7161,58 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 50,
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 50,
                                                                     "negate": false
                                                                 }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Temporary until door rando",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Charge",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Knowledge",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Lay Power Bomb"
                                                             }
                                                         ]
                                                     }
@@ -7451,6 +7289,83 @@
                                                         "type": "tricks",
                                                         "name": "Suitless",
                                                         "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tile Group (POWERBEAM)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 50,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Temporary until door rando",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -7729,91 +7644,6 @@
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3000.0,
-                        "y": 3700.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_015",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Cold Room (Storm Missile Gate) (Charge)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Slide"
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 50,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Tile Group (POWERBEAM)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Tile Group (BOMB)": {
                     "node_type": "configurable_node",
                     "heal": false,
@@ -7910,6 +7740,61 @@
                         ]
                     },
                     "connections": {
+                        "Door to Cold Room (Storm Missile Gate) (Charge)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 50,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Event - Grapple Block (grapplepulloff1x2_002)": {
                             "type": "and",
                             "data": {
@@ -7970,141 +7855,20 @@
                                 ]
                             }
                         },
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s070_basesanc:default:grapplepulloff1x2_002",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 100,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -2800.0,
-                        "y": 3200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_071",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (POWERBEAM)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s070_basesanc:default:grapplepulloff1x2_002",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
                         "Tunnel to Cold Room (Storm Missile Gate)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    },
+                                    {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Morph",
+                                            "type": "events",
+                                            "name": "s070_basesanc:default:grapplepulloff1x2_002",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -8131,18 +7895,18 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 200,
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 200,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -8291,7 +8055,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 2": {
+                        "Tile Group (POWERBEAM)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8301,6 +8065,15 @@
                                         "data": {
                                             "type": "items",
                                             "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s070_basesanc:default:grapplepulloff1x2_002",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -8327,18 +8100,18 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 200,
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 200,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -12396,8 +12169,8 @@
                                 "negate": false
                             }
                         },
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "or",
+                        "Tunnel to Cold Room (Energy Recharge Station)": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -12405,32 +12178,49 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "Gravity",
+                                            "name": "Morph",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "damage",
-                                                        "name": "Cold",
-                                                        "amount": 50,
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Suitless",
-                                                        "amount": 2,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 250,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -12579,132 +12369,6 @@
                         }
                     }
                 },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 500.0,
-                        "y": 3200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_072",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (MISSILE)": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "damage",
-                                                        "name": "Cold",
-                                                        "amount": 50,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Suitless",
-                                                        "amount": 2,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Tunnel to Cold Room (Energy Recharge Station)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 200,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
                 "Event - Storm Missile Gate": {
                     "node_type": "event",
                     "heal": false,
@@ -12752,19 +12416,14 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
+                        "Tile Group (MISSILE)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Ballspark"
                                     },
                                     {
                                         "type": "or",
@@ -12788,18 +12447,18 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 200,
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 250,
                                                                     "negate": false
                                                                 }
                                                             }

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -299,7 +299,9 @@ Extra - asset_id: collision_camera_006
   * Pickup 128; Major Location? False
   * Extra - actor_name: item_missiletankplus_001
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
-  > Tile Group (SPEEDBOOST)
+  > Tile Group (WEIGHT)
+      Trivial
+  > Tile Group (POWERBEAM)
       Trivial
 
 > Tile Group (WEIGHT); Heals? False
@@ -311,20 +313,6 @@ Extra - asset_id: collision_camera_006
   > Door to Transport to Dairon
       Trivial
 
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_049
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Missile+ Tank)
-      Trivial
-  > Tile Group (WEIGHT)
-      Trivial
-  > Tile Group (POWERBEAM)
-      Trivial
-
 > Tile Group (POWERBEAM); Heals? False
   * Layers: default
   * Configurable Node
@@ -334,9 +322,14 @@ Extra - asset_id: collision_camera_006
   * Extra - tile_types: ('POWERBEAM',)
   > Door to Cold Room (Small)
       Morph Ball
+  > Pickup (Missile+ Tank)
+      All of the following:
+          Ballspark
+          Any of the following:
+              # These methods are temporary until door rando is supported
+              Gravity Suit or Walljump (Beginner) or Simple IBJ or Use Spin Boost
+              Heat/Cold Runs (Beginner) and Cold Damage ≥ 30
   > Tile Group (WEIGHT)
-      Trivial
-  > Tile Group (SPEEDBOOST)
       Trivial
 
 > Tunnel to Fan Room Access; Heals? False
@@ -470,8 +463,8 @@ Extra - asset_id: collision_camera_009
   * Pickup 131; Major Location? True
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
-  > Tile Group (SPEEDBOOST) 1
-      Morph Ball
+  > Ledge above Slope
+      Trivial
 
 > Event - Blob to Elevator (db_reg_b2_003); Heals? False
   * Layers: default
@@ -525,30 +518,6 @@ Extra - asset_id: collision_camera_009
   > Tile Group (POWERBEAM) 4
       Trivial
 
-> Tile Group (SPEEDBOOST) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_045
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Energy Part)
-      Morph Ball
-  > Tile Group (SPEEDBOOST) 2
-      Trivial
-
-> Tile Group (SPEEDBOOST) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_046
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Tile Group (SPEEDBOOST) 1
-      Space Jump or Speed Booster or Infinite Bomb Jump (Beginner)
-  > Ledge above Slope
-      Trivial
-
 > Tile Group (POWERBEAM) 4; Heals? False
   * Layers: default
   * Configurable Node
@@ -577,8 +546,10 @@ Extra - asset_id: collision_camera_009
 
 > Ledge above Slope; Heals? False
   * Layers: default
-  > Tile Group (SPEEDBOOST) 2
-      Flash Shift or Speed Booster or Use Spin Boost
+  > Pickup (Energy Part)
+      All of the following:
+          After Ferenia - db_reg_b2_003 and Ballspark
+          Flash Shift or Speedbooster Conservation (Beginner) or Use Spin Boost
   > Tile Group (POWERBEAM) 4
       Morph Ball
   > Bottom
@@ -846,8 +817,8 @@ Extra - asset_id: collision_camera_012
   * Extra - right_shield_def: None
   > Dock to Transport to Ghavoran
       Trivial
-  > Tile Group (POWERBEAM) 2
-      Trivial
+  > Tile Group (WEIGHT) 2
+      Can Slide
 
 > Pickup (Space Jump); Heals? False
   * Layers: default
@@ -873,8 +844,10 @@ Extra - asset_id: collision_camera_012
   * Pickup 130; Major Location? False
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
-  > Tile Group (SPEEDBOOST)
-      Trivial
+  > Tile Group (WEIGHT) 2
+      Any of the following:
+          Lay Bomb or Lay Power Bomb
+          Movement (Beginner) and Can Slide
 
 > Event - Blob from below (db_reg_b2_001); Heals? False
   * Layers: default
@@ -929,62 +902,11 @@ Extra - asset_id: collision_camera_012
   * Extra - tile_types: ('WEIGHT',)
   > Door to Space Jump Room Access (Top)
       Trivial
-
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_024
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
   > Pickup (Missile+ Tank)
-      Trivial
-  > Tile Group (BOMB) 1
-      Trivial
-
-> Tile Group (POWERBEAM) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_025
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-  > Tile Group (WEIGHT) 2
-      Can Slide
-  > Tile Group (BOMB) 1
-      Morph Ball
-  > Tile Group (POWERBEAM) 2
       All of the following:
-          Morph Ball
-          Cross Bomb or Speed Booster
-
-> Tile Group (BOMB) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_026
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('BOMB',)
-  > Tile Group (WEIGHT) 2
-      Can Slide
-  > Tile Group (SPEEDBOOST)
-      Space Jump or Speed Booster or Simple IBJ
-  > Tile Group (POWERBEAM) 1
-      Morph Ball
-
-> Tile Group (POWERBEAM) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_027
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-  > Tile Group (WEIGHT) 2
-      Can Slide
-  > Tile Group (POWERBEAM) 1
-      All of the following:
-          Lay Cross Comb
-          Speed Booster or Can Slide
+          Ballspark
+          Power Bombs or Lay Bomb
+          Cross Bomb or Walljump (Beginner)
 
 > Tile Group (BOMB) 2; Heals? False
   * Layers: default
@@ -1565,12 +1487,16 @@ Extra - asset_id: collision_camera_018
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
           Simple IBJ or Use Spin Boost
-  > Tile Group (SPEEDBOOST) 1
+  > Tile Group (POWERBEAM)
       All of the following:
-          Can Slide
+          Speed Booster
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
+          Any of the following:
+              # Temporary until door rando
+              Charge Beam
+              Knowledge (Beginner) and Lay Power Bomb
 
 > Door to Cold Room (Storm Missile Gate) (Grapple); Heals? False
   * Layers: default
@@ -1585,6 +1511,15 @@ Extra - asset_id: collision_camera_018
       Any of the following:
           Gravity Suit
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
+  > Tile Group (POWERBEAM)
+      All of the following:
+          Speed Booster
+          Any of the following:
+              Gravity Suit
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
+          All of the following:
+              # Temporary until door rando
+              Grapple Beam
 
 > Event - Grapple Block (grapplepulloff1x2_002); Heals? False
   * Layers: default
@@ -1629,22 +1564,6 @@ Extra - asset_id: collision_camera_018
           Gravity Suit
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
 
-> Tile Group (SPEEDBOOST) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_015
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to Cold Room (Storm Missile Gate) (Charge)
-      All of the following:
-          Can Slide
-          Any of the following:
-              Gravity Suit
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
-  > Tile Group (POWERBEAM)
-      Trivial
-
 > Tile Group (BOMB); Heals? False
   * Layers: default
   * Configurable Node
@@ -1666,33 +1585,21 @@ Extra - asset_id: collision_camera_018
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
+  > Door to Cold Room (Storm Missile Gate) (Charge)
+      All of the following:
+          Can Slide
+          Any of the following:
+              Gravity Suit
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
   > Event - Grapple Block (grapplepulloff1x2_002)
       All of the following:
           Grapple Beam
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
-  > Tile Group (SPEEDBOOST) 1
-      Trivial
-  > Tile Group (SPEEDBOOST) 2
-      All of the following:
-          Morph Ball and After Ferenia - grapplepulloff1x2_002
-          Any of the following:
-              Gravity Suit
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
-
-> Tile Group (SPEEDBOOST) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_071
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Tile Group (POWERBEAM)
-      Morph Ball and After Ferenia - grapplepulloff1x2_002
   > Tunnel to Cold Room (Storm Missile Gate)
       All of the following:
-          Morph Ball
+          After Ferenia - grapplepulloff1x2_002 and Ballspark
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
@@ -1713,9 +1620,9 @@ Extra - asset_id: collision_camera_018
 > Tunnel to Cold Room (Storm Missile Gate); Heals? False
   * Layers: default
   * Morph Ball Tunnel to Cold Room (Storm Missile Gate)/Tunnel to Cold Room (Energy Recharge Station)
-  > Tile Group (SPEEDBOOST) 2
+  > Tile Group (POWERBEAM)
       All of the following:
-          Morph Ball
+          Morph Ball and After Ferenia - grapplepulloff1x2_002
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
@@ -2578,10 +2485,12 @@ Extra - asset_id: collision_camera_030
   * Extra - tile_types: ('MISSILE',)
   > Pickup (Missile Tank)
       Morph Ball
-  > Tile Group (SPEEDBOOST)
-      Any of the following:
-          Gravity Suit
-          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
+  > Tunnel to Cold Room (Energy Recharge Station)
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Gravity Suit
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 250
 
 > Tile Group (BOMB); Heals? False
   * Layers: default
@@ -2603,24 +2512,6 @@ Extra - asset_id: collision_camera_030
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
 
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_072
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Tile Group (MISSILE)
-      Any of the following:
-          Gravity Suit
-          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
-  > Tunnel to Cold Room (Energy Recharge Station)
-      All of the following:
-          Morph Ball
-          Any of the following:
-              Gravity Suit
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
-
 > Event - Storm Missile Gate; Heals? False
   * Layers: default
   * Event Ferenia - Storm Missile Gate Cold
@@ -2630,12 +2521,12 @@ Extra - asset_id: collision_camera_030
 > Tunnel to Cold Room (Energy Recharge Station); Heals? False
   * Layers: default
   * Morph Ball Tunnel to Cold Room (Energy Recharge Station)/Tunnel to Cold Room (Storm Missile Gate)
-  > Tile Group (SPEEDBOOST)
+  > Tile Group (MISSILE)
       All of the following:
-          Morph Ball
+          Ballspark
           Any of the following:
               Gravity Suit
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 250
 
 ----------------
 Wave Beam Tutorial

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -7767,15 +7767,6 @@
                                     }
                                 ]
                             }
-                        },
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Speed",
-                                "amount": 1,
-                                "negate": false
-                            }
                         }
                     }
                 },
@@ -7815,6 +7806,27 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Pickup (Energy Part)": {
+                            "type": "and",
+                            "data": {
+                                "comment": "Temporary until door rando support",
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Spin",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -7853,6 +7865,39 @@
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        },
+                        "Pickup (Energy Part)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Space",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -7951,13 +7996,11 @@
                     "pickup_index": 112,
                     "major_location": true,
                     "connections": {
-                        "Tile Group (SPEEDBOOST) 1": {
-                            "type": "resource",
+                        "Door to Energy Recharge Station": {
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -8151,124 +8194,6 @@
                             }
                         },
                         "Tunnel to Above Pulse Radar": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 5200.0,
-                        "y": 6700.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_038",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Energy Part)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Space",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 2": {
-                            "type": "template",
-                            "data": "Can Slide"
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 5600.0,
-                        "y": 6500.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_036",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Above Golzuna": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Flash",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
-                                    }
-                                ]
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST) 1": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -11099,43 +11024,6 @@
                                 "comment": null,
                                 "items": []
                             }
-                        },
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -900.0,
-                        "y": -2300.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_021",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Missile Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
                         }
                     }
                 },
@@ -11167,13 +11055,30 @@
                                 "items": []
                             }
                         },
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "resource",
+                        "Pickup (Missile Tank)": {
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Speed",
-                                "amount": 1,
-                                "negate": false
+                                "comment": "Temporary until door rando support",
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Grapple",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -1661,8 +1661,6 @@ Extra - asset_id: collision_camera_024
           Any of the following:
               Space Jump or Speed Booster or Simple IBJ
               Flash Shift and Walljump (Beginner) and Use Spin Boost
-  > Tile Group (SPEEDBOOST) 2
-      Speed Booster
 
 > Door to Above Golzuna; Heals? False
   * Layers: default
@@ -1675,6 +1673,10 @@ Extra - asset_id: collision_camera_024
   * Extra - right_shield_def: None
   > Door to Save Station East
       Trivial
+  > Pickup (Energy Part)
+      All of the following:
+          # Temporary until door rando support
+          Spin Boost and Ballspark
 
 > Door to Energy Recharge Station; Heals? False
   * Layers: default
@@ -1687,6 +1689,10 @@ Extra - asset_id: collision_camera_024
   * Extra - right_shield_def: None
   > Door to Save Station East
       Trivial
+  > Pickup (Energy Part)
+      All of the following:
+          Ballspark
+          Space Jump or Simple IBJ
 
 > Door to Above Pulse Radar; Heals? False
   * Layers: default
@@ -1717,8 +1723,8 @@ Extra - asset_id: collision_camera_024
   * Pickup 112; Major Location? True
   * Extra - actor_name: item_energyfragment
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
-  > Tile Group (SPEEDBOOST) 1
-      Morph Ball
+  > Door to Energy Recharge Station
+      Trivial
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -1758,32 +1764,6 @@ Extra - asset_id: collision_camera_024
   > Tile Group (POWERBEAM) 2
       Morph Ball
   > Tunnel to Above Pulse Radar
-      Morph Ball
-
-> Tile Group (SPEEDBOOST) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_038
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Energy Part)
-      All of the following:
-          Morph Ball
-          Space Jump or Simple IBJ
-  > Tile Group (SPEEDBOOST) 2
-      Can Slide
-
-> Tile Group (SPEEDBOOST) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_036
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Door to Above Golzuna
-      Flash Shift or Use Spin Boost
-  > Tile Group (SPEEDBOOST) 1
       Morph Ball
 
 > Tile Group (WEIGHT) 2; Heals? False
@@ -2401,18 +2381,6 @@ blast shields
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Door to Flipper Room
       Trivial
-  > Tile Group (SPEEDBOOST)
-      Trivial
-
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_021
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Missile Tank)
-      Trivial
 
 > Center Platform; Heals? False
   * Layers: default
@@ -2420,8 +2388,10 @@ blast shields
       Trivial
   > Door to Transport to Elun
       Trivial
-  > Tile Group (SPEEDBOOST)
-      Speed Booster
+  > Pickup (Missile Tank)
+      All of the following:
+          # Temporary until door rando support
+          Grapple Beam and Speed Booster
 
 ----------------
 Spin Boost Room

--- a/randovania/games/dread/json_data/Hanubia.json
+++ b/randovania/games/dread/json_data/Hanubia.json
@@ -1101,9 +1101,12 @@
                                 "items": []
                             }
                         },
-                        "Event - Breakable (Glass Tube)": {
-                            "type": "template",
-                            "data": "Lay Power Bomb"
+                        "Inside breakable tube": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         },
                         "Ammo Recharge": {
                             "type": "and",
@@ -1237,37 +1240,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Breakable (Glass Tube)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Space",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "Escape",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Under Tile Groups at room top": {
+                        "Inside breakable tube": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1303,41 +1276,15 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
                                                 }
                                             ]
                                         }
                                     }
                                 ]
-                            }
-                        }
-                    }
-                },
-                "Under Tile Groups at room top": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3352.155887230514,
-                        "y": 2024.5992260917633,
-                        "z": 0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "connections": {
-                        "Tile Group (SCREWATTACK)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }
@@ -1365,6 +1312,27 @@
                                 "negate": true
                             }
                         },
+                        "Event - Breakable (Glass Tube)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Power Bomb"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Event - Breakable (block_hyperbeam_000)": {
                             "type": "resource",
                             "data": {
@@ -1384,13 +1352,6 @@
                             }
                         },
                         "Tile Group (SCREWATTACK)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SPEEDBOOST)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1422,6 +1383,10 @@
                                 "negate": true
                             }
                         },
+                        "Event - Breakable (Glass Tube)": {
+                            "type": "template",
+                            "data": "Lay Power Bomb"
+                        },
                         "Dock to Escape Room 3": {
                             "type": "resource",
                             "data": {
@@ -1431,7 +1396,33 @@
                                 "negate": false
                             }
                         },
-                        "Under Tile Groups at room top": {
+                        "Next to Hyper Block": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s080_shipyard:default:block_pbtube",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tile Group (SCREWATTACK)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1460,13 +1451,8 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
                                                 }
                                             ]
                                         }
@@ -1593,57 +1579,6 @@
                             "data": {
                                 "comment": null,
                                 "items": []
-                            }
-                        },
-                        "Inside breakable tube": {
-                            "type": "resource",
-                            "data": {
-                                "type": "events",
-                                "name": "s080_shipyard:default:block_pbtube",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3800.0,
-                        "y": 2400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_032",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Event - Breakable (Glass Tube)": {
-                            "type": "template",
-                            "data": "Lay Power Bomb"
-                        },
-                        "Next to Hyper Block": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Inside breakable tube": {
-                            "type": "resource",
-                            "data": {
-                                "type": "events",
-                                "name": "s080_shipyard:default:block_pbtube",
-                                "amount": 1,
-                                "negate": false
                             }
                         }
                     }
@@ -2418,7 +2353,24 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (BOMB)": {
+                        "Door to Navigation Station (Top)": {
+                            "type": "and",
+                            "data": {
+                                "comment": "Temporary. Will likely need removed with door rando",
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Wave",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tile Group (BOMB) 1": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2485,13 +2437,11 @@
                     "pickup_index": 135,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (BOMB SPEEDBOOST)": {
-                            "type": "resource",
+                        "Tile Group (BOMB) 2": {
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -2526,14 +2476,14 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Start Point 2": {
+                        "Door to Navigation Station (Top)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Tile Group (BOMB SPEEDBOOST)": {
+                        "Tile Group (BOMB) 2": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2573,6 +2523,13 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Start Point 2": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Tile Group (BOMB) 2": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2718,7 +2675,7 @@
                                 "negate": false
                             }
                         },
-                        "Tile Group (BOMB)": {
+                        "Tile Group (BOMB) 1": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -2746,13 +2703,6 @@
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
                     "connections": {
-                        "Door from Tank Room": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Door to Navigation Station (Top)": {
                             "type": "and",
                             "data": {
@@ -2762,7 +2712,7 @@
                         }
                     }
                 },
-                "Tile Group (BOMB)": {
+                "Tile Group (BOMB) 1": {
                     "node_type": "configurable_node",
                     "heal": false,
                     "coordinates": {
@@ -2795,12 +2745,12 @@
                         }
                     }
                 },
-                "Tile Group (BOMB SPEEDBOOST)": {
+                "Tile Group (BOMB) 2": {
                     "node_type": "configurable_node",
                     "heal": false,
                     "coordinates": {
-                        "x": 3100.0,
-                        "y": -500.0,
+                        "x": 3400.0,
+                        "y": -250.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -2811,18 +2761,46 @@
                         "actor_name": "breakabletilegroup_046",
                         "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
                         "tile_types": [
-                            "BOMB",
-                            "SPEEDBOOST"
+                            "BOMB"
                         ]
                     },
                     "connections": {
                         "Pickup (Power Bomb Tank)": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Temporary until door rando. Wave likely removed at that point",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Wave",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "HanubiaTankSpeed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Door from Tank Room": {
@@ -3039,6 +3017,13 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Event - Prepare Speedboost": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -3106,6 +3091,30 @@
                             }
                         },
                         "Tile Group (BOMB)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Prepare Speedboost": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 4800.0,
+                        "y": -100.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "HanubiaTankSpeed",
+                    "connections": {
+                        "Door to Speedboost Puzzle Room": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Hanubia.txt
+++ b/randovania/games/dread/json_data/Hanubia.txt
@@ -287,8 +287,8 @@ Extra - asset_id: collision_camera_004
   * Extra - right_shield_def: None
   > Door to Transport to Ghavoran
       Trivial
-  > Event - Breakable (Glass Tube)
-      Lay Power Bomb
+  > Inside breakable tube
+      Trivial
   > Ammo Recharge
       Trivial
   > Start Point
@@ -325,43 +325,38 @@ Extra - asset_id: collision_camera_004
 > Dock to Escape Room 3; Heals? False
   * Layers: default
   * Open Passage to Escape Room 3/Dock to Entrance Tall Room
-  > Event - Breakable (Glass Tube)
-      Space Jump and After Escape Sequence and Lay Bomb
-  > Under Tile Groups at room top
+  > Inside breakable tube
       All of the following:
           After Escape Sequence
-          Space Jump or Speed Booster
-
-> Under Tile Groups at room top; Heals? False
-  * Layers: default
-  > Tile Group (SCREWATTACK)
-      Trivial
-  > Tile Group (SPEEDBOOST)
-      Trivial
+          Space Jump or Speed Booster or Simple IBJ
 
 > Next to Hyper Block; Heals? False
   * Layers: default
   > Door to Total Recharge Station North
       Before Escape Sequence
+  > Event - Breakable (Glass Tube)
+      Speed Booster and Lay Power Bomb
   > Event - Breakable (block_hyperbeam_000)
       Hyper Beam
   > Dock to Ship Room
       After Hanubia - block_hyperbeam_000
   > Tile Group (SCREWATTACK)
       Trivial
-  > Tile Group (SPEEDBOOST)
-      Trivial
 
 > Inside breakable tube; Heals? False
   * Layers: default
   > Door to Navigation Station
       Before Escape Sequence
+  > Event - Breakable (Glass Tube)
+      Lay Power Bomb
   > Dock to Escape Room 3
       After Escape Sequence
-  > Under Tile Groups at room top
+  > Next to Hyper Block
+      Speed Booster and After Hanubia - block_pbtube
+  > Tile Group (SCREWATTACK)
       All of the following:
           After Hanubia - block_pbtube
-          Space Jump or Speed Booster
+          Space Jump or Simple IBJ
 
 > Dock to Ship Room; Heals? False
   * Layers: default
@@ -395,21 +390,6 @@ Extra - asset_id: collision_camera_004
       Lay Power Bomb
   > Next to Hyper Block
       Trivial
-  > Inside breakable tube
-      After Hanubia - block_pbtube
-
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_032
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Event - Breakable (Glass Tube)
-      Lay Power Bomb
-  > Next to Hyper Block
-      Trivial
-  > Inside breakable tube
-      After Hanubia - block_pbtube
 
 ----------------
 Gold Chozo Warrior Arena
@@ -596,7 +576,11 @@ Extra - asset_id: collision_camera_009
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Tile Group (BOMB)
+  > Door to Navigation Station (Top)
+      All of the following:
+          # Temporary. Will likely need removed with door rando
+          Wave Beam
+  > Tile Group (BOMB) 1
       Trivial
 
 > Door to Tank Room; Heals? False
@@ -616,8 +600,8 @@ Extra - asset_id: collision_camera_009
   * Pickup 135; Major Location? False
   * Extra - actor_name: item_powerbombtank_000
   * Extra - actor_def: actordef:actors/items/item_powerbombtank/charclasses/item_powerbombtank.bmsad
-  > Tile Group (BOMB SPEEDBOOST)
-      Morph Ball
+  > Tile Group (BOMB) 2
+      Trivial
 
 > Door from Tank Room; Heals? False
   * Layers: default
@@ -628,9 +612,9 @@ Extra - asset_id: collision_camera_009
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Start Point 2
+  > Door to Navigation Station (Top)
       Trivial
-  > Tile Group (BOMB SPEEDBOOST)
+  > Tile Group (BOMB) 2
       Trivial
 
 > Door to Navigation Station (Top); Heals? False
@@ -643,6 +627,8 @@ Extra - asset_id: collision_camera_009
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorwavebeam_003
   * Extra - right_shield_def: actordef:actors/props/doorwavebeam/charclasses/doorwavebeam.bmsad
   > Start Point 2
+      Trivial
+  > Tile Group (BOMB) 2
       Trivial
 
 > Tunnel to Ferenia Shortcut; Heals? False
@@ -669,19 +655,17 @@ Extra - asset_id: collision_camera_009
       Morph Ball and After Hanubia - grapplepulloff1x2
   > Event - Pull Grapple Block (grapplepulloff1x2)
       Grapple Beam
-  > Tile Group (BOMB)
+  > Tile Group (BOMB) 1
       Morph Ball
 
 > Start Point 2; Heals? False; Spawn Point
   * Layers: default
   * Extra - start_point_actor_name: SP_AccessPoint_10B
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door from Tank Room
-      Trivial
   > Door to Navigation Station (Top)
       Trivial
 
-> Tile Group (BOMB); Heals? False
+> Tile Group (BOMB) 1; Heals? False
   * Layers: default
   * Configurable Node
   * Extra - actor_name: breakabletilegroup_030
@@ -692,14 +676,18 @@ Extra - asset_id: collision_camera_009
   > Start Point 1
       Can Slide
 
-> Tile Group (BOMB SPEEDBOOST); Heals? False
+> Tile Group (BOMB) 2; Heals? False
   * Layers: default
   * Configurable Node
   * Extra - actor_name: breakabletilegroup_046
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - tile_types: ('BOMB', 'SPEEDBOOST')
+  * Extra - tile_types: ('BOMB',)
   > Pickup (Power Bomb Tank)
-      Morph Ball
+      All of the following:
+          Ballspark
+          Any of the following:
+              # Temporary until door rando. Wave likely removed at that point
+              Wave Beam or After Hanubia - Prepare Speedboost in Tank Room
   > Door from Tank Room
       Trivial
 
@@ -751,6 +739,8 @@ Extra - asset_id: collision_camera_010
   * Extra - right_shield_def: None
   > Dock to EMMI Zone Exit West (Top)
       Trivial
+  > Event - Prepare Speedboost
+      Trivial
 
 > Tile Group (BOMB); Heals? False
   * Layers: default
@@ -772,6 +762,12 @@ Extra - asset_id: collision_camera_010
   > Dock to EMMI Zone Exit West (Top)
       Trivial
   > Tile Group (BOMB)
+      Trivial
+
+> Event - Prepare Speedboost; Heals? False
+  * Layers: default
+  * Event Hanubia - Prepare Speedboost in Tank Room
+  > Door to Speedboost Puzzle Room
       Trivial
 
 ----------------

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -929,6 +929,22 @@
             "DaironTeleportToArtariaSpeedBlocksDestroyed": {
                 "long_name": "Dairon - Teleport To Artaria Speed Blocks Destroyed",
                 "extra": {}
+            },
+            "BureniaEarlyGravEPart": {
+                "long_name": "Burenia - Early Gravity Energy Part",
+                "extra": {}
+            },
+            "DaironEMMIExitEastSpeedBlocks": {
+                "long_name": "Dairon - EMMI Zone Exit East Speed Blocks Destroyed",
+                "extra": {}
+            },
+            "DaironYellowEMMIChase": {
+                "long_name": "Dairon - Yellow EMMI Chase",
+                "extra": {}
+            },
+            "HanubiaTankSpeed": {
+                "long_name": "Hanubia - Prepare Speedboost in Tank Room",
+                "extra": {}
             }
         },
         "tricks": {


### PR DESCRIPTION
- Removes all Speed Booster Tile Group nodes in all regions
- Reimplements the logic without using them
- For speed requirements that would require using a door, added temporary requirements until door rando is supported
- Completely reworked Dairon - Freezer logic since most of the room had to be redone anyway
- A few extra fixes around the above room to account for the power generator event (No more Bomb Room without first turning on the generator!)
- Added a few events to account for some speed requirements
- Added event in Dairon - EMMI Zone Exit East for the speed blocks being destroyed so that coming through Ferenia does not equal death