### PR TITLE
Dread: Remove Speed Block in Elun

### DIFF
--- a/randovania/games/dread/json_data/Elun.json
+++ b/randovania/games/dread/json_data/Elun.json
@@ -2361,11 +2361,20 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (POWERBEAM)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
                                     {
                                         "type": "template",
                                         "data": "Can Slide"
@@ -2373,7 +2382,7 @@
                                 ]
                             }
                         },
-                        "Tile Group (SPEEDBOOST)": {
+                        "Tile Group (POWERBEAM)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2423,7 +2432,7 @@
                     "pickup_index": 117,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (SPEEDBOOST)": {
+                        "Tile Group (POWERBEAM)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2454,30 +2463,8 @@
                     },
                     "connections": {
                         "Door to Gyroscope Room": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Ballspark"
                         },
                         "Tunnel to Bottom Morph Launcher": {
                             "type": "and",
@@ -2494,43 +2481,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SPEEDBOOST)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 5813.398692810458,
-                        "y": -1692.5925925925926,
-                        "z": 0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_004",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SPEEDBOOST"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Missile Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (POWERBEAM)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }

--- a/randovania/games/dread/json_data/Elun.txt
+++ b/randovania/games/dread/json_data/Elun.txt
@@ -561,9 +561,9 @@ Extra - asset_id: collision_camera_008
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  > Pickup (Missile Tank)
+      Speed Booster and Can Slide
   > Tile Group (POWERBEAM)
-      Can Slide
-  > Tile Group (SPEEDBOOST)
       Can Slide
   > Tunnel to Vertical Bomb Maze
       Morph Ball
@@ -573,7 +573,7 @@ Extra - asset_id: collision_camera_008
   * Pickup 117; Major Location? False
   * Extra - actor_name: item_missiletank_002
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Tile Group (SPEEDBOOST)
+  > Tile Group (POWERBEAM)
       Trivial
 
 > Tile Group (POWERBEAM); Heals? False
@@ -584,21 +584,9 @@ Extra - asset_id: collision_camera_008
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
   > Door to Gyroscope Room
-      Morph Ball and Speed Booster
+      Ballspark
   > Tunnel to Bottom Morph Launcher
       Morph Ball
-
-> Tile Group (SPEEDBOOST); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_004
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SPEEDBOOST',)
-  > Pickup (Missile Tank)
-      Trivial
-  > Tile Group (POWERBEAM)
-      Trivial
 
 > Tunnel to Vertical Bomb Maze; Heals? False
   * Layers: default

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -929,22 +929,6 @@
             "DaironTeleportToArtariaSpeedBlocksDestroyed": {
                 "long_name": "Dairon - Teleport To Artaria Speed Blocks Destroyed",
                 "extra": {}
-            },
-            "BureniaEarlyGravEPart": {
-                "long_name": "Burenia - Early Gravity Energy Part",
-                "extra": {}
-            },
-            "DaironEMMIExitEastSpeedBlocks": {
-                "long_name": "Dairon - EMMI Zone Exit East Speed Blocks Destroyed",
-                "extra": {}
-            },
-            "DaironYellowEMMIChase": {
-                "long_name": "Dairon - Yellow EMMI Chase",
-                "extra": {}
-            },
-            "HanubiaTankSpeed": {
-                "long_name": "Hanubia - Prepare Speedboost in Tank Room",
-                "extra": {}
             }
         },
         "tricks": {

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -929,6 +929,22 @@
             "DaironTeleportToArtariaSpeedBlocksDestroyed": {
                 "long_name": "Dairon - Teleport To Artaria Speed Blocks Destroyed",
                 "extra": {}
+            },
+            "BureniaEarlyGravEPart": {
+                "long_name": "Burenia - Early Gravity Energy Part",
+                "extra": {}
+            },
+            "DaironEMMIExitEastSpeedBlocks": {
+                "long_name": "Dairon - EMMI Zone Exit East Speed Blocks Destroyed",
+                "extra": {}
+            },
+            "DaironYellowEMMIChase": {
+                "long_name": "Dairon - Yellow EMMI Chase",
+                "extra": {}
+            },
+            "HanubiaTankSpeed": {
+                "long_name": "Hanubia - Prepare Speedboost in Tank Room",
+                "extra": {}
             }
         },
         "tricks": {


### PR DESCRIPTION
- Removes the Speed Booster Tile Group node in Fan Room
- Reimplements logic around it