### PR TITLE
add preset describer config for hanubia_easier_path_to_itorash in dread

### DIFF
--- a/randovania/games/dread/layout/preset_describer.py
+++ b/randovania/games/dread/layout/preset_describer.py
@@ -44,6 +44,7 @@ class DreadPresetDescriber(GamePresetDescriber):
                 ),
                 {
                     "Open Hanubia Shortcut": configuration.hanubia_shortcut_no_grapple,
+                    "Easier Path to Itorash in Hanubia": configuration.hanubia_easier_path_to_itorash
                 }
             ]
         }


### PR DESCRIPTION
As I mentioned [here](https://discord.com/channels/914291389293027329/914294231877713940/972019943375781898), Dread doesn't display that `hanubia_easier_path_to_itorash` is enabled in the preset description. I opted to just fix the bug myself.