### PR TITLE
Only check client headers when using online features.

### DIFF
--- a/randovania/gui/lib/qt_network_client.py
+++ b/randovania/gui/lib/qt_network_client.py
@@ -14,7 +14,7 @@ from randovania.network_client.game_session import GameSessionEntry, User, GameS
     GameSessionAuditLog
 from randovania.network_client.network_client import NetworkClient, ConnectionState, UnableToConnect
 from randovania.network_common.error import (InvalidAction, NotAuthorizedForAction, ServerError, RequestTimeout,
-                                             NotLoggedIn, UserNotAuthorized)
+                                             NotLoggedIn, UserNotAuthorized, UnsupportedClient)
 
 
 class QtNetworkClient(QWidget, NetworkClient):
@@ -151,6 +151,13 @@ def handle_network_errors(fn):
                 "You're not authorized to use this build.\nPlease check #dev-builds for more details.",
             )
 
+        except UnsupportedClient as e:
+            s = e.detail.replace('\n', '<br />')
+            await async_dialog.warning(
+                self, "Unsupported client",
+                s,
+            )
+
         except UnableToConnect as e:
             s = e.reason.replace('\n', '<br />')
             await async_dialog.warning(self, "Connection Error",
@@ -160,5 +167,7 @@ def handle_network_errors(fn):
             await async_dialog.warning(self, "Connection Error",
                                        f"<b>Timeout while communicating with the server:</b><br /><br />{e}"
                                        f"<br />Further attempts will wait for longer.")
+
+        return None
 
     return wrapper

--- a/randovania/gui/lib/wait_dialog.py
+++ b/randovania/gui/lib/wait_dialog.py
@@ -19,6 +19,6 @@ async def cancellable_wait(parent: Optional[QtWidgets.QWidget], task: asyncio.Ta
     message_box.rejected.connect(task.cancel)
     message_box.show()
     try:
-        await task
+        return await task
     finally:
         message_box.close()

--- a/randovania/gui/main_online_interaction.py
+++ b/randovania/gui/main_online_interaction.py
@@ -89,13 +89,16 @@ class OnlineInteractions(QtWidgets.QWidget):
         browser = GameSessionBrowserDialog(network_client)
 
         try:
-            await wait_dialog.cancellable_wait(
+            result = await wait_dialog.cancellable_wait(
                 self,
                 asyncio.ensure_future(browser.refresh()),
                 "Communicating",
                 "Requesting the session list...",
             )
         except asyncio.CancelledError:
+            return
+
+        if not result:
             return
 
         if await async_dialog.execute_dialog(browser) == browser.Accepted:

--- a/randovania/gui/online_game_list_window.py
+++ b/randovania/gui/online_game_list_window.py
@@ -60,6 +60,7 @@ class GameSessionBrowserDialog(QDialog, Ui_GameSessionBrowserDialog):
             self.update_list()
         finally:
             self.refresh_button.setEnabled(True)
+        return True
 
     @asyncSlot()
     async def _refresh_slot(self):

--- a/randovania/network_common/__init__.py
+++ b/randovania/network_common/__init__.py
@@ -1,6 +1,6 @@
 import randovania
 
-SERVER_API_VERSION = 5
+SERVER_API_VERSION = 6
 
 
 def connection_headers():

--- a/randovania/network_common/error.py
+++ b/randovania/network_common/error.py
@@ -101,6 +101,26 @@ class UserNotAuthorized(BaseNetworkError):
         return 8
 
 
+class UnsupportedClient(BaseNetworkError):
+    def __init__(self, message: str):
+        self.message = message
+
+    @classmethod
+    def code(cls):
+        return 9
+
+    @property
+    def detail(self):
+        return self.message
+
+    @classmethod
+    def from_detail(cls, detail) -> "UnsupportedClient":
+        return cls(detail)
+
+    def __str__(self):
+        return f"Unsupported client: {self.message}"
+
+
 def decode_error(data: dict) -> Optional[BaseNetworkError]:
     if "error" not in data:
         return None

--- a/randovania/server/app.py
+++ b/randovania/server/app.py
@@ -1,57 +1,13 @@
 import logging
-from distutils.version import StrictVersion
-from enum import Enum
 from logging.config import dictConfig
-from typing import Dict
 
 import flask
 import werkzeug.middleware.proxy_fix
 from flask_socketio import ConnectionRefusedError
 
 import randovania
-from randovania.network_common import connection_headers
-from randovania.server import game_session, user_session, database
+from randovania.server import game_session, user_session, database, client_check
 from randovania.server.server_app import ServerApp
-
-
-class ClientVersionCheck(Enum):
-    STRICT = "strict"
-    MATCH_MAJOR_MINOR = "match-major-minor"
-    IGNORE = "ignore"
-
-
-def check_client_version(version_checking: ClientVersionCheck, client_version: str, server_version: str):
-    if version_checking == ClientVersionCheck.STRICT:
-        if server_version != client_version:
-            raise ConnectionRefusedError(f"Incompatible client version '{client_version}', "
-                                         f"expected '{server_version}'")
-    elif version_checking == ClientVersionCheck.MATCH_MAJOR_MINOR:
-        server = StrictVersion(server_version.split(".dev")[0])
-        client = StrictVersion(client_version.split(".dev")[0])
-        if server.version[:2] != client.version[:2]:
-            shorter_client = "{}.{}".format(*client.version[:2])
-            shorter_server = "{}.{}".format(*server.version[:2])
-            raise ConnectionRefusedError(f"Incompatible client version '{shorter_client}', "
-                                         f"expected '{shorter_server}'")
-
-
-def check_client_headers(expected_headers: Dict[str, str], environ: Dict[str, str]):
-    wrong_headers = {}
-    for name, expected in expected_headers.items():
-        value = environ.get("HTTP_{}".format(name.upper().replace("-", "_")))
-        if value != expected:
-            wrong_headers[name] = value
-
-    if wrong_headers:
-        message = "\n".join(
-            f"Expected '{expected_headers[name]}' for '{name}', got '{value}'."
-            for name, value in wrong_headers.items()
-        )
-        raise ConnectionRefusedError(
-            "Incompatible client:\n{}\n\nServer is version {}, please confirm you're updated.".format(
-                message, randovania.VERSION,
-            )
-        )
 
 
 def create_app():
@@ -82,7 +38,7 @@ def create_app():
     app.config["DISCORD_REDIRECT_URI"] = f'{configuration["server_address"]}/login_callback'
     app.config["FERNET_KEY"] = configuration["server_config"]["fernet_key"].encode("ascii")
     app.config["ENFORCE_ROLE"] = configuration["server_config"].get("enforce_role")
-    version_checking = ClientVersionCheck(configuration["server_config"]["client_version_checking"])
+    version_checking = client_check.ClientVersionCheck(configuration["server_config"]["client_version_checking"])
 
     database.db.init(configuration["server_config"]['database_path'])
     database.db.connect(reuse_if_open=True)
@@ -101,8 +57,6 @@ def create_app():
         return randovania.VERSION
 
     server_version = randovania.VERSION
-    expected_headers = connection_headers()
-    expected_headers.pop("X-Randovania-Version")
 
     @sio.sio.server.on("connect")
     def connect(sid, environ):
@@ -111,8 +65,13 @@ def create_app():
                 raise ConnectionRefusedError("unknown client version")
 
             client_app_version = environ["HTTP_X_RANDOVANIA_VERSION"]
-            check_client_version(version_checking, client_app_version, server_version)
-            check_client_headers(expected_headers, environ)
+            error_message = client_check.check_client_version(version_checking, client_app_version, server_version)
+            if error_message is None and not randovania.is_dev_version():
+                error_message = client_check.check_client_headers(sio.expected_headers, environ)
+
+            if error_message is not None:
+                raise ConnectionRefusedError(error_message)
+
             connected_clients.inc()
 
             forwarded_for = environ.get('HTTP_X_FORWARDED_FOR')

--- a/randovania/server/client_check.py
+++ b/randovania/server/client_check.py
@@ -1,0 +1,44 @@
+from distutils.version import StrictVersion
+from enum import Enum
+from typing import Dict
+
+import randovania
+
+
+class ClientVersionCheck(Enum):
+    STRICT = "strict"
+    MATCH_MAJOR_MINOR = "match-major-minor"
+    IGNORE = "ignore"
+
+
+def check_client_version(version_checking: ClientVersionCheck, client_version: str, server_version: str):
+    if version_checking == ClientVersionCheck.STRICT:
+        if server_version != client_version:
+            return f"Incompatible client version '{client_version}', expected '{server_version}'"
+
+    elif version_checking == ClientVersionCheck.MATCH_MAJOR_MINOR:
+        server = StrictVersion(server_version.split(".dev")[0])
+        client = StrictVersion(client_version.split(".dev")[0])
+        if server.version[:2] != client.version[:2]:
+            shorter_client = "{}.{}".format(*client.version[:2])
+            shorter_server = "{}.{}".format(*server.version[:2])
+            return f"Incompatible client version '{shorter_client}', expected '{shorter_server}'"
+
+
+def check_client_headers(expected_headers: Dict[str, str], environ: Dict[str, str]):
+    wrong_headers = {}
+    for name, expected in expected_headers.items():
+        value = environ.get("HTTP_{}".format(name.upper().replace("-", "_")))
+        if value != expected:
+            wrong_headers[name] = value
+
+    if wrong_headers:
+        message = "\n".join(
+            f"Expected '{expected_headers[name]}' for '{name}', got '{value}'."
+            for name, value in wrong_headers.items()
+        )
+        return (
+            "Incompatible client:\n{}\n\nServer is version {}, please confirm you're updated.".format(
+                message, randovania.VERSION,
+            )
+        )

--- a/randovania/server/game_session.py
+++ b/randovania/server/game_session.py
@@ -729,9 +729,9 @@ def report_user_disconnected(sio: ServerApp, user_id: int, log):
 
 
 def setup_app(sio: ServerApp):
-    sio.on("list_game_sessions", list_game_sessions)
-    sio.on("create_game_session", create_game_session)
-    sio.on("join_game_session", join_game_session)
+    sio.on("list_game_sessions", list_game_sessions, with_header_check=True)
+    sio.on("create_game_session", create_game_session, with_header_check=True)
+    sio.on("join_game_session", join_game_session, with_header_check=True)
     sio.on("disconnect_game_session", disconnect_game_session)
     sio.on("game_session_request_update", game_session_request_update)
     sio.on("game_session_admin_session", game_session_admin_session)

--- a/test/server/test_client_check.py
+++ b/test/server/test_client_check.py
@@ -1,0 +1,71 @@
+import pytest
+
+from randovania.server import client_check
+
+
+@pytest.fixture(name="expected_headers")
+def _expected_headers():
+    return {
+        "X-Randovania-API-Version": "2",
+        "X-Randovania-Preset-Version": "13",
+        "X-Randovania-Permalink-Version": "4",
+        "X-Randovania-Description-Version": "2",
+    }
+
+
+def test_check_client_headers_valid(expected_headers):
+    result = client_check.check_client_headers(
+        expected_headers,
+        {
+            "HTTP_X_RANDOVANIA_API_VERSION": "2",
+            "HTTP_X_RANDOVANIA_PRESET_VERSION": "13",
+            "HTTP_X_RANDOVANIA_PERMALINK_VERSION": "4",
+            "HTTP_X_RANDOVANIA_DESCRIPTION_VERSION": "2",
+        }
+    )
+    assert result is None
+
+
+def test_check_client_headers_missing(expected_headers):
+    result = client_check.check_client_headers(
+        expected_headers,
+        {
+            "HTTP_X_RANDOVANIA_API_VERSION": "2",
+            "HTTP_X_RANDOVANIA_PRESET_VERSION": "13",
+            "HTTP_X_RANDOVANIA_PERMALINK_VERSION": "4",
+        }
+    )
+    assert result is not None
+
+
+def test_check_client_headers_wrong_value(expected_headers):
+    result = client_check.check_client_headers(
+        expected_headers,
+        {
+            "HTTP_X_RANDOVANIA_API_VERSION": "2",
+            "HTTP_X_RANDOVANIA_PRESET_VERSION": "10",
+            "HTTP_X_RANDOVANIA_PERMALINK_VERSION": "7",
+            "HTTP_X_RANDOVANIA_DESCRIPTION_VERSION": "2",
+        }
+    )
+    assert result is not None
+
+
+@pytest.mark.parametrize(["mode", "client_version", "server_version", "expected"], [
+    (client_check.ClientVersionCheck.STRICT, "1.0", "1.0", True),
+    (client_check.ClientVersionCheck.STRICT, "1.0", "1.0.1", False),
+    (client_check.ClientVersionCheck.STRICT, "1.0", "1.1", False),
+    (client_check.ClientVersionCheck.MATCH_MAJOR_MINOR, "1.0", "1.0", True),
+    (client_check.ClientVersionCheck.MATCH_MAJOR_MINOR, "1.0", "1.0.1", True),
+    (client_check.ClientVersionCheck.MATCH_MAJOR_MINOR, "1.0", "1.1", False),
+    (client_check.ClientVersionCheck.IGNORE, "1.0", "1.0", True),
+    (client_check.ClientVersionCheck.IGNORE, "1.0", "1.0.1", True),
+    (client_check.ClientVersionCheck.IGNORE, "1.0", "1.1", True),
+])
+def test_check_client_version(mode, client_version, server_version, expected):
+    result = client_check.check_client_version(mode, client_version, server_version)
+
+    if expected:
+        assert result is None
+    else:
+        assert result is not None

--- a/test/server/test_server_app.py
+++ b/test/server/test_server_app.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, call
 import flask
 import pytest
 
+import randovania.server.client_check
 from randovania.network_common.error import NotLoggedIn, ServerError, InvalidSession
 from randovania.server import database
 from randovania.server.server_app import ServerApp, EnforceDiscordRole
@@ -201,4 +202,3 @@ def test_verify_user(mocker, valid):
     assert mock_session.return_value.headers == {
         "Authorization": "Bot da_token",
     }
-


### PR DESCRIPTION
This allows the use of old dev builds.