### PR TITLE
Optimize generation + validation combined by 48%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.4.0] - 2022-06-01
 
 - Changed: Reduced the lag you get the first time you open the Games tab.
+- Changed: Optimized the game generation. As example, Echoes' Starter Preset is 37% faster.
+- Changed: Optimized the game validation. As example, Echoes' Starter Preset is 65% faster.
 - Removed: The server and discord bot are entirely removed from the distributed executables.
 
 ### Cave Story

--- a/randovania/game_description/data_reader.py
+++ b/randovania/game_description/data_reader.py
@@ -1,4 +1,3 @@
-import copy
 import json
 from pathlib import Path
 from typing import List, Callable, TypeVar, Tuple, Dict, Type, Optional, Hashable, Any
@@ -458,7 +457,7 @@ def read_minimal_logic_db(data: Optional[dict]) -> Optional[MinimalLogicData]:
 
 
 def decode_data_with_world_reader(data: Dict) -> Tuple[WorldReader, GameDescription]:
-    data = game_migration.migrate_to_current(copy.deepcopy(data))
+    data = game_migration.migrate_to_current(data)
 
     game = RandovaniaGame(data["game"])
 

--- a/randovania/game_description/game_migration.py
+++ b/randovania/game_description/game_migration.py
@@ -398,4 +398,5 @@ _MIGRATIONS = {
 
 
 def migrate_to_current(data: dict):
-    return migration_lib.migrate_to_version(data, CURRENT_VERSION, _MIGRATIONS)
+    return migration_lib.migrate_to_version(data, CURRENT_VERSION, _MIGRATIONS,
+                                            copy_before_migrating=True)

--- a/randovania/game_description/world/dock_lock_node.py
+++ b/randovania/game_description/world/dock_lock_node.py
@@ -17,7 +17,7 @@ class DockLockNode(ResourceNode):
 
     @classmethod
     def create_from_dock(cls, dock: DockNode) -> DockLockNode:
-        lock_identifier = dock.get_lock_node_identifier_from_identifier(dock.identifier)
+        lock_identifier = dock.lock_node_identifier
         return DockLockNode(
             identifier=lock_identifier,
             heal=False,

--- a/randovania/game_description/world/dock_node.py
+++ b/randovania/game_description/world/dock_node.py
@@ -48,20 +48,17 @@ class DockNode(Node):
     default_dock_weakness: DockWeakness
     override_default_open_requirement: typing.Optional[Requirement]
     override_default_lock_requirement: typing.Optional[Requirement]
+    lock_node_identifier: NodeIdentifier = dataclasses.field(init=False, hash=False, compare=False)
+
+    def __post_init__(self):
+        object.__setattr__(self, "lock_node_identifier", dataclasses.replace(
+            self.identifier,
+            node_name=f"Lock - {self.name}",
+        ))
+        return super().__post_init__()
 
     def __repr__(self):
         return "DockNode({!r} -> {})".format(self.name, self.default_connection)
-
-    def get_lock_node_identifier_from_identifier(self, self_identifier: NodeIdentifier):
-        return dataclasses.replace(
-            self_identifier,
-            node_name=f"Lock - {self.name}",
-        )
-
-    def get_lock_node_identifier(self, context: NodeContext) -> NodeIdentifier:
-        return self.get_lock_node_identifier_from_identifier(
-            context.node_provider.identifier_for_node(self),
-        )
 
     def get_front_weakness(self, context: NodeContext) -> DockWeakness:
         self_identifier = context.node_provider.identifier_for_node(self)
@@ -129,7 +126,7 @@ class DockNode(Node):
         if forward_lock is None and back_lock is None:
             return None
 
-        lock_node = context.node_provider.node_by_identifier(self.get_lock_node_identifier(context))
+        lock_node = context.node_provider.node_by_identifier(self.lock_node_identifier)
         return lock_node, requirement
 
     def get_target_identifier(self, context: NodeContext) -> typing.Optional[NodeIdentifier]:

--- a/randovania/game_description/world/node_identifier.py
+++ b/randovania/game_description/world/node_identifier.py
@@ -1,11 +1,10 @@
 import dataclasses
-from dataclasses import dataclass
 
 from randovania.game_description.resources.resource_type import ResourceType
 from randovania.game_description.world.area_identifier import AreaIdentifier
 
 
-@dataclass(frozen=True, order=True)
+@dataclasses.dataclass(frozen=True, order=True)
 class NodeIdentifier:
     area_identifier: AreaIdentifier
     node_name: str

--- a/randovania/game_description/world/world_list.py
+++ b/randovania/game_description/world/world_list.py
@@ -24,6 +24,7 @@ class WorldList(NodeProvider):
     _nodes_to_world: Dict[Node, World]
     _nodes: Optional[Tuple[Node, ...]]
     _pickup_index_to_node: Dict[PickupIndex, PickupNode]
+    _identifier_to_node: Dict[NodeIdentifier, Node]
 
     def __deepcopy__(self, memodict):
         return WorldList(
@@ -32,7 +33,7 @@ class WorldList(NodeProvider):
 
     def __init__(self, worlds: List[World]):
         self.worlds = worlds
-        self._nodes = None
+        self.invalidate_node_cache()
 
     def _refresh_node_cache(self):
         self._nodes_to_area, self._nodes_to_world = _calculate_nodes_to_area_world(self.worlds)
@@ -53,6 +54,7 @@ class WorldList(NodeProvider):
 
     def invalidate_node_cache(self):
         self._nodes = None
+        self._identifier_to_node = {}
 
     def _iterate_over_nodes(self) -> Iterator[Node]:
         for world in self.worlds:
@@ -189,10 +191,16 @@ class WorldList(NodeProvider):
                             static_resources, damage_multiplier, database).simplify()
 
     def node_by_identifier(self, identifier: NodeIdentifier) -> Node:
+        cache_result = self._identifier_to_node.get(identifier)
+        if cache_result is not None:
+            return cache_result
+
         area = self.area_by_area_location(identifier.area_location)
         node = area.node_with_name(identifier.node_name)
         if node is not None:
+            self._identifier_to_node[identifier] = node
             return node
+
         raise ValueError(f"No node with name {identifier.node_name} found in {area}")
 
     def area_by_area_location(self, location: AreaIdentifier) -> Area:

--- a/randovania/lib/migration_lib.py
+++ b/randovania/lib/migration_lib.py
@@ -1,10 +1,16 @@
+import copy
 from typing import Callable
 
 
-def migrate_to_version(data: dict, version: int, migrations: dict[int, Callable[[dict], dict]]) -> dict:
+def migrate_to_version(data: dict, version: int, migrations: dict[int, Callable[[dict], dict]],
+                       *, copy_before_migrating: bool = False) -> dict:
     schema_version = data.get("schema_version", 1)
 
     while schema_version < version:
+        if copy_before_migrating:
+            data = copy.deepcopy(data)
+            copy_before_migrating = False
+
         data = migrations[schema_version](data)
         schema_version += 1
 

--- a/randovania/resolver/event_pickup.py
+++ b/randovania/resolver/event_pickup.py
@@ -100,3 +100,5 @@ def replace_with_event_pickups(game: GameDescription):
                     connections[combined_node] = connections.pop(event_node)
 
             area.connections[combined_node] = area.connections.pop(next_node)
+
+    game.world_list.invalidate_node_cache()

--- a/randovania/resolver/resolver.py
+++ b/randovania/resolver/resolver.py
@@ -112,7 +112,7 @@ async def _inner_advance_depth(state: State,
         if _should_check_if_action_is_safe(state, action, logic.game.dangerous_resources,
                                            logic.game.world_list.all_nodes):
 
-            potential_state = state.act_on_node(action, path=reach.path_to_node[action], new_energy=energy)
+            potential_state = state.act_on_node(action, path=reach.path_to_node(action), new_energy=energy)
             potential_reach = ResolverReach.calculate_reach(logic, potential_state)
 
             # If we can go back to where we were, it's a simple safe node
@@ -134,7 +134,7 @@ async def _inner_advance_depth(state: State,
     has_action = False
     for action, energy in reach.satisfiable_actions(state, logic.game.victory_condition):
         new_result = await _inner_advance_depth(
-            state=state.act_on_node(action, path=reach.path_to_node[action], new_energy=energy),
+            state=state.act_on_node(action, path=reach.path_to_node(action), new_energy=energy),
             logic=logic,
             status_update=status_update,
         )

--- a/randovania/resolver/resolver_reach.py
+++ b/randovania/resolver/resolver_reach.py
@@ -14,34 +14,38 @@ from randovania.resolver.state import State
 
 
 class ResolverReach:
-    _nodes: Tuple[Node, ...]
-    _energy_at_node: Dict[Node, int]
-    path_to_node: Dict[Node, Tuple[Node, ...]]
+    _node_indices: Tuple[int, ...]
+    _energy_at_node: Dict[int, int]
+    _path_to_node: Dict[int, Tuple[Node, ...]]
     _satisfiable_requirements: SatisfiableRequirements
-    _safe_nodes: FrozenSet[Node]
     _logic: Logic
 
     @property
     def nodes(self) -> Iterator[Node]:
-        return iter(self._nodes)
+        all_nodes = self._logic.game.world_list.all_nodes
+        for index in self._node_indices:
+            yield all_nodes[index]
 
     @property
     def satisfiable_requirements(self) -> SatisfiableRequirements:
         return self._satisfiable_requirements
+
+    def path_to_node(self, node: Node) -> Tuple[Node, ...]:
+        return self._path_to_node[node.get_index()]
 
     @property
     def satisfiable_as_requirement_set(self) -> RequirementSet:
         return RequirementSet(self._satisfiable_requirements)
 
     def __init__(self,
-                 nodes: Dict[Node, int],
-                 path_to_node: Dict[Node, Tuple[Node, ...]],
+                 nodes: Dict[int, int],
+                 path_to_node: Dict[int, Tuple[Node, ...]],
                  requirements: SatisfiableRequirements,
                  logic: Logic):
-        self._nodes = tuple(nodes.keys())
+        self._node_indices = tuple(nodes.keys())
         self._energy_at_node = nodes
         self._logic = logic
-        self.path_to_node = path_to_node
+        self._path_to_node = path_to_node
         self._satisfiable_requirements = requirements
 
     @classmethod
@@ -49,32 +53,34 @@ class ResolverReach:
                         logic: Logic,
                         initial_state: State) -> "ResolverReach":
 
-        checked_nodes: Dict[Node, int] = {}
+        all_nodes = logic.game.world_list.all_nodes
+        checked_nodes: Dict[int, int] = {}
         database = initial_state.resource_database
         context = initial_state.node_context()
 
         # Keys: nodes to check
         # Value: how much energy was available when visiting that node
-        nodes_to_check: Dict[Node, int] = {
-            initial_state.node: initial_state.energy
+        nodes_to_check: Dict[int, int] = {
+            initial_state.node.get_index(): initial_state.energy
         }
 
-        reach_nodes: Dict[Node, int] = {}
-        requirements_by_node: Dict[Node, Set[RequirementList]] = defaultdict(set)
+        reach_nodes: Dict[int, int] = {}
+        requirements_by_node: Dict[int, Set[RequirementList]] = defaultdict(set)
 
-        path_to_node: Dict[Node, Tuple[Node, ...]] = {}
-        path_to_node[initial_state.node] = tuple()
+        path_to_node: Dict[int, Tuple[Node, ...]] = {}
+        path_to_node[initial_state.node.get_index()] = tuple()
 
         while nodes_to_check:
-            node = next(iter(nodes_to_check))
-            energy = nodes_to_check.pop(node)
+            node_index = next(iter(nodes_to_check))
+            node = all_nodes[node_index]
+            energy = nodes_to_check.pop(node_index)
 
             if node.heal:
                 energy = initial_state.maximum_energy
 
-            checked_nodes[node] = energy
-            if node != initial_state.node:
-                reach_nodes[node] = energy
+            checked_nodes[node_index] = energy
+            if node_index != initial_state.node.get_index():
+                reach_nodes[node_index] = energy
 
             requirement_to_leave = node.requirement_to_leave(context)
 
@@ -82,7 +88,9 @@ class ResolverReach:
                 if target_node is None:
                     continue
 
-                if checked_nodes.get(target_node, math.inf) <= energy or nodes_to_check.get(target_node,
+                target_node_index = target_node.get_index()
+
+                if checked_nodes.get(target_node_index, math.inf) <= energy or nodes_to_check.get(target_node_index,
                                                                                             math.inf) <= energy:
                     continue
 
@@ -98,23 +106,23 @@ class ResolverReach:
                                                                                   initial_state.resource_database)
 
                 if satisfied:
-                    nodes_to_check[target_node] = energy - requirement.damage(initial_state.resources, database)
-                    path_to_node[target_node] = path_to_node[node] + (node,)
+                    nodes_to_check[target_node_index] = energy - requirement.damage(initial_state.resources, database)
+                    path_to_node[target_node_index] = path_to_node[node_index] + (node_index,)
 
                 elif target_node:
                     # If we can't go to this node, store the reason in order to build the satisfiable requirements.
                     # Note we ignore the 'additional requirements' here because it'll be added on the end.
-                    requirements_by_node[target_node].update(
+                    requirements_by_node[target_node_index].update(
                         requirement.as_set(initial_state.resource_database).alternatives)
 
         # Discard satisfiable requirements of nodes reachable by other means
-        for node in set(reach_nodes.keys()).intersection(requirements_by_node.keys()):
-            requirements_by_node.pop(node)
+        for node_index in set(reach_nodes.keys()).intersection(requirements_by_node.keys()):
+            requirements_by_node.pop(node_index)
 
         if requirements_by_node:
             satisfiable_requirements = frozenset.union(
-                *[RequirementSet(requirements).union(logic.get_additional_requirements(node)).alternatives
-                  for node, requirements in requirements_by_node.items()])
+                *[RequirementSet(requirements).union(logic.get_additional_requirements(all_nodes[node_index])).alternatives
+                  for node_index, requirements in requirements_by_node.items()])
         else:
             satisfiable_requirements = frozenset()
 
@@ -127,8 +135,9 @@ class ResolverReach:
 
         for node in self.collectable_resource_nodes(state):
             additional_requirements = self._logic.get_additional_requirements(node)
-            if additional_requirements.satisfied(state.resources, self._energy_at_node[node], state.resource_database):
-                yield node, self._energy_at_node[node]
+            energy = self._energy_at_node[node.get_index()]
+            if additional_requirements.satisfied(state.resources, energy, state.resource_database):
+                yield node, energy
             else:
                 debug.log_skip_action_missing_requirement(node, self._logic.game,
                                                           self._logic.get_additional_requirements(node))

--- a/test/resolver/test_resolver_reach.py
+++ b/test/resolver/test_resolver_reach.py
@@ -15,15 +15,19 @@ def test_possible_actions_empty():
 
 def test_possible_actions_no_resources():
     state = MagicMock()
-    node_a = MagicMock()
-    node_b = MagicMock()
+    node_a = MagicMock(name="node_a")
+    node_b = MagicMock(name="node_b")
     node_b.can_collect.return_value = False
+    logic = MagicMock()
+    logic.game.world_list.all_nodes = [node_a, node_b]
+    node_a.get_index.return_value = 0
+    node_b.get_index.return_value = 1
 
     type(node_a).is_resource_node = prop_a = PropertyMock(return_value=False)
     type(node_b).is_resource_node = prop_b = PropertyMock(return_value=True)
 
     # Run
-    reach = ResolverReach({node_a: 1, node_b: 1}, {}, frozenset(), MagicMock())
+    reach = ResolverReach({0: 1, 1: 1}, {}, frozenset(), logic)
     options = list(action for action, damage in reach.possible_actions(state))
 
     # Assert
@@ -38,12 +42,15 @@ def test_possible_actions_with_event():
     logic = MagicMock()
     state = MagicMock()
 
-    event = MagicMock(spec=EventNode)
+    event = MagicMock(spec=EventNode, name="event node")
+    event.get_index.return_value = 0
     type(event).is_resource_node = prop = PropertyMock(return_value=True)
     event.can_collect.return_value = True
 
+    logic.game.world_list.all_nodes = [event]
+
     # Run
-    reach = ResolverReach({event: 1}, {}, frozenset(), logic)
+    reach = ResolverReach({0: 1}, {}, frozenset(), logic)
     options = list(action for action, damage in reach.possible_actions(state))
 
     # Assert


### PR DESCRIPTION
If you're curious, the biggest gains were from:
* `randovania/resolver/resolver_reach.py`
* `randovania/generator/old_generator_reach.py`

Using indices of a list as keys instead of dicts is fast.