### PR TITLE
[WIP] Added hints to Prime 1

### DIFF
--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -17,7 +17,7 @@ from randovania.game_description.world.pickup_node import PickupNode
 from randovania.game_description.world.world_list import WorldList
 from randovania.games.game import RandovaniaGame
 from randovania.games.prime1.exporter.hint_namer import PrimeHintNamer
-from randovania.games.prime1.layout.hint_configuration import ArtifactHintMode, PhazonSuitHintMode
+from randovania.games.prime1.layout.hint_configuration import ArtifactHintMode, PhazonSuitHintMode, LoreHintMode
 from randovania.games.prime1.layout.prime_configuration import PrimeConfiguration, RoomRandoMode
 from randovania.games.prime1.layout.prime_cosmetic_patches import PrimeCosmeticPatches
 from randovania.games.prime1.patcher import prime1_elevators, prime_items
@@ -689,6 +689,21 @@ class PrimePatchDataFactory(BasePatchDataFactory):
                 True,
             )
 
+        equipment = [
+            db.resource_database.get_item(index)
+            for index in prime_items.EQUIPMENT
+        ]
+        if hint_config.lore == LoreHintMode.DISABLED:
+            resulting_lore_hints = {item: "{} is lost somewhere on Tallon IV.".format(item.long_name) for item in equipment}
+        else:
+            resulting_lore_hints = guaranteed_item_hint.create_guaranteed_hints_for_resources(
+                self.description.all_patches,
+                self.players_config, namer,
+                hint_config.lore == LoreHintMode.HIDE_AREA,
+                [db.resource_database.get_item(index) for index in prime_items.EQUIPMENT],
+                True,
+            )
+
         # Tweaks
         ctwk_config = {}
         if self.configuration.small_samus:
@@ -772,7 +787,6 @@ class PrimePatchDataFactory(BasePatchDataFactory):
                 "platedBeetle": get_random_size(0.05, 6.0),
                 "cloakedDrone": get_random_size(0.05, 6.0), # only scales width (lmao)
             }
-
         return {
             "seed": seed,
             "preferences": {
@@ -838,6 +852,10 @@ class PrimePatchDataFactory(BasePatchDataFactory):
                 "artifactHints": {
                     artifact.long_name: text
                     for artifact, text in resulting_hints.items()
+                },
+                "loreHints": {
+                    item.long_name: text
+                    for item, text in  resulting_lore_hints.items()
                 },
                 "artifactTempleLayerOverrides": {
                     artifact.long_name: self.patches.starting_items.get(artifact, 0) == 0

--- a/randovania/games/prime1/layout/hint_configuration.py
+++ b/randovania/games/prime1/layout/hint_configuration.py
@@ -24,7 +24,17 @@ class PhazonSuitHintMode(BitPackEnum, Enum):
     def default(cls) -> "PhazonSuitHintMode":
         return cls.PRECISE
 
+class LoreHintMode(BitPackEnum, Enum):
+    DISABLED = "disabled"
+    HIDE_AREA = "hide-area"
+    PRECISE = "precise"
+
+    @classmethod
+    def default(cls) -> "LoreHintMode":
+        return cls.PRECISE
+
 @dataclasses.dataclass(frozen=True)
 class HintConfiguration(BitPackDataclass, JsonDataclass, DataclassPostInitTypeCheck):
     artifacts: ArtifactHintMode
     phazon_suit: PhazonSuitHintMode
+    lore: LoreHintMode

--- a/randovania/games/prime1/patcher/prime_items.py
+++ b/randovania/games/prime1/patcher/prime_items.py
@@ -18,3 +18,30 @@ ARTIFACT_ITEMS = [
 ]
 ARTIFACT_NAMES = ["Artifact of " + item for item in ARTIFACT_ITEMS]
 ARTIFACT_MODEL = list(ARTIFACT_NAMES)
+
+EQUIPMENT = [
+    "Charge",
+    "Power",
+    "Wave",
+    "Ice",
+    "Plasma",
+    "Grapple",
+    "Combat",
+    "Scan",
+    "Thermal",
+    "X-Ray",
+    "SpaceJump",
+    "EnergyTank",
+    "MorphBall",
+    "Bombs",
+    "Boost",
+    "Spider",
+    "PowerSuit",
+    "VariaSuit",
+    "GravitySuit",
+    "PhazonSuit",
+    "Supers",
+    "Wavebuster",
+    "IceSpreader",
+    "Flamethrower",
+]

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -6,7 +6,7 @@ from randovania.game_description import migration_data, default_database
 from randovania.games.game import RandovaniaGame
 from randovania.lib import migration_lib
 
-CURRENT_VERSION = 29
+CURRENT_VERSION = 30
 
 
 def _migrate_v1(preset: dict) -> dict:
@@ -606,6 +606,11 @@ def _migrate_v28(preset: dict) -> dict:
 
     return preset
 
+def _migrate_v29(preset: dict) -> dict:
+    if preset["game"] == "prime1" and "lore" not in preset["configuration"]["hints"].keys():
+        preset["configuration"]["hints"]["lore"] = "hide-area"
+    return preset
+
 
 _MIGRATIONS = {
     1: _migrate_v1,  # v1.1.1-247-gaf9e4a69
@@ -636,6 +641,7 @@ _MIGRATIONS = {
     26: _migrate_v26,
     27: _migrate_v27,
     28: _migrate_v28,
+    29: _migrate_v29,
 }
 
 


### PR DESCRIPTION
The goal of this PR is to add a hint system to Prime 1. Overriding the STRGs of the Chozo Lore and Space Pirate Logs, it will ideally give hints to the player of where their and other's items are located.

It currently needs to be tweaked. The way it's implemented has the hints being way too direct and doesn't leave much room for mystery. It also uses up far too many slots at once (a total of 24 at the moment, one for each major collectible). It doesn't hint towards expansions which it absolutely should to cut down on the major spoilers.

For what it is, it's completely functional, if not basically cheating
![image](https://user-images.githubusercontent.com/18319621/171941973-bb6bdcea-7c65-4a6d-881f-63ea46602914.png)

There currently isn't a GUI toggle for it. Need to implement that 

TODO:
- [ ] Add GUI
- [ ] Add minor items
- [ ] Add joke hints
- [ ] Possibly limit hints to one per room
- [ ] Enable/Disable Space Pirate Frigate hint
- [ ] Improve code
- [ ] Shuffle hints thoroughly before sending to patcher (Or shuffle them in the patcher)

Randomprime PR that accompanies it: https://github.com/toasterparty/randomprime/pull/46

