### PR TITLE
Dread: East Artaria Revision

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -10551,6 +10551,15 @@
                                                                         {
                                                                             "type": "template",
                                                                             "data": "Open Charge Door"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Movement",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
                                                                         }
                                                                     ]
                                                                 }

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -6989,6 +6989,15 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Event - Charge Beam Access Blob (Below)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Wave",
+                                "amount": 1,
+                                "negate": false
+                            }
                         }
                     }
                 },
@@ -7022,7 +7031,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Charge Beam Access Blob": {
+                        "Event - Charge Beam Access Blob (Above)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7086,11 +7095,11 @@
                         }
                     }
                 },
-                "Event - Charge Beam Access Blob": {
+                "Event - Charge Beam Access Blob (Above)": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": -7000.0,
+                        "x": -6800.0,
                         "y": -7600.0,
                         "z": 0.0
                     },
@@ -7299,6 +7308,30 @@
                         "default"
                     ],
                     "extra": {},
+                    "connections": {
+                        "Door to Cold Introduction (Missile)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Charge Beam Access Blob (Below)": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -6800.0,
+                        "y": -7900.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "s010_cave:default:PRP_DB_CV_010",
                     "connections": {
                         "Door to Cold Introduction (Missile)": {
                             "type": "and",
@@ -9878,17 +9911,50 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Open Charge Door"
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
                                                     "type": "template",
                                                     "data": "Simple IBJ"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -9947,8 +10013,20 @@
                             }
                         },
                         "Event - Thermal Device East Blob": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Event - Thermal Device West Blob": {
                             "type": "or",
@@ -10018,8 +10096,20 @@
                             }
                         },
                         "Event - Thermal Device West Blob": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -10445,21 +10535,50 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "Speed",
-                                                                    "amount": 1,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Speed",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Open Charge Door"
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "Grapple",
-                                                                    "amount": 1,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Grapple",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Movement",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -10536,6 +10655,67 @@
                                                         "name": "Space",
                                                         "amount": 1,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Grapple",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Lava",
+                                                                    "amount": 500,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -15653,6 +15833,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -15738,6 +15927,15 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -18690,10 +18888,12 @@
                             }
                         },
                         "Door to Thermal Device (Upper)": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "events",
+                                "name": "ArtariaThermalItemDoor",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -19056,6 +19256,39 @@
                                 "amount": 1,
                                 "negate": false
                             }
+                        },
+                        "Event - Open Item Door": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Missile"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Beam"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "MissileAmmo",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -19092,6 +19325,30 @@
                         "Start Point": {
                             "type": "template",
                             "data": "Can Slide"
+                        }
+                    }
+                },
+                "Event - Open Item Door": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 18900.4,
+                        "y": 1600.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "ArtariaThermalItemDoor",
+                    "connections": {
+                        "Start Point": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 }
@@ -19770,7 +20027,7 @@
                                     },
                                     {
                                         "type": "template",
-                                        "data": "Shoot Ice Missile"
+                                        "data": "Destroy Enky"
                                     }
                                 ]
                             }
@@ -19939,7 +20196,7 @@
                                     },
                                     {
                                         "type": "template",
-                                        "data": "Shoot Ice Missile"
+                                        "data": "Destroy Enky"
                                     }
                                 ]
                             }
@@ -20123,15 +20380,39 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Beam"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Bomb"
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
                         },
                         "Event - ArbEnky Blob East": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 }
@@ -21353,12 +21634,29 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Grapple",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -21695,6 +21993,53 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Simple IBJ"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Morph",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "SWJ",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Open Charge Door"
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -22081,12 +22426,29 @@
                                         "data": "Simple IBJ"
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DBoost",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -2325,7 +2325,7 @@ Extra - asset_id: collision_camera_023_B
                   Heat/Cold Runs (Intermediate) and Heat Damage ≥ 200
               Any of the following:
                   Spider Magnet or Space Jump
-                  Speed Booster and Open Charge Door
+                  Speed Booster and Movement (Beginner) and Open Charge Door
                   Grapple Beam and Movement (Intermediate)
 
 > Pickup (Missile Tank); Heals? False

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -1541,6 +1541,8 @@ Extra - asset_id: collision_camera_013
   * Extra - right_shield_def: None
   > Door to Intro Room
       Trivial
+  > Event - Charge Beam Access Blob (Below)
+      Wave Beam
 
 > Door to Cold Introduction (Power); Heals? False
   * Layers: default
@@ -1551,7 +1553,7 @@ Extra - asset_id: collision_camera_013
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Event - Charge Beam Access Blob
+  > Event - Charge Beam Access Blob (Above)
       Trivial
   > Dock to Cold Introduction
       After Artaria - Charge Beam Access Blob
@@ -1568,7 +1570,7 @@ Extra - asset_id: collision_camera_013
   > Tunnel to Cold Introduction
       Morph Ball
 
-> Event - Charge Beam Access Blob; Heals? False
+> Event - Charge Beam Access Blob (Above); Heals? False
   * Layers: default
   * Event Artaria - Charge Beam Access Blob
   * Extra - actor_name: PRP_DB_CV_010
@@ -1614,6 +1616,12 @@ Extra - asset_id: collision_camera_013
 
 > Start Point; Heals? False; Spawn Point
   * Layers: default
+  > Door to Cold Introduction (Missile)
+      Trivial
+
+> Event - Charge Beam Access Blob (Below); Heals? False
+  * Layers: default
+  * Event Artaria - Charge Beam Access Blob
   > Door to Cold Introduction (Missile)
       Trivial
 
@@ -2184,7 +2192,10 @@ Extra - asset_id: collision_camera_022
   > Tunnel to David Jaffe Room
       All of the following:
           Morph Ball
-          Speed Booster or Simple IBJ
+          Any of the following:
+              Simple IBJ
+              Speed Booster and Open Charge Door
+              Movement (Intermediate) and Use Spin Boost
 
 > Door to Thermal Device; Heals? False
   * Layers: default
@@ -2200,7 +2211,7 @@ Extra - asset_id: collision_camera_022
   > Door to Invisible Corpius Room
       After Artaria - Thermal Device West Blob
   > Event - Thermal Device East Blob
-      Shoot Beam
+      Lay Bomb or Shoot Beam
   > Event - Thermal Device West Blob
       Wave Beam or Pseudo-Wave Beam (Intermediate)
 
@@ -2216,7 +2227,7 @@ Extra - asset_id: collision_camera_022
   > Door to Thermal Device
       After Artaria - Thermal Device West Blob
   > Event - Thermal Device West Blob
-      Shoot Beam
+      Lay Bomb or Shoot Beam
 
 > Event - Thermal Device East Blob; Heals? False
   * Layers: default
@@ -2312,7 +2323,10 @@ Extra - asset_id: collision_camera_023_B
               Any of the following:
                   Varia Suit
                   Heat/Cold Runs (Intermediate) and Heat Damage ≥ 200
-              Grapple Beam or Spider Magnet or Space Jump or Speed Booster
+              Any of the following:
+                  Spider Magnet or Space Jump
+                  Speed Booster and Open Charge Door
+                  Grapple Beam and Movement (Intermediate)
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -2322,7 +2336,10 @@ Extra - asset_id: collision_camera_023_B
   > Door to Hot Room Hub
       All of the following:
           Varia Suit
-          Spider Magnet or Space Jump
+          Any of the following:
+              Gravity Suit or Spider Magnet or Space Jump
+              Grapple Beam and Movement (Intermediate)
+              Heat/Cold Runs (Intermediate) and Lava Damage ≥ 500
 
 > Start Point; Heals? False; Spawn Point
   * Layers: default
@@ -3416,12 +3433,12 @@ Extra - asset_id: collision_camera_054
       Trivial
   > Dock to EMMI Zone Exit South
       Any of the following:
-          Simple IBJ or Use Spin Boost
+          Speed Booster or Simple IBJ or Use Spin Boost
           Flash Shift and Walljump (Beginner)
           Morph Ball and Single-wall Wall Jump (Intermediate)
   > Pickup (Missile Tank)
       Any of the following:
-          Grapple Beam or Spider Magnet or Simple IBJ or Use Spin Boost
+          Grapple Beam or Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
           Flash Shift and Walljump (Beginner)
           Morph Ball and Single-wall Wall Jump (Intermediate)
   > Dock to Charge Beam Access
@@ -4100,7 +4117,7 @@ Extra - asset_id: collision_camera_066
   > Door to Save Station East
       Trivial
   > Door to Thermal Device (Upper)
-      Trivial
+      After Artaria - Open Thermal Device Item Door
 
 > Door to Save Station East; Heals? False
   * Layers: default
@@ -4205,6 +4222,10 @@ Extra - asset_id: collision_camera_067
       Trivial
   > Tile Group (MISSILE)
       Morph Ball
+  > Event - Open Item Door
+      All of the following:
+          Shoot Missile
+          Missiles ≥ 2 or Shoot Beam
 
 > Tile Group (MISSILE); Heals? False
   * Layers: default
@@ -4217,6 +4238,12 @@ Extra - asset_id: collision_camera_067
       Morph Ball
   > Start Point
       Can Slide
+
+> Event - Open Item Door; Heals? False
+  * Layers: default
+  * Event Artaria - Open Thermal Device Item Door
+  > Start Point
+      Trivial
 
 ----------------
 Navigation Station South
@@ -4373,7 +4400,7 @@ Extra - asset_id: collision_camera_070
   * Extra - actor_name: DoorEmmy06
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Total Recharge
-      Before Artaria - Central Unit or Shoot Ice Missile
+      Before Artaria - Central Unit or Destroy Enky
 
 > Dock to Teleport to Dairon (DoorEmmy07); Heals? False
   * Layers: default
@@ -4410,7 +4437,7 @@ Extra - asset_id: collision_camera_070
   > Door to Navigation Station North (Thermal)
       Trivial
   > Dock to Teleport to Dairon (DoorEmmy06)
-      Before Artaria - Central Unit or Shoot Ice Missile
+      Before Artaria - Central Unit or Destroy Enky
 
 > Tile Group (BOMB); Heals? False
   * Layers: default
@@ -4439,9 +4466,11 @@ Extra - asset_id: collision_camera_070
   > Dock to Teleport to Dairon (DoorEmmy07)
       After Artaria - ArbEnky Blob West and Can Slide
   > Event - ArbEnky Blob West
-      After Artaria - ArbEnky Blob East and Shoot Beam
+      All of the following:
+          After Artaria - ArbEnky Blob East
+          Lay Bomb or Shoot Beam
   > Event - ArbEnky Blob East
-      Shoot Beam
+      Lay Bomb or Shoot Beam
 
 ----------------
 EMMI First Chase End
@@ -4733,7 +4762,9 @@ Extra - asset_id: collision_camera_077
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Elevator to Cataris - Transport to Artaria
-      Grapple Beam or Spider Magnet or Space Jump or Walljump (Beginner) or Simple IBJ
+      Any of the following:
+          Spider Magnet or Space Jump or Walljump (Beginner) or Simple IBJ
+          Grapple Beam and Movement (Beginner)
 
 > Elevator to Cataris - Transport to Artaria; Heals? False; Spawn Point
   * Layers: default
@@ -4787,6 +4818,8 @@ Extra - asset_id: collision_camera_078
               All of the following:
                   Flash Shift
                   Grapple Beam or Walljump (Beginner)
+              Morph Ball and Single-wall Wall Jump (Beginner)
+              Speed Booster and Open Charge Door
   > Door to Transport to Cataris
       All of the following:
           Morph Ball
@@ -4839,7 +4872,8 @@ Extra - asset_id: collision_camera_079
   * Extra - right_shield_def: None
   > Door to Transport to Cataris
       Any of the following:
-          Spider Magnet or Morph Ball or Simple IBJ or Use Spin Boost
+          Spider Magnet or Simple IBJ or Use Spin Boost
+          Morph Ball and Damage Boost (Beginner)
           Flash Shift and Grapple Beam
 
 > Door to Transport to Cataris; Heals? False

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -929,6 +929,10 @@
             "BureniaEarlyGravEPart": {
                 "long_name": "Burenia - Early Gravity Energy Part",
                 "extra": {}
+            },
+            "ArtariaThermalItemDoor": {
+                "long_name": "Artaria - Open Thermal Device Item Door",
+                "extra": {}
             }
         },
         "tricks": {
@@ -1945,6 +1949,39 @@
                                 "name": "WBJ",
                                 "amount": 2,
                                 "negate": false
+                            }
+                        }
+                    ]
+                }
+            },
+            "Open Charge Door": {
+                "type": "or",
+                "data": {
+                    "comment": null,
+                    "items": [
+                        {
+                            "type": "template",
+                            "data": "Shoot Charge Beam"
+                        },
+                        {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Power Bomb"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Knowledge",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     ]

--- a/randovania/games/dread/json_data/header.txt
+++ b/randovania/games/dread/json_data/header.txt
@@ -113,6 +113,11 @@ Templates
           # Gain a little extra height in water without Gravity Suit by using a Cross Bomb
           No Gravity Suit and Water Bomb Jump (Intermediate) and Lay Cross Comb
 
+* Open Charge Door:
+      Any of the following:
+          Shoot Charge Beam
+          Knowledge (Beginner) and Lay Power Bomb
+
 ====================
 Dock Weaknesses
 


### PR DESCRIPTION
Revised the logic for rooms in east Artaria:
- Added event in Thermal Device for opening the door to the item without Morph Ball
- Accounted for the Charge doors along the way when using Speed Booster as an option in the area
- Added Damage Boost trick to the Morph Ball method of taking Lower Path to Cataris
- Added Speed Booster method of reaching the upper parts of Energy Recharge Station South
- Added Wave Beam option for the Charge Beam Access blob
- Added Bomb option for destroying exposed blobs in these rooms
- Other various methods of reaching nodes