### PR TITLE
Improve patch requirements and optimize it

### DIFF
--- a/randovania/game_description/data_reader.py
+++ b/randovania/game_description/data_reader.py
@@ -196,8 +196,9 @@ def read_dock_lock(data: Optional[dict], resource_database: ResourceDatabase) ->
 
 # Dock Weakness
 
-def read_dock_weakness(name: str, item: dict, resource_database: ResourceDatabase) -> DockWeakness:
+def read_dock_weakness(index: int, name: str, item: dict, resource_database: ResourceDatabase) -> DockWeakness:
     return DockWeakness(
+        index,
         name,
         frozen_lib.wrap(item["extra"]),
         read_requirement(item["requirement"], resource_database),
@@ -219,10 +220,17 @@ def read_dock_weakness_database(data: dict,
     dock_types = read_dict(data["types"], read_dock_type)
     weaknesses: dict[DockType, dict[str, DockWeakness]] = {}
     dock_rando: dict[DockType, DockRandoParams] = {}
+    next_index = 0
+
+    def get_index():
+        nonlocal next_index
+        result = next_index
+        next_index += 1
+        return result
 
     for dock_type, type_data in zip(dock_types, data["types"].values()):
         weaknesses[dock_type] = {
-            weak_name: read_dock_weakness(weak_name, weak_data, resource_database)
+            weak_name: read_dock_weakness(get_index(), weak_name, weak_data, resource_database)
             for weak_name, weak_data in type_data["items"].items()
         }
 

--- a/randovania/game_description/game_description.py
+++ b/randovania/game_description/game_description.py
@@ -106,7 +106,8 @@ class GameDescription:
         if not self.mutable:
             raise ValueError("self is not mutable")
 
-        self.world_list.patch_requirements(resources, damage_multiplier, self.resource_database)
+        self.world_list.patch_requirements(resources, damage_multiplier, self.resource_database,
+                                           self.dock_weakness_database)
         self._dangerous_resources = None
 
     def get_default_elevator_connection(self) -> dict[NodeIdentifier, AreaIdentifier]:

--- a/randovania/game_description/world/dock.py
+++ b/randovania/game_description/world/dock.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass
 from enum import unique, Enum
 from typing import Iterator, Optional
@@ -54,6 +55,7 @@ class DockWeakness:
     The requirements for the weakness is required for every single use, but
     only from the front. The lock's requirement (if a lock is present) only needs to be satisfied once.
     """
+    weakness_index: int = dataclasses.field(compare=False)
     name: str
     extra: frozendict
     requirement: Requirement

--- a/randovania/game_description/world/dock_node.py
+++ b/randovania/game_description/world/dock_node.py
@@ -60,24 +60,24 @@ class DockNode(Node):
 
         return None
 
-    def _get_open_requirement(self, weakness: DockWeakness) -> Requirement:
+    def _get_open_requirement(self, context: NodeContext, weakness: DockWeakness) -> Requirement:
         if weakness is self.default_dock_weakness and self.override_default_open_requirement is not None:
             return self.override_default_open_requirement
         else:
-            return weakness.requirement
+            return context.node_provider.open_requirement_for(weakness)
 
-    def _get_lock_requirement(self, weakness: DockWeakness) -> Requirement:
+    def _get_lock_requirement(self, context: NodeContext, weakness: DockWeakness) -> Requirement:
         if weakness is self.default_dock_weakness and self.override_default_lock_requirement is not None:
             return self.override_default_lock_requirement
         else:
-            return weakness.lock.requirement
+            return context.node_provider.lock_requirement_for(weakness)
 
     def _open_dock_connection(self, context: NodeContext, target_node: Node,
                               ) -> tuple[Node, Requirement]:
 
         forward_weakness = self.get_front_weakness(context)
 
-        reqs: list[Requirement] = [self._get_open_requirement(forward_weakness)]
+        reqs: list[Requirement] = [self._get_open_requirement(context, forward_weakness)]
 
         # This dock has a lock, so require it
         if forward_weakness.lock is not None:
@@ -97,7 +97,7 @@ class DockNode(Node):
         forward_lock = forward_weakness.lock
 
         if forward_lock is not None:
-            requirement = self._get_lock_requirement(forward_weakness)
+            requirement = self._get_lock_requirement(context, forward_weakness)
 
         back_weakness = self.get_back_weakness(context)
         back_lock = None

--- a/randovania/game_description/world/node_provider.py
+++ b/randovania/game_description/world/node_provider.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from randovania.game_description.requirements.base import Requirement
     from randovania.game_description.world.area import Area
     from randovania.game_description.world.area_identifier import AreaIdentifier
+    from randovania.game_description.world.dock import DockWeakness
     from randovania.game_description.world.node import Node
     from randovania.game_description.world.node_identifier import NodeIdentifier
     from randovania.game_description.world.world import World
@@ -84,3 +85,9 @@ class NodeProvider:
             raise IndexError("Area '{}' default_node ({}) is missing".format(area.name, area.default_node))
 
         return node
+
+    def open_requirement_for(self, weakness: DockWeakness) -> Requirement:
+        return weakness.requirement
+
+    def lock_requirement_for(self, weakness: DockWeakness) -> Requirement:
+        return weakness.lock.requirement

--- a/randovania/game_description/world/world_list.py
+++ b/randovania/game_description/world/world_list.py
@@ -9,6 +9,7 @@ from randovania.game_description.resources.resource_database import ResourceData
 from randovania.game_description.resources.resource_info import ResourceCollection
 from randovania.game_description.world.area import Area
 from randovania.game_description.world.area_identifier import AreaIdentifier
+from randovania.game_description.world.dock import DockWeakness, DockWeaknessDatabase
 from randovania.game_description.world.dock_node import DockNode
 from randovania.game_description.world.node import Node, NodeContext, NodeIndex
 from randovania.game_description.world.node_identifier import NodeIdentifier
@@ -29,6 +30,8 @@ class WorldList(NodeProvider):
     _pickup_index_to_node: dict[PickupIndex, PickupNode]
     _identifier_to_node: dict[NodeIdentifier, Node]
     _patched_node_connections: Optional[dict[NodeIndex, dict[NodeIndex, Requirement]]]
+    _patches_dock_open_requirements: Optional[list[Requirement]]
+    _patches_dock_lock_requirements: Optional[list[Optional[Requirement]]]
 
     def __deepcopy__(self, memodict):
         return WorldList(
@@ -38,6 +41,8 @@ class WorldList(NodeProvider):
     def __init__(self, worlds: List[World]):
         self.worlds = worlds
         self._patched_node_connections = None
+        self._patches_dock_open_requirements = None
+        self._patches_dock_lock_requirements = None
         self.invalidate_node_cache()
 
     def _refresh_node_cache(self):
@@ -182,7 +187,7 @@ class WorldList(NodeProvider):
         yield from self.area_connections_from(node)
 
     def patch_requirements(self, static_resources: ResourceCollection, damage_multiplier: float,
-                           database: ResourceDatabase) -> None:
+                           database: ResourceDatabase, dock_weakness_database: DockWeaknessDatabase) -> None:
         """
         Patches all Node connections, assuming the given resources will never change their quantity.
         This is removes all checking for tricks and difficulties in runtime since these never change.
@@ -190,16 +195,10 @@ class WorldList(NodeProvider):
         :param static_resources:
         :param damage_multiplier:
         :param database:
+        :param dock_weakness_database
         :return:
         """
-
-        # for node in area.nodes:
-        #     if isinstance(node, DockNode):
-        #         requirement = node.default_dock_weakness.requirement
-        #         object.__setattr__(node.default_dock_weakness, "requirement",
-        #                            requirement.patch_requirements(static_resources,
-        #                                                           damage_multiplier,
-        #                                                           database).simplify())
+        # Area Connections
         self._patched_node_connections = {
             node.node_index: {
                 target.node_index: value.patch_requirements(static_resources, damage_multiplier, database).simplify()
@@ -207,10 +206,22 @@ class WorldList(NodeProvider):
             }
             for _, area, node in self.all_worlds_areas_nodes
         }
-        # FIXME: hack to find what's using the old value
-        for world in self.worlds:
-            for area in world.areas:
-                object.__setattr__(area, "connections", None)
+
+        # Dock Weaknesses
+        self._patches_dock_open_requirements = []
+        self._patches_dock_lock_requirements = []
+        for weakness in sorted(dock_weakness_database.all_weaknesses, key=lambda it: it.weakness_index):
+            assert len(self._patches_dock_open_requirements) == weakness.weakness_index
+            self._patches_dock_open_requirements.append(
+                weakness.requirement.patch_requirements(static_resources, damage_multiplier, database).simplify()
+            )
+            if weakness.lock is None:
+                self._patches_dock_lock_requirements.append(None)
+            else:
+                self._patches_dock_lock_requirements.append(
+                    weakness.lock.requirement.patch_requirements(
+                        static_resources, damage_multiplier, database).simplify()
+                )
 
     def node_by_identifier(self, identifier: NodeIdentifier) -> Node:
         cache_result = self._identifier_to_node.get(identifier)
@@ -269,6 +280,16 @@ class WorldList(NodeProvider):
         self.ensure_has_node_cache()
         self._nodes_to_area[node.node_index] = area
         self._nodes_to_world[node.node_index] = self.world_with_area(area)
+
+    def open_requirement_for(self, weakness: DockWeakness) -> Requirement:
+        if self._patches_dock_open_requirements is not None:
+            return self._patches_dock_open_requirements[weakness.weakness_index]
+        return weakness.requirement
+
+    def lock_requirement_for(self, weakness: DockWeakness) -> Requirement:
+        if self._patches_dock_lock_requirements is not None:
+            return self._patches_dock_lock_requirements[weakness.weakness_index]
+        return weakness.lock.requirement
 
 
 def _calculate_nodes_to_area_world(worlds: Iterable[World]):

--- a/test/game_description/world/test_world_list.py
+++ b/test/game_description/world/test_world_list.py
@@ -28,8 +28,8 @@ def test_connections_from_dock_blast_shield(empty_patches):
     req_1 = ResourceRequirement.simple(SimpleResourceInfo(0, "Ev1", "Ev1", ResourceType.EVENT))
     req_2 = ResourceRequirement.simple(SimpleResourceInfo(1, "Ev2", "Ev2", ResourceType.EVENT))
     dock_type = DockType("Type", "Type", frozendict())
-    weak_1 = DockWeakness("Weak 1", frozendict(), req_1, None)
-    weak_2 = DockWeakness("Weak 2", frozendict(), trivial, DockLock(DockLockType.FRONT_BLAST_BACK_BLAST, req_2))
+    weak_1 = DockWeakness(0, "Weak 1", frozendict(), req_1, None)
+    weak_2 = DockWeakness(1, "Weak 2", frozendict(), trivial, DockLock(DockLockType.FRONT_BLAST_BACK_BLAST, req_2))
 
     node_1_identifier = NodeIdentifier.create("W", "Area 1", "Node 1")
     node_2_identifier = NodeIdentifier.create("W", "Area 2", "Node 2")


### PR DESCRIPTION
Closes #3298.

For `DaTmoSINQL63aukNRpBXJajbBiAka4MQVCsh` (seed hash `42QSEDKA`), the times are:
Old: 128.270 seconds
New: 94.390 seconds
Speedup: 35,89%