### PR TITLE
Added logic for traversing rooms with Trooper Pirates and Scatter Bombus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.5.0] - 2022-07-01
 
 - Added: Preferences are now saved separately for each version. This means newer Randovania versions don't break the preferences of older versions. 
+- Added: Exporting presets now fills in default file name
+- Added: Logging messages when receiving events from the server.
+- Changed: Internal changes to server for hopefully less expired sessions.
 
 ### Cave Story
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.5.0] - 2022-07-01
 
 - Added: Preferences are now saved separately for each version. This means newer Randovania versions don't break the preferences of older versions. 
-- Added: Exporting presets now fills in default file name
-- Added: Logging messages when receiving events from the server.
-- Changed: Internal changes to server for hopefully less expired sessions.
 
 ### Cave Story
 
@@ -34,7 +31,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Logic Database
 
-- Nothing.
+- Added: Advancing through rooms containing Trooper Pirates now requires either the proper beam(s), basic defensive capabilities (varies slightly by room), or Combat (Intermediate), except where noted. Rooms affected:
+    - Elite Control
+    - Elite Research
+    - Ore Processing - Climbing the room vanilla now requires Power Beam. Ore Processing climb without Power Beam now requires Combat (Advanced).
+    - Central Dynamo
+    - Omega Research
+    - Mine Security Station
+    - Metroid Quarantine B - The Standable Terrain method of traversing the room now requires Combat (Advanced) without Plasma Beam.
+    - Phazon Processing Center - This room is only affected after picking up the item in Plasma Processing.
+- Added: Advancing through rooms containing Scatter Bombus now requires Morph Ball, Wave Beam, Movement tricks, or basic defensive capabilities. Rooms affected:
+    - Ice Ruins Access
+    - Canyon Entryway
+    - Temple Entryway
+    - Hydra Lab Entryway
+    - West Tower Entrance
+    - Aether Lab Entryway
+    - Lower Edge Tunnel
+    - Lake Tunnel
 
 ### Metroid Prime 2: Echoes
 

--- a/randovania/games/prime1/json_data/Magmoor Caverns.json
+++ b/randovania/games/prime1/json_data/Magmoor Caverns.json
@@ -15379,7 +15379,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Pickup (Plasma Beam)": {
+                        "Event - Plasma Beam": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -15403,6 +15403,26 @@
                     "major_location": true,
                     "connections": {
                         "Door to Geothermal Core": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Plasma Beam": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": null,
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "Event56",
+                    "connections": {
+                        "Pickup (Plasma Beam)": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/prime1/json_data/Magmoor Caverns.txt
+++ b/randovania/games/prime1/json_data/Magmoor Caverns.txt
@@ -1594,7 +1594,7 @@ Extra - aabb: [324.22482, -808.70245, 85.270874, 412.18738, -720.1435, 116.73451
   * Plasma Door to Geothermal Core/Door to Plasma Processing
   * Extra - dock_index: 0
   * Extra - nonstandard: False
-  > Pickup (Plasma Beam)
+  > Event - Plasma Beam
       Trivial
 
 > Pickup (Plasma Beam); Heals? False
@@ -1602,6 +1602,12 @@ Extra - aabb: [324.22482, -808.70245, 85.270874, 412.18738, -720.1435, 116.73451
   * Pickup 98; Major Location? True
   * Extra - position_required: False
   > Door to Geothermal Core
+      Trivial
+
+> Event - Plasma Beam; Heals? False
+  * Layers: default
+  * Event Plasma Processing Item
+  > Pickup (Plasma Beam)
       Trivial
 
 ----------------

--- a/randovania/games/prime1/json_data/Phazon Mines.json
+++ b/randovania/games/prime1/json_data/Phazon Mines.json
@@ -1563,6 +1563,10 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Power Beam"
                                                 }
                                             ]
                                         }
@@ -1597,6 +1601,27 @@
                                                         "name": "SJump",
                                                         "amount": 2,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Power Beam"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -1634,42 +1659,80 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Waste Disposal": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Use Grapple Beam"
-                                    },
-                                    {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
-                                            "comment": "https://youtu.be/oRZOljmytRQ",
+                                            "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "template",
+                                                    "data": "Use Grapple Beam"
+                                                },
+                                                {
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Standable",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": "https://youtu.be/oRZOljmytRQ",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Standable",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "https://youtu.be/7ATtR9o9PRw",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "SpaceJump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "LJump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
-                                            "comment": "https://youtu.be/7ATtR9o9PRw",
+                                            "comment": null,
                                             "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Wave Beam"
+                                                },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "SpaceJump",
-                                                        "amount": 1,
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 100,
                                                         "negate": false
                                                     }
                                                 },
@@ -1677,7 +1740,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "LJump",
+                                                        "name": "Combat",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -2254,6 +2317,65 @@
                                 "comment": null,
                                 "items": [
                                     {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Event55",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Ice Beam"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Wave Beam"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 200,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Mine Security Station Doors Unlocked": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
                                         "type": "template",
                                         "data": "Shoot Wave Beam"
                                     },
@@ -2316,6 +2438,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Event55",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
                                     }
                                 ]
                             }
@@ -2354,8 +2485,13 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Shoot Wave Beam"
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Event55",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     },
                                     {
                                         "type": "or",
@@ -2363,11 +2499,27 @@
                                             "comment": null,
                                             "items": [
                                                 {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Ice Beam"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Wave Beam"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Charge",
-                                                        "amount": 1,
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 200,
                                                         "negate": false
                                                     }
                                                 },
@@ -2376,34 +2528,8 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Combat",
-                                                        "amount": 3,
+                                                        "amount": 2,
                                                         "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Damage",
-                                                                    "amount": 200,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Combat",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
                                                     }
                                                 }
                                             ]
@@ -2459,6 +2585,87 @@
                                             "name": "PowerBomb",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Mine Security Station Doors Unlocked": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Wave Beam"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Charge",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 200,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Event55",
+                                            "amount": 1,
+                                            "negate": true
                                         }
                                     }
                                 ]
@@ -2545,6 +2752,33 @@
                     "pickup_index": 205,
                     "major_location": false,
                     "connections": {}
+                },
+                "Event - Mine Security Station Doors Unlocked": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": null,
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "Event55",
+                    "connections": {
+                        "Door to Security Access A": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Door to Security Access B": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -3435,6 +3669,48 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Power Beam"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Wave Beam"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 200,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -3544,10 +3820,45 @@
                             }
                         },
                         "Door to Security Access B": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Power Beam"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Wave Beam"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "damage",
+                                            "name": "Damage",
+                                            "amount": 200,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Combat",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Event - Rock Wall in Elite Research Destroyed": {
@@ -4462,15 +4773,6 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "Event51",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
                                                     "type": "and",
                                                     "data": {
                                                         "comment": "https://youtu.be/VOesQWYfL-4",
@@ -4482,6 +4784,53 @@
                                                                     "name": "Standable",
                                                                     "amount": 2,
                                                                     "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "Event51",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Shoot Ice Beam"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 200,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Combat",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -4545,7 +4894,7 @@
                             }
                         },
                         "Event - Elite Pirate Defeated": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": "https://youtu.be/mx0rQa9ZAY4",
                                 "items": [
@@ -5093,59 +5442,171 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Transport Access": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "SpaceJump",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": "Halfway up: https://youtu.be/vOr2W2ut25k All the way up: https://youtu.be/gU2yAun0Zvg",
+                                                        "comment": null,
                                                         "items": [
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Standable",
-                                                                    "amount": 2,
+                                                                    "type": "items",
+                                                                    "name": "SpaceJump",
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
-                                                                "type": "and",
+                                                                "type": "or",
                                                                 "data": {
-                                                                    "comment": null,
+                                                                    "comment": "Halfway up: https://youtu.be/vOr2W2ut25k All the way up: https://youtu.be/gU2yAun0Zvg",
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
-                                                                                "type": "items",
-                                                                                "name": "MorphBall",
-                                                                                "amount": 1,
+                                                                                "type": "tricks",
+                                                                                "name": "Standable",
+                                                                                "amount": 2,
                                                                                 "negate": false
                                                                             }
                                                                         },
                                                                         {
-                                                                            "type": "resource",
+                                                                            "type": "and",
                                                                             "data": {
-                                                                                "type": "items",
-                                                                                "name": "Spider",
-                                                                                "amount": 1,
-                                                                                "negate": false
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "MorphBall",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Spider",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "MorphBall",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Bombs",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Spider",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "BJ",
+                                                                                            "amount": 4,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Standable",
+                                                                                            "amount": 4,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "CBJ",
+                                                                                            "amount": 5,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Standable",
+                                                                                            "amount": 5,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "LJump",
+                                                                                            "amount": 4,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         }
                                                                     ]
@@ -5158,97 +5619,73 @@
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "MorphBall",
+                                                        "type": "events",
+                                                        "name": "Event56",
                                                         "amount": 1,
-                                                        "negate": false
+                                                        "negate": true
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Bombs",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
+                                                    "type": "and",
                                                     "data": {
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "and",
+                                                                "type": "resource",
                                                                 "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Spider",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "BJ",
-                                                                                "amount": 4,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Standable",
-                                                                                "amount": 4,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
+                                                                    "type": "events",
+                                                                    "name": "Event56",
+                                                                    "amount": 1,
+                                                                    "negate": false
                                                                 }
                                                             },
                                                             {
-                                                                "type": "and",
+                                                                "type": "or",
                                                                 "data": {
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
-                                                                            "type": "resource",
+                                                                            "type": "and",
                                                                             "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "CBJ",
-                                                                                "amount": 5,
-                                                                                "negate": false
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Shoot Plasma Beam"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Shoot Wave Beam"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Shoot Power Beam"
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         },
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
                                                                                 "type": "tricks",
-                                                                                "name": "Standable",
-                                                                                "amount": 5,
+                                                                                "name": "Combat",
+                                                                                "amount": 2,
                                                                                 "negate": false
                                                                             }
                                                                         },
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "LJump",
-                                                                                "amount": 4,
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 300,
                                                                                 "negate": false
                                                                             }
                                                                         }
@@ -5362,17 +5799,129 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Maintenance Tunnel": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "or",
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "PhazonSuit",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Movement",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "damage",
+                                                                                            "name": "Phazon",
+                                                                                            "amount": 45,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "SpaceJump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": "https://youtu.be/SjS_b_HBmqE",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Standable",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "MorphBall",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Bombs",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Spider",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
                                                     "data": {
                                                         "comment": null,
                                                         "items": [
@@ -5380,152 +5929,84 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
-                                                                    "name": "PhazonSuit",
+                                                                    "name": "MorphBall",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Movement",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Phazon",
-                                                                                "amount": 45,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "SpaceJump",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": "https://youtu.be/SjS_b_HBmqE",
-                                                        "items": [
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Standable",
+                                                                    "type": "items",
+                                                                    "name": "Bombs",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
-                                                                "type": "and",
+                                                                "type": "resource",
                                                                 "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "MorphBall",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Bombs",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Spider",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
+                                                                    "type": "damage",
+                                                                    "name": "Phazon",
+                                                                    "amount": 65,
+                                                                    "negate": false
                                                                 }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "MorphBall",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Bombs",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "damage",
-                                                        "name": "Phazon",
-                                                        "amount": 65,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
+                                                            },
                                                             {
-                                                                "type": "and",
+                                                                "type": "or",
                                                                 "data": {
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Spider",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "BJ",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Standable",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "LJump",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
                                                                             "type": "resource",
                                                                             "data": {
-                                                                                "type": "items",
-                                                                                "name": "Spider",
-                                                                                "amount": 1,
+                                                                                "type": "tricks",
+                                                                                "name": "CBJ",
+                                                                                "amount": 4,
                                                                                 "negate": false
                                                                             }
                                                                         },
@@ -5533,8 +6014,8 @@
                                                                             "type": "resource",
                                                                             "data": {
                                                                                 "type": "tricks",
-                                                                                "name": "BJ",
-                                                                                "amount": 3,
+                                                                                "name": "BSJ",
+                                                                                "amount": 4,
                                                                                 "negate": false
                                                                             }
                                                                         },
@@ -5558,41 +6039,85 @@
                                                                         }
                                                                     ]
                                                                 }
-                                                            },
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "Event56",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "CBJ",
-                                                                    "amount": 4,
+                                                                    "type": "events",
+                                                                    "name": "Event56",
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "or",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "BSJ",
-                                                                    "amount": 4,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Standable",
-                                                                    "amount": 3,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "LJump",
-                                                                    "amount": 3,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Shoot Plasma Beam"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Shoot Wave Beam"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Shoot Power Beam"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Combat",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 200,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -5669,6 +6194,86 @@
                                             "name": "PowerBomb",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "Event56",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "Event56",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Shoot Plasma Beam"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Shoot Wave Beam"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Shoot Power Beam"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Combat",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 200,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -5824,10 +6429,45 @@
                             }
                         },
                         "Door to Dynamo Access": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Power Beam"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Wave Beam"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "damage",
+                                            "name": "Damage",
+                                            "amount": 200,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Combat",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -5943,6 +6583,48 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "SJump",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Power Beam"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Wave Beam"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 200,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -7390,6 +8072,36 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Ice Beam"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 200,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -7512,39 +8224,86 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Dynamo Access": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
-                                "comment": "Fast climb with Standable: https://youtu.be/MtpgWKgaF-U",
+                                "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "items",
-                                            "name": "SpaceJump",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
+                                            "comment": "Fast climb with Standable: https://youtu.be/MtpgWKgaF-U",
                                             "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "MorphBall",
+                                                        "name": "SpaceJump",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "MorphBall",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Bombs",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "CBJ",
+                                                                    "amount": 4,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Standable",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Ice Beam"
+                                                },
+                                                {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Bombs",
-                                                        "amount": 1,
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 200,
                                                         "negate": false
                                                     }
                                                 },
@@ -7552,16 +8311,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "CBJ",
-                                                        "amount": 4,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Standable",
+                                                        "name": "Combat",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -7602,6 +8352,36 @@
                                             "name": "PowerBomb",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Ice Beam"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 200,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -8255,6 +9035,27 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Plasma Beam"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -8388,6 +9189,36 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Plasma Beam"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 300,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -8424,10 +9255,45 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Save Station Mines C": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Plasma Beam"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Wave Beam"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Combat",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "damage",
+                                            "name": "Damage",
+                                            "amount": 200,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -8585,26 +9451,59 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Plasma Beam"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Wave Beam"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 300,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
                         },
                         "Door to Elite Quarters Access": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "SpaceJump",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
@@ -8612,70 +9511,129 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "MorphBall",
+                                                        "name": "SpaceJump",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Bombs",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "MorphBall",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Bombs",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "BJ",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "BJ",
+                                                        "name": "SJump",
                                                         "amount": 1,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Scan",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Standable",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Dash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "SJump",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Scan",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Plasma Beam"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Wave Beam"
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Standable",
-                                                        "amount": 1,
+                                                        "name": "Combat",
+                                                        "amount": 2,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Dash",
-                                                        "amount": 1,
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 200,
                                                         "negate": false
                                                     }
                                                 }
@@ -8780,21 +9738,12 @@
                     "extra": {},
                     "connections": {
                         "Door to Quarantine Access B": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "SpaceJump",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
@@ -8802,52 +9751,99 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "MorphBall",
+                                                        "name": "SpaceJump",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Bombs",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "MorphBall",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Bombs",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "BJ",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Phazon",
+                                                                    "amount": 150,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "BJ",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "damage",
-                                                        "name": "Phazon",
-                                                        "amount": 150,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "SJump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Phazon",
+                                                                    "amount": 50,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
+                                                    "type": "template",
+                                                    "data": "Shoot Plasma Beam"
+                                                },
+                                                {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "SJump",
-                                                        "amount": 1,
+                                                        "name": "Combat",
+                                                        "amount": 2,
                                                         "negate": false
                                                     }
                                                 },
@@ -8855,8 +9851,8 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "damage",
-                                                        "name": "Phazon",
-                                                        "amount": 50,
+                                                        "name": "Damage",
+                                                        "amount": 300,
                                                         "negate": false
                                                     }
                                                 }

--- a/randovania/games/prime1/json_data/Phazon Mines.json
+++ b/randovania/games/prime1/json_data/Phazon Mines.json
@@ -8095,33 +8095,12 @@
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Shoot Ice Beam"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "damage",
-                                                        "name": "Damage",
-                                                        "amount": 200,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Combat",
-                                                        "amount": 2,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
+                                            "type": "events",
+                                            "name": "Event25",
+                                            "amount": 1,
+                                            "negate": true
                                         }
                                     }
                                 ]
@@ -9053,6 +9032,23 @@
                                                                         }
                                                                     ]
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": "https://www.youtube.com/watch?v=v3VMpJELp_4",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Dash",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
                                                             }
                                                         ]
                                                     }
@@ -9067,12 +9063,29 @@
                                                                 "data": "Shoot Plasma Beam"
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Combat",
-                                                                    "amount": 3,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Combat",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 200,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]

--- a/randovania/games/prime1/json_data/Phazon Mines.json
+++ b/randovania/games/prime1/json_data/Phazon Mines.json
@@ -3711,6 +3711,27 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Any Beam"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 300,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/prime1/json_data/Phazon Mines.txt
+++ b/randovania/games/prime1/json_data/Phazon Mines.txt
@@ -266,13 +266,14 @@ Extra - aabb: [66.58455, 129.7148, 11.163003, 138.8284, 204.85583, 77.01038]
   > Door to Elevator Access A
       Any of the following:
           All of the following:
-              Morph Ball and Spider Ball
+              Morph Ball and Spider Ball and Shoot Power Beam
               Any of the following:
                   Morph Ball Bomb
                   Boost Ball and Power Bomb ≥ 3 and Wall Boost (Advanced)
           All of the following:
               # https://youtu.be/gnqifLICKyo
               Space Jump Boots and Slope Jump (Intermediate) and Standable Terrain (Intermediate)
+              Combat (Advanced) or Shoot Power Beam
 
 > Door to Storage Depot B; Heals? False
   * Layers: default
@@ -280,14 +281,16 @@ Extra - aabb: [66.58455, 129.7148, 11.163003, 138.8284, 204.85583, 77.01038]
   * Extra - dock_index: 1
   * Extra - nonstandard: False
   > Door to Waste Disposal
-      Any of the following:
-          Use Grapple Beam
-          All of the following:
-              # https://youtu.be/oRZOljmytRQ
-              Standable Terrain (Beginner)
-          All of the following:
-              # https://youtu.be/7ATtR9o9PRw
-              Space Jump Boots and L-Jump (Beginner)
+      All of the following:
+          Any of the following:
+              Use Grapple Beam
+              All of the following:
+                  # https://youtu.be/oRZOljmytRQ
+                  Standable Terrain (Beginner)
+              All of the following:
+                  # https://youtu.be/7ATtR9o9PRw
+                  Space Jump Boots and L-Jump (Beginner)
+          Combat (Beginner) or Normal Damage ≥ 100 or Shoot Wave Beam
   > Door to Elevator Access A
       Trivial
 
@@ -358,7 +361,13 @@ Extra - aabb: [-36.12424, -29.465834, -4.4074636, 29.15716, 66.50636, 24.451797]
   * Extra - nonstandard: False
   > Door to Security Access B
       All of the following:
-          Shoot Wave Beam
+          After Mine Security Station Unlock Doors
+          Any of the following:
+              Combat (Intermediate) or Normal Damage ≥ 200
+              Shoot Ice Beam and Shoot Wave Beam
+  > Event - Mine Security Station Doors Unlocked
+      All of the following:
+          Before Mine Security Station Unlock Doors and Shoot Wave Beam
           Any of the following:
               Charge Beam or Combat (Advanced)
               Combat (Intermediate) and Normal Damage ≥ 200
@@ -370,14 +379,20 @@ Extra - aabb: [-36.12424, -29.465834, -4.4074636, 29.15716, 66.50636, 24.451797]
   * Extra - nonstandard: False
   > Door to Security Access A
       All of the following:
-          Shoot Wave Beam
+          After Mine Security Station Unlock Doors
           Any of the following:
-              Charge Beam or Combat (Advanced)
-              Combat (Intermediate) and Normal Damage ≥ 200
+              Combat (Intermediate) or Normal Damage ≥ 200
+              Shoot Ice Beam and Shoot Wave Beam
   > Door to Storage Depot A
       After Mine Security Station Barrier
   > Event - Mine Security Station Barrier Opened
       Morph Ball and Power Bomb and Scan Visor
+  > Event - Mine Security Station Doors Unlocked
+      All of the following:
+          Before Mine Security Station Unlock Doors and Shoot Wave Beam
+          Any of the following:
+              Charge Beam or Combat (Advanced)
+              Combat (Intermediate) and Normal Damage ≥ 200
 
 > Door to Storage Depot A; Heals? False
   * Layers: default
@@ -397,6 +412,14 @@ Extra - aabb: [-36.12424, -29.465834, -4.4074636, 29.15716, 66.50636, 24.451797]
   * Layers: items_every_room
   * Pickup 205; Major Location? False
   * Extra - position_required: True
+
+> Event - Mine Security Station Doors Unlocked; Heals? False
+  * Layers: default
+  * Event Mine Security Station Unlock Doors
+  > Door to Security Access A
+      Trivial
+  > Door to Security Access B
+      Trivial
 
 ----------------
 Research Access
@@ -568,6 +591,9 @@ Extra - aabb: [-86.10738, 118.43238, 15.926657, 29.835865, 233.99252, 83.92861]
               # Standable for fast ascent: https://youtu.be/ezNh_4a3uNg
               Space Jump Boots
               Morph Ball Bomb and Morph Ball and Bomb Jump (Intermediate)
+          Any of the following:
+              Combat (Intermediate) or Normal Damage ≥ 200
+              Shoot Power Beam and Shoot Wave Beam
 
 > Event - Rock Wall in Elite Research Destroyed; Heals? False
   * Layers: default
@@ -593,7 +619,9 @@ Extra - aabb: [-86.10738, 118.43238, 15.926657, 29.835865, 233.99252, 83.92861]
   > Door to Research Access
       After Elite Research Rock Wall
   > Door to Security Access B
-      Trivial
+      Any of the following:
+          Combat (Intermediate) or Normal Damage ≥ 200
+          Shoot Power Beam and Shoot Wave Beam
   > Event - Rock Wall in Elite Research Destroyed
       All of the following:
           Morph Ball and Scan Visor
@@ -750,10 +778,12 @@ Extra - aabb: [-18.74421, 79.04062, -74.48461, 91.819305, 157.94768, -0.48807144
       All of the following:
           After Elite Control Barriers
           Any of the following:
-              After Elite Pirate Fight (Elite Control)
               All of the following:
                   # https://youtu.be/VOesQWYfL-4
                   Standable Terrain (Intermediate)
+              All of the following:
+                  After Elite Pirate Fight (Elite Control)
+                  Combat (Intermediate) or Normal Damage ≥ 200 or Shoot Ice Beam
   > Event - Elite Control Barriers Lowered
       All of the following:
           Scan Visor
@@ -763,9 +793,9 @@ Extra - aabb: [-18.74421, 79.04062, -74.48461, 91.819305, 157.94768, -0.48807144
                   # https://youtu.be/VOesQWYfL-4
                   Standable Terrain (Intermediate)
   > Event - Elite Pirate Defeated
-      All of the following:
+      Any of the following:
           # https://youtu.be/mx0rQa9ZAY4
-          Charge Beam and Combat (Beginner) and Normal Damage ≥ 200
+          Charge Beam or Combat (Beginner) or Normal Damage ≥ 200
 
 > Pickup (Items Every Room); Heals? False
   * Layers: items_every_room
@@ -860,18 +890,26 @@ Extra - aabb: [-132.15839, 87.526505, -111.61871, -26.354706, 153.05708, -8.0265
   * Extra - dock_index: 1
   * Extra - nonstandard: False
   > Door to Transport Access
-      Any of the following:
-          All of the following:
-              Space Jump Boots
-              Any of the following:
-                  # Halfway up: https://youtu.be/vOr2W2ut25k All the way up: https://youtu.be/gU2yAun0Zvg
-                  Standable Terrain (Intermediate)
-                  Morph Ball and Spider Ball
-          All of the following:
-              Morph Ball Bomb and Morph Ball
-              Any of the following:
-                  Spider Ball and Bomb Jump (Expert) and Standable Terrain (Expert)
-                  Complex Bomb Jump (Hypermode) and L-Jump (Expert) and Standable Terrain (Hypermode)
+      All of the following:
+          Any of the following:
+              All of the following:
+                  Space Jump Boots
+                  Any of the following:
+                      # Halfway up: https://youtu.be/vOr2W2ut25k All the way up: https://youtu.be/gU2yAun0Zvg
+                      Standable Terrain (Intermediate)
+                      Morph Ball and Spider Ball
+              All of the following:
+                  Morph Ball Bomb and Morph Ball
+                  Any of the following:
+                      Spider Ball and Bomb Jump (Expert) and Standable Terrain (Expert)
+                      Complex Bomb Jump (Hypermode) and L-Jump (Expert) and Standable Terrain (Hypermode)
+          Any of the following:
+              Before Plasma Processing Item
+              All of the following:
+                  After Plasma Processing Item
+                  Any of the following:
+                      Combat (Intermediate) or Normal Damage ≥ 300
+                      Shoot Plasma Beam and Shoot Power Beam and Shoot Wave Beam
   > Door to Processing Center Access
       Any of the following:
           Phazon Suit
@@ -885,27 +923,42 @@ Extra - aabb: [-132.15839, 87.526505, -111.61871, -26.354706, 153.05708, -8.0265
   * Extra - dock_index: 2
   * Extra - nonstandard: False
   > Door to Maintenance Tunnel
-      Any of the following:
-          All of the following:
-              Space Jump Boots
-              Any of the following:
-                  Phazon Suit
-                  Movement (Beginner) and Phazon Damage ≥ 45
-              Any of the following:
-                  # https://youtu.be/SjS_b_HBmqE
-                  Standable Terrain (Beginner)
-                  Morph Ball Bomb and Morph Ball and Spider Ball
-          All of the following:
-              Morph Ball Bomb and Morph Ball and Phazon Damage ≥ 65
-              Any of the following:
-                  Bomb Space Jump (Expert) or Complex Bomb Jump (Expert) or L-Jump (Advanced) or Standable Terrain (Advanced)
-                  Spider Ball and Bomb Jump (Advanced) and L-Jump (Advanced) and Standable Terrain (Advanced)
+      All of the following:
+          Any of the following:
+              All of the following:
+                  Space Jump Boots
+                  Any of the following:
+                      Phazon Suit
+                      Movement (Beginner) and Phazon Damage ≥ 45
+                  Any of the following:
+                      # https://youtu.be/SjS_b_HBmqE
+                      Standable Terrain (Beginner)
+                      Morph Ball Bomb and Morph Ball and Spider Ball
+              All of the following:
+                  Morph Ball Bomb and Morph Ball and Phazon Damage ≥ 65
+                  Any of the following:
+                      Bomb Space Jump (Expert) or Complex Bomb Jump (Expert) or L-Jump (Advanced) or Standable Terrain (Advanced)
+                      Spider Ball and Bomb Jump (Advanced) and L-Jump (Advanced) and Standable Terrain (Advanced)
+          Any of the following:
+              Before Plasma Processing Item
+              All of the following:
+                  After Plasma Processing Item
+                  Any of the following:
+                      Combat (Intermediate) or Normal Damage ≥ 200
+                      Shoot Plasma Beam and Shoot Power Beam and Shoot Wave Beam
   > Pickup (Missile)
       All of the following:
           Morph Ball and Power Bomb and Space Jump Boots
           Any of the following:
               # https://youtu.be/cxZ7-YewvDw
               Thermal Visor or X-Ray Visor or Invisible Objects (Beginner)
+          Any of the following:
+              Before Plasma Processing Item
+              All of the following:
+                  After Plasma Processing Item
+                  Any of the following:
+                      Combat (Intermediate) or Normal Damage ≥ 200
+                      Shoot Plasma Beam and Shoot Power Beam and Shoot Wave Beam
 
 > Pickup (Missile); Heals? False
   * Layers: default
@@ -936,7 +989,9 @@ Extra - aabb: [-30.495464, -73.79053, -86.16589, 78.22917, 33.54581, 12.443928]
   > Door to Map Station Mines
       Morph Ball and Power Bomb
   > Door to Dynamo Access
-      Trivial
+      Any of the following:
+          Combat (Intermediate) or Normal Damage ≥ 200
+          Shoot Power Beam and Shoot Wave Beam
 
 > Door to Dynamo Access; Heals? False
   * Layers: default
@@ -949,6 +1004,9 @@ Extra - aabb: [-30.495464, -73.79053, -86.16589, 78.22917, 33.54581, 12.443928]
           Any of the following:
               Space Jump Boots or Slope Jump (Intermediate)
               Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner)
+          Any of the following:
+              Combat (Intermediate) or Normal Damage ≥ 200
+              Shoot Power Beam and Shoot Wave Beam
 
 > Pickup (Items Every Room); Heals? False
   * Layers: items_every_room
@@ -1199,6 +1257,7 @@ Extra - aabb: [122.126015, -44.231895, -102.18276, 201.19897, 105.61425, -30.731
       All of the following:
           # The Security Drone event triggers door locks on all doors in Central Dynamo except for the door to Quarantine Access A. However, if Samus leaves this room without picking up the item, the doors to Save Station Mines B and Dynamo Access will then permanently be sealed, making it impossible to backtrack through the room.
           Morph Ball and Power Bomb and Knowledge (Beginner)
+          Combat (Intermediate) or Normal Damage ≥ 200 or Shoot Ice Beam
   > Door to Save Station Mines B
       After Invisible Drone
   > Event - Security Drone
@@ -1220,12 +1279,16 @@ Extra - aabb: [122.126015, -44.231895, -102.18276, 201.19897, 105.61425, -30.731
   * Extra - dock_index: 2
   * Extra - nonstandard: False
   > Door to Dynamo Access
-      Any of the following:
-          # Fast climb with Standable: https://youtu.be/MtpgWKgaF-U
-          Space Jump Boots
-          Morph Ball Bomb and Morph Ball and Complex Bomb Jump (Expert) and Standable Terrain (Intermediate)
+      All of the following:
+          Any of the following:
+              # Fast climb with Standable: https://youtu.be/MtpgWKgaF-U
+              Space Jump Boots
+              Morph Ball Bomb and Morph Ball and Complex Bomb Jump (Expert) and Standable Terrain (Intermediate)
+          Combat (Intermediate) or Normal Damage ≥ 200 or Shoot Ice Beam
   > Door to Quarantine Access A
-      Morph Ball and Power Bomb and After Invisible Drone
+      All of the following:
+          Morph Ball and Power Bomb and After Invisible Drone
+          Combat (Intermediate) or Normal Damage ≥ 200 or Shoot Ice Beam
 
 > Event - Security Drone; Heals? False
   * Layers: default
@@ -1353,6 +1416,7 @@ Extra - aabb: [-108.57961, -160.31125, -168.22823, 77.58658, -50.59403, -92.4295
           All of the following:
               Space Jump Boots and Slope Jump (Beginner) and Standable Terrain (Intermediate)
               L-Jump (Intermediate) or Use Grapple Beam
+              Combat (Advanced) or Shoot Plasma Beam
           All of the following:
               Morph Ball
               Any of the following:
@@ -1362,6 +1426,7 @@ Extra - aabb: [-108.57961, -160.31125, -168.22823, 77.58658, -50.59403, -92.4295
                           Use Grapple Beam
                           Scan Visor and Combat/Scan Dash (Expert)
                   Morph Ball Bomb and Scan Visor and Complex Bomb Jump (Expert) and Combat/Scan Dash (Expert) and Standable Terrain (Intermediate)
+              Combat (Intermediate) or Normal Damage ≥ 300 or Shoot Plasma Beam
 
 > Door to Elite Quarters Access; Heals? False
   * Layers: default
@@ -1369,7 +1434,9 @@ Extra - aabb: [-108.57961, -160.31125, -168.22823, 77.58658, -50.59403, -92.4295
   * Extra - dock_index: 1
   * Extra - nonstandard: False
   > Door to Save Station Mines C
-      Trivial
+      Any of the following:
+          Combat (Intermediate) or Normal Damage ≥ 200
+          Shoot Plasma Beam and Shoot Wave Beam
 
 > Door to Save Station Mines C; Heals? False
   * Layers: default
@@ -1382,11 +1449,18 @@ Extra - aabb: [-108.57961, -160.31125, -168.22823, 77.58658, -50.59403, -92.4295
           Any of the following:
               Space Jump Boots and Single Room Out of Bounds (Advanced) and Standable Terrain (Advanced)
               Morph Ball Bomb and Bomb Jump (Advanced) and Complex Bomb Jump (Expert) and Single Room Out of Bounds (Expert) and Standable Terrain (Hypermode)
+          Any of the following:
+              Combat (Intermediate) or Normal Damage ≥ 300
+              Shoot Plasma Beam and Shoot Wave Beam
   > Door to Elite Quarters Access
-      Any of the following:
-          Space Jump Boots or Slope Jump (Beginner)
-          Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner)
-          Scan Visor and Combat/Scan Dash (Beginner) and Standable Terrain (Beginner)
+      All of the following:
+          Any of the following:
+              Space Jump Boots or Slope Jump (Beginner)
+              Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner)
+              Scan Visor and Combat/Scan Dash (Beginner) and Standable Terrain (Beginner)
+          Any of the following:
+              Combat (Intermediate) or Normal Damage ≥ 200
+              Shoot Plasma Beam and Shoot Wave Beam
   > Pickup (Missile)
       Shoot Super Missile
   > Event - Metroid Quarantine B Barrier Lowered
@@ -1410,10 +1484,12 @@ Extra - aabb: [-108.57961, -160.31125, -168.22823, 77.58658, -50.59403, -92.4295
 > Front of Barrier; Heals? False
   * Layers: default
   > Door to Quarantine Access B
-      Any of the following:
-          Space Jump Boots
-          Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner) and Phazon Damage ≥ 150
-          Slope Jump (Beginner) and Phazon Damage ≥ 50
+      All of the following:
+          Any of the following:
+              Space Jump Boots
+              Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner) and Phazon Damage ≥ 150
+              Slope Jump (Beginner) and Phazon Damage ≥ 50
+          Combat (Intermediate) or Normal Damage ≥ 300 or Shoot Plasma Beam
   > Door to Save Station Mines C
       After Metroid Quarantine B Barrier
   > Event - Metroid Quarantine B Barrier Lowered

--- a/randovania/games/prime1/json_data/Phazon Mines.txt
+++ b/randovania/games/prime1/json_data/Phazon Mines.txt
@@ -1257,8 +1257,7 @@ Extra - aabb: [122.126015, -44.231895, -102.18276, 201.19897, 105.61425, -30.731
   > Door to Quarantine Access A
       All of the following:
           # The Security Drone event triggers door locks on all doors in Central Dynamo except for the door to Quarantine Access A. However, if Samus leaves this room without picking up the item, the doors to Save Station Mines B and Dynamo Access will then permanently be sealed, making it impossible to backtrack through the room.
-          Morph Ball and Power Bomb and Knowledge (Beginner)
-          Combat (Intermediate) or Normal Damage ≥ 200 or Shoot Ice Beam
+          Morph Ball and Power Bomb and Before Invisible Drone and Knowledge (Beginner)
   > Door to Save Station Mines B
       After Invisible Drone
   > Event - Security Drone
@@ -1415,9 +1414,17 @@ Extra - aabb: [-108.57961, -160.31125, -168.22823, 77.58658, -50.59403, -92.4295
   > Front of Barrier
       Any of the following:
           All of the following:
-              Space Jump Boots and Slope Jump (Beginner) and Standable Terrain (Intermediate)
-              L-Jump (Intermediate) or Use Grapple Beam
-              Combat (Advanced) or Shoot Plasma Beam
+              Space Jump Boots
+              Any of the following:
+                  All of the following:
+                      Slope Jump (Beginner) and Standable Terrain (Intermediate)
+                      L-Jump (Intermediate) or Use Grapple Beam
+                  Any of the following:
+                      # https://www.youtube.com/watch?v=v3VMpJELp_4
+                      Combat/Scan Dash (Advanced)
+              Any of the following:
+                  Shoot Plasma Beam
+                  Combat (Advanced) and Normal Damage ≥ 200
           All of the following:
               Morph Ball
               Any of the following:

--- a/randovania/games/prime1/json_data/Phazon Mines.txt
+++ b/randovania/games/prime1/json_data/Phazon Mines.txt
@@ -594,6 +594,7 @@ Extra - aabb: [-86.10738, 118.43238, 15.926657, 29.835865, 233.99252, 83.92861]
           Any of the following:
               Combat (Intermediate) or Normal Damage ≥ 200
               Shoot Power Beam and Shoot Wave Beam
+          Normal Damage ≥ 300 or Shoot Any Beam
 
 > Event - Rock Wall in Elite Research Destroyed; Heals? False
   * Layers: default

--- a/randovania/games/prime1/json_data/Phendrana Drifts.json
+++ b/randovania/games/prime1/json_data/Phendrana Drifts.json
@@ -923,6 +923,10 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Move Past Scatter Bombu"
                                     }
                                 ]
                             }
@@ -1032,6 +1036,10 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Move Past Scatter Bombu"
                                     }
                                 ]
                             }
@@ -1433,6 +1441,10 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Move Past Scatter Bombu"
                                     }
                                 ]
                             }
@@ -1508,6 +1520,10 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Move Past Scatter Bombu"
                                     }
                                 ]
                             }
@@ -3195,11 +3211,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Ice Ruins West": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                            "type": "template",
+                            "data": "Move Past Scatter Bombu"
                         }
                     }
                 },
@@ -3230,11 +3243,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Phendrana Canyon": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                            "type": "template",
+                            "data": "Move Past Scatter Bombu"
                         }
                     }
                 },
@@ -5501,11 +5511,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Research Lab Hydra": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                            "type": "template",
+                            "data": "Move Past Scatter Bombu"
                         }
                     }
                 },
@@ -5536,11 +5543,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Research Entrance": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                            "type": "template",
+                            "data": "Move Past Scatter Bombu"
                         }
                     }
                 },
@@ -8226,11 +8230,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Observatory": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                            "type": "template",
+                            "data": "Move Past Scatter Bombu"
                         }
                     }
                 },
@@ -8261,11 +8262,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to West Tower": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                            "type": "template",
+                            "data": "Move Past Scatter Bombu"
                         }
                     }
                 },
@@ -12808,11 +12806,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Gravity Chamber": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                            "type": "template",
+                            "data": "Move Past Scatter Bombu"
                         }
                     }
                 },
@@ -12843,11 +12838,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Hunter Cave": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                            "type": "template",
+                            "data": "Move Past Scatter Bombu"
                         }
                     }
                 },
@@ -12911,11 +12903,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Research Lab Aether": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                            "type": "template",
+                            "data": "Move Past Scatter Bombu"
                         }
                     }
                 },
@@ -12946,11 +12935,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to East Tower": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                            "type": "template",
+                            "data": "Move Past Scatter Bombu"
                         }
                     }
                 },

--- a/randovania/games/prime1/json_data/Phendrana Drifts.txt
+++ b/randovania/games/prime1/json_data/Phendrana Drifts.txt
@@ -167,7 +167,7 @@ Extra - aabb: [-189.07504, -135.11505, 8.018242, -107.17695, -96.79799, 16.83149
   * Extra - nonstandard: False
   > Door to Phendrana Shorelines
       All of the following:
-          Shoot Any Beam
+          Move Past Scatter Bombu and Shoot Any Beam
           Any of the following:
               Missile or Plasma Beam
               All of the following:
@@ -181,7 +181,7 @@ Extra - aabb: [-189.07504, -135.11505, 8.018242, -107.17695, -96.79799, 16.83149
   * Extra - nonstandard: False
   > Door to Chozo Ice Temple
       All of the following:
-          Shoot Any Beam
+          Move Past Scatter Bombu and Shoot Any Beam
           Any of the following:
               Missile or Plasma Beam
               All of the following:
@@ -284,7 +284,7 @@ Extra - aabb: [3.3935394, -191.50578, 5.5963664, 85.29246, -155.06895, 16.848936
   * Extra - nonstandard: False
   > Door to Phendrana Shorelines
       All of the following:
-          Shoot Any Beam
+          Move Past Scatter Bombu and Shoot Any Beam
           Charge Beam or Missile or Plasma Beam
 
 > Door to Phendrana Shorelines; Heals? False; Spawn Point
@@ -294,7 +294,7 @@ Extra - aabb: [3.3935394, -191.50578, 5.5963664, 85.29246, -155.06895, 16.848936
   * Extra - nonstandard: False
   > Door to Ice Ruins East
       All of the following:
-          Shoot Any Beam
+          Move Past Scatter Bombu and Shoot Any Beam
           Charge Beam or Missile or Plasma Beam
 
 > Pickup (Items Every Room); Heals? False
@@ -562,7 +562,7 @@ Extra - aabb: [-159.93053, -350.92947, 12.996344, -77.84514, -316.2018, 21.63486
   * Extra - dock_index: 0
   * Extra - nonstandard: False
   > Door to Ice Ruins West
-      Trivial
+      Move Past Scatter Bombu
 
 > Door to Ice Ruins West; Heals? False; Spawn Point
   * Layers: default
@@ -570,7 +570,7 @@ Extra - aabb: [-159.93053, -350.92947, 12.996344, -77.84514, -316.2018, 21.63486
   * Extra - dock_index: 1
   * Extra - nonstandard: False
   > Door to Phendrana Canyon
-      Trivial
+      Move Past Scatter Bombu
 
 > Pickup (Items Every Room); Heals? False
   * Layers: items_every_room
@@ -944,7 +944,7 @@ Extra - aabb: [-28.796726, -754.66785, 69.92066, 2.6015024, -672.8125, 78.665184
   * Extra - dock_index: 0
   * Extra - nonstandard: False
   > Door to Research Lab Hydra
-      Trivial
+      Move Past Scatter Bombu
 
 > Door to Research Lab Hydra; Heals? False
   * Layers: default
@@ -952,7 +952,7 @@ Extra - aabb: [-28.796726, -754.66785, 69.92066, 2.6015024, -672.8125, 78.665184
   * Extra - dock_index: 1
   * Extra - nonstandard: False
   > Door to Research Entrance
-      Trivial
+      Move Past Scatter Bombu
 
 > Pickup (Items Every Room); Heals? False
   * Layers: items_every_room
@@ -1356,7 +1356,7 @@ Extra - aabb: [-75.53778, -850.37726, 125.85868, -44.117958, -806.7567, 132.2145
   * Extra - dock_index: 0
   * Extra - nonstandard: False
   > Door to Observatory
-      Trivial
+      Move Past Scatter Bombu
 
 > Door to Observatory; Heals? False
   * Layers: default
@@ -1364,7 +1364,7 @@ Extra - aabb: [-75.53778, -850.37726, 125.85868, -44.117958, -806.7567, 132.2145
   * Extra - dock_index: 1
   * Extra - nonstandard: False
   > Door to West Tower
-      Trivial
+      Move Past Scatter Bombu
 
 > Pickup (Items Every Room); Heals? False
   * Layers: items_every_room
@@ -2059,7 +2059,7 @@ Extra - aabb: [272.45688, -1238.1077, -0.50142527, 337.07877, -1222.7445, 16.980
   * Extra - dock_index: 0
   * Extra - nonstandard: False
   > Door to Gravity Chamber
-      Trivial
+      Move Past Scatter Bombu
 
 > Door to Gravity Chamber; Heals? False
   * Layers: default
@@ -2067,7 +2067,7 @@ Extra - aabb: [272.45688, -1238.1077, -0.50142527, 337.07877, -1222.7445, 16.980
   * Extra - dock_index: 1
   * Extra - nonstandard: False
   > Door to Hunter Cave
-      Trivial
+      Move Past Scatter Bombu
 
 > Pickup (Items Every Room); Heals? False
   * Layers: items_every_room
@@ -2086,7 +2086,7 @@ Extra - aabb: [31.992785, -850.3618, 126.190765, 63.412605, -806.7413, 132.16058
   * Extra - dock_index: 0
   * Extra - nonstandard: False
   > Door to Research Lab Aether
-      Trivial
+      Move Past Scatter Bombu
 
 > Door to Research Lab Aether; Heals? False
   * Layers: default
@@ -2094,7 +2094,7 @@ Extra - aabb: [31.992785, -850.3618, 126.190765, 63.412605, -806.7413, 132.16058
   * Extra - dock_index: 1
   * Extra - nonstandard: False
   > Door to East Tower
-      Trivial
+      Move Past Scatter Bombu
 
 > Pickup (Items Every Room); Heals? False
   * Layers: items_every_room

--- a/randovania/games/prime1/json_data/header.json
+++ b/randovania/games/prime1/json_data/header.json
@@ -538,6 +538,14 @@
             "Event54": {
                 "long_name": "Chozo - Fallen Rubble",
                 "extra": {}
+            },
+            "Event55": {
+                "long_name": "Mine Security Station Unlock Doors",
+                "extra": {}
+            },
+            "Event56": {
+                "long_name": "Plasma Processing Item",
+                "extra": {}
             }
         },
         "tricks": {
@@ -1101,6 +1109,71 @@
                                     }
                                 ]
                             }
+                        }
+                    ]
+                }
+            },
+            "Move Past Scatter Bombu": {
+                "type": "or",
+                "data": {
+                    "comment": null,
+                    "items": [
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "MorphBall",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Movement",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "damage",
+                                            "name": "Damage",
+                                            "amount": 100,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "tricks",
+                                "name": "Movement",
+                                "amount": 2,
+                                "negate": false
+                            }
+                        },
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "damage",
+                                "name": "Damage",
+                                "amount": 200,
+                                "negate": false
+                            }
+                        },
+                        {
+                            "type": "template",
+                            "data": "Shoot Wave Beam"
                         }
                     ]
                 }

--- a/randovania/games/prime1/json_data/header.json
+++ b/randovania/games/prime1/json_data/header.json
@@ -1146,7 +1146,7 @@
                                         "data": {
                                             "type": "damage",
                                             "name": "Damage",
-                                            "amount": 100,
+                                            "amount": 12,
                                             "negate": false
                                         }
                                     }
@@ -1167,7 +1167,7 @@
                             "data": {
                                 "type": "damage",
                                 "name": "Damage",
-                                "amount": 200,
+                                "amount": 30,
                                 "negate": false
                             }
                         },

--- a/randovania/games/prime1/json_data/header.txt
+++ b/randovania/games/prime1/json_data/header.txt
@@ -38,6 +38,11 @@ Templates
           Shoot Any Beam
           Morph Ball Bomb and Morph Ball and Scan Visor
 
+* Move Past Scatter Bombu:
+      Any of the following:
+          Morph Ball or Movement (Intermediate) or Normal Damage ≥ 200 or Shoot Wave Beam
+          Movement (Beginner) and Normal Damage ≥ 100
+
 ====================
 Dock Weaknesses
 

--- a/randovania/games/prime1/json_data/header.txt
+++ b/randovania/games/prime1/json_data/header.txt
@@ -40,8 +40,8 @@ Templates
 
 * Move Past Scatter Bombu:
       Any of the following:
-          Morph Ball or Movement (Intermediate) or Normal Damage ≥ 200 or Shoot Wave Beam
-          Movement (Beginner) and Normal Damage ≥ 100
+          Morph Ball or Movement (Intermediate) or Normal Damage ≥ 30 or Shoot Wave Beam
+          Movement (Beginner) and Normal Damage ≥ 12
 
 ====================
 Dock Weaknesses


### PR DESCRIPTION
This logic is very useful for door rando seeds in particular, where you may find yourself in rooms with enemies without the means to properly defend yourself.

- Added: Advancing through rooms containing Trooper Pirates now requires either the proper beam(s), basic defensive capabilities (varies slightly by room), or Combat (Intermediate), except where noted. Rooms affected:
    - Elite Control
    - Elite Research
    - Ore Processing - Climbing the room vanilla now requires Power Beam. Ore Processing climb without Power Beam now requires Combat (Advanced).
    - Central Dynamo
    - Omega Research
    - Mine Security Station
    - Metroid Quarantine B - The Standable Terrain method of traversing the room now requires Combat (Advanced) without Plasma Beam.
    - Phazon Processing Center - This room is only affected after picking up the item in Plasma Processing.
   
- Added: Advancing through rooms containing Scatter Bombus now requires Morph Ball, Wave Beam, Movement tricks, or basic defensive capabilities. Rooms affected:
    - Ice Ruins Access
    - Canyon Entryway
    - Temple Entryway
    - Hydra Lab Entryway
    - West Tower Entrance
    - Aether Lab Entryway
    - Lower Edge Tunnel
    - Lake Tunnel