### PR TITLE
Lowered Trooper Pirate damage requirements.

### DIFF
--- a/randovania/games/prime1/json_data/Phazon Mines.json
+++ b/randovania/games/prime1/json_data/Phazon Mines.json
@@ -1732,7 +1732,7 @@
                                                     "data": {
                                                         "type": "damage",
                                                         "name": "Damage",
-                                                        "amount": 100,
+                                                        "amount": 50,
                                                         "negate": false
                                                     }
                                                 },
@@ -2351,7 +2351,7 @@
                                                     "data": {
                                                         "type": "damage",
                                                         "name": "Damage",
-                                                        "amount": 200,
+                                                        "amount": 125,
                                                         "negate": false
                                                     }
                                                 },
@@ -2417,7 +2417,7 @@
                                                                             "data": {
                                                                                 "type": "damage",
                                                                                 "name": "Damage",
-                                                                                "amount": 200,
+                                                                                "amount": 125,
                                                                                 "negate": false
                                                                             }
                                                                         },
@@ -2519,7 +2519,7 @@
                                                     "data": {
                                                         "type": "damage",
                                                         "name": "Damage",
-                                                        "amount": 200,
+                                                        "amount": 125,
                                                         "negate": false
                                                     }
                                                 },
@@ -2649,7 +2649,7 @@
                                                                 "data": {
                                                                     "type": "damage",
                                                                     "name": "Damage",
-                                                                    "amount": 200,
+                                                                    "amount": 125,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -3696,7 +3696,7 @@
                                                     "data": {
                                                         "type": "damage",
                                                         "name": "Damage",
-                                                        "amount": 200,
+                                                        "amount": 125,
                                                         "negate": false
                                                     }
                                                 },
@@ -3726,7 +3726,7 @@
                                                     "data": {
                                                         "type": "damage",
                                                         "name": "Damage",
-                                                        "amount": 300,
+                                                        "amount": 200,
                                                         "negate": false
                                                     }
                                                 }
@@ -3866,7 +3866,7 @@
                                         "data": {
                                             "type": "damage",
                                             "name": "Damage",
-                                            "amount": 200,
+                                            "amount": 125,
                                             "negate": false
                                         }
                                     },
@@ -4838,7 +4838,7 @@
                                                                             "data": {
                                                                                 "type": "damage",
                                                                                 "name": "Damage",
-                                                                                "amount": 200,
+                                                                                "amount": 125,
                                                                                 "negate": false
                                                                             }
                                                                         },
@@ -5706,7 +5706,7 @@
                                                                             "data": {
                                                                                 "type": "damage",
                                                                                 "name": "Damage",
-                                                                                "amount": 300,
+                                                                                "amount": 200,
                                                                                 "negate": false
                                                                             }
                                                                         }
@@ -6134,7 +6134,7 @@
                                                                             "data": {
                                                                                 "type": "damage",
                                                                                 "name": "Damage",
-                                                                                "amount": 200,
+                                                                                "amount": 125,
                                                                                 "negate": false
                                                                             }
                                                                         }
@@ -6284,7 +6284,7 @@
                                                                             "data": {
                                                                                 "type": "damage",
                                                                                 "name": "Damage",
-                                                                                "amount": 200,
+                                                                                "amount": 125,
                                                                                 "negate": false
                                                                             }
                                                                         }
@@ -6475,7 +6475,7 @@
                                         "data": {
                                             "type": "damage",
                                             "name": "Damage",
-                                            "amount": 200,
+                                            "amount": 125,
                                             "negate": false
                                         }
                                     },
@@ -6637,7 +6637,7 @@
                                                     "data": {
                                                         "type": "damage",
                                                         "name": "Damage",
-                                                        "amount": 200,
+                                                        "amount": 125,
                                                         "negate": false
                                                     }
                                                 },
@@ -8303,7 +8303,7 @@
                                                     "data": {
                                                         "type": "damage",
                                                         "name": "Damage",
-                                                        "amount": 200,
+                                                        "amount": 125,
                                                         "negate": false
                                                     }
                                                 },
@@ -9081,7 +9081,7 @@
                                                                             "data": {
                                                                                 "type": "damage",
                                                                                 "name": "Damage",
-                                                                                "amount": 200,
+                                                                                "amount": 125,
                                                                                 "negate": false
                                                                             }
                                                                         }
@@ -9247,7 +9247,7 @@
                                                                 "data": {
                                                                     "type": "damage",
                                                                     "name": "Damage",
-                                                                    "amount": 300,
+                                                                    "amount": 200,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -9323,7 +9323,7 @@
                                         "data": {
                                             "type": "damage",
                                             "name": "Damage",
-                                            "amount": 200,
+                                            "amount": 125,
                                             "negate": false
                                         }
                                     }
@@ -9521,7 +9521,7 @@
                                                     "data": {
                                                         "type": "damage",
                                                         "name": "Damage",
-                                                        "amount": 300,
+                                                        "amount": 200,
                                                         "negate": false
                                                     }
                                                 }
@@ -9667,7 +9667,7 @@
                                                     "data": {
                                                         "type": "damage",
                                                         "name": "Damage",
-                                                        "amount": 200,
+                                                        "amount": 125,
                                                         "negate": false
                                                     }
                                                 }
@@ -9886,7 +9886,7 @@
                                                     "data": {
                                                         "type": "damage",
                                                         "name": "Damage",
-                                                        "amount": 300,
+                                                        "amount": 200,
                                                         "negate": false
                                                     }
                                                 }

--- a/randovania/games/prime1/json_data/Phazon Mines.txt
+++ b/randovania/games/prime1/json_data/Phazon Mines.txt
@@ -290,7 +290,7 @@ Extra - aabb: [66.58455, 129.7148, 11.163003, 138.8284, 204.85583, 77.01038]
               All of the following:
                   # https://youtu.be/7ATtR9o9PRw
                   Space Jump Boots and L-Jump (Beginner)
-          Combat (Beginner) or Normal Damage ≥ 100 or Shoot Wave Beam
+          Combat (Beginner) or Normal Damage ≥ 50 or Shoot Wave Beam
   > Door to Elevator Access A
       Trivial
 
@@ -363,14 +363,14 @@ Extra - aabb: [-36.12424, -29.465834, -4.4074636, 29.15716, 66.50636, 24.451797]
       All of the following:
           After Mine Security Station Unlock Doors
           Any of the following:
-              Combat (Intermediate) or Normal Damage ≥ 200
+              Combat (Intermediate) or Normal Damage ≥ 125
               Shoot Ice Beam and Shoot Wave Beam
   > Event - Mine Security Station Doors Unlocked
       All of the following:
           Before Mine Security Station Unlock Doors and Shoot Wave Beam
           Any of the following:
               Charge Beam or Combat (Advanced)
-              Combat (Intermediate) and Normal Damage ≥ 200
+              Combat (Intermediate) and Normal Damage ≥ 125
 
 > Door to Security Access B; Heals? False
   * Layers: default
@@ -381,7 +381,7 @@ Extra - aabb: [-36.12424, -29.465834, -4.4074636, 29.15716, 66.50636, 24.451797]
       All of the following:
           After Mine Security Station Unlock Doors
           Any of the following:
-              Combat (Intermediate) or Normal Damage ≥ 200
+              Combat (Intermediate) or Normal Damage ≥ 125
               Shoot Ice Beam and Shoot Wave Beam
   > Door to Storage Depot A
       After Mine Security Station Barrier
@@ -392,7 +392,7 @@ Extra - aabb: [-36.12424, -29.465834, -4.4074636, 29.15716, 66.50636, 24.451797]
           Before Mine Security Station Unlock Doors and Shoot Wave Beam
           Any of the following:
               Charge Beam or Combat (Advanced)
-              Combat (Intermediate) and Normal Damage ≥ 200
+              Combat (Intermediate) and Normal Damage ≥ 125
 
 > Door to Storage Depot A; Heals? False
   * Layers: default
@@ -592,9 +592,9 @@ Extra - aabb: [-86.10738, 118.43238, 15.926657, 29.835865, 233.99252, 83.92861]
               Space Jump Boots
               Morph Ball Bomb and Morph Ball and Bomb Jump (Intermediate)
           Any of the following:
-              Combat (Intermediate) or Normal Damage ≥ 200
+              Combat (Intermediate) or Normal Damage ≥ 125
               Shoot Power Beam and Shoot Wave Beam
-          Normal Damage ≥ 300 or Shoot Any Beam
+          Normal Damage ≥ 200 or Shoot Any Beam
 
 > Event - Rock Wall in Elite Research Destroyed; Heals? False
   * Layers: default
@@ -621,7 +621,7 @@ Extra - aabb: [-86.10738, 118.43238, 15.926657, 29.835865, 233.99252, 83.92861]
       After Elite Research Rock Wall
   > Door to Security Access B
       Any of the following:
-          Combat (Intermediate) or Normal Damage ≥ 200
+          Combat (Intermediate) or Normal Damage ≥ 125
           Shoot Power Beam and Shoot Wave Beam
   > Event - Rock Wall in Elite Research Destroyed
       All of the following:
@@ -784,7 +784,7 @@ Extra - aabb: [-18.74421, 79.04062, -74.48461, 91.819305, 157.94768, -0.48807144
                   Standable Terrain (Intermediate)
               All of the following:
                   After Elite Pirate Fight (Elite Control)
-                  Combat (Intermediate) or Normal Damage ≥ 200 or Shoot Ice Beam
+                  Combat (Intermediate) or Normal Damage ≥ 125 or Shoot Ice Beam
   > Event - Elite Control Barriers Lowered
       All of the following:
           Scan Visor
@@ -909,7 +909,7 @@ Extra - aabb: [-132.15839, 87.526505, -111.61871, -26.354706, 153.05708, -8.0265
               All of the following:
                   After Plasma Processing Item
                   Any of the following:
-                      Combat (Intermediate) or Normal Damage ≥ 300
+                      Combat (Intermediate) or Normal Damage ≥ 200
                       Shoot Plasma Beam and Shoot Power Beam and Shoot Wave Beam
   > Door to Processing Center Access
       Any of the following:
@@ -945,7 +945,7 @@ Extra - aabb: [-132.15839, 87.526505, -111.61871, -26.354706, 153.05708, -8.0265
               All of the following:
                   After Plasma Processing Item
                   Any of the following:
-                      Combat (Intermediate) or Normal Damage ≥ 200
+                      Combat (Intermediate) or Normal Damage ≥ 125
                       Shoot Plasma Beam and Shoot Power Beam and Shoot Wave Beam
   > Pickup (Missile)
       All of the following:
@@ -958,7 +958,7 @@ Extra - aabb: [-132.15839, 87.526505, -111.61871, -26.354706, 153.05708, -8.0265
               All of the following:
                   After Plasma Processing Item
                   Any of the following:
-                      Combat (Intermediate) or Normal Damage ≥ 200
+                      Combat (Intermediate) or Normal Damage ≥ 125
                       Shoot Plasma Beam and Shoot Power Beam and Shoot Wave Beam
 
 > Pickup (Missile); Heals? False
@@ -991,7 +991,7 @@ Extra - aabb: [-30.495464, -73.79053, -86.16589, 78.22917, 33.54581, 12.443928]
       Morph Ball and Power Bomb
   > Door to Dynamo Access
       Any of the following:
-          Combat (Intermediate) or Normal Damage ≥ 200
+          Combat (Intermediate) or Normal Damage ≥ 125
           Shoot Power Beam and Shoot Wave Beam
 
 > Door to Dynamo Access; Heals? False
@@ -1006,7 +1006,7 @@ Extra - aabb: [-30.495464, -73.79053, -86.16589, 78.22917, 33.54581, 12.443928]
               Space Jump Boots or Slope Jump (Intermediate)
               Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner)
           Any of the following:
-              Combat (Intermediate) or Normal Damage ≥ 200
+              Combat (Intermediate) or Normal Damage ≥ 125
               Shoot Power Beam and Shoot Wave Beam
 
 > Pickup (Items Every Room); Heals? False
@@ -1284,7 +1284,7 @@ Extra - aabb: [122.126015, -44.231895, -102.18276, 201.19897, 105.61425, -30.731
               # Fast climb with Standable: https://youtu.be/MtpgWKgaF-U
               Space Jump Boots
               Morph Ball Bomb and Morph Ball and Complex Bomb Jump (Expert) and Standable Terrain (Intermediate)
-          Combat (Intermediate) or Normal Damage ≥ 200 or Shoot Ice Beam
+          Combat (Intermediate) or Normal Damage ≥ 125 or Shoot Ice Beam
   > Door to Quarantine Access A
       All of the following:
           Morph Ball and Power Bomb and After Invisible Drone
@@ -1424,7 +1424,7 @@ Extra - aabb: [-108.57961, -160.31125, -168.22823, 77.58658, -50.59403, -92.4295
                       Combat/Scan Dash (Advanced)
               Any of the following:
                   Shoot Plasma Beam
-                  Combat (Advanced) and Normal Damage ≥ 200
+                  Combat (Advanced) and Normal Damage ≥ 125
           All of the following:
               Morph Ball
               Any of the following:
@@ -1434,7 +1434,7 @@ Extra - aabb: [-108.57961, -160.31125, -168.22823, 77.58658, -50.59403, -92.4295
                           Use Grapple Beam
                           Scan Visor and Combat/Scan Dash (Expert)
                   Morph Ball Bomb and Scan Visor and Complex Bomb Jump (Expert) and Combat/Scan Dash (Expert) and Standable Terrain (Intermediate)
-              Combat (Intermediate) or Normal Damage ≥ 300 or Shoot Plasma Beam
+              Combat (Intermediate) or Normal Damage ≥ 200 or Shoot Plasma Beam
 
 > Door to Elite Quarters Access; Heals? False
   * Layers: default
@@ -1443,7 +1443,7 @@ Extra - aabb: [-108.57961, -160.31125, -168.22823, 77.58658, -50.59403, -92.4295
   * Extra - nonstandard: False
   > Door to Save Station Mines C
       Any of the following:
-          Combat (Intermediate) or Normal Damage ≥ 200
+          Combat (Intermediate) or Normal Damage ≥ 125
           Shoot Plasma Beam and Shoot Wave Beam
 
 > Door to Save Station Mines C; Heals? False
@@ -1458,7 +1458,7 @@ Extra - aabb: [-108.57961, -160.31125, -168.22823, 77.58658, -50.59403, -92.4295
               Space Jump Boots and Single Room Out of Bounds (Advanced) and Standable Terrain (Advanced)
               Morph Ball Bomb and Bomb Jump (Advanced) and Complex Bomb Jump (Expert) and Single Room Out of Bounds (Expert) and Standable Terrain (Hypermode)
           Any of the following:
-              Combat (Intermediate) or Normal Damage ≥ 300
+              Combat (Intermediate) or Normal Damage ≥ 200
               Shoot Plasma Beam and Shoot Wave Beam
   > Door to Elite Quarters Access
       All of the following:
@@ -1467,7 +1467,7 @@ Extra - aabb: [-108.57961, -160.31125, -168.22823, 77.58658, -50.59403, -92.4295
               Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner)
               Scan Visor and Combat/Scan Dash (Beginner) and Standable Terrain (Beginner)
           Any of the following:
-              Combat (Intermediate) or Normal Damage ≥ 200
+              Combat (Intermediate) or Normal Damage ≥ 125
               Shoot Plasma Beam and Shoot Wave Beam
   > Pickup (Missile)
       Shoot Super Missile
@@ -1497,7 +1497,7 @@ Extra - aabb: [-108.57961, -160.31125, -168.22823, 77.58658, -50.59403, -92.4295
               Space Jump Boots
               Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner) and Phazon Damage ≥ 150
               Slope Jump (Beginner) and Phazon Damage ≥ 50
-          Combat (Intermediate) or Normal Damage ≥ 300 or Shoot Plasma Beam
+          Combat (Intermediate) or Normal Damage ≥ 200 or Shoot Plasma Beam
   > Door to Save Station Mines C
       After Metroid Quarantine B Barrier
   > Event - Metroid Quarantine B Barrier Lowered


### PR DESCRIPTION
Hopefully will fix some issues the resolver seemed to be running into with Door Rando. Even if these numbers weren't the cause, I forgot to account for damage strictness multipliers when I initially wrote the numbers, so these needed to be changed anyway.