### PR TITLE
Expect a released GIL from native packages

### DIFF
--- a/randovania/patching/patchers/gamecube/iso_packager.py
+++ b/randovania/patching/patchers/gamecube/iso_packager.py
@@ -1,87 +1,9 @@
-import multiprocessing
-from distutils.version import StrictVersion
 from pathlib import Path
 
-try:
-    import nod
-except ImportError:
-    nod = None
+import nod
 
 from randovania.interface_common.game_workdir import validate_game_files_path
 from randovania.lib.status_update_lib import ProgressUpdateCallable
-
-
-def _disc_unpack_process(output_pipe,
-                         iso: Path,
-                         game_files_path: Path,
-                         ):
-    def progress_callback(path, progress):
-        output_pipe.send((False, path, progress))
-
-    def _helper():
-        try:
-            disc, is_wii = nod.open_disc_from_image(str(iso))
-            data_partition = disc.get_data_partition()
-            if not data_partition:
-                raise RuntimeError(
-                    "Could not find a data partition in '{}'.\nIs it a valid Metroid Prime 2 ISO?".format(
-                        iso))
-
-            context = nod.ExtractionContext()
-            context.set_progress_callback(progress_callback)
-            data_partition.extract_to_directory(str(game_files_path), context)
-            return True, None, 100
-
-        except RuntimeError as e:
-            return True, str(e), 0
-
-    output_pipe.send(_helper())
-
-
-def _disc_pack_process(status_queue,
-                       iso: Path,
-                       game_files_path: Path,
-                       ):
-    def fprogress_callback(progress: float, name: str, bytes: int):
-        status_queue.send((False, name, progress))
-
-    def _helper():
-        try:
-            disc_builder = nod.DiscBuilderGCN(str(iso), fprogress_callback)
-            disc_builder.build_from_directory(str(game_files_path))
-            return True, None, 100
-
-        except RuntimeError as e:
-            return True, str(e), 0
-
-    status_queue.send(_helper())
-
-
-def _shared_process_code(target,
-                         iso: Path,
-                         game_files_path: Path,
-                         on_finish_message: str,
-                         progress_update: ProgressUpdateCallable):
-    receiving_pipe, output_pipe = multiprocessing.Pipe(False)
-    process = multiprocessing.Process(
-        target=target,
-        args=(output_pipe, iso, game_files_path)
-    )
-    process.start()
-    try:
-        finished = False
-        message = ""
-        percentage = 0
-        while not finished:
-            progress_update(message, percentage)
-            finished, message, percentage = receiving_pipe.recv()
-
-        if isinstance(message, str):
-            raise RuntimeError(message)
-
-        progress_update(on_finish_message, 1)
-    finally:
-        process.terminate()
 
 
 def unpack_iso(iso: Path,
@@ -94,13 +16,18 @@ def unpack_iso(iso: Path,
         raise RuntimeError("Unable to create files dir {}:\n{}".format(
             game_files_path, e))
 
-    _shared_process_code(
-        target=_disc_unpack_process,
-        iso=iso,
-        game_files_path=game_files_path,
-        on_finish_message="Finished extracting ISO",
-        progress_update=progress_update
-    )
+    disc, is_wii = nod.open_disc_from_image(iso)
+    data_partition = disc.get_data_partition()
+    if not data_partition:
+        raise RuntimeError(
+            f"Could not find a data partition in '{iso}'.\nIs it a valid Metroid Prime 2 ISO?"
+        )
+
+    context = nod.ExtractionContext()
+    context.set_progress_callback(progress_update)
+    data_partition.extract_to_directory(game_files_path, context)
+
+    progress_update("Finished extracting ISO", 1)
 
 
 def pack_iso(iso: Path,
@@ -109,21 +36,13 @@ def pack_iso(iso: Path,
              ):
     validate_game_files_path(game_files_path.joinpath("files"))
 
-    nod_version = StrictVersion(getattr(nod, "VERSION", "0.0.0"))
-    if nod_version < StrictVersion("1.1.0"):
-        raise RuntimeError("Installed nod version ({}) is older than required 1.1.0".format(nod_version))
-
-    if nod.DiscBuilderGCN.calculate_total_size_required(str(game_files_path)) is None:
+    if nod.DiscBuilderGCN.calculate_total_size_required(game_files_path) is None:
         raise RuntimeError("Image built with given directory would pass the maximum size.")
 
-    _shared_process_code(
-        target=_disc_pack_process,
-        iso=iso,
-        game_files_path=game_files_path,
-        on_finish_message="Finished packing ISO",
-        progress_update=progress_update
-    )
+    def fprogress_callback(progress: float, name: str, byte_count: int):
+        progress_update(name, progress)
 
+    disc_builder = nod.DiscBuilderGCN(iso, fprogress_callback)
+    disc_builder.build_from_directory(game_files_path)
 
-def can_process_iso() -> bool:
-    return nod is not None
+    progress_update("Finished packing ISO", 1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -122,7 +122,7 @@ kiwisolver==1.4.3
     # via matplotlib
 lupa==1.13
     # via cave-story-randomizer
-lzokay==1.0.1
+lzokay==1.1.0
     # via retro-data-structures
 markdown==3.3.7
     # via randovania (setup.py)
@@ -184,7 +184,7 @@ py==1.11.0
     # via
     #   pytest
     #   pytest-forked
-py-randomprime==1.7.0
+py-randomprime==1.8.0
     # via randovania (setup.py)
 pycparser==2.21
     # via cffi

--- a/requirements.txt
+++ b/requirements.txt
@@ -142,7 +142,7 @@ multidict==6.0.2
     #   yarl
 networkx==2.8.4
     # via randovania (setup.py)
-nod==1.7.0
+nod==1.8.0
     # via
     #   randovania (setup.py)
     #   retro-data-structures

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ gui =
     dolphin-memory-engine>=1.0.2
     markdown
     matplotlib>=3.3.3
-    nod>=1.5
+    nod>=1.8
     pid>=3.0.0
     pypresence
     pyqtdarktheme

--- a/test/games/patchers/gamecube/test_iso_packager.py
+++ b/test/games/patchers/gamecube/test_iso_packager.py
@@ -1,214 +1,57 @@
-import sys
-from multiprocessing import connection
 from unittest.mock import patch, MagicMock, ANY, call
 
 import pytest
 
 from randovania.patching.patchers.gamecube import iso_packager
 
-work_around_pytest_qt_bug = False  # TODO: pytest-qt bug
 
-
-@patch("nod.ExtractionContext", autospec=work_around_pytest_qt_bug)
-@patch("nod.open_disc_from_image", autospec=work_around_pytest_qt_bug)
-def test_disc_unpack_process_valid(mock_open_disc_from_image: MagicMock,
-                                   mock_extraction_context: MagicMock,
-                                   ):
-    # TODO: invalid ISO
-
+def test_unpack_iso_bad_iso(mocker):
     # Setup
-    output_pipe = MagicMock()
     iso = MagicMock()
     game_files_path = MagicMock()
 
-    disc = MagicMock()
-    mock_open_disc_from_image.return_value = disc, False
-    data_partition = disc.get_data_partition.return_value
-
-    def set_progress_side_effect(callable):
-        callable("first path", 0.5)
-
-    context = mock_extraction_context.return_value
-    context.set_progress_callback.side_effect = set_progress_side_effect
-
-    # Run
-    iso_packager._disc_unpack_process(output_pipe, iso, game_files_path)
-
-    # Assert
-    mock_open_disc_from_image.assert_called_once_with(str(iso))
-    disc.get_data_partition.assert_called_once_with()
-    mock_extraction_context.assert_called_once_with()
-    context.set_progress_callback.assert_called_once_with(ANY)
-    data_partition.extract_to_directory.assert_called_once_with(str(game_files_path), context)
-
-    output_pipe.send.assert_has_calls([
-        call((False, "first path", 0.5)),
-        call((True, None, 100)),
-    ])
-
-
-@patch("nod.ExtractionContext", autospec=work_around_pytest_qt_bug)
-@patch("nod.open_disc_from_image", autospec=work_around_pytest_qt_bug)
-def test_disc_unpack_process_invalid(mock_open_disc_from_image: MagicMock,
-                                     mock_extraction_context: MagicMock,
-                                     ):
-    # Setup
-    output_pipe = MagicMock()
-    iso = MagicMock()
-    game_files_path = MagicMock()
+    mock_nod = mocker.patch("randovania.patching.patchers.gamecube.iso_packager.nod")
 
     disc = MagicMock()
-    mock_open_disc_from_image.return_value = disc, False
+    mock_nod.open_disc_from_image.return_value = disc, False
     disc.get_data_partition.return_value = None
 
     # Run
-    iso_packager._disc_unpack_process(output_pipe, iso, game_files_path)
+    with pytest.raises(RuntimeError, match=f"Could not find a data partition in '{iso}'."
+                                           f"\nIs it a valid Metroid Prime 2 ISO?"):
+        iso_packager.unpack_iso(iso, game_files_path, MagicMock())
 
     # Assert
-    mock_open_disc_from_image.assert_called_once_with(str(iso))
+    mock_nod.open_disc_from_image.assert_called_once_with(iso)
     disc.get_data_partition.assert_called_once_with()
-    mock_extraction_context.assert_not_called()
-
-    output_pipe.send.assert_called_once_with(
-        (True, "Could not find a data partition in '{}'.\nIs it a valid Metroid Prime 2 ISO?".format(iso), 0)
-    )
+    mock_nod.ExtractionContext.assert_not_called()
 
 
-@patch("nod.DiscBuilderGCN", autospec=work_around_pytest_qt_bug)
-def test_disc_pack_process_success(mock_disc_builder: MagicMock,
-                                   ):
-    # Setup
-    status_queue = MagicMock()
-    iso = MagicMock()
-    game_files_path = MagicMock()
-    disc_builder = mock_disc_builder.return_value
-
-    def builder_side_effect(_, callback):
-        callback(0.5, "file one", 123456)
-        return disc_builder
-
-    mock_disc_builder.side_effect = builder_side_effect
-
-    # Run
-    iso_packager._disc_pack_process(status_queue, iso, game_files_path)
-
-    # Assert
-    mock_disc_builder.assert_called_once_with(str(iso), ANY)
-    disc_builder.build_from_directory.assert_called_once_with(str(game_files_path))
-    status_queue.send.assert_has_calls([
-        call((False, "file one", 0.5)),
-        call((True, None, 100)),
-    ])
-
-
-@patch("nod.DiscBuilderGCN", autospec=work_around_pytest_qt_bug)
-def test_disc_pack_process_failure(mock_disc_builder: MagicMock,
-                                   ):
-    # Setup
-    status_queue = MagicMock()
-    iso = MagicMock()
-    game_files_path = MagicMock()
-
-    mock_disc_builder.side_effect = RuntimeError("Failure to do stuff")
-
-    # Run
-    iso_packager._disc_pack_process(status_queue, iso, game_files_path)
-
-    # Assert
-    mock_disc_builder.assert_called_once_with(str(iso), ANY)
-    status_queue.send.assert_called_once_with((True, "Failure to do stuff", 0))
-
-
-def test_shared_process_code_success():
-    # Setup
-    mock_target = MagicMock()
-    iso = MagicMock()
-    game_files_path = MagicMock()
-    on_finish_message = MagicMock()
-    progress_update = MagicMock()
-
-    process = MagicMock()
-
-    def process_effect(target, args):
-        output_pipe: connection.Connection = args[0]
-        output_pipe.send((False, "Message 1", 0.2))
-        output_pipe.send((False, "Message 2", 0.5))
-        output_pipe.send((True, None, 100))
-        return process
-
-    # Run
-    with patch("multiprocessing.Process", side_effect=process_effect,
-               autospec=work_around_pytest_qt_bug) as mock_process:
-        iso_packager._shared_process_code(mock_target, iso, game_files_path, on_finish_message, progress_update)
-
-    mock_process.assert_called_once_with(target=mock_target, args=(ANY, iso, game_files_path))
-    process.start.assert_called_once_with()
-    process.terminate.assert_called_once_with()
-    progress_update.assert_has_calls([
-        call("", 0),
-        call("Message 1", 0.2),
-        call("Message 2", 0.5),
-        call(on_finish_message, 1),
-    ])
-
-
-def test_shared_process_code_failure():
-    # Setup
-    mock_target = MagicMock()
-    iso = MagicMock()
-    game_files_path = MagicMock()
-    on_finish_message = MagicMock()
-    progress_update = MagicMock()
-
-    process = MagicMock()
-
-    def process_effect(target, args):
-        output_pipe: connection.Connection = args[0]
-        output_pipe.send((False, "Message 1", 0.2))
-        output_pipe.send((True, "You got an error!", 100))
-        return process
-
-    # Run
-    with patch("multiprocessing.Process", side_effect=process_effect,
-               autospec=work_around_pytest_qt_bug) as mock_process:
-        with pytest.raises(RuntimeError) as exception:
-            iso_packager._shared_process_code(mock_target, iso, game_files_path, on_finish_message, progress_update)
-
-    mock_process.assert_called_once_with(target=mock_target, args=(ANY, iso, game_files_path))
-    process.start.assert_called_once_with()
-    process.terminate.assert_called_once_with()
-    progress_update.assert_has_calls([
-        call("", 0),
-        call("Message 1", 0.2),
-    ])
-    assert str(exception.value) == "You got an error!"
-
-
-@patch("randovania.patching.patchers.gamecube.iso_packager._shared_process_code", autospec=True)
-def test_unpack_iso_success(mock_shared_process_code: MagicMock,
-                            ):
+def test_unpack_iso_success(mocker):
     # Setup
     iso = MagicMock()
     game_files_path = MagicMock()
     progress_update = MagicMock()
+
+    mock_disc = MagicMock()
+
+    mock_nod = mocker.patch("randovania.patching.patchers.gamecube.iso_packager.nod")
+    mock_nod.open_disc_from_image.return_value = (mock_disc, False)
 
     # Run
     iso_packager.unpack_iso(iso, game_files_path, progress_update)
 
     # Assert
     game_files_path.mkdir.assert_called_once_with(parents=True, exist_ok=True)
-    mock_shared_process_code.assert_called_once_with(
-        target=iso_packager._disc_unpack_process,
-        iso=iso,
-        game_files_path=game_files_path,
-        on_finish_message="Finished extracting ISO",
-        progress_update=progress_update
+    mock_nod.open_disc_from_image.assert_called_once_with(iso)
+    mock_disc.get_data_partition.assert_called_once_with()
+    mock_disc.get_data_partition.return_value.extract_to_directory.assert_called_once_with(
+        game_files_path, mock_nod.ExtractionContext.return_value,
     )
+    mock_nod.ExtractionContext.return_value.set_progress_callback.assert_called_once_with(progress_update)
 
 
-@patch("randovania.patching.patchers.gamecube.iso_packager._shared_process_code", autospec=True)
-def test_unpack_iso_failure(mock_shared_process_code: MagicMock,
-                            ):
+def test_unpack_iso_failure():
     # Setup
     iso = MagicMock()
     game_files_path = MagicMock()
@@ -223,16 +66,13 @@ def test_unpack_iso_failure(mock_shared_process_code: MagicMock,
 
     # Assert
     game_files_path.mkdir.assert_called_once_with(parents=True, exist_ok=True)
-    mock_shared_process_code.assert_not_called()
     assert str(exception.value) == "Unable to create files dir {}:\n{}".format(game_files_path, exception_message)
 
 
 @pytest.mark.parametrize("iso_too_big", [False, True])
 @patch("randovania.patching.patchers.gamecube.iso_packager.nod")
-@patch("randovania.patching.patchers.gamecube.iso_packager._shared_process_code", autospec=True)
 @patch("randovania.patching.patchers.gamecube.iso_packager.validate_game_files_path", autospec=True)
 def test_pack_iso(mock_validate_game_files_path: MagicMock,
-                  mock_shared_process_code: MagicMock,
                   mock_nod: MagicMock,
                   iso_too_big: bool):
     # Setup
@@ -244,7 +84,6 @@ def test_pack_iso(mock_validate_game_files_path: MagicMock,
 
     mock_calculate_total_size_required = mock_nod.DiscBuilderGCN.calculate_total_size_required
     mock_calculate_total_size_required.side_effect = sizes
-    mock_nod.VERSION = "1.1.0"
 
     def run():
         iso_packager.pack_iso(iso, game_files_path, progress_update)
@@ -261,46 +100,13 @@ def test_pack_iso(mock_validate_game_files_path: MagicMock,
     mock_validate_game_files_path.assert_called_once_with(game_files_path.joinpath.return_value)
 
     mock_calculate_total_size_required.assert_has_calls([
-        call(str(game_files_path))
+        call(game_files_path)
         for _ in sizes
     ])
 
     if iso_too_big:
-        mock_shared_process_code.assert_not_called()
+        mock_nod.DiscBuilderGCN.assert_not_called()
     else:
-        mock_shared_process_code.assert_called_once_with(
-            target=iso_packager._disc_pack_process,
-            iso=iso,
-            game_files_path=game_files_path,
-            on_finish_message="Finished packing ISO",
-            progress_update=progress_update
-        )
-
-
-@patch("randovania.patching.patchers.gamecube.iso_packager.nod")
-@patch("randovania.patching.patchers.gamecube.iso_packager.validate_game_files_path", autospec=True)
-def test_pack_iso_invalid_version(mock_validate_game_files_path: MagicMock,
-                                  mock_nod: MagicMock,
-                                  ):
-    # Setup
-    game_files_path = MagicMock()
-    mock_nod.VERSION = "1.0.0"
-
-    # Run
-    with pytest.raises(RuntimeError) as exception:
-        iso_packager.pack_iso(None, game_files_path, None)
-
-    # Assert
-    mock_validate_game_files_path.assert_called_once_with(game_files_path.joinpath.return_value)
-    assert str(exception.value) == "Installed nod version (1.0) is older than required 1.1.0"
-
-
-def test_can_process_iso_success():
-    assert iso_packager.can_process_iso()
-
-
-def test_can_process_iso_failure():
-    with patch.dict(sys.modules, nod=None):
-        del sys.modules["randovania.patching.patchers.gamecube.iso_packager"]
-        from randovania.patching.patchers.gamecube.iso_packager import can_process_iso
-        assert not can_process_iso()
+        mock_nod.DiscBuilderGCN.assert_called_once_with(iso, ANY)
+        mock_nod.DiscBuilderGCN.return_value.build_from_directory.assert_called_once_with(game_files_path)
+        progress_update.assert_called_once_with("Finished packing ISO", 1)


### PR DESCRIPTION
This simplifies the code for using nod, as well as improve GUI responsiveness when exporting Prime 1 and when converting assets.