### PR TITLE
Dread: Revise logic for Ghavoran's EMMI Zone

### DIFF
--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -4069,16 +4069,55 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Map Station Access (dooremmy_002)": {
+                        "Dock to Map Station Access (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Dock to EMMI Zone Exit West": {
+                            "type": "and",
+                            "data": {
+                                "comment": "If you start in the room direclty below this one, you can carry a speed boost all the way to here",
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Plasma Beam"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Speedbooster",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
-                "Dock to Map Station Access (dooremmy_002)": {
+                "Dock to Map Station Access (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4098,7 +4137,7 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "Map Station Access",
-                        "node_name": "Dock to EMMI Zone Exit Southeast (dooremmy_002)"
+                        "node_name": "Dock to EMMI Zone Exit Southeast (Lower)"
                     },
                     "default_dock_weakness": "EMMI Door",
                     "override_default_open_requirement": null,
@@ -4111,14 +4150,40 @@
                                 "items": []
                             }
                         },
-                        "Dock to Map Station Access (dooremmy_003)": {
+                        "Dock to Map Station Access (Upper)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Slide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Slide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "resource",
@@ -4127,6 +4192,41 @@
                                             "name": "Grapple",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Flash",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -4149,13 +4249,91 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "This room allows for a bomb jump out of the water without a WBJ",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Bomb",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "IBJ",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "If you start in the room directly below this one, you can carry a speed boost all the way here",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Plasma Beam"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Speedbooster",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
                         }
                     }
                 },
-                "Dock to Map Station Access (dooremmy_003)": {
+                "Dock to Map Station Access (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4175,13 +4353,13 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "Map Station Access",
-                        "node_name": "Dock to EMMI Zone Exit Southeast (dooremmy_003)"
+                        "node_name": "Dock to EMMI Zone Exit Southeast (Upper)"
                     },
                     "default_dock_weakness": "EMMI Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Map Station Access (dooremmy_002)": {
+                        "Dock to Map Station Access (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4225,12 +4403,62 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "Slide",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Slide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Slide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Lay Bomb"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Lay Power Bomb"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -4268,7 +4496,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Map Station Access (dooremmy_003)": {
+                        "Dock to Map Station Access (Upper)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -4305,12 +4533,29 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "Slide",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Slide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Slide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -4390,7 +4635,7 @@
                 "asset_id": "collision_camera_012"
             },
             "nodes": {
-                "Dock to EMMI Zone Exit Southeast (dooremmy_002)": {
+                "Dock to EMMI Zone Exit Southeast (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4410,7 +4655,7 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "EMMI Zone Exit Southeast",
-                        "node_name": "Dock to Map Station Access (dooremmy_002)"
+                        "node_name": "Dock to Map Station Access (Lower)"
                     },
                     "default_dock_weakness": "EMMI Door",
                     "override_default_open_requirement": null,
@@ -4445,12 +4690,51 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Flash",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Magnet",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -4459,15 +4743,31 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "You can bomb jump out of this water without a WBJ",
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Simple IBJ"
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
@@ -4477,77 +4777,30 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Simple IBJ"
+                                                                "data": "Lay Bomb"
                                                             },
                                                             {
-                                                                "type": "template",
-                                                                "data": "Use Spin Boost"
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Gravity",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             }
                                                         ]
                                                     }
                                                 }
                                             ]
                                         }
-                                    }
-                                ]
-                            }
-                        },
-                        "Stick to Spider Magnet Wall": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
+                                    },
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "Magnet",
+                                            "name": "Space",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Flash",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Space",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
                                         }
                                     }
                                 ]
@@ -4555,7 +4808,7 @@
                         }
                     }
                 },
-                "Dock to EMMI Zone Exit Southeast (dooremmy_003)": {
+                "Dock to EMMI Zone Exit Southeast (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4575,7 +4828,7 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "EMMI Zone Exit Southeast",
-                        "node_name": "Dock to Map Station Access (dooremmy_003)"
+                        "node_name": "Dock to Map Station Access (Upper)"
                     },
                     "default_dock_weakness": "EMMI Door",
                     "override_default_open_requirement": null,
@@ -4658,7 +4911,7 @@
                         ]
                     },
                     "connections": {
-                        "Dock to EMMI Zone Exit Southeast (dooremmy_002)": {
+                        "Dock to EMMI Zone Exit Southeast (Lower)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -4699,7 +4952,7 @@
                         ]
                     },
                     "connections": {
-                        "Dock to EMMI Zone Exit Southeast (dooremmy_002)": {
+                        "Dock to EMMI Zone Exit Southeast (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4770,7 +5023,7 @@
                         ]
                     },
                     "connections": {
-                        "Dock to EMMI Zone Exit Southeast (dooremmy_003)": {
+                        "Dock to EMMI Zone Exit Southeast (Upper)": {
                             "type": "template",
                             "data": "Can Slide"
                         },
@@ -4833,7 +5086,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Dock to EMMI Zone Exit Southeast (dooremmy_002)": {
+                        "Dock to EMMI Zone Exit Southeast (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4856,29 +5109,6 @@
                                 "name": "Morph",
                                 "amount": 1,
                                 "negate": false
-                            }
-                        }
-                    }
-                },
-                "Stick to Spider Magnet Wall": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3129.45,
-                        "y": -189.39,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "connections": {
-                        "Ledge Grab": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }
@@ -5016,7 +5246,7 @@
                 "asset_id": "collision_camera_014"
             },
             "nodes": {
-                "Door to EMMI Zone Middle Path (doorgrapplegrapple_006)": {
+                "Door to EMMI Zone Middle Path (Grapple)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5040,7 +5270,7 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "EMMI Zone Middle Path",
-                        "node_name": "Door to EMMI Zone Exit West (doorgrapplegrapple_006)"
+                        "node_name": "Door to EMMI Zone Exit West (Grapple)"
                     },
                     "default_dock_weakness": "Grapple Beam Door",
                     "override_default_open_requirement": null,
@@ -5116,14 +5346,14 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Middle Path (doorgrapplegrapple_006)": {
+                        "Door to EMMI Zone Middle Path (Grapple)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Door to EMMI Zone Middle Path (doorpowerpower_009)": {
+                        "Door to EMMI Zone Middle Path (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5132,7 +5362,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone Middle Path (doorpowerpower_009)": {
+                "Door to EMMI Zone Middle Path (Power)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5156,7 +5386,7 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "EMMI Zone Middle Path",
-                        "node_name": "Door to EMMI Zone Exit West (doorpowerpower_009)"
+                        "node_name": "Door to EMMI Zone Exit West (Power)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -5211,17 +5441,129 @@
                                         "data": "Use Spin Boost"
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Grapple",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
                                         "type": "template",
                                         "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Magnet",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Slide",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Slide",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",
@@ -5240,9 +5582,35 @@
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Magnet",
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
                                                         "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SWJ",
+                                                        "amount": 2,
                                                         "negate": false
                                                     }
                                                 }
@@ -5408,13 +5776,8 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "WBJ",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Perform WBJ"
                                     }
                                 ]
                             }
@@ -5524,6 +5887,36 @@
                                     {
                                         "type": "template",
                                         "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Ice Missile"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "MissileAmmo",
+                                                        "amount": 5,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Movement",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -5845,7 +6238,7 @@
                 "asset_id": "collision_camera_018"
             },
             "nodes": {
-                "Door to EMMI Zone Exit West (doorgrapplegrapple_006)": {
+                "Door to EMMI Zone Exit West (Grapple)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5869,13 +6262,13 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "EMMI Zone Exit West",
-                        "node_name": "Door to EMMI Zone Middle Path (doorgrapplegrapple_006)"
+                        "node_name": "Door to EMMI Zone Middle Path (Grapple)"
                     },
                     "default_dock_weakness": "Grapple Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Exit West (doorpowerpower_009)": {
+                        "Door to EMMI Zone Exit West (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5891,7 +6284,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone Exit West (doorpowerpower_009)": {
+                "Door to EMMI Zone Exit West (Power)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5915,13 +6308,13 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "EMMI Zone Exit West",
-                        "node_name": "Door to EMMI Zone Middle Path (doorpowerpower_009)"
+                        "node_name": "Door to EMMI Zone Middle Path (Power)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Exit West (doorgrapplegrapple_006)": {
+                        "Door to EMMI Zone Exit West (Grapple)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5968,6 +6361,10 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spin Boost"
                                     }
                                 ]
                             }
@@ -6004,7 +6401,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Exit West (doorpowerpower_009)": {
+                        "Door to EMMI Zone Exit West (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6036,7 +6433,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Exit West (doorgrapplegrapple_006)": {
+                        "Door to EMMI Zone Exit West (Grapple)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6078,7 +6475,7 @@
                 "asset_id": "collision_camera_019"
             },
             "nodes": {
-                "Door to EMMI Zone Exit Northeast (doorpowerpower_010)": {
+                "Door to EMMI Zone Exit Northeast (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6102,7 +6499,7 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "EMMI Zone Exit Northeast",
-                        "node_name": "Door to Central Unit Access (doorpowerpower_010)"
+                        "node_name": "Door to Central Unit Access (Upper)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -6152,7 +6549,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone Exit Northeast (doorpowerpower_011)": {
+                "Door to EMMI Zone Exit Northeast (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6176,7 +6573,7 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "EMMI Zone Exit Northeast",
-                        "node_name": "Door to Central Unit Access (doorpowerpower_011)"
+                        "node_name": "Door to Central Unit Access (Lower)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -6221,7 +6618,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Exit Northeast (doorpowerpower_010)": {
+                        "Door to EMMI Zone Exit Northeast (Upper)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -6243,6 +6640,36 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Slide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Slide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -6252,6 +6679,15 @@
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        },
+                        "Pickup (Ice Missile)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "GhavoranCU",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -6312,25 +6748,238 @@
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
                     "connections": {
-                        "Door to EMMI Zone Exit Northeast (doorpowerpower_011)": {
+                        "Door to EMMI Zone Exit Northeast (Upper)": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Grapple",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SWJ",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "GhavoranCU",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Slide"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Door to EMMI Zone Exit Northeast (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
+                        "Door to EMMI Zone Exit Northwest": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SWJ",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Slide"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "GhavoranCU",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Dock to Central Unit": {
                             "type": "template",
                             "data": "Can Slide"
-                        },
-                        "Pickup (Ice Missile)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "events",
-                                "name": "GhavoranCU",
-                                "amount": 1,
-                                "negate": false
-                            }
                         }
                     }
                 },
@@ -6363,12 +7012,29 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "GhavoranCU",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -6383,6 +7049,27 @@
                                     {
                                         "type": "template",
                                         "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -6486,7 +7173,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Spin Boost Tower (dooremmy)": {
+                        "Dock to Spin Boost Tower (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6542,7 +7229,7 @@
                         }
                     }
                 },
-                "Dock to Spin Boost Tower (dooremmy)": {
+                "Dock to Spin Boost Tower (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6577,7 +7264,7 @@
                         }
                     }
                 },
-                "Dock to Spin Boost Tower (dooremmy_007)": {
+                "Dock to Spin Boost Tower (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6603,7 +7290,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Central Unit Access (doorpowerpower_011)": {
+                        "Door to Central Unit Access (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6631,7 +7318,7 @@
                         }
                     }
                 },
-                "Door to Central Unit Access (doorpowerpower_010)": {
+                "Door to Central Unit Access (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6655,13 +7342,13 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "Central Unit Access",
-                        "node_name": "Door to EMMI Zone Exit Northeast (doorpowerpower_010)"
+                        "node_name": "Door to EMMI Zone Exit Northeast (Upper)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Central Unit Access (doorpowerpower_011)": {
+                        "Door to Central Unit Access (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6670,7 +7357,7 @@
                         }
                     }
                 },
-                "Door to Central Unit Access (doorpowerpower_011)": {
+                "Door to Central Unit Access (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6694,13 +7381,13 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "Central Unit Access",
-                        "node_name": "Door to EMMI Zone Exit Northeast (doorpowerpower_011)"
+                        "node_name": "Door to EMMI Zone Exit Northeast (Lower)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Spin Boost Tower (dooremmy_007)": {
+                        "Dock to Spin Boost Tower (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6721,7 +7408,7 @@
                                 ]
                             }
                         },
-                        "Door to Central Unit Access (doorpowerpower_010)": {
+                        "Door to Central Unit Access (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6751,7 +7438,7 @@
                         ]
                     },
                     "connections": {
-                        "Dock to Spin Boost Tower (dooremmy_007)": {
+                        "Dock to Spin Boost Tower (Upper)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -6964,7 +7651,7 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "EMMI Zone Exit Northeast",
-                        "node_name": "Dock to Spin Boost Tower (dooremmy)"
+                        "node_name": "Dock to Spin Boost Tower (Lower)"
                     },
                     "default_dock_weakness": "EMMI Door",
                     "override_default_open_requirement": null,
@@ -7013,7 +7700,7 @@
                     "default_connection": {
                         "world_name": "Ghavoran",
                         "area_name": "EMMI Zone Exit Northeast",
-                        "node_name": "Dock to Spin Boost Tower (dooremmy_007)"
+                        "node_name": "Dock to Spin Boost Tower (Upper)"
                     },
                     "default_dock_weakness": "EMMI Door",
                     "override_default_open_requirement": null,
@@ -11057,10 +11744,6 @@
                                 "amount": 1,
                                 "negate": false
                             }
-                        },
-                        "Tile Group (BOMB) 1": {
-                            "type": "template",
-                            "data": "Lay Cross Comb"
                         }
                     }
                 },
@@ -11116,8 +11799,77 @@
                     },
                     "connections": {
                         "Pickup (Missile Tank)": {
-                            "type": "template",
-                            "data": "Lay Cross Comb"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tile Group (WEIGHT)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Bomb Ledge": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -11141,7 +11893,15 @@
                             "BOMB"
                         ]
                     },
-                    "connections": {}
+                    "connections": {
+                        "Tunnel to Map Station Access": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 },
                 "Tunnel to Map Station Access": {
                     "node_type": "dock",
@@ -11166,18 +11926,56 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Get on Bomb Block": {
-                            "type": "resource",
+                        "Bomb Ledge": {
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "Gravity",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Perform WBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Space",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "WSJ",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
                 },
-                "Get on Bomb Block": {
+                "Bomb Ledge": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -11198,6 +11996,13 @@
                                 "name": "Morph",
                                 "amount": 1,
                                 "negate": false
+                            }
+                        },
+                        "Tile Group (BOMB) 2": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         },
                         "Tunnel to Map Station Access": {

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -4108,7 +4108,7 @@
                                         "data": {
                                             "type": "tricks",
                                             "name": "Speedbooster",
-                                            "amount": 1,
+                                            "amount": 3,
                                             "negate": false
                                         }
                                     }
@@ -4222,7 +4222,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Walljump",
-                                                        "amount": 2,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -4743,7 +4743,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "You can bomb jump out of this water without a WBJ",
+                                            "comment": "This room allows for a bomb jump out of the water without a WBJ",
                                             "items": [
                                                 {
                                                     "type": "or",

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -827,7 +827,7 @@ Extra - asset_id: collision_camera_011
   > Dock to EMMI Zone Exit West
       All of the following:
           # If you start in the room direclty below this one, you can carry a speed boost all the way to here
-          Morph Ball and Speed Booster and Speedbooster Conservation (Beginner) and Shoot Plasma Beam
+          Morph Ball and Speed Booster and Speedbooster Conservation (Advanced) and Shoot Plasma Beam
 
 > Dock to Map Station Access (Lower); Heals? False
   * Layers: default
@@ -840,7 +840,7 @@ Extra - asset_id: collision_camera_011
       Any of the following:
           Grapple Beam or Space Jump or Lay Cross Comb
           Slide and Slide Jump (Beginner) and Use Spin Boost
-          Flash Shift and Walljump (Intermediate)
+          Flash Shift and Walljump (Beginner)
           Gravity Suit and Simple IBJ
           All of the following:
               # This room allows for a bomb jump out of the water without a WBJ
@@ -905,7 +905,7 @@ Extra - asset_id: collision_camera_012
               Grapple Beam
               Flash Shift or Spider Magnet or Movement (Beginner) or Walljump (Beginner) or Use Spin Boost
           All of the following:
-              # You can bomb jump out of this water without a WBJ
+              # This room allows for a bomb jump out of the water without a WBJ
               Walljump (Beginner) or Simple IBJ or Use Spin Boost
               Gravity Suit or Lay Bomb
 

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -822,30 +822,47 @@ Extra - asset_id: collision_camera_011
   * Extra - left_shield_def: actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Dock to Map Station Access (dooremmy_002)
+  > Dock to Map Station Access (Lower)
       Trivial
+  > Dock to EMMI Zone Exit West
+      All of the following:
+          # If you start in the room direclty below this one, you can carry a speed boost all the way to here
+          Morph Ball and Speed Booster and Speedbooster Conservation (Beginner) and Shoot Plasma Beam
 
-> Dock to Map Station Access (dooremmy_002); Heals? False
+> Dock to Map Station Access (Lower); Heals? False
   * Layers: default
-  * EMMI Door to Map Station Access/Dock to EMMI Zone Exit Southeast (dooremmy_002)
+  * EMMI Door to Map Station Access/Dock to EMMI Zone Exit Southeast (Lower)
   * Extra - actor_name: dooremmy_002
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to Blue EMMI Introduction
       Trivial
-  > Dock to Map Station Access (dooremmy_003)
+  > Dock to Map Station Access (Upper)
       Any of the following:
-          Grapple Beam or Use Spin Boost
+          Grapple Beam or Space Jump or Lay Cross Comb
+          Slide and Slide Jump (Beginner) and Use Spin Boost
+          Flash Shift and Walljump (Intermediate)
           Gravity Suit and Simple IBJ
+          All of the following:
+              # This room allows for a bomb jump out of the water without a WBJ
+              Bomb and Morph Ball and Infinite Bomb Jump (Intermediate)
+          All of the following:
+              # If you start in the room directly below this one, you can carry a speed boost all the way here
+              Morph Ball and Speed Booster and Speedbooster Conservation (Advanced) and Shoot Plasma Beam
 
-> Dock to Map Station Access (dooremmy_003); Heals? False
+> Dock to Map Station Access (Upper); Heals? False
   * Layers: default
-  * EMMI Door to Map Station Access/Dock to EMMI Zone Exit Southeast (dooremmy_003)
+  * EMMI Door to Map Station Access/Dock to EMMI Zone Exit Southeast (Upper)
   * Extra - actor_name: dooremmy_003
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Dock to Map Station Access (dooremmy_002)
+  > Dock to Map Station Access (Lower)
       Trivial
   > Dock to EMMI Zone Exit West
-      Flash Shift or Grapple Beam or Spider Magnet or Slide Jump (Beginner) or Use Spin Boost
+      Any of the following:
+          Flash Shift or Grapple Beam or Spider Magnet or Use Spin Boost
+          Slide and Slide Jump (Beginner)
+          All of the following:
+              Speed Booster
+              Lay Bomb or Lay Power Bomb
 
 > Dock to EMMI Zone Exit West; Heals? False
   * Layers: default
@@ -856,8 +873,10 @@ Extra - asset_id: collision_camera_011
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Dock to Map Station Access (dooremmy_003)
-      Flash Shift or Grapple Beam or Spider Magnet or Slide Jump (Beginner) or Use Spin Boost
+  > Dock to Map Station Access (Upper)
+      Any of the following:
+          Flash Shift or Grapple Beam or Spider Magnet or Use Spin Boost
+          Slide and Slide Jump (Beginner)
   > Tunnel to Blue EMMI Introduction
       Trivial
 
@@ -872,27 +891,27 @@ Map Station Access
 Extra - total_boundings: {'x1': -5000.0, 'x2': -2900.0, 'y1': -900.0, 'y2': 1300.0}
 Extra - polygon: [[-2900.0, 1300.0], [-5000.0, 1300.0], [-5000.0, -900.0], [-2900.0, -900.0]]
 Extra - asset_id: collision_camera_012
-> Dock to EMMI Zone Exit Southeast (dooremmy_002); Heals? False
+> Dock to EMMI Zone Exit Southeast (Lower); Heals? False
   * Layers: default
-  * EMMI Door to EMMI Zone Exit Southeast/Dock to Map Station Access (dooremmy_002)
+  * EMMI Door to EMMI Zone Exit Southeast/Dock to Map Station Access (Lower)
   * Extra - actor_name: dooremmy_002
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Tile Group (BOMB) 1
       Morph Ball
   > Ledge Grab
       Any of the following:
-          Flash Shift and Grapple Beam
+          Space Jump
           All of the following:
-              Gravity Suit
-              Simple IBJ or Use Spin Boost
-  > Stick to Spider Magnet Wall
-      All of the following:
-          Spider Magnet
-          Flash Shift or Grapple Beam or Gravity Suit or Space Jump
+              Grapple Beam
+              Flash Shift or Spider Magnet or Movement (Beginner) or Walljump (Beginner) or Use Spin Boost
+          All of the following:
+              # You can bomb jump out of this water without a WBJ
+              Walljump (Beginner) or Simple IBJ or Use Spin Boost
+              Gravity Suit or Lay Bomb
 
-> Dock to EMMI Zone Exit Southeast (dooremmy_003); Heals? False
+> Dock to EMMI Zone Exit Southeast (Upper); Heals? False
   * Layers: default
-  * EMMI Door to EMMI Zone Exit Southeast/Dock to Map Station Access (dooremmy_003)
+  * EMMI Door to EMMI Zone Exit Southeast/Dock to Map Station Access (Upper)
   * Extra - actor_name: dooremmy_003
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Tile Group (BOMB) 3
@@ -919,7 +938,7 @@ Extra - asset_id: collision_camera_012
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Dock to EMMI Zone Exit Southeast (dooremmy_002)
+  > Dock to EMMI Zone Exit Southeast (Lower)
       Morph Ball
   > Tunnel to Map Station Access Secret
       Morph Ball
@@ -930,7 +949,7 @@ Extra - asset_id: collision_camera_012
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('WEIGHT',)
-  > Dock to EMMI Zone Exit Southeast (dooremmy_002)
+  > Dock to EMMI Zone Exit Southeast (Lower)
       Trivial
 
 > Tile Group (BOMB) 2; Heals? False
@@ -952,7 +971,7 @@ Extra - asset_id: collision_camera_012
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Dock to EMMI Zone Exit Southeast (dooremmy_003)
+  > Dock to EMMI Zone Exit Southeast (Upper)
       Can Slide
   > Door to Map Station
       Morph Ball
@@ -965,17 +984,12 @@ Extra - asset_id: collision_camera_012
 
 > Ledge Grab; Heals? False
   * Layers: default
-  > Dock to EMMI Zone Exit Southeast (dooremmy_002)
+  > Dock to EMMI Zone Exit Southeast (Lower)
       Trivial
   > Tile Group (WEIGHT)
       Morph Ball
   > Tile Group (BOMB) 2
       Morph Ball
-
-> Stick to Spider Magnet Wall; Heals? False
-  * Layers: default
-  > Ledge Grab
-      Trivial
 
 ----------------
 Map Station
@@ -1008,9 +1022,9 @@ EMMI Zone Exit West
 Extra - total_boundings: {'x1': -10000.0, 'x2': -7900.0, 'y1': 300.0, 'y2': 4200.0}
 Extra - polygon: [[-7900.0, 4200.0], [-10000.0, 4200.0], [-10000.0, 300.0], [-7900.0, 300.0]]
 Extra - asset_id: collision_camera_014
-> Door to EMMI Zone Middle Path (doorgrapplegrapple_006); Heals? False
+> Door to EMMI Zone Middle Path (Grapple); Heals? False
   * Layers: default
-  * Grapple Beam Door to EMMI Zone Middle Path/Door to EMMI Zone Exit West (doorgrapplegrapple_006)
+  * Grapple Beam Door to EMMI Zone Middle Path/Door to EMMI Zone Exit West (Grapple)
   * Extra - actor_name: doorgrapplegrapple_006
   * Extra - actor_def: actordef:actors/props/doorgrapplegrapple/charclasses/doorgrapplegrapple.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1033,14 +1047,14 @@ Extra - asset_id: collision_camera_014
   * EMMI Door to Early Ice Room/Dock to EMMI Zone Exit West (Upper)
   * Extra - actor_name: dooremmy_005
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Door to EMMI Zone Middle Path (doorgrapplegrapple_006)
+  > Door to EMMI Zone Middle Path (Grapple)
       Trivial
-  > Door to EMMI Zone Middle Path (doorpowerpower_009)
+  > Door to EMMI Zone Middle Path (Power)
       Trivial
 
-> Door to EMMI Zone Middle Path (doorpowerpower_009); Heals? False
+> Door to EMMI Zone Middle Path (Power); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone Middle Path/Door to EMMI Zone Exit West (doorpowerpower_009)
+  * Power Beam Door to EMMI Zone Middle Path/Door to EMMI Zone Exit West (Power)
   * Extra - actor_name: doorpowerpower_009
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1061,8 +1075,17 @@ Extra - asset_id: collision_camera_014
   * Extra - right_shield_def: None
   > Upper Platform
       Any of the following:
-          Grapple Beam or Simple IBJ or Use Spin Boost
-          Flash Shift and Spider Magnet
+          Simple IBJ or Use Spin Boost
+          All of the following:
+              Grapple Beam
+              Flash Shift or Movement (Beginner) or Walljump (Beginner)
+          All of the following:
+              Spider Magnet
+              Any of the following:
+                  Flash Shift or Walljump (Beginner)
+                  Slide and Slide Jump (Intermediate)
+          Flash Shift and Walljump (Beginner)
+          Morph Ball and Single-wall Wall Jump (Intermediate)
 
 > Tunnel to EMMI Zone Middle Path; Heals? False
   * Layers: default
@@ -1092,7 +1115,7 @@ Extra - asset_id: collision_camera_015
   > Dock to EMMI Zone Exit West (Upper)
       Trivial
   > Spin Boost Ledge
-      Gravity Suit or Water Bomb Jump (Beginner) or Use Spin Boost
+      Gravity Suit or Perform WBJ or Use Spin Boost
 
 > Dock to EMMI Zone Exit West (Upper); Heals? False
   * Layers: default
@@ -1115,7 +1138,9 @@ Extra - asset_id: collision_camera_015
   > Dock to EMMI Zone Exit West (Lower)
       Trivial
   > Dock to EMMI Zone Exit Northwest
-      Simple IBJ or Use Spin Boost
+      Any of the following:
+          Movement (Beginner) or Simple IBJ or Use Spin Boost
+          Missiles ≥ 5 and Shoot Ice Missile
 
 ----------------
 EMMI Zone Exit Northwest
@@ -1193,33 +1218,33 @@ EMMI Zone Middle Path
 Extra - total_boundings: {'x1': -8000.0, 'x2': -2900.0, 'y1': 2550.0, 'y2': 4200.0}
 Extra - polygon: [[-2900.0, 4200.0], [-8000.0, 4200.0], [-8000.0, 2550.0], [-2900.0, 2550.0]]
 Extra - asset_id: collision_camera_018
-> Door to EMMI Zone Exit West (doorgrapplegrapple_006); Heals? False
+> Door to EMMI Zone Exit West (Grapple); Heals? False
   * Layers: default
-  * Grapple Beam Door to EMMI Zone Exit West/Door to EMMI Zone Middle Path (doorgrapplegrapple_006)
+  * Grapple Beam Door to EMMI Zone Exit West/Door to EMMI Zone Middle Path (Grapple)
   * Extra - actor_name: doorgrapplegrapple_006
   * Extra - actor_def: actordef:actors/props/doorgrapplegrapple/charclasses/doorgrapplegrapple.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Exit West (doorpowerpower_009)
+  > Door to EMMI Zone Exit West (Power)
       Trivial
   > Tunnel to EMMI Zone Exit West
       Trivial
 
-> Door to EMMI Zone Exit West (doorpowerpower_009); Heals? False
+> Door to EMMI Zone Exit West (Power); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone Exit West/Door to EMMI Zone Middle Path (doorpowerpower_009)
+  * Power Beam Door to EMMI Zone Exit West/Door to EMMI Zone Middle Path (Power)
   * Extra - actor_name: doorpowerpower_009
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Exit West (doorgrapplegrapple_006)
+  > Door to EMMI Zone Exit West (Grapple)
       Trivial
   > Door to EMMI Zone Exit Northeast
-      Flash Shift or Grapple Beam or Gravity Suit or Morph Ball
+      Flash Shift or Grapple Beam or Gravity Suit or Morph Ball or Use Spin Boost
 
 > Door to EMMI Zone Exit Northeast; Heals? False
   * Layers: default
@@ -1230,13 +1255,13 @@ Extra - asset_id: collision_camera_018
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Exit West (doorpowerpower_009)
+  > Door to EMMI Zone Exit West (Power)
       Trivial
 
 > Tunnel to EMMI Zone Exit West; Heals? False
   * Layers: default
   * Ghavoran EMMI Tunnel to EMMI Zone Exit West/Tunnel to EMMI Zone Middle Path
-  > Door to EMMI Zone Exit West (doorgrapplegrapple_006)
+  > Door to EMMI Zone Exit West (Grapple)
       Trivial
 
 ----------------
@@ -1245,9 +1270,9 @@ Central Unit Access
 Extra - total_boundings: {'x1': -7000.0, 'x2': -2900.0, 'y1': 4100.0, 'y2': 6400.0}
 Extra - polygon: [[-2900.0, 6400.0], [-7000.0, 6400.0], [-7000.0, 4100.0], [-2900.0, 4100.0]]
 Extra - asset_id: collision_camera_019
-> Door to EMMI Zone Exit Northeast (doorpowerpower_010); Heals? False
+> Door to EMMI Zone Exit Northeast (Upper); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone Exit Northeast/Door to Central Unit Access (doorpowerpower_010)
+  * Power Beam Door to EMMI Zone Exit Northeast/Door to Central Unit Access (Upper)
   * Extra - actor_name: doorpowerpower_010
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1259,9 +1284,9 @@ Extra - asset_id: collision_camera_019
   > Room Center
       Trivial
 
-> Door to EMMI Zone Exit Northeast (doorpowerpower_011); Heals? False
+> Door to EMMI Zone Exit Northeast (Lower); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone Exit Northeast/Door to Central Unit Access (doorpowerpower_011)
+  * Power Beam Door to EMMI Zone Exit Northeast/Door to Central Unit Access (Lower)
   * Extra - actor_name: doorpowerpower_011
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1280,10 +1305,14 @@ Extra - asset_id: collision_camera_019
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Exit Northeast (doorpowerpower_010)
-      Flash Shift or Space Jump
+  > Door to EMMI Zone Exit Northeast (Upper)
+      Any of the following:
+          Flash Shift or Space Jump
+          Slide and Slide Jump (Beginner) and Use Spin Boost
   > Room Center
       Trivial
+  > Pickup (Ice Missile)
+      After Ghavoran - Central Unit
 
 > Tunnel to EMMI Zone Exit Northwest; Heals? False
   * Layers: default
@@ -1301,18 +1330,33 @@ Extra - asset_id: collision_camera_019
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_IceMissiles
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to EMMI Zone Exit Northeast (doorpowerpower_011)
+  > Door to EMMI Zone Exit Northeast (Upper)
+      Any of the following:
+          Grapple Beam or Space Jump or Simple IBJ
+          Morph Ball and Single-wall Wall Jump (Intermediate)
+          All of the following:
+              Walljump (Beginner)
+              Flash Shift or Use Spin Boost
+          Speed Booster and After Ghavoran - Central Unit and Can Slide
+  > Door to EMMI Zone Exit Northeast (Lower)
       Trivial
+  > Door to EMMI Zone Exit Northwest
+      Any of the following:
+          Space Jump or Simple IBJ
+          Morph Ball and Single-wall Wall Jump (Intermediate)
+          Walljump (Beginner) and Use Spin Boost
+          Speed Booster and After Ghavoran - Central Unit and Can Slide
   > Dock to Central Unit
       Can Slide
-  > Pickup (Ice Missile)
-      After Ghavoran - Central Unit
 
 > Dock to Central Unit; Heals? False
   * Layers: default
   * EMMI Door to Central Unit/Dock to Central Unit Access
   > Tunnel to EMMI Zone Exit Northwest
-      Space Jump or Speed Booster or Simple IBJ
+      Any of the following:
+          Space Jump or Simple IBJ
+          Speed Booster and After Ghavoran - Central Unit
+          Walljump (Beginner) and Use Spin Boost
   > Room Center
       Can Slide
 
@@ -1340,14 +1384,14 @@ Extra - asset_id: collision_camera_020
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Dock to Spin Boost Tower (dooremmy)
+  > Dock to Spin Boost Tower (Lower)
       Trivial
   > Tile Group (WEIGHT)
       All of the following:
           Morph Ball and After Ghavoran - Central Unit
           Space Jump or Simple IBJ
 
-> Dock to Spin Boost Tower (dooremmy); Heals? False
+> Dock to Spin Boost Tower (Lower); Heals? False
   * Layers: default
   * EMMI Door to Spin Boost Tower/Dock to EMMI Zone Exit Northeast (dooremmy)
   * Extra - actor_name: dooremmy
@@ -1355,38 +1399,38 @@ Extra - asset_id: collision_camera_020
   > Door to EMMI Zone Middle Path
       Trivial
 
-> Dock to Spin Boost Tower (dooremmy_007); Heals? False
+> Dock to Spin Boost Tower (Upper); Heals? False
   * Layers: default
   * EMMI Door to Spin Boost Tower/Dock to EMMI Zone Exit Northeast (dooremmy_007)
   * Extra - actor_name: dooremmy_007
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Door to Central Unit Access (doorpowerpower_011)
+  > Door to Central Unit Access (Lower)
       Morph Ball and After Ghavoran - Central Unit
 
-> Door to Central Unit Access (doorpowerpower_010); Heals? False
+> Door to Central Unit Access (Upper); Heals? False
   * Layers: default
-  * Power Beam Door to Central Unit Access/Door to EMMI Zone Exit Northeast (doorpowerpower_010)
+  * Power Beam Door to Central Unit Access/Door to EMMI Zone Exit Northeast (Upper)
   * Extra - actor_name: doorpowerpower_010
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Central Unit Access (doorpowerpower_011)
+  > Door to Central Unit Access (Lower)
       Trivial
 
-> Door to Central Unit Access (doorpowerpower_011); Heals? False
+> Door to Central Unit Access (Lower); Heals? False
   * Layers: default
-  * Power Beam Door to Central Unit Access/Door to EMMI Zone Exit Northeast (doorpowerpower_011)
+  * Power Beam Door to Central Unit Access/Door to EMMI Zone Exit Northeast (Lower)
   * Extra - actor_name: doorpowerpower_011
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Dock to Spin Boost Tower (dooremmy_007)
+  > Dock to Spin Boost Tower (Upper)
       After Ghavoran - Central Unit and Can Slide
-  > Door to Central Unit Access (doorpowerpower_010)
+  > Door to Central Unit Access (Upper)
       Trivial
 
 > Tile Group (WEIGHT); Heals? False
@@ -1395,7 +1439,7 @@ Extra - asset_id: collision_camera_020
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('WEIGHT',)
-  > Dock to Spin Boost Tower (dooremmy_007)
+  > Dock to Spin Boost Tower (Upper)
       Morph Ball
 
 ----------------
@@ -1439,7 +1483,7 @@ Extra - asset_id: collision_camera_021
 
 > Dock to EMMI Zone Exit Northeast (dooremmy); Heals? False
   * Layers: default
-  * EMMI Door to EMMI Zone Exit Northeast/Dock to Spin Boost Tower (dooremmy)
+  * EMMI Door to EMMI Zone Exit Northeast/Dock to Spin Boost Tower (Lower)
   * Extra - actor_name: dooremmy
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Upper Center Platform
@@ -1447,7 +1491,7 @@ Extra - asset_id: collision_camera_021
 
 > Dock to EMMI Zone Exit Northeast (dooremmy_007); Heals? False
   * Layers: default
-  * EMMI Door to EMMI Zone Exit Northeast/Dock to Spin Boost Tower (dooremmy_007)
+  * EMMI Door to EMMI Zone Exit Northeast/Dock to Spin Boost Tower (Upper)
   * Extra - actor_name: dooremmy_007
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Ammo Recharge
@@ -2324,8 +2368,6 @@ Extra - asset_id: collision_camera_028
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Tile Group (WEIGHT)
       Morph Ball
-  > Tile Group (BOMB) 1
-      Lay Cross Comb
 
 > Tile Group (WEIGHT); Heals? False
   * Layers: default
@@ -2344,7 +2386,15 @@ Extra - asset_id: collision_camera_028
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
   > Pickup (Missile Tank)
-      Lay Cross Comb
+      Any of the following:
+          Lay Cross Comb
+          All of the following:
+              Gravity Suit and Movement (Expert)
+              Flash Shift or Use Spin Boost
+  > Tile Group (WEIGHT)
+      Trivial
+  > Bomb Ledge
+      Trivial
 
 > Tile Group (BOMB) 2; Heals? False
   * Layers: default
@@ -2353,17 +2403,23 @@ Extra - asset_id: collision_camera_028
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
+  > Tunnel to Map Station Access
+      Trivial
 
 > Tunnel to Map Station Access; Heals? False
   * Layers: default
   * Morph Ball Tunnel to Map Station Access/Tunnel to Map Station Access Secret
-  > Get on Bomb Block
-      Gravity Suit
+  > Bomb Ledge
+      Any of the following:
+          Gravity Suit or Perform WBJ
+          Space Jump and Water Space Jump (Beginner)
 
-> Get on Bomb Block; Heals? False
+> Bomb Ledge; Heals? False
   * Layers: default
   > Tile Group (BOMB) 1
       Morph Ball
+  > Tile Group (BOMB) 2
+      Trivial
   > Tunnel to Map Station Access
       Trivial
 


### PR DESCRIPTION
Revises the rest of the EMMI Zone in Ghavoran as well as the three rooms off to the sides of it. Every room in the PR has seen many changes.
- The Ice Missile pickup is now accessed from the door to EMMI Zone Exit West since it is not possible to defeat the EMMI on the ground floor, and to defeat it you would have to have gone up here to either defeat it here or on the other side
- The Room Center node in Central Unit Access now connects to the two upper doors
- Added Ice Missile and Movement methods for climbing Early Ice Room
- EMMI Zone Exit West has been given various other methods of climbing
- EMMI Zone Exit Southeast now has a Speedbooster Conservation to reach the upper doors without going through Map Station Access
- Water Space Jump has been added in Map Station Access Secret to get to the Bomb Ledge. Expert Movement with Flash or Spin Boost + Gravity has also been added for the pickup in that room
- Spin Boost added to EMMI Zone Middle Path