### PR TITLE
Dread: Finalize Ghavoran logic revision

### DIFF
--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -8011,10 +8011,6 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
-                                    },
-                                    {
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
@@ -8025,7 +8021,20 @@
                                     },
                                     {
                                         "type": "template",
+                                        "data": "Use Spin Boost"
+                                    },
+                                    {
+                                        "type": "template",
                                         "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Movement",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -8374,6 +8383,32 @@
                                     {
                                         "type": "template",
                                         "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Slide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Slide",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -8530,7 +8565,7 @@
                         "Door to Above Pulse Radar": {
                             "type": "or",
                             "data": {
-                                "comment": null,
+                                "comment": "This jump is doable, but it is pretty tight and lag may cause some issues",
                                 "items": [
                                     {
                                         "type": "template",
@@ -8547,6 +8582,67 @@
                                             "name": "Movement",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Flash",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "GhavoranAmmoRechargeEnkyAbove",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -8804,13 +8804,6 @@
                                 "comment": null,
                                 "items": []
                             }
-                        },
-                        "Save Station": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
                         }
                     }
                 },
@@ -8850,6 +8843,13 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Save Station": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -8872,7 +8872,7 @@
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
                     "connections": {
-                        "Door to Spin Boost Tower": {
+                        "Door to Chozo Warrior Arena": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9176,13 +9176,8 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Ice",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Shoot Ice Missile"
                                                 },
                                                 {
                                                     "type": "template",
@@ -9192,7 +9187,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Movement",
+                                                        "name": "FrozenEnemy",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -9578,6 +9573,15 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -9669,6 +9673,15 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -9676,6 +9689,27 @@
                                     {
                                         "type": "template",
                                         "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -9692,6 +9726,15 @@
                         "Tile Group (POWERBEAM) 3": {
                             "type": "template",
                             "data": "Can Slide"
+                        },
+                        "Tile Group (WEIGHT) 3": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
+                            }
                         }
                     }
                 },
@@ -9717,13 +9760,8 @@
                     },
                     "connections": {
                         "Tile Group (POWERBEAM) 2": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
+                            "type": "template",
+                            "data": "Can Slide"
                         },
                         "Tunnel to Above Pulse Radar": {
                             "type": "resource",
@@ -9979,13 +10017,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Tile Group (POWERBEAM) 1": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
+                            "type": "template",
+                            "data": "Can Slide"
                         }
                     }
                 },
@@ -10177,10 +10210,6 @@
                                         "data": "Use Spin Boost"
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
-                                    },
-                                    {
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
@@ -10298,7 +10327,7 @@
                         "area_name": "Total Recharge Station North",
                         "node_name": "Door to Teleport to Burenia (Missile)"
                     },
-                    "default_dock_weakness": "Power Beam Door",
+                    "default_dock_weakness": "Missile Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -10479,18 +10508,64 @@
                                 "negate": false
                             }
                         },
-                        "Tile Group (SCREWATTACK)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
                         "Pickup (Missile Tank)": {
-                            "type": "template",
-                            "data": "Lay Cross Comb"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -10557,8 +10632,63 @@
                             }
                         },
                         "Dock to Energy Recharge Station": {
-                            "type": "template",
-                            "data": "Lay Cross Comb"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -10760,12 +10890,24 @@
                                         "data": "Use Spin Boost"
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "IBJ",
-                                            "amount": 2,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Bomb"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "IBJ",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -10818,13 +10960,8 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Can Slide"
                                     }
                                 ]
                             }
@@ -10834,15 +10971,6 @@
                             "data": {
                                 "comment": null,
                                 "items": []
-                            }
-                        },
-                        "Tile Group (SCREWATTACK)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
                             }
                         },
                         "Dock to Transport to Ferenia": {
@@ -10979,6 +11107,78 @@
                                 "items": []
                             }
                         },
+                        "Tile Group (SCREWATTACK)": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Slide",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Slide",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Event - Storm Missile Gate": {
                             "type": "template",
                             "data": "Activate Storm Missile Locks"
@@ -11039,66 +11239,6 @@
                         }
                     }
                 },
-                "Tile Group (WEIGHT) 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 8100.0,
-                        "y": 1100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_025",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Door from Chozo Warrior Arena": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT) 2": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 7200.0,
-                        "y": 600.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_026",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Door from Chozo Warrior Arena": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Tile Group (SCREWATTACK)": {
                     "node_type": "configurable_node",
                     "heal": false,
@@ -11120,6 +11260,13 @@
                         ]
                     },
                     "connections": {
+                        "Door from Chozo Warrior Arena": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Door to Teleport to Burenia (Missile)": {
                             "type": "resource",
                             "data": {
@@ -11127,20 +11274,6 @@
                                 "name": "Morph",
                                 "amount": 1,
                                 "negate": false
-                            }
-                        },
-                        "Tile Group (WEIGHT) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (WEIGHT) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }
@@ -13093,6 +13226,32 @@
                                 "negate": false
                             }
                         },
+                        "Dock to Teleport to Burenia": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Movement",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Left Water Ledge": {
                             "type": "and",
                             "data": {
@@ -13379,6 +13538,36 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Dock to Teleport to Burenia": {
+                            "type": "and",
+                            "data": {
+                                "comment": "https://www.youtube.com/watch?v=3CYTkKutYFo",
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Perform WBJ"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "WSJ",
+                                            "amount": 3,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Spin",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Left Water Ledge": {
                             "type": "or",
                             "data": {
@@ -13398,13 +13587,8 @@
                                         "data": "Use Spin Boost"
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "WBJ",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Perform WBJ"
                                     }
                                 ]
                             }
@@ -13552,15 +13736,6 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "Grapple",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
                                             "name": "Magnet",
                                             "amount": 1,
                                             "negate": false
@@ -13573,6 +13748,49 @@
                                             "name": "Gravity",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -13647,13 +13865,8 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Ballspark"
                                                 },
                                                 {
                                                     "type": "resource",
@@ -13662,6 +13875,154 @@
                                                         "name": "GhavoranPulseRadarEnky",
                                                         "amount": 1,
                                                         "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Top Room": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Movement",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Use Spin Boost"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Magnet",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Space",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Simple IBJ"
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -13707,6 +14068,15 @@
                             "data": {
                                 "type": "events",
                                 "name": "GhavoranPulseRadarEnky",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Left Water Ledge": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -13819,13 +14189,6 @@
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
                     "connections": {
-                        "Pickup (Pulse Radar)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Tile Group (POWERBEAM) 1": {
                             "type": "and",
                             "data": {
@@ -14316,8 +14679,63 @@
                             "data": "Can Slide"
                         },
                         "Alcove 2": {
-                            "type": "template",
-                            "data": "Lay Cross Comb"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -14487,8 +14905,63 @@
                             }
                         },
                         "Alcove 2": {
-                            "type": "template",
-                            "data": "Lay Cross Comb"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -14507,8 +14980,63 @@
                     "extra": {},
                     "connections": {
                         "Tile Group (BOMB) 2": {
-                            "type": "template",
-                            "data": "Lay Cross Comb"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Tile Group (WEIGHT) 1": {
                             "type": "template",
@@ -14524,8 +15052,63 @@
                             }
                         },
                         "Alcove 1": {
-                            "type": "template",
-                            "data": "Lay Cross Comb"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 }
@@ -15536,6 +16119,22 @@
                         "Tile Group (POWERBEAM) 1": {
                             "type": "template",
                             "data": "Can Slide"
+                        },
+                        "Tile Group (POWERBEAM) 2": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Power Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -15657,10 +16256,64 @@
                     },
                     "connections": {
                         "Pickup (Missile Tank)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Tile Group (POWERBEAM) 2": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Movement option is for shooting the block while hanging on the ledge. Pseudo-wave is performed in the tunnel section to the right of the block",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Wave",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Pseudo",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Tile Group (POWERBEAM) 3": {

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -1523,7 +1523,7 @@ Extra - asset_id: collision_camera_021
   * Extra - actor_name: dooremmy
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Upper Center Platform
-      Flash Shift or Simple IBJ or Use Spin Boost
+      Flash Shift or Movement (Beginner) or Simple IBJ or Use Spin Boost
 
 > Dock to EMMI Zone Exit Northeast (dooremmy_007); Heals? False
   * Layers: default
@@ -1599,7 +1599,9 @@ Extra - asset_id: collision_camera_021
   > Door to Save Station Center
       Trivial
   > Dock to EMMI Zone Exit Northeast (dooremmy)
-      Flash Shift or Simple IBJ or Use Spin Boost
+      Any of the following:
+          Flash Shift or Simple IBJ or Use Spin Boost
+          Slide and Slide Jump (Intermediate)
   > Dock to EMMI Zone Exit Northeast (dooremmy_007)
       After Ghavoran - Ammo Recharge Enky Below
   > Event - Breakable (grapplepulloff1x2_000)
@@ -1625,7 +1627,14 @@ Extra - asset_id: collision_camera_021
 > Ledge Below PB Tank; Heals? False
   * Layers: default
   > Door to Above Pulse Radar
-      Movement (Beginner) or Simple IBJ or Use Spin Boost
+      Any of the following:
+          # This jump is doable, but it is pretty tight and lag may cause some issues
+          Movement (Beginner) or Simple IBJ or Use Spin Boost
+          All of the following:
+              Walljump (Beginner)
+              Any of the following:
+                  Flash Shift
+                  Speed Booster and After Ghavoran - Ammo Recharge Enky Above
   > Pickup (Power Bomb Tank)
       Any of the following:
           Use Spin Boost

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -1663,8 +1663,6 @@ Extra - asset_id: collision_camera_022
   * Extra - right_shield_def: actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad
   > Door to Chozo Warrior Arena
       Trivial
-  > Save Station
-      Trivial
 
 > Door to Chozo Warrior Arena; Heals? False
   * Layers: default
@@ -1677,6 +1675,8 @@ Extra - asset_id: collision_camera_022
   * Extra - right_shield_def: None
   > Door to Spin Boost Tower
       Trivial
+  > Save Station
+      Trivial
 
 > Save Station; Heals? False; Spawn Point
   * Layers: default
@@ -1684,7 +1684,7 @@ Extra - asset_id: collision_camera_022
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
   * Extra - start_point_actor_name: savestation_000_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad
-  > Door to Spin Boost Tower
+  > Door to Chozo Warrior Arena
       Trivial
 
 ----------------
@@ -1757,7 +1757,7 @@ Extra - asset_id: collision_camera_024
   > Door to Above Golzuna
       Any of the following:
           Space Jump or Speed Booster or Simple IBJ
-          Ice Missile and After Elun - Release X Parasites and Movement (Intermediate) and Use Spin Boost
+          After Elun - Release X Parasites and Stand on Frozen Enemy (Intermediate) and Shoot Ice Missile and Use Spin Boost
   > Door to Energy Recharge Station
       Trivial
   > Pickup (Missile Tank)
@@ -1838,7 +1838,7 @@ Extra - asset_id: collision_camera_024
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Door to Save Station East
       Any of the following:
-          After Ghavoran - Pulse Radar Enky and Ballspark
+          After Ghavoran - Pulse Radar Enky and Movement (Beginner) and Ballspark
           Bomb and Movement (Expert) and Lay Cross Comb
   > Tile Group (WEIGHT) 3
       Morph Ball
@@ -1853,11 +1853,17 @@ Extra - asset_id: collision_camera_024
   > Pickup (Missile Tank)
       Any of the following:
           Lay Cross Comb
-          After Ghavoran - Pulse Radar Enky and Ballspark
+          All of the following:
+              Movement (Beginner)
+              Any of the following:
+                  Use Spin Boost
+                  After Ghavoran - Pulse Radar Enky and Ballspark
   > Tile Group (BOMB) 3
       Morph Ball
   > Tile Group (POWERBEAM) 3
       Can Slide
+  > Tile Group (WEIGHT) 3
+      Morph Ball
 
 > Tile Group (POWERBEAM) 1; Heals? False
   * Layers: default
@@ -1867,7 +1873,7 @@ Extra - asset_id: collision_camera_024
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
   > Tile Group (POWERBEAM) 2
-      Morph Ball
+      Can Slide
   > Tunnel to Above Pulse Radar
       Morph Ball
 
@@ -1941,7 +1947,7 @@ Extra - asset_id: collision_camera_024
   * Layers: default
   * Slide Tunnel to Above Pulse Radar/Tunnel to Golzuna Tower
   > Tile Group (POWERBEAM) 1
-      Morph Ball
+      Can Slide
 
 > Tunnel to Pulse Radar Room; Heals? False
   * Layers: default
@@ -1985,7 +1991,7 @@ Extra - asset_id: collision_camera_024
   > Tile Group (POWERBOMB)
       Trivial
   > Tile Group (SCREWATTACK)
-      Walljump (Beginner) or Simple IBJ or Use Spin Boost
+      Walljump (Beginner) or Use Spin Boost
   > Dock to Total Recharge Station North
       After Ghavoran - Storm Missile Gate
 
@@ -2012,7 +2018,7 @@ Extra - asset_id: collision_camera_024
 
 > Door to Total Recharge Station North; Heals? False
   * Layers: default
-  * Power Beam Door to Total Recharge Station North/Door to Teleport to Burenia (Missile)
+  * Missile Door to Total Recharge Station North/Door to Teleport to Burenia (Missile)
   * Extra - actor_name: doorpowerpower_014
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2057,10 +2063,12 @@ Extra - asset_id: collision_camera_024
   * Open Passage to Energy Recharge Station/Dock to Teleport to Burenia
   > Tile Group (WEIGHT) 1
       Morph Ball
-  > Tile Group (SCREWATTACK)
-      Morph Ball
   > Pickup (Missile Tank)
-      Lay Cross Comb
+      Any of the following:
+          Lay Cross Comb
+          All of the following:
+              Morph Ball and Movement (Intermediate)
+              Flash Shift or Use Spin Boost
 
 > Tunnel to Energy Recharge Station (Top); Heals? False
   * Layers: default
@@ -2076,7 +2084,11 @@ Extra - asset_id: collision_camera_024
   > Tile Group (WEIGHT) 1
       Morph Ball
   > Dock to Energy Recharge Station
-      Lay Cross Comb
+      Any of the following:
+          Lay Cross Comb
+          All of the following:
+              Morph Ball and Movement (Intermediate)
+              Flash Shift or Use Spin Boost
 
 > Dock to Total Recharge Station North; Heals? False
   * Layers: default
@@ -2104,7 +2116,9 @@ Extra - asset_id: collision_camera_025_B
           Morph Ball and Before Ghavoran - Ferenia Transport Grapple Box
           Grapple Beam or Spider Magnet or Space Jump or Speed Booster or Walljump (Beginner) or Simple IBJ
   > Door to Teleport to Burenia (Power Beam)
-      Infinite Bomb Jump (Intermediate) or Use Spin Boost
+      Any of the following:
+          Use Spin Boost
+          Infinite Bomb Jump (Intermediate) and Lay Bomb
 
 > Door to Teleport to Burenia (Missile); Heals? False
   * Layers: default
@@ -2116,11 +2130,9 @@ Extra - asset_id: collision_camera_025_B
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorshieldmissile_001
   * Extra - right_shield_def: actordef:actors/props/doorshieldmissile/charclasses/doorshieldmissile.bmsad
   > Door from Chozo Warrior Arena
-      Morph Ball and Before Ghavoran - Ferenia Transport Grapple Box
+      Before Ghavoran - Ferenia Transport Grapple Box and Can Slide
   > Total Recharge
       Trivial
-  > Tile Group (SCREWATTACK)
-      Morph Ball
   > Dock to Transport to Ferenia
       After Ghavoran - Ferenia Transport Enky Left and After Ghavoran - Ferenia Transport Enky Right and After Ghavoran - Ferenia Transport Grapple Box
   > Event - Ferenia Transport Grapple Box (Front)
@@ -2141,6 +2153,14 @@ Extra - asset_id: collision_camera_025_B
   * Extra - right_shield_def: None
   > Door from Chozo Warrior Arena
       Trivial
+  > Tile Group (SCREWATTACK)
+      Any of the following:
+          Space Jump
+          All of the following:
+              Walljump (Beginner)
+              Any of the following:
+                  Use Spin Boost
+                  Slide and Slide Jump (Beginner)
   > Event - Storm Missile Gate
       Activate Storm Missile Locks
 
@@ -2160,24 +2180,6 @@ Extra - asset_id: collision_camera_025_B
   > Door to Teleport to Burenia (Power Beam)
       Trivial
 
-> Tile Group (WEIGHT) 1; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_025
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Door from Chozo Warrior Arena
-      Trivial
-
-> Tile Group (WEIGHT) 2; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_026
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Door from Chozo Warrior Arena
-      Trivial
-
 > Tile Group (SCREWATTACK); Heals? False
   * Layers: default
   * Configurable Node
@@ -2185,12 +2187,10 @@ Extra - asset_id: collision_camera_025_B
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SCREWATTACK',)
+  > Door from Chozo Warrior Arena
+      Trivial
   > Door to Teleport to Burenia (Missile)
       Morph Ball
-  > Tile Group (WEIGHT) 1
-      Trivial
-  > Tile Group (WEIGHT) 2
-      Trivial
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -2596,6 +2596,8 @@ Extra - asset_id: collision_camera_031
       Morph Ball
   > Tile Group (BOMB) 2
       Morph Ball
+  > Dock to Teleport to Burenia
+      No Gravity Suit or Movement (Beginner)
   > Left Water Ledge
       Trivial
 
@@ -2666,8 +2668,12 @@ Extra - asset_id: collision_camera_031
 > Tunnel to Teleport to Burenia (Bottom); Heals? False
   * Layers: default
   * Morph Ball Tunnel to Teleport to Burenia/Tunnel to Energy Recharge Station (Bottom)
+  > Dock to Teleport to Burenia
+      All of the following:
+          # https://www.youtube.com/watch?v=3CYTkKutYFo
+          Spin Boost and Water Space Jump (Advanced) and Perform WBJ
   > Left Water Ledge
-      Gravity Suit or Water Bomb Jump (Beginner) or Use Spin Boost
+      Gravity Suit or Perform WBJ or Use Spin Boost
 
 > Dock to Teleport to Burenia; Heals? False
   * Layers: default
@@ -2688,7 +2694,11 @@ Extra - asset_id: collision_camera_031
           Morph Ball
           Grapple Beam or Gravity Suit or Spider Magnet
   > Tile Group (SCREWATTACK) 2
-      Grapple Beam or Gravity Suit or Spider Magnet
+      Any of the following:
+          Gravity Suit or Spider Magnet
+          All of the following:
+              Grapple Beam
+              Movement (Beginner) or Walljump (Beginner)
   > Tunnel to Teleport to Burenia (Bottom)
       Trivial
   > Dock to Teleport to Burenia
@@ -2697,7 +2707,20 @@ Extra - asset_id: collision_camera_031
           All of the following:
               Gravity Suit
               Flash Shift or Simple IBJ or Use Spin Boost
-          Speed Booster and After Ghavoran - Pulse Radar Enky
+          After Ghavoran - Pulse Radar Enky and Ballspark
+  > Top Room
+      Any of the following:
+          All of the following:
+              Grapple Beam
+              Any of the following:
+                  Walljump (Beginner)
+                  Movement (Beginner) and Use Spin Boost
+          All of the following:
+              Spider Magnet
+              Walljump (Beginner) or Use Spin Boost
+          All of the following:
+              Gravity Suit
+              Space Jump or Walljump (Beginner) or Simple IBJ
 
 > Top Room; Heals? False
   * Layers: default
@@ -2707,6 +2730,8 @@ Extra - asset_id: collision_camera_031
       Morph Ball
   > Dock to Golzuna Tower
       After Ghavoran - Pulse Radar Enky
+  > Left Water Ledge
+      Morph Ball
   > Event - Pulse Radar Enky
       Destroy Enky
 
@@ -2734,8 +2759,6 @@ Extra - asset_id: collision_camera_032
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_SonarObtained
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Pickup (Pulse Radar)
-      Trivial
   > Tile Group (POWERBEAM) 1
       Trivial
 
@@ -2872,7 +2895,11 @@ Extra - asset_id: collision_camera_033
   > Tile Group (WEIGHT) 2
       Can Slide
   > Alcove 2
-      Lay Cross Comb
+      Any of the following:
+          Lay Cross Comb
+          All of the following:
+              Morph Ball and Movement (Expert)
+              Flash Shift or Use Spin Boost
 
 > Tile Group (WEIGHT) 1; Heals? False
   * Layers: default
@@ -2917,18 +2944,30 @@ Extra - asset_id: collision_camera_033
   > Tile Group (WEIGHT) 1
       Morph Ball
   > Alcove 2
-      Lay Cross Comb
+      Any of the following:
+          Lay Cross Comb
+          All of the following:
+              Morph Ball and Movement (Expert)
+              Flash Shift or Use Spin Boost
 
 > Alcove 2; Heals? False
   * Layers: default
   > Tile Group (BOMB) 2
-      Lay Cross Comb
+      Any of the following:
+          Lay Cross Comb
+          All of the following:
+              Morph Ball and Movement (Expert)
+              Flash Shift or Use Spin Boost
   > Tile Group (WEIGHT) 1
       Can Slide
   > Tile Group (WEIGHT) 2
       Morph Ball
   > Alcove 1
-      Lay Cross Comb
+      Any of the following:
+          Lay Cross Comb
+          All of the following:
+              Morph Ball and Movement (Expert)
+              Flash Shift or Use Spin Boost
 
 ----------------
 Transport to Hanubia
@@ -3152,6 +3191,8 @@ Extra - asset_id: collision_camera_039
       Morph Ball
   > Tile Group (POWERBEAM) 1
       Can Slide
+  > Tile Group (POWERBEAM) 2
+      Lay Bomb or Lay Power Bomb
 
 > Door to Golzuna Tower; Heals? False
   * Layers: default
@@ -3191,7 +3232,13 @@ Extra - asset_id: collision_camera_039
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
   > Pickup (Missile Tank)
-      Trivial
+      Morph Ball
+  > Tile Group (POWERBEAM) 2
+      All of the following:
+          Morph Ball
+          Any of the following:
+              # Movement option is for shooting the block while hanging on the ledge. Pseudo-wave is performed in the tunnel section to the right of the block
+              Wave Beam or Movement (Beginner) or Pseudo-Wave Beam (Beginner)
   > Tile Group (POWERBEAM) 3
       Can Slide
 


### PR DESCRIPTION
- A few more changes to Spin Boost Tower
- Total Recharge Station North removed the crumble block nodes as they are redundant
- Made it impossible to reach the Screw Attack nodes in the above room and Teleport to Burenia if coming from above since you cannot use Screw Attack while in morph ball
- Added a connection to the Screw Attack node in Total Recharge Station North as there was not one previously
- Added various tricks to connections in Energy Recharge Station
- Added Flash Shift and Spin Boost methods for crossing the crumble blocks in Cross Bomb Tutorial and Teleport to Burenia
- Changed Ballspark to go from Orange to Golzuna Tower proper to beginner movement
- Changed Movement to Stand on Frozen Enemy now that this trick exists for climbing Golzuna Tower with Ice Missiles
- Removed the connection from Start Point to Pulse Radar pickup as this can cause issues if starting here in the future
- Added connection to the powerbeam block below orange as there was not one previously