### PR TITLE
Optimize customize preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed: The multi-pickup placement, using the new weighting, is now the default mode. The old behavior has been removed.
 - Changed: Error messages when a permalink is incompatible have been improved with more details.
+- Changed: The Customize Preset dialog now creates each tab as you click then. This means the dialog is now faster to first open, but there's a short delay when opening certain tabs. 
 - Fixed: Exceptions when exporting a game now use the improved error dialog.
 - Fixed: Gracefully handle unsupported old versions of the preferences file.
 

--- a/randovania/games/blank/gui/preset_settings/__init__.py
+++ b/randovania/games/blank/gui/preset_settings/__init__.py
@@ -5,9 +5,6 @@ from randovania.interface_common.preset_editor import PresetEditor
 
 
 def preset_tabs(editor: PresetEditor, window_manager: WindowManager):
-    game_enum = editor.game
-    game_description = default_database.game_description_for(game_enum)
-
     from randovania.gui.preset_settings.trick_level_tab import PresetTrickLevel
     from randovania.gui.preset_settings.location_pool_tab import PresetLocationPool
     from randovania.gui.preset_settings.item_pool_tab import PresetItemPool
@@ -15,9 +12,9 @@ def preset_tabs(editor: PresetEditor, window_manager: WindowManager):
     from randovania.games.blank.gui.preset_settings.blank_patches_tab import PresetBlankPatches
 
     return [
-        PresetTrickLevel(editor, game_description, window_manager),
-        PresetLocationPool(editor, game_description),
-        PresetItemPool(editor),
-        PresetBlankPatches(editor),
-        PresetDockRando(editor, game_description),
+        PresetTrickLevel,
+        PresetLocationPool,
+        PresetItemPool,
+        PresetBlankPatches,
+        PresetDockRando,
     ]

--- a/randovania/games/blank/gui/preset_settings/blank_patches_tab.py
+++ b/randovania/games/blank/gui/preset_settings/blank_patches_tab.py
@@ -1,14 +1,16 @@
 from PySide6 import QtWidgets
 
+from randovania.game_description.game_description import GameDescription
 from randovania.games.blank.layout import BlankConfiguration
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
 
 
 class PresetBlankPatches(PresetTab):
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
 
         self.root_widget = QtWidgets.QWidget(self)
         self.root_layout = QtWidgets.QVBoxLayout(self.root_widget)

--- a/randovania/games/cave_story/gui/preset_settings/__init__.py
+++ b/randovania/games/cave_story/gui/preset_settings/__init__.py
@@ -5,9 +5,6 @@ from randovania.interface_common.preset_editor import PresetEditor
 
 
 def cs_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
-    game_enum = editor.game
-    game_description = default_database.game_description_for(game_enum)
-
     from randovania.gui.preset_settings.trick_level_tab import PresetTrickLevel
     from randovania.games.cave_story.gui.preset_settings.cs_starting_area_tab import PresetCSStartingArea
     from randovania.games.cave_story.gui.preset_settings.cs_generation_tab import PresetCSGeneration
@@ -17,11 +14,11 @@ def cs_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
     from randovania.games.cave_story.gui.preset_settings.cs_hp_tab import PresetCSHP
 
     return [
-        PresetTrickLevel(editor, game_description, window_manager),
-        PresetCSStartingArea(editor, game_description),
-        PresetCSGeneration(editor, game_description),
-        PresetCSObjective(editor),
-        PresetLocationPool(editor, game_description),
-        CSPresetItemPool(editor),
-        PresetCSHP(editor)
+        PresetTrickLevel,
+        PresetCSStartingArea,
+        PresetCSGeneration,
+        PresetCSObjective,
+        PresetLocationPool,
+        CSPresetItemPool,
+        PresetCSHP,
     ]

--- a/randovania/games/cave_story/gui/preset_settings/cs_generation_tab.py
+++ b/randovania/games/cave_story/gui/preset_settings/cs_generation_tab.py
@@ -3,15 +3,16 @@ from typing import Iterable
 from PySide6.QtWidgets import *
 
 from randovania.game_description.game_description import GameDescription
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.generation_tab import PresetGeneration
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
 
 
 class PresetCSGeneration(PresetGeneration):
-    def __init__(self, editor: PresetEditor, game_description: GameDescription) -> None:
+    def setupUi(self, obj):
+        super().setupUi(obj)
         self._create_puppy_checkbox()
-        super().__init__(editor, game_description)
 
     @property
     def game_specific_widgets(self) -> Iterable[QWidget] | None:

--- a/randovania/games/cave_story/gui/preset_settings/cs_goal_tab.py
+++ b/randovania/games/cave_story/gui/preset_settings/cs_goal_tab.py
@@ -1,16 +1,18 @@
 from PySide6 import QtCore
 
+from randovania.game_description.game_description import GameDescription
 from randovania.games.cave_story.layout.cs_configuration import CSObjective
 from randovania.gui.generated.preset_cs_objective_ui import Ui_PresetCSObjective
 from randovania.gui.lib.common_qt_lib import set_combo_with_value
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
 
 
 class PresetCSObjective(PresetTab, Ui_PresetCSObjective):
-    def __init__(self, editor: PresetEditor) -> None:
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         self.goal_layout.setAlignment(QtCore.Qt.AlignTop)

--- a/randovania/games/cave_story/gui/preset_settings/cs_hp_tab.py
+++ b/randovania/games/cave_story/gui/preset_settings/cs_hp_tab.py
@@ -1,12 +1,14 @@
+from randovania.game_description.game_description import GameDescription
 from randovania.gui.generated.preset_cs_hp_ui import Ui_PresetCSHP
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
 
 
 class PresetCSHP(PresetTab, Ui_PresetCSHP):
-    def __init__(self, editor: PresetEditor) -> None:
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         self.starting_hp_spin_box.valueChanged.connect(self._on_starting_hp_changed)

--- a/randovania/games/cave_story/gui/preset_settings/cs_item_pool_tab.py
+++ b/randovania/games/cave_story/gui/preset_settings/cs_item_pool_tab.py
@@ -1,4 +1,6 @@
+from randovania.game_description.game_description import GameDescription
 from randovania.games.cave_story.layout.cs_configuration import CSObjective
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.item_pool_tab import PresetItemPool
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.base.major_item_state import MajorItemState
@@ -6,8 +8,8 @@ from randovania.layout.preset import Preset
 
 
 class CSPresetItemPool(PresetItemPool):
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.previousObj = CSObjective.NORMAL_ENDING
 
     def on_preset_changed(self, preset: Preset):

--- a/randovania/games/dread/gui/preset_settings/__init__.py
+++ b/randovania/games/dread/gui/preset_settings/__init__.py
@@ -5,11 +5,7 @@ from randovania.interface_common.preset_editor import PresetEditor
 
 
 def dread_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
-    game_enum = editor.game
-    game_description = default_database.game_description_for(game_enum)
-
     from randovania.gui.preset_settings.trick_level_tab import PresetTrickLevel
-    from randovania.gui.preset_settings.elevators_tab import PresetElevators
     from randovania.gui.preset_settings.starting_area_tab import PresetMetroidStartingArea
     from randovania.gui.preset_settings.generation_tab import PresetGeneration
     from randovania.gui.preset_settings.location_pool_tab import PresetLocationPool
@@ -19,14 +15,14 @@ def dread_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
     from randovania.games.dread.gui.preset_settings.dread_goal_tab import PresetDreadGoal
 
     return [
-        PresetTrickLevel(editor, game_description, window_manager),
+        PresetTrickLevel,
         *([
-              PresetMetroidStartingArea(editor, game_description),
+              PresetMetroidStartingArea,
           ] if window_manager.is_preview_mode else []),
-        PresetGeneration(editor, game_description),
-        PresetLocationPool(editor, game_description),
-        PresetDreadGoal(editor),
-        DreadPresetItemPool(editor),
-        PresetDreadEnergy(editor),
-        PresetDreadPatches(editor),
+        PresetGeneration,
+        PresetLocationPool,
+        PresetDreadGoal,
+        DreadPresetItemPool,
+        PresetDreadEnergy,
+        PresetDreadPatches,
     ]

--- a/randovania/games/dread/gui/preset_settings/dread_energy_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_energy_tab.py
@@ -1,6 +1,8 @@
+from randovania.game_description.game_description import GameDescription
 from randovania.games.dread.layout.dread_configuration import DreadConfiguration
 from randovania.gui.generated.preset_dread_energy_ui import Ui_PresetDreadEnergy
 from randovania.gui.lib import signal_handling
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
@@ -8,8 +10,8 @@ from randovania.layout.preset import Preset
 
 class PresetDreadEnergy(PresetTab, Ui_PresetDreadEnergy):
 
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         self.energy_tank_capacity_spin_box.valueChanged.connect(self._persist_tank_capacity)

--- a/randovania/games/dread/gui/preset_settings/dread_goal_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_goal_tab.py
@@ -3,9 +3,11 @@ from typing import Callable
 
 from PySide6 import QtCore
 
+from randovania.game_description.game_description import GameDescription
 from randovania.games.dread.layout.dread_configuration import DreadConfiguration, DreadArtifactConfig
 from randovania.gui.generated.preset_dread_goal_ui import Ui_PresetDreadGoal
 from randovania.gui.lib import signal_handling
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
@@ -13,8 +15,8 @@ from randovania.layout.preset import Preset
 
 class PresetDreadGoal(PresetTab, Ui_PresetDreadGoal):
 
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         self.goal_layout.setAlignment(QtCore.Qt.AlignTop)

--- a/randovania/games/dread/gui/preset_settings/dread_item_pool_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_item_pool_tab.py
@@ -4,8 +4,10 @@ import functools
 from PySide6 import QtWidgets
 
 from randovania.game_description import default_database
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.item.major_item import MajorItem
 from randovania.gui.lib.scroll_protected import ScrollProtectedSpinBox
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.item_pool_tab import PresetItemPool
 from randovania.gui.preset_settings.pickup_style_widget import PickupStyleWidget
 from randovania.interface_common.preset_editor import PresetEditor
@@ -14,8 +16,8 @@ from randovania.layout.preset import Preset
 
 
 class DreadPresetItemPool(PresetItemPool):
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         item_database = default_database.item_database_for_game(self.game)
 
         size_policy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed)

--- a/randovania/games/dread/gui/preset_settings/dread_patches_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_patches_tab.py
@@ -2,8 +2,10 @@ import typing
 
 from PySide6 import QtWidgets
 
+from randovania.game_description.game_description import GameDescription
 from randovania.gui.generated.preset_dread_patches_ui import Ui_PresetDreadPatches
 from randovania.gui.lib import signal_handling
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
@@ -16,8 +18,8 @@ _FIELDS = [
 
 
 class PresetDreadPatches(PresetTab, Ui_PresetDreadPatches):
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         # Signals

--- a/randovania/games/game.py
+++ b/randovania/games/game.py
@@ -52,7 +52,7 @@ class GameLayout:
 
 @dataclass(frozen=True)
 class GameGui:
-    tab_provider: Callable[[PresetEditor, WindowManager], Iterable[PresetTab]]
+    tab_provider: Callable[[PresetEditor, WindowManager], Iterable[type[PresetTab]]]
     """Provides a set of tabs for configuring the game's logic and gameplay settings."""
 
     cosmetic_dialog: type[BaseCosmeticPatchesDialog]

--- a/randovania/games/prime1/gui/preset_settings/__init__.py
+++ b/randovania/games/prime1/gui/preset_settings/__init__.py
@@ -5,9 +5,6 @@ from randovania.interface_common.preset_editor import PresetEditor
 
 
 def prime1_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
-    game_enum = editor.game
-    game_description = default_database.game_description_for(game_enum)
-
     from randovania.gui.preset_settings.trick_level_tab import PresetTrickLevel
     from randovania.gui.preset_settings.patcher_energy_tab import PresetPatcherEnergy
     from randovania.gui.preset_settings.elevators_tab import PresetElevators
@@ -20,15 +17,15 @@ def prime1_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
     from randovania.games.prime1.gui.preset_settings.prime_generation_tab import PresetPrimeGeneration
     from randovania.gui.preset_settings.dock_rando_tab import PresetDockRando
     return [
-        PresetTrickLevel(editor, game_description, window_manager),
-        PresetPatcherEnergy(editor, game_enum),
-        PresetElevators(editor, game_description),
-        PresetMetroidStartingArea(editor, game_description),
-        PresetPrimeGeneration(editor, game_description),
-        PresetPrimeGoal(editor),
-        PresetPrimeHints(editor),
-        PresetDockRando(editor, game_description),
-        PresetPrimePatches(editor),
-        PresetLocationPool(editor, game_description),
-        MetroidPresetItemPool(editor),
+        PresetTrickLevel,
+        PresetPatcherEnergy,
+        PresetElevators,
+        PresetMetroidStartingArea,
+        PresetPrimeGeneration,
+        PresetPrimeGoal,
+        PresetPrimeHints,
+        PresetDockRando,
+        PresetPrimePatches,
+        PresetLocationPool,
+        MetroidPresetItemPool,
     ]

--- a/randovania/games/prime1/gui/preset_settings/prime_generation_tab.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_generation_tab.py
@@ -3,20 +3,27 @@ from typing import Iterable
 from PySide6.QtWidgets import *
 
 from randovania.game_description.game_description import GameDescription
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.generation_tab import PresetGeneration
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
 
 
 class PresetPrimeGeneration(PresetGeneration):
-    def __init__(self, editor: PresetEditor, game_description: GameDescription) -> None:
-        self.min_progression_label = QLabel(
-            "Only place artifacts after this many actions were performed by the generator.")
-        self.min_progression_spin = QSpinBox()
+    min_progression_label: QLabel
+    min_progression_spin: QSpinBox
+
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
 
         self.min_progression_spin.valueChanged.connect(self._on_spin_changed)
 
-        super().__init__(editor, game_description)
+    def setupUi(self, obj):
+        super().setupUi(obj)
+
+        self.min_progression_label = QLabel(
+            "Only place artifacts after this many actions were performed by the generator.")
+        self.min_progression_spin = QSpinBox()
 
     @property
     def game_specific_widgets(self) -> Iterable[QWidget] | None:

--- a/randovania/games/prime1/gui/preset_settings/prime_goal_tab.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_goal_tab.py
@@ -1,7 +1,9 @@
 from PySide6 import QtCore
 
+from randovania.game_description.game_description import GameDescription
 from randovania.games.prime1.layout.artifact_mode import LayoutArtifactMode
 from randovania.gui.generated.preset_prime_goal_ui import Ui_PresetPrimeGoal
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
@@ -9,8 +11,8 @@ from randovania.layout.preset import Preset
 
 class PresetPrimeGoal(PresetTab, Ui_PresetPrimeGoal):
 
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         self.goal_layout.setAlignment(QtCore.Qt.AlignTop)

--- a/randovania/games/prime1/gui/preset_settings/prime_hints_tab.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_hints_tab.py
@@ -2,9 +2,11 @@ import dataclasses
 
 from PySide6 import QtCore
 
+from randovania.game_description.game_description import GameDescription
 from randovania.games.prime1.layout.hint_configuration import ArtifactHintMode, PhazonSuitHintMode
 from randovania.gui.generated.preset_prime_hints_ui import Ui_PresetPrimeHints
 from randovania.gui.lib.common_qt_lib import set_combo_with_value
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
@@ -12,8 +14,8 @@ from randovania.layout.preset import Preset
 
 class PresetPrimeHints(PresetTab, Ui_PresetPrimeHints):
 
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         self.hint_layout.setAlignment(QtCore.Qt.AlignTop)

--- a/randovania/games/prime1/gui/preset_settings/prime_patches_tab.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_patches_tab.py
@@ -2,9 +2,11 @@ import typing
 
 from PySide6 import QtWidgets
 
+from randovania.game_description.game_description import GameDescription
 from randovania.games.prime1.layout.prime_configuration import LayoutCutsceneMode, RoomRandoMode
 from randovania.gui.generated.preset_prime_patches_ui import Ui_PresetPrimePatches
 from randovania.gui.lib import signal_handling
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
@@ -32,8 +34,8 @@ _FIELDS = [
 
 
 class PresetPrimePatches(PresetTab, Ui_PresetPrimePatches):
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         self.description_label.setText(self.description_label.text().replace("color:#0000ff;", ""))

--- a/randovania/games/prime2/gui/preset_settings/__init__.py
+++ b/randovania/games/prime2/gui/preset_settings/__init__.py
@@ -4,9 +4,6 @@ from randovania.interface_common.preset_editor import PresetEditor
 
 
 def prime2_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
-    game_enum = editor.game
-    game_description = default_database.game_description_for(game_enum)
-
     from randovania.gui.preset_settings.trick_level_tab import PresetTrickLevel
     from randovania.gui.preset_settings.patcher_energy_tab import PresetPatcherEnergy
     from randovania.gui.preset_settings.elevators_tab import PresetElevators
@@ -20,16 +17,16 @@ def prime2_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
     from randovania.gui.preset_settings.location_pool_tab import PresetLocationPool
     from randovania.games.prime2.gui.preset_settings.echoes_item_pool_tab import EchoesPresetItemPool
     return [
-        PresetTrickLevel(editor, game_description, window_manager),
-        PresetPatcherEnergy(editor, game_enum),
-        PresetElevators(editor, game_description),
-        PresetMetroidStartingArea(editor, game_description),
-        PresetGeneration(editor, game_description),
-        PresetEchoesGoal(editor),
-        PresetEchoesHints(editor),
-        PresetEchoesTranslators(editor),
-        PresetEchoesBeamConfiguration(editor),
-        PresetEchoesPatches(editor),
-        PresetLocationPool(editor, game_description),
-        EchoesPresetItemPool(editor),
+        PresetTrickLevel,
+        PresetPatcherEnergy,
+        PresetElevators,
+        PresetMetroidStartingArea,
+        PresetGeneration,
+        PresetEchoesGoal,
+        PresetEchoesHints,
+        PresetEchoesTranslators,
+        PresetEchoesBeamConfiguration,
+        PresetEchoesPatches,
+        PresetLocationPool,
+        EchoesPresetItemPool,
     ]

--- a/randovania/games/prime2/gui/preset_settings/echoes_beam_configuration_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_beam_configuration_tab.py
@@ -4,8 +4,10 @@ import functools
 from PySide6 import QtWidgets
 from PySide6.QtWidgets import QComboBox
 
+from randovania.game_description.game_description import GameDescription
 from randovania.games.prime2.layout.beam_configuration import BeamAmmoConfiguration
 from randovania.gui.generated.preset_echoes_beam_configuration_ui import Ui_PresetEchoesBeamConfiguration
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
@@ -20,8 +22,8 @@ _BEAMS = {
 
 class PresetEchoesBeamConfiguration(PresetTab, Ui_PresetEchoesBeamConfiguration):
 
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         def _add_header(text: str, col: int):

--- a/randovania/games/prime2/gui/preset_settings/echoes_goal_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_goal_tab.py
@@ -1,17 +1,18 @@
 from PySide6 import QtCore
 
+from randovania.game_description.game_description import GameDescription
 from randovania.games.prime2.layout.echoes_configuration import LayoutSkyTempleKeyMode, EchoesConfiguration
 from randovania.gui.generated.preset_echoes_goal_ui import Ui_PresetEchoesGoal
 from randovania.gui.lib.common_qt_lib import set_combo_with_value
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
 
 
 class PresetEchoesGoal(PresetTab, Ui_PresetEchoesGoal):
-
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         self.goal_layout.setAlignment(QtCore.Qt.AlignTop)

--- a/randovania/games/prime2/gui/preset_settings/echoes_hints_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_hints_tab.py
@@ -2,9 +2,11 @@ import dataclasses
 
 from PySide6 import QtCore
 
+from randovania.game_description.game_description import GameDescription
 from randovania.games.prime2.layout.hint_configuration import SkyTempleKeyHintMode
 from randovania.gui.generated.preset_echoes_hints_ui import Ui_PresetEchoesHints
 from randovania.gui.lib.common_qt_lib import set_combo_with_value
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
@@ -12,8 +14,8 @@ from randovania.layout.preset import Preset
 
 class PresetEchoesHints(PresetTab, Ui_PresetEchoesHints):
 
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         self.hint_layout.setAlignment(QtCore.Qt.AlignTop)

--- a/randovania/games/prime2/gui/preset_settings/echoes_item_pool_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_item_pool_tab.py
@@ -1,8 +1,10 @@
 from PySide6 import QtWidgets
 
 from randovania.game_description import default_database
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.item.item_database import ItemDatabase
 from randovania.games.game import RandovaniaGame
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.metroid_item_pool_tab import MetroidPresetItemPool
 from randovania.gui.preset_settings.split_ammo_widget import SplitAmmoWidget
 from randovania.interface_common.preset_editor import PresetEditor
@@ -12,8 +14,8 @@ from randovania.layout.preset import Preset
 class EchoesPresetItemPool(MetroidPresetItemPool):
     _split_ammo_widgets: list[SplitAmmoWidget]
 
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         item_database = default_database.item_database_for_game(self.game)
 
         self._create_split_ammo_widgets(item_database)

--- a/randovania/games/prime2/gui/preset_settings/echoes_patches_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_patches_tab.py
@@ -1,13 +1,15 @@
+from randovania.game_description.game_description import GameDescription
 from randovania.games.prime2.layout.echoes_configuration import EchoesConfiguration
 from randovania.gui.generated.preset_echoes_patches_ui import Ui_PresetEchoesPatches
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
 
 
 class PresetEchoesPatches(PresetTab, Ui_PresetEchoesPatches):
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         self.include_menu_mod_label.setText(self.include_menu_mod_label.text().replace("color:#0000ff;", ""))

--- a/randovania/games/prime2/gui/preset_settings/echoes_translators_tab.py
+++ b/randovania/games/prime2/gui/preset_settings/echoes_translators_tab.py
@@ -4,6 +4,7 @@ from PySide6 import QtWidgets, QtCore
 from PySide6.QtWidgets import QComboBox
 
 from randovania.game_description import default_database
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.world.configurable_node import ConfigurableNode
 from randovania.game_description.world.node_identifier import NodeIdentifier
 from randovania.games.game import RandovaniaGame
@@ -12,6 +13,7 @@ from randovania.games.prime2.layout.echoes_configuration import EchoesConfigurat
 from randovania.games.prime2.layout.translator_configuration import LayoutTranslatorRequirement, TranslatorConfiguration
 from randovania.gui.generated.preset_echoes_translators_ui import Ui_PresetEchoesTranslators
 from randovania.gui.lib.common_qt_lib import set_combo_with_value
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
@@ -43,8 +45,8 @@ def gate_data():
 class PresetEchoesTranslators(PresetTab, Ui_PresetEchoesTranslators):
     _combo_for_gate: dict[NodeIdentifier, QComboBox]
 
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         self.translators_layout.setAlignment(QtCore.Qt.AlignTop)

--- a/randovania/games/prime3/gui/preset_settings/__init__.py
+++ b/randovania/games/prime3/gui/preset_settings/__init__.py
@@ -4,9 +4,6 @@ from randovania.interface_common.preset_editor import PresetEditor
 
 
 def prime3_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
-    game_enum = editor.game
-    game_description = default_database.game_description_for(game_enum)
-
     from randovania.gui.preset_settings.trick_level_tab import PresetTrickLevel
     from randovania.gui.preset_settings.patcher_energy_tab import PresetPatcherEnergy
     from randovania.gui.preset_settings.starting_area_tab import PresetMetroidStartingArea
@@ -14,10 +11,10 @@ def prime3_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
     from randovania.gui.preset_settings.location_pool_tab import PresetLocationPool
     from randovania.gui.preset_settings.metroid_item_pool_tab import MetroidPresetItemPool
     return [
-        PresetTrickLevel(editor, game_description, window_manager),
-        PresetPatcherEnergy(editor, game_enum),
-        PresetMetroidStartingArea(editor, game_description),
-        PresetGeneration(editor, game_description),
-        PresetLocationPool(editor, game_description),
-        MetroidPresetItemPool(editor),
+        PresetTrickLevel,
+        PresetPatcherEnergy,
+        PresetMetroidStartingArea,
+        PresetGeneration,
+        PresetLocationPool,
+        MetroidPresetItemPool,
     ]

--- a/randovania/games/super_metroid/gui/preset_settings/__init__.py
+++ b/randovania/games/super_metroid/gui/preset_settings/__init__.py
@@ -1,11 +1,8 @@
-from randovania.game_description import default_database
 from randovania.gui.lib.window_manager import WindowManager
 from randovania.interface_common.preset_editor import PresetEditor
 
 
 def super_metroid_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
-    game_enum = editor.game
-    game_description = default_database.game_description_for(game_enum)
     from randovania.gui.preset_settings.trick_level_tab import PresetTrickLevel
     from randovania.gui.preset_settings.starting_area_tab import PresetMetroidStartingArea
     from randovania.gui.preset_settings.generation_tab import PresetGeneration
@@ -13,14 +10,11 @@ def super_metroid_preset_tabs(editor: PresetEditor, window_manager: WindowManage
     from randovania.gui.preset_settings.metroid_item_pool_tab import MetroidPresetItemPool
     from randovania.games.super_metroid.gui.preset_settings.super_patches_tab import PresetSuperPatchConfiguration
 
-    itemPoolTab = MetroidPresetItemPool(editor)
-    itemPoolTab.pickup_style_widget.hide()
-
     return [
-        PresetTrickLevel(editor, game_description, window_manager),
-        PresetMetroidStartingArea(editor, game_description),
-        PresetGeneration(editor, game_description),
-        PresetLocationPool(editor, game_description),
-        itemPoolTab,
-        PresetSuperPatchConfiguration(editor),
+        PresetTrickLevel,
+        PresetMetroidStartingArea,
+        PresetGeneration,
+        PresetLocationPool,
+        MetroidPresetItemPool,
+        PresetSuperPatchConfiguration,
     ]

--- a/randovania/games/super_metroid/gui/preset_settings/super_patches_tab.py
+++ b/randovania/games/super_metroid/gui/preset_settings/super_patches_tab.py
@@ -3,8 +3,10 @@ import functools
 
 from PySide6.QtWidgets import QCheckBox
 
+from randovania.game_description.game_description import GameDescription
 from randovania.games.super_metroid.layout.super_metroid_patch_configuration import SuperPatchConfiguration
 from randovania.gui.generated.preset_patcher_super_patches_ui import Ui_PresetPatcherSuperPatches
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
@@ -14,9 +16,10 @@ class PresetSuperPatchConfiguration(PresetTab, Ui_PresetPatcherSuperPatches):
     checkboxes = {}
     radio_buttons = {}
 
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
+
         self.checkboxes = {
             "instant_g4": self.instant_g4_checkbox,
             "fast_doors_and_elevators": self.fast_doors_checkbox,

--- a/randovania/gui/game_specific_gui.py
+++ b/randovania/gui/game_specific_gui.py
@@ -1,7 +1,10 @@
+from typing import Iterable
+
 from PySide6 import QtWidgets
 
 from randovania.gui.dialog.base_cosmetic_patches_dialog import BaseCosmeticPatchesDialog
 from randovania.gui.lib.window_manager import WindowManager
+from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.base.cosmetic_patches import BaseCosmeticPatches
 
@@ -15,5 +18,5 @@ def create_dialog_for_cosmetic_patches(
     return dialog_class(parent, initial_patches)
 
 
-def preset_editor_tabs_for(editor: PresetEditor, window_manager: WindowManager):
+def preset_editor_tabs_for(editor: PresetEditor, window_manager: WindowManager) -> Iterable[type[PresetTab]]:
     return editor.game.gui.tab_provider(editor, window_manager)

--- a/randovania/gui/lib/area_list_helper.py
+++ b/randovania/gui/lib/area_list_helper.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Callable
+from typing import Callable, Sequence
 
 from PySide6 import QtWidgets, QtCore
 
@@ -105,7 +105,7 @@ class AreaListHelper:
 
         return checks_for_world, checks_for_area
 
-    def update_area_list(self, areas_to_check: list[AreaIdentifier],
+    def update_area_list(self, areas_to_check: Sequence[AreaIdentifier],
                          invert_check: bool,
                          location_for_world: dict[str, QtWidgets.QCheckBox],
                          location_for_area: dict[AreaIdentifier, QtWidgets.QCheckBox],

--- a/randovania/gui/lib/foldable.py
+++ b/randovania/gui/lib/foldable.py
@@ -3,10 +3,10 @@ from PySide6.QtWidgets import QGridLayout, QLayout, QToolButton, QWidget, QFrame
 
 
 class Foldable(QWidget):
-    _mainLayout: QGridLayout
-    _toggleButton: QToolButton
-    _headerLine: QFrame
-    _contentArea: QScrollArea
+    _main_layout: QGridLayout
+    _toggle_button: QToolButton
+    _header_line: QFrame
+    _content_area: QScrollArea
     _folded: bool
 
     def __init__(self, title: str, initially_folded: bool = True, parent: QWidget = None):
@@ -14,39 +14,39 @@ class Foldable(QWidget):
 
         self._folded = initially_folded
 
-        self._toggleButton = QToolButton(self)
-        self._toggleButton.setStyleSheet("QToolButton { height: 20px; }")
-        font = self._toggleButton.font()
+        self._toggle_button = QToolButton(self)
+        self._toggle_button.setStyleSheet("QToolButton { height: 20px; }")
+        font = self._toggle_button.font()
         font.setBold(True)
         font.setPixelSize(13)
-        self._toggleButton.setFont(font)
-        self._toggleButton.setMaximumHeight(20)
-        self._toggleButton.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
-        self._toggleButton.setArrowType(Qt.ArrowType.RightArrow)
-        self._toggleButton.setText(title)
-        self._toggleButton.setCheckable(True)
-        self._toggleButton.setChecked(False)
-        self._toggleButton.clicked.connect(self._on_click)
+        self._toggle_button.setFont(font)
+        self._toggle_button.setMaximumHeight(20)
+        self._toggle_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+        self._toggle_button.setArrowType(Qt.ArrowType.RightArrow)
+        self._toggle_button.setText(title)
+        self._toggle_button.setCheckable(True)
+        self._toggle_button.setChecked(False)
+        self._toggle_button.clicked.connect(self._on_click)
 
-        self._headerLine = QFrame(self)
-        self._headerLine.setFrameShape(QFrame.HLine)
-        self._headerLine.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
+        self._header_line = QFrame(self)
+        self._header_line.setFrameShape(QFrame.HLine)
+        self._header_line.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
 
-        self._contentArea = QFrame(self)
-        self._contentArea.setObjectName("foldable_contentArea")
-        self._contentArea.setStyleSheet("#foldable_contentArea { border: none; }")
-        self._contentArea.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self._content_area = QFrame(self)
+        self._content_area.setObjectName("foldable_contentArea")
+        self._content_area.setStyleSheet("#foldable_contentArea { border: none; }")
+        self._content_area.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
 
-        self._mainLayout = QGridLayout(self)
-        self._mainLayout.setVerticalSpacing(0)
-        self._mainLayout.setContentsMargins(0, 0, 0, 0)
-        self._mainLayout.addWidget(self._toggleButton, 0, 0, 1, 1, Qt.AlignLeft)
-        self._mainLayout.addWidget(self._headerLine, 0, 1, 1, 1)
-        self._mainLayout.addWidget(self._contentArea, 1, 0, 1, 2)
+        self._main_layout = QGridLayout(self)
+        self._main_layout.setVerticalSpacing(0)
+        self._main_layout.setContentsMargins(0, 0, 0, 0)
+        self._main_layout.addWidget(self._toggle_button, 0, 0, 1, 1, Qt.AlignLeft)
+        self._main_layout.addWidget(self._header_line, 0, 1, 1, 1)
+        self._main_layout.addWidget(self._content_area, 1, 0, 1, 2)
 
     @property
     def contents(self):
-        return self._contentArea
+        return self._content_area
 
     def _on_click(self, checked: bool):
         if self._folded:
@@ -56,16 +56,16 @@ class Foldable(QWidget):
 
     def _unfold(self):
         self._folded = False
-        self._contentArea.show()
-        self._toggleButton.setArrowType(Qt.ArrowType.DownArrow)
+        self._content_area.show()
+        self._toggle_button.setArrowType(Qt.ArrowType.DownArrow)
 
     def _fold(self):
         self._folded = True
-        self._contentArea.hide()
-        self._toggleButton.setArrowType(Qt.ArrowType.RightArrow)
+        self._content_area.hide()
+        self._toggle_button.setArrowType(Qt.ArrowType.RightArrow)
 
     def set_content_layout(self, content_layout: QLayout):
-        self._contentArea.setLayout(content_layout)
+        self._content_area.setLayout(content_layout)
         if self._folded:
             self._fold()
         else:

--- a/randovania/gui/lib/foldable.py
+++ b/randovania/gui/lib/foldable.py
@@ -1,43 +1,43 @@
+from PySide6 import QtCore, QtWidgets
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QGridLayout, QLayout, QToolButton, QWidget, QFrame, QScrollArea, QSizePolicy
 
 
-class Foldable(QWidget):
-    _main_layout: QGridLayout
-    _toggle_button: QToolButton
-    _header_line: QFrame
-    _content_area: QScrollArea
+class Foldable(QtWidgets.QWidget):
+    _main_layout: QtWidgets.QGridLayout
+    _toggle_button: QtWidgets.QToolButton
+    _header_line: QtWidgets.QFrame
+    _content_area: QtWidgets.QFrame
     _folded: bool
 
-    def __init__(self, title: str, initially_folded: bool = True, parent: QWidget = None):
+    def __init__(self, title: str, initially_folded: bool = True, parent: QtWidgets.QWidget = None):
         super().__init__(parent)
 
         self._folded = initially_folded
 
-        self._toggle_button = QToolButton(self)
+        self._toggle_button = QtWidgets.QToolButton(self)
         self._toggle_button.setStyleSheet("QToolButton { height: 20px; }")
         font = self._toggle_button.font()
         font.setBold(True)
         font.setPixelSize(13)
         self._toggle_button.setFont(font)
         self._toggle_button.setMaximumHeight(20)
-        self._toggle_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
-        self._toggle_button.setArrowType(Qt.ArrowType.RightArrow)
+        self._toggle_button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+        self._toggle_button.setArrowType(QtCore.Qt.ArrowType.RightArrow)
         self._toggle_button.setText(title)
         self._toggle_button.setCheckable(True)
         self._toggle_button.setChecked(False)
         self._toggle_button.clicked.connect(self._on_click)
 
-        self._header_line = QFrame(self)
-        self._header_line.setFrameShape(QFrame.HLine)
-        self._header_line.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
+        self._header_line = QtWidgets.QFrame(self)
+        self._header_line.setFrameShape(QtWidgets.QFrame.HLine)
+        self._header_line.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Maximum)
 
-        self._content_area = QFrame(self)
+        self._content_area = QtWidgets.QFrame(self)
         self._content_area.setObjectName("foldable_contentArea")
         self._content_area.setStyleSheet("#foldable_contentArea { border: none; }")
-        self._content_area.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self._content_area.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
 
-        self._main_layout = QGridLayout(self)
+        self._main_layout = QtWidgets.QGridLayout(self)
         self._main_layout.setVerticalSpacing(0)
         self._main_layout.setContentsMargins(0, 0, 0, 0)
         self._main_layout.addWidget(self._toggle_button, 0, 0, 1, 1, Qt.AlignLeft)
@@ -64,7 +64,7 @@ class Foldable(QWidget):
         self._content_area.hide()
         self._toggle_button.setArrowType(Qt.ArrowType.RightArrow)
 
-    def set_content_layout(self, content_layout: QLayout):
+    def set_content_layout(self, content_layout: QtWidgets.QLayout):
         self._content_area.setLayout(content_layout)
         if self._folded:
             self._fold()

--- a/randovania/gui/preset_settings/dock_rando_tab.py
+++ b/randovania/gui/preset_settings/dock_rando_tab.py
@@ -9,6 +9,7 @@ from randovania.game_description.world.dock import DockRandoParams, DockType, Do
 from randovania.gui.generated.preset_dock_rando_ui import Ui_PresetDockRando
 from randovania.gui.lib import common_qt_lib, signal_handling
 from randovania.gui.lib.foldable import Foldable
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.base.dock_rando_configuration import DockRandoMode
@@ -18,8 +19,8 @@ from randovania.layout.preset import Preset
 class PresetDockRando(PresetTab, Ui_PresetDockRando):
     type_checks: dict[DockType, dict[DockWeakness, dict[str, QtWidgets.QCheckBox]]]
 
-    def __init__(self, editor: PresetEditor, game_description: GameDescription) -> None:
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         # Mode

--- a/randovania/gui/preset_settings/elevators_tab.py
+++ b/randovania/gui/preset_settings/elevators_tab.py
@@ -13,6 +13,7 @@ from randovania.games.game import RandovaniaGame
 from randovania.gui.generated.preset_elevators_ui import Ui_PresetElevators
 from randovania.gui.lib import common_qt_lib, signal_handling
 from randovania.gui.lib.area_list_helper import AreaListHelper
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.lib.teleporters import TeleporterShuffleMode, TeleporterTargetList, TeleporterList, \
@@ -28,10 +29,9 @@ class PresetElevators(PresetTab, Ui_PresetElevators, AreaListHelper):
     _elevator_target_for_world: dict[str, QtWidgets.QCheckBox]
     _elevator_target_for_area: dict[AreaIdentifier, QtWidgets.QCheckBox]
 
-    def __init__(self, editor: PresetEditor, game: GameDescription):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
-        self.game_description = game
 
         self.elevator_layout.setAlignment(QtCore.Qt.AlignTop)
 

--- a/randovania/gui/preset_settings/generation_tab.py
+++ b/randovania/gui/preset_settings/generation_tab.py
@@ -7,7 +7,9 @@ from randovania.game_description.game_description import GameDescription
 from randovania.games.game import RandovaniaGame
 from randovania.gui.generated.preset_generation_ui import Ui_PresetGeneration
 from randovania.gui.lib import common_qt_lib, signal_handling
-from randovania.gui.preset_settings.preset_tab import PresetTab, PresetEditor
+from randovania.gui.lib.window_manager import WindowManager
+from randovania.gui.preset_settings.preset_tab import PresetTab
+from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.base.available_locations import RandomizationMode
 from randovania.layout.base.damage_strictness import LayoutDamageStrictness
 from randovania.layout.base.logical_resource_action import LayoutLogicalResourceAction
@@ -15,8 +17,8 @@ from randovania.layout.preset import Preset
 
 
 class PresetGeneration(PresetTab, Ui_PresetGeneration):
-    def __init__(self, editor: PresetEditor, game_description: GameDescription) -> None:
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         # Game-specific Settings

--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -6,6 +6,7 @@ from PySide6 import QtWidgets, QtCore
 
 from randovania.exporter import item_names
 from randovania.game_description import default_database
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.item.ammo import Ammo
 from randovania.game_description.item.item_category import ItemCategory
 from randovania.game_description.item.item_database import ItemDatabase
@@ -19,6 +20,7 @@ from randovania.gui.generated.preset_item_pool_ui import Ui_PresetItemPool
 from randovania.gui.lib import common_qt_lib
 from randovania.gui.lib.foldable import Foldable
 from randovania.gui.lib.scroll_protected import ScrollProtectedComboBox, ScrollProtectedSpinBox
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.item_configuration_widget import ItemConfigurationWidget
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.gui.preset_settings.progressive_item_widget import ProgressiveItemWidget
@@ -57,8 +59,8 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
 
     _progressive_widgets: list[ProgressiveItemWidget]
 
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
         size_policy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed)

--- a/randovania/gui/preset_settings/location_pool_row_widget.py
+++ b/randovania/gui/preset_settings/location_pool_row_widget.py
@@ -1,12 +1,12 @@
 from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QDialog
+from PySide6.QtWidgets import QDialog, QWidget
 
 from randovania.game_description.world.pickup_node import PickupNode
 from randovania.gui.generated.widget_location_pool_row_ui import Ui_LocationPoolRowWidget
 
 
-class LocationPoolRowWidget(QDialog, Ui_LocationPoolRowWidget):
-    changed = Signal()
+class LocationPoolRowWidget(QWidget, Ui_LocationPoolRowWidget):
+    changed = Signal(PickupNode)
     node: PickupNode
 
     def __init__(self, node: PickupNode, location_name: str):
@@ -16,28 +16,19 @@ class LocationPoolRowWidget(QDialog, Ui_LocationPoolRowWidget):
         self.node = node
         self.label_location_name.setText(location_name)
 
-        self.radio_vanilla.setVisible(False)
-        self.radio_vanilla.setToolTip("Not yet implemented, coming soon")
-        self.radio_fixed.setVisible(False)
-        self.radio_fixed.setToolTip("Not yet implemented, coming soon")
-        self.combo_fixed_item.setVisible(False)
-        self.combo_fixed_item.setToolTip("Not yet implemented, coming soon")
-
-        self.radio_vanilla.toggled.connect(self._on_radio_changed)
         self.radio_shuffled.toggled.connect(self._on_radio_changed)
         self.radio_shuffled_no_progression.toggled.connect(self._on_radio_changed)
-        self.radio_fixed.toggled.connect(self._on_radio_changed)
 
     def set_can_have_progression(self, progression: bool):
         if progression:
             self.radio_shuffled.setChecked(True)
         else:
             self.radio_shuffled_no_progression.setChecked(True)
-        self.changed.emit()
+        self.changed.emit(self.node)
 
     def _on_radio_changed(self, checked: bool):
         if checked:
-            self.changed.emit()
+            self.changed.emit(self.node)
 
     @property
     def can_have_progression(self):

--- a/randovania/gui/preset_settings/location_pool_tab.py
+++ b/randovania/gui/preset_settings/location_pool_tab.py
@@ -13,6 +13,7 @@ from randovania.games.game import RandovaniaGame
 from randovania.gui.generated.preset_location_pool_ui import Ui_PresetLocationPool
 from randovania.gui.lib.area_list_helper import AreaListHelper, dark_world_flags
 from randovania.gui.lib.foldable import Foldable
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.location_pool_row_widget import LocationPoolRowWidget
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
@@ -27,10 +28,9 @@ class PresetLocationPool(PresetTab, Ui_PresetLocationPool, AreaListHelper):
     _during_batch_update: bool
     _major_minor: bool
 
-    def __init__(self, editor: PresetEditor, game: GameDescription):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
-        self.game_description = game
         self._during_batch_update = False
 
         self._row_widget_for_node = {}

--- a/randovania/gui/preset_settings/metroid_item_pool_tab.py
+++ b/randovania/gui/preset_settings/metroid_item_pool_tab.py
@@ -3,8 +3,10 @@ import dataclasses
 from PySide6 import QtWidgets
 
 from randovania.game_description import default_database
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.resources.item_resource_info import ItemResourceInfo
 from randovania.gui.lib.scroll_protected import ScrollProtectedSpinBox
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.item_pool_tab import PresetItemPool
 from randovania.gui.preset_settings.pickup_style_widget import PickupStyleWidget
 from randovania.interface_common.preset_editor import PresetEditor
@@ -13,10 +15,9 @@ from randovania.layout.preset import Preset
 
 
 class MetroidPresetItemPool(PresetItemPool):
-    def __init__(self, editor: PresetEditor):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         item_database = default_database.item_database_for_game(self.game)
-        game_description = default_database.game_description_for(self.game)
 
         size_policy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed)
 

--- a/randovania/gui/preset_settings/patcher_energy_tab.py
+++ b/randovania/gui/preset_settings/patcher_energy_tab.py
@@ -1,11 +1,13 @@
 import dataclasses
 
+from randovania.game_description.game_description import GameDescription
 from randovania.games.game import RandovaniaGame
 from randovania.games.prime1.layout.prime_configuration import PrimeConfiguration
 from randovania.games.prime2.layout.echoes_configuration import EchoesConfiguration
 from randovania.games.prime3.layout.corruption_configuration import CorruptionConfiguration
 from randovania.gui.generated.preset_patcher_energy_ui import Ui_PresetPatcherEnergy
 from randovania.gui.lib import signal_handling
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.preset import Preset
@@ -13,10 +15,10 @@ from randovania.layout.preset import Preset
 
 class PresetPatcherEnergy(PresetTab, Ui_PresetPatcherEnergy):
 
-    def __init__(self, editor: PresetEditor, game_enum: RandovaniaGame):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
-        self.game_enum = game_enum
+        self.game_enum = game_description.game
 
         self.energy_tank_capacity_spin_box.valueChanged.connect(self._persist_tank_capacity)
         signal_handling.on_checked(self.dangerous_tank_check, self._persist_dangerous_tank)

--- a/randovania/gui/preset_settings/preset_tab.py
+++ b/randovania/gui/preset_settings/preset_tab.py
@@ -1,15 +1,23 @@
+from __future__ import annotations
+
 import dataclasses
+import typing
 
 from PySide6 import QtWidgets
 
-from randovania.interface_common.preset_editor import PresetEditor
-from randovania.layout.preset import Preset
+if typing.TYPE_CHECKING:
+    from randovania.game_description.game_description import GameDescription
+    from randovania.gui.lib.window_manager import WindowManager
+    from randovania.interface_common.preset_editor import PresetEditor
+    from randovania.layout.preset import Preset
 
 
 class PresetTab(QtWidgets.QMainWindow):
-    def __init__(self, editor: PresetEditor) -> None:
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
         super().__init__()
         self._editor = editor
+        self.game_description = game_description
+        self._window_manager = window_manager
 
     @classmethod
     def tab_title(cls) -> str:

--- a/randovania/gui/preset_settings/starting_area_tab.py
+++ b/randovania/gui/preset_settings/starting_area_tab.py
@@ -7,6 +7,7 @@ from randovania.game_description.world.area_identifier import AreaIdentifier
 from randovania.games.game import RandovaniaGame
 from randovania.gui.generated.preset_starting_area_ui import Ui_PresetStartingArea
 from randovania.gui.lib.area_list_helper import AreaListHelper
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.base.base_configuration import StartingLocationList
@@ -14,15 +15,15 @@ from randovania.layout.preset import Preset
 
 
 class PresetStartingArea(PresetTab, Ui_PresetStartingArea, AreaListHelper):
+    starting_area_quick_fill_default: QtWidgets.QPushButton
     _starting_location_for_world: dict[str, QtWidgets.QCheckBox]
     _starting_location_for_area: dict[AreaIdentifier, QtWidgets.QCheckBox]
 
     _num_quick_fill_buttons: int
 
-    def __init__(self, editor: PresetEditor, game: GameDescription):
-        super().__init__(editor)
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
-        self.game_description = game
 
         self.starting_area_layout.setAlignment(QtCore.Qt.AlignTop)
 

--- a/randovania/gui/preset_settings/trick_level_tab.py
+++ b/randovania/gui/preset_settings/trick_level_tab.py
@@ -20,11 +20,8 @@ from randovania.lib import enum_lib
 class PresetTrickLevel(PresetTab, Ui_PresetTrickLevel):
 
     def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
-        super().__init__(editor)
+        super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
-
-        self.game_description = game_description
-        self._window_manager = window_manager
 
         self.trick_level_layout.setAlignment(QtCore.Qt.AlignTop)
         signal_handling.on_checked(self.underwater_abuse_check, self._on_underwater_abuse_check)

--- a/randovania/gui/ui_files/widget_location_pool_row.ui
+++ b/randovania/gui/ui_files/widget_location_pool_row.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>LocationPoolRowWidget</class>
- <widget class="QDialog" name="LocationPoolRowWidget">
+ <widget class="QWidget" name="LocationPoolRowWidget">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
     <width>616</width>
-    <height>52</height>
+    <height>41</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -27,10 +27,7 @@
 				Item Configuration
 			</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="spacing">
-    <number>4</number>
-   </property>
+  <layout class="QHBoxLayout" name="root_layout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -44,127 +41,52 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="label_location_name">
-       <property name="font">
-        <font>
-         <pointsize>8</pointsize>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Location name</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QRadioButton" name="radio_shuffled">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>This location is shuffled normally</string>
-       </property>
-       <property name="text">
-        <string>Shuffled</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QRadioButton" name="radio_shuffled_no_progression">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>This location is shuffled, but cannot contain a item required for progression</string>
-       </property>
-       <property name="text">
-        <string>Shuffled (no progression)</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QLabel" name="label_location_name">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Location name</string>
+     </property>
+    </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>12</number>
+    <widget class="QRadioButton" name="radio_shuffled">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="sizeConstraint">
-      <enum>QLayout::SetDefaultConstraint</enum>
+     <property name="toolTip">
+      <string>This location is shuffled normally</string>
      </property>
-     <property name="topMargin">
-      <number>0</number>
+     <property name="text">
+      <string>Shuffled</string>
      </property>
-     <item>
-      <widget class="QRadioButton" name="radio_vanilla">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>This location is unchanged and will contain the same item as in the base game</string>
-       </property>
-       <property name="text">
-        <string>Vanilla</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QRadioButton" name="radio_fixed">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>This location contains a fixed item of your choosing</string>
-         </property>
-         <property name="text">
-          <string>Fixed			</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="combo_fixed_item">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="currentText">
-          <string>No item</string>
-         </property>
-         <item>
-          <property name="text">
-           <string>No item</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-      </layout>
-     </item>
-    </layout>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="radio_shuffled_no_progression">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>This location is shuffled, but cannot contain a item required for progression</string>
+     </property>
+     <property name="text">
+      <string>Shuffled (no progression)</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/test/games/dread/gui/test_dread_energy_tab.py
+++ b/test/games/dread/gui/test_dread_energy_tab.py
@@ -1,5 +1,6 @@
 import dataclasses
 import uuid
+from unittest.mock import MagicMock
 
 from PySide6 import QtCore
 
@@ -9,8 +10,8 @@ from randovania.games.game import RandovaniaGame
 from randovania.interface_common.preset_editor import PresetEditor
 
 
-def test_toggle_immediate_parts(skip_qtbot, preset_manager):
-    game = RandovaniaGame.METROID_DREAD
+def test_toggle_immediate_parts(skip_qtbot, dread_game_description, preset_manager):
+    game = dread_game_description.game
     base = preset_manager.default_preset_for_game(game).get_preset()
     preset = dataclasses.replace(base,
                                  uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'),
@@ -18,7 +19,7 @@ def test_toggle_immediate_parts(skip_qtbot, preset_manager):
     base_configuration = preset.configuration
     assert isinstance(base_configuration, DreadConfiguration)
 
-    tab = PresetDreadEnergy(editor := PresetEditor(preset))
+    tab = PresetDreadEnergy(editor := PresetEditor(preset), dread_game_description, MagicMock())
     skip_qtbot.addWidget(tab)
     tab.on_preset_changed(preset)
 

--- a/test/games/super_metroid/gui/test_patches_tab.py
+++ b/test/games/super_metroid/gui/test_patches_tab.py
@@ -1,3 +1,6 @@
+from unittest.mock import MagicMock
+
+from randovania.game_description import default_database
 from randovania.games.super_metroid.gui.preset_settings.super_patches_tab import PresetSuperPatchConfiguration
 from randovania.games.super_metroid.layout.super_metroid_configuration import SuperMetroidConfiguration
 from randovania.interface_common.preset_editor import PresetEditor
@@ -9,8 +12,10 @@ def test_elements_init(skip_qtbot, test_files_dir):
     preset = VersionedPreset.from_file_sync(preset_path).get_preset()
     assert isinstance(preset.configuration, SuperMetroidConfiguration)
 
+    game = default_database.game_description_for(preset.game)
+
     editor = PresetEditor(preset)
-    super_patches_tab = PresetSuperPatchConfiguration(editor)
+    super_patches_tab = PresetSuperPatchConfiguration(editor, game, MagicMock())
     skip_qtbot.addWidget(super_patches_tab)
 
     # Test whether visual elements are initialized correctly

--- a/test/gui/lib/test_foldable.py
+++ b/test/gui/lib/test_foldable.py
@@ -10,7 +10,7 @@ def test_foldable_initial_state(skip_qtbot):
     skip_qtbot.addWidget(foldable_2)
 
     # Assert
-    assert foldable._toggleButton.text() == "My foldable title"
+    assert foldable._toggle_button.text() == "My foldable title"
     assert not foldable._folded
     assert foldable_2._folded
 
@@ -24,8 +24,8 @@ def test_foldable_actions(skip_qtbot):
     # Run & Assert
     foldable._unfold()
     assert not foldable._folded
-    assert not foldable._contentArea.isHidden()
+    assert not foldable._content_area.isHidden()
 
     foldable._fold()
     assert foldable._folded
-    assert foldable._contentArea.isHidden()
+    assert foldable._content_area.isHidden()

--- a/test/gui/preset_settings/test_generation_tab.py
+++ b/test/gui/preset_settings/test_generation_tab.py
@@ -28,7 +28,7 @@ def test_on_preset_changed(skip_qtbot, preset_manager, game_data):
                                  uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'),
                                  base_preset_uuid=base.uuid)
     editor = PresetEditor(preset)
-    window: PresetGeneration = tab(editor, default_database.game_description_for(game))
+    window: PresetGeneration = tab(editor, default_database.game_description_for(game), MagicMock())
     parent = QGroupBox()
     window.setParent(parent)
 
@@ -45,7 +45,7 @@ def test_persist_local_first_progression(skip_qtbot, preset_manager):
     game = RandovaniaGame.BLANK
 
     editor = MagicMock()
-    window = PresetGeneration(editor, default_database.game_description_for(game))
+    window = PresetGeneration(editor, default_database.game_description_for(game), MagicMock())
     window.setParent(parent)
 
     # Run

--- a/test/gui/preset_settings/test_item_pool_tab.py
+++ b/test/gui/preset_settings/test_item_pool_tab.py
@@ -1,5 +1,6 @@
 import dataclasses
 import uuid
+from unittest.mock import MagicMock
 
 from randovania.game_description import default_database
 from randovania.games.game import RandovaniaGame
@@ -8,16 +9,16 @@ from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.base.major_item_state import MajorItemState
 
 
-def test_on_default_item_updated(skip_qtbot, preset_manager):
+def test_on_default_item_updated(skip_qtbot, echoes_game_description, preset_manager):
     # Setup
-    game = RandovaniaGame.METROID_PRIME_ECHOES
+    game = echoes_game_description.game
     base = preset_manager.default_preset_for_game(game).get_preset()
     preset = dataclasses.replace(base,
                                  uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'),
                                  base_preset_uuid=base.uuid)
 
     editor = PresetEditor(preset)
-    window = PresetItemPool(editor)
+    window = PresetItemPool(editor, echoes_game_description, MagicMock())
 
     item_database = default_database.item_database_for_game(window.game)
     item = item_database.major_items["Dark Beam"]

--- a/test/gui/preset_settings/test_location_pool_row_widget.py
+++ b/test/gui/preset_settings/test_location_pool_row_widget.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from randovania.game_description.resources.pickup_index import PickupIndex
@@ -57,7 +59,7 @@ def test_location_pool_row_disabled_on_major_minor_split(customized_preset, echo
     # Setup
     preset_editor = PresetEditor(customized_preset)
 
-    location_pool_tab = PresetLocationPool(preset_editor, echoes_game_description)
+    location_pool_tab = PresetLocationPool(preset_editor, echoes_game_description, MagicMock())
 
     # Get the first major location in the list, and the first non-major one
     # Then, put it in a state which will have to be changed in the case where

--- a/test/gui/preset_settings/test_preset_elevator.py
+++ b/test/gui/preset_settings/test_preset_elevator.py
@@ -1,5 +1,6 @@
 import dataclasses
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -19,7 +20,7 @@ def test_on_preset_changed(skip_qtbot, preset_manager, game):
                                  uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'),
                                  base_preset_uuid=base.uuid)
     editor = PresetEditor(preset)
-    window = PresetElevators(editor, default_database.game_description_for(preset.game))
+    window = PresetElevators(editor, default_database.game_description_for(preset.game), MagicMock())
 
     # Run
     window.on_preset_changed(editor.create_custom_preset_with())

--- a/test/gui/preset_settings/test_starting_area.py
+++ b/test/gui/preset_settings/test_starting_area.py
@@ -1,5 +1,6 @@
 import dataclasses
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 from PySide6 import QtCore
@@ -23,7 +24,7 @@ def test_on_preset_changed(skip_qtbot, preset_manager, game):
                                  uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'),
                                  base_preset_uuid=base.uuid)
     editor = PresetEditor(preset)
-    window = PresetStartingArea(editor, default_database.game_description_for(preset.game))
+    window = PresetStartingArea(editor, default_database.game_description_for(preset.game), MagicMock())
 
     # Run
     window.on_preset_changed(editor.create_custom_preset_with())
@@ -40,7 +41,7 @@ def test_starting_location_world_select(skip_qtbot, preset_manager):
                                  uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'),
                                  base_preset_uuid=base.uuid)
     editor = PresetEditor(preset)
-    window = PresetMetroidStartingArea(editor, default_database.game_description_for(preset.game))
+    window = PresetMetroidStartingArea(editor, default_database.game_description_for(preset.game), MagicMock())
     skip_qtbot.addWidget(window)
 
     # Run
@@ -69,7 +70,7 @@ def test_quick_fill_default(skip_qtbot, preset_manager, game_enum: RandovaniaGam
                                  uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'),
                                  base_preset_uuid=base.uuid)
     editor = PresetEditor(preset)
-    window = PresetStartingArea(editor, default_database.game_description_for(preset.game))
+    window = PresetStartingArea(editor, default_database.game_description_for(preset.game), MagicMock())
     skip_qtbot.addWidget(window)
 
     # Run
@@ -86,7 +87,7 @@ def test_quick_fill_cs_classic(skip_qtbot, preset_manager):
                                  uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'),
                                  base_preset_uuid=base.uuid)
     editor = PresetEditor(preset)
-    window = PresetCSStartingArea(editor, default_database.game_description_for(preset.game))
+    window = PresetCSStartingArea(editor, default_database.game_description_for(preset.game), MagicMock())
     skip_qtbot.addWidget(window)
 
     # Run

--- a/test/gui/test_game_specific_gui.py
+++ b/test/gui/test_game_specific_gui.py
@@ -1,19 +1,25 @@
 from unittest.mock import MagicMock
 
+from randovania.game_description import default_database
 from randovania.games.game import RandovaniaGame
 from randovania.gui import game_specific_gui
+from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.interface_common.preset_editor import PresetEditor
+from randovania.layout import filtered_database
 
 
 def test_preset_editor_tabs_for(skip_qtbot, game_enum: RandovaniaGame, preset_manager):
     preset = preset_manager.default_preset_for_game(game_enum)
     editor = PresetEditor(preset.get_preset().fork())
     window_manager = MagicMock()
+    game = filtered_database.game_description_for_layout(preset.get_preset().configuration)
 
     # Run
-    result = game_specific_gui.preset_editor_tabs_for(editor, window_manager)
-    for it in result:
-        skip_qtbot.addWidget(it)
+    tabs = list(game_specific_gui.preset_editor_tabs_for(editor, window_manager))
+
+    for it in tabs:
+        assert issubclass(it, PresetTab)
+        skip_qtbot.addWidget(it(editor, game, window_manager))
 
     # Assert
-    assert len(result) >= 3
+    assert len(tabs) >= 3

--- a/test/gui/test_game_specific_gui.py
+++ b/test/gui/test_game_specific_gui.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock
 
-from randovania.game_description import default_database
 from randovania.games.game import RandovaniaGame
 from randovania.gui import game_specific_gui
 from randovania.gui.preset_settings.preset_tab import PresetTab
@@ -19,7 +18,9 @@ def test_preset_editor_tabs_for(skip_qtbot, game_enum: RandovaniaGame, preset_ma
 
     for it in tabs:
         assert issubclass(it, PresetTab)
-        skip_qtbot.addWidget(it(editor, game, window_manager))
+        tab = it(editor, game, window_manager)
+        tab.on_preset_changed(preset.get_preset())
+        skip_qtbot.addWidget(tab)
 
     # Assert
     assert len(tabs) >= 3


### PR DESCRIPTION
By keeping only the current tab active, we massively decrease the time it takes to create the window at the cost of some small freeze when opening the slow tabs.
As the tabs are now re-created each time it's opened, they now use the filtered database for the current configuration.

Remove the hidden elements from the location pool tab, as they cause significant slowdown to creation.