### PR TITLE
Dread: Fix Pulse Radar and Dairon Freezer

### DIFF
--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -12504,7 +12504,7 @@
                                 ]
                             }
                         },
-                        "Door to Energy Recharge Station West (Lower)": {
+                        "Pickup (Missile Tank - Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12542,6 +12542,15 @@
                                                     }
                                                 },
                                                 {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
                                                     "type": "and",
                                                     "data": {
                                                         "comment": null,
@@ -12568,15 +12577,6 @@
                                                     }
                                                 }
                                             ]
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s030_baselab:default:powergenerator_002",
-                                            "amount": 1,
-                                            "negate": false
                                         }
                                     }
                                 ]

--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -10834,15 +10834,6 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
                                                     "type": "and",
                                                     "data": {
                                                         "comment": null,
@@ -10869,6 +10860,15 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:powergenerator_002",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -11297,52 +11297,138 @@
                     "major_location": false,
                     "connections": {
                         "Door to Energy Recharge Station West (Lower)": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
+                                            "type": "events",
+                                            "name": "s030_baselab:default:powergenerator_002",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "damage",
-                                                        "name": "Cold",
-                                                        "amount": 20,
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 20,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Freezer Center": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:db_reg_b1_001",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Suitless",
-                                                        "amount": 2,
-                                                        "negate": false
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 30,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s030_baselab:default:powergenerator_002",
-                                            "amount": 1,
-                                            "negate": true
                                         }
                                     }
                                 ]
@@ -11369,10 +11455,12 @@
                     "event_name": "s030_baselab:default:db_reg_b1_001",
                     "connections": {
                         "Door to Energy Recharge Station West (Lower)": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "events",
+                                "name": "s030_baselab:default:powergenerator_002",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -12342,15 +12430,6 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
                                                     "type": "and",
                                                     "data": {
                                                         "comment": null,
@@ -12402,15 +12481,6 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Walljump",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
                                                                     "name": "Movement",
                                                                     "amount": 2,
                                                                     "negate": false
@@ -12420,6 +12490,15 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:powergenerator_002",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -12487,51 +12566,17 @@
                                                             }
                                                         ]
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
                                                 }
                                             ]
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Walljump",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
+                                            "type": "events",
+                                            "name": "s030_baselab:default:powergenerator_002",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -2298,11 +2298,11 @@ Extra - asset_id: collision_camera_025
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
           Space Jump or Movement (Intermediate)
-  > Door to Energy Recharge Station West (Lower)
+  > Pickup (Missile Tank - Upper)
       All of the following:
-          Morph Ball and After Dairon - Freezer Hidden Left Blob and After Dairon - powergenerator_002
+          Morph Ball and After Dairon - Freezer Hidden Left Blob
           Any of the following:
-              Gravity Suit
+              Gravity Suit or Before Dairon - powergenerator_002
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
   > Tile Group (SCREWATTACK)
       All of the following:

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -2120,9 +2120,9 @@ Extra - asset_id: collision_camera_025
   * Extra - right_shield_def: None
   > Door to Energy Recharge Station West (Lower)
       All of the following:
-          Morph Ball
+          Morph Ball and After Dairon - powergenerator_002
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 120
   > Freezer Center
       Any of the following:
@@ -2174,9 +2174,17 @@ Extra - asset_id: collision_camera_025
   * Extra - actor_name: item_missiletank_006
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Door to Energy Recharge Station West (Lower)
-      Any of the following:
-          Gravity Suit or Before Dairon - powergenerator_002
-          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 20
+      All of the following:
+          After Dairon - powergenerator_002
+          Any of the following:
+              Gravity Suit
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 20
+  > Freezer Center
+      All of the following:
+          Morph Ball and After Dairon - Freezer Hidden Left Blob
+          Any of the following:
+              Gravity Suit or Before Dairon - powergenerator_002
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
 
 > Event - Hidden Blob from left (db_reg_b1_001); Heals? False
   * Layers: default
@@ -2184,7 +2192,7 @@ Extra - asset_id: collision_camera_025
   * Extra - actor_name: db_reg_b1_001
   * Extra - actor_def: actordef:actors/props/db_reg_b1_001/charclasses/db_reg_b1_001.bmsad
   > Door to Energy Recharge Station West (Lower)
-      Trivial
+      After Dairon - powergenerator_002
 
 > Event - Right Blob from right (db_reg_b1_002); Heals? False
   * Layers: default
@@ -2285,20 +2293,17 @@ Extra - asset_id: collision_camera_025
                   Flash Shift and Walljump (Beginner)
   > Door to Energy Recharge Station West (Upper)
       All of the following:
-          Speed Booster
+          Speed Booster and After Dairon - powergenerator_002
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
-          Any of the following:
-              Space Jump
-              Movement (Intermediate) and Walljump (Beginner)
+          Space Jump or Movement (Intermediate)
   > Door to Energy Recharge Station West (Lower)
       All of the following:
-          Morph Ball and After Dairon - Freezer Hidden Left Blob
+          Morph Ball and After Dairon - Freezer Hidden Left Blob and After Dairon - powergenerator_002
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
-          Speed Booster or Walljump (Beginner) or Simple IBJ or Use Spin Boost
   > Tile Group (SCREWATTACK)
       All of the following:
           Speed Booster

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -14285,6 +14285,13 @@
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
                     "connections": {
+                        "Pickup (Pulse Radar)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Tile Group (POWERBEAM) 1": {
                             "type": "and",
                             "data": {
@@ -14395,7 +14402,7 @@
                         ]
                     },
                     "connections": {
-                        "Pickup (Pulse Radar)": {
+                        "Start Point": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -2768,6 +2768,8 @@ Extra - asset_id: collision_camera_032
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_SonarObtained
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
+  > Pickup (Pulse Radar)
+      Trivial
   > Tile Group (POWERBEAM) 1
       Trivial
 
@@ -2801,7 +2803,7 @@ Extra - asset_id: collision_camera_032
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('WEIGHT',)
-  > Pickup (Pulse Radar)
+  > Start Point
       Trivial
 
 > Tile Group (WEIGHT) 2; Heals? False


### PR DESCRIPTION
Reverts the changes I made to Pulse Radar Room and adds the Power Switch 2 event to access the western doors in Dairon's Freezer.