### PR TITLE
Dread: Revise logic for the right half of Artaria EMMI Zone

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -2609,12 +2609,46 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "Movement",
-                                            "amount": 2,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Bomb",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -2595,29 +2595,17 @@
                             }
                         },
                         "Dock to Early Cloak Room (Water Blob)": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "and",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Lay Bomb"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Movement",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     },
                                     {
@@ -2844,11 +2832,20 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Early Cloak Room (Water Blob)": {
+                        "Next to Pickup": {
                             "type": "or",
                             "data": {
-                                "comment": null,
+                                "comment": "If this lock is unmoved, it can cause death if the room has been loaded",
                                 "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Knowledge",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
                                     {
                                         "type": "resource",
                                         "data": {
@@ -2856,61 +2853,6 @@
                                             "name": "ArtariaEmmiMagnetDoorLock",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Next to Pickup": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "events",
-                                                                    "name": "ArtariaEmmiMagnetDoorLock",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Knowledge",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Knowledge",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                }
-                                            ]
                                         }
                                     }
                                 ]
@@ -2991,15 +2933,6 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Walljump",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
                                                     "type": "template",
                                                     "data": "Shoot Ice Missile"
                                                 },
@@ -3071,46 +3004,12 @@
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Movement",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Walljump",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "Grapple",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -3237,7 +3136,7 @@
             }
         },
         "White EMMI Introduction": {
-            "default_node": "Warp from Entrance",
+            "default_node": "Start Point",
             "valid_starting_location": false,
             "extra": {
                 "total_boundings": {
@@ -3318,6 +3217,15 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -3372,29 +3280,38 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "or",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "events",
-                                                                    "name": "ArtariaCU",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "events",
-                                                                    "name": "ElunReleaseX",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "events",
+                                                        "name": "ArtariaCU",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SWJ",
+                                                        "amount": 2,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -3404,15 +3321,70 @@
                             }
                         },
                         "Door to EMMI Zone First Entrance": {
-                            "type": "resource",
+                            "type": "or",
                             "data": {
-                                "type": "events",
-                                "name": "ArtariaEmmiFirstChase",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spin Boost"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Flash",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Walljump",
+                                            "amount": 3,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         },
-                        "Door to EMMI Zone Spinner": {
+                        "Event - First Chase Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Diffusion or Wave"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Pseudo",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Start Point": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -3532,52 +3504,32 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Teleport to Dairon (Lower)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "ArtariaEmmiFirstChase",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Door to EMMI Zone Spinner": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Slide"
+                                        "data": "Use Spin Boost"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "events",
-                                            "name": "ArtariaEmmiFirstChase",
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Flash",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -3585,14 +3537,9 @@
                                 ]
                             }
                         },
-                        "Event - EMMI First Chase": {
-                            "type": "resource",
-                            "data": {
-                                "type": "events",
-                                "name": "ArtariaEmmiFirstChase",
-                                "amount": 1,
-                                "negate": true
-                            }
+                        "Start Point": {
+                            "type": "template",
+                            "data": "Can Slide"
                         }
                     }
                 },
@@ -3626,39 +3573,11 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Teleport to Dairon (Lower)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "events",
-                                "name": "s010_cave:default:PRP_DB_CV_002",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Door to EMMI Zone First Entrance": {
+                        "Start Point": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "ArtariaEmmiFirstChase",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }
@@ -3681,53 +3600,54 @@
                     },
                     "event_name": "s010_cave:default:PRP_DB_CV_002",
                     "connections": {
+                        "Start Point": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Start Point": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 3057.1,
+                        "y": -1613.78,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "connections": {
+                        "Door to Teleport to Dairon (Lower)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "s010_cave:default:PRP_DB_CV_002",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Door to EMMI Zone First Entrance": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
                         "Door to EMMI Zone Spinner": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
-                        }
-                    }
-                },
-                "Event - EMMI First Chase": {
-                    "node_type": "event",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 5651.44,
-                        "y": -1541.42,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "event_name": "ArtariaEmmiFirstChase",
-                    "connections": {
-                        "Warp from Entrance": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Warp from Entrance": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 3057.103372028745,
-                        "y": -1613.7783305693752,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "connections": {
+                        },
                         "Event - First Chase Blob": {
                             "type": "and",
                             "data": {
@@ -3807,7 +3727,7 @@
                                 "items": []
                             }
                         },
-                        "Teleporter to Dairon - Teleport to Artaria": {
+                        "Door to EMMI Zone Exit North (Upper)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -3848,14 +3768,14 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI First Chase End (DoorFrame_015)": {
+                        "Door to EMMI First Chase End (Middle)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Door to EMMI First Chase End (DoorFrame_016)": {
+                        "Door to EMMI First Chase End (Bottom)": {
                             "type": "template",
                             "data": "Can Slide"
                         }
@@ -3898,7 +3818,7 @@
                                 "items": []
                             }
                         },
-                        "Door to EMMI First Chase End (DoorPowerPower_001)": {
+                        "Door to EMMI First Chase End (Top)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3907,7 +3827,7 @@
                         }
                     }
                 },
-                "Dock to Arbitrary Enky Room (DoorEmmy06)": {
+                "Dock to Arbitrary Enky Room (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3933,7 +3853,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Arbitrary Enky Room (DoorEmmy07)": {
+                        "Dock to Arbitrary Enky Room (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3943,7 +3863,7 @@
                                         "data": {
                                             "type": "tricks",
                                             "name": "Movement",
-                                            "amount": 2,
+                                            "amount": 1,
                                             "negate": false
                                         }
                                     },
@@ -3959,7 +3879,7 @@
                                 ]
                             }
                         },
-                        "Door to EMMI First Chase End (DoorPowerPower_001)": {
+                        "Door to EMMI First Chase End (Top)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3967,34 +3887,12 @@
                             }
                         },
                         "Tunnel to EMMI Zone Exit North": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Ballspark"
                         }
                     }
                 },
-                "Dock to Arbitrary Enky Room (DoorEmmy07)": {
+                "Dock to Arbitrary Enky Room (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4020,7 +3918,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Arbitrary Enky Room (DoorEmmy06)": {
+                        "Dock to Arbitrary Enky Room (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4036,7 +3934,7 @@
                         }
                     }
                 },
-                "Door to EMMI First Chase End (DoorPowerPower_001)": {
+                "Door to EMMI First Chase End (Top)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4060,7 +3958,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "EMMI First Chase End",
-                        "node_name": "Door to Teleport to Dairon (DoorPowerPower_001)"
+                        "node_name": "Door to Teleport to Dairon (Top)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -4072,10 +3970,17 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Dock to Arbitrary Enky Room (Lower)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
-                "Door to EMMI First Chase End (DoorFrame_015)": {
+                "Door to EMMI First Chase End (Middle)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4099,7 +4004,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "EMMI First Chase End",
-                        "node_name": "Door to Teleport to Dairon (DoorFrame_015)"
+                        "node_name": "Door to Teleport to Dairon (Middle)"
                     },
                     "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
@@ -4114,7 +4019,7 @@
                         }
                     }
                 },
-                "Door to EMMI First Chase End (DoorFrame_016)": {
+                "Door to EMMI First Chase End (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4138,7 +4043,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "EMMI First Chase End",
-                        "node_name": "Door to Teleport to Dairon (DoorFrame_016)"
+                        "node_name": "Door to Teleport to Dairon (Bottom)"
                     },
                     "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
@@ -4247,7 +4152,7 @@
                         ]
                     },
                     "connections": {
-                        "Dock to Arbitrary Enky Room (DoorEmmy07)": {
+                        "Dock to Arbitrary Enky Room (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4325,7 +4230,7 @@
                         ]
                     },
                     "connections": {
-                        "Dock to Arbitrary Enky Room (DoorEmmy07)": {
+                        "Dock to Arbitrary Enky Room (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4432,13 +4337,11 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Arbitrary Enky Room (DoorEmmy07)": {
-                            "type": "resource",
+                        "Dock to Arbitrary Enky Room (Upper)": {
+                            "type": "and",
                             "data": {
-                                "type": "tricks",
-                                "name": "Movement",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -8131,12 +8034,12 @@
                 "asset_id": "collision_camera_015"
             },
             "nodes": {
-                "Door to White EMMI Arena (1)": {
+                "Door to White EMMI Arena (Power)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 2591.2315433473564,
-                        "y": -4032.7992246143695,
+                        "x": 2591.23,
+                        "y": -4032.8,
                         "z": 0.0
                     },
                     "description": "",
@@ -8155,13 +8058,13 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "White EMMI Arena",
-                        "node_name": "Door to EMMI Zone Spinner (1)"
+                        "node_name": "Door to EMMI Zone Spinner (Power)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to White EMMI Arena (DoorFrame_010)": {
+                        "Door to White EMMI Arena (Middle)": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -8170,13 +8073,42 @@
                                 "negate": false
                             }
                         },
-                        "Door to White EMMI Arena (DoorFrame_011)": {
-                            "type": "resource",
+                        "Door to White EMMI Arena (Top)": {
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "Space",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Tunnel to White EMMI Arena": {
@@ -8216,16 +8148,58 @@
                     "pickup_index": 5,
                     "major_location": false,
                     "connections": {
-                        "Door to White EMMI Arena (DoorFrame_011)": {
+                        "Door to White EMMI Arena (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Door to White EMMI Arena (Top)": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spin Boost"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Slide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Slide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
-                "Door to White EMMI Arena (DoorFrame_009)": {
+                "Door to White EMMI Arena (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8249,7 +8223,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "White EMMI Arena",
-                        "node_name": "Door to EMMI Zone Spinner (DoorFrame_009)"
+                        "node_name": "Door to EMMI Zone Spinner (Bottom)"
                     },
                     "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
@@ -8264,12 +8238,12 @@
                         }
                     }
                 },
-                "Door to White EMMI Arena (DoorFrame_010)": {
+                "Door to White EMMI Arena (Middle)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 2749.690670626083,
-                        "y": -3072.7233358079684,
+                        "x": 2749.69,
+                        "y": -3072.72,
                         "z": 0.0
                     },
                     "description": "",
@@ -8288,13 +8262,13 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "White EMMI Arena",
-                        "node_name": "Door to EMMI Zone Spinner (DoorFrame_010)"
+                        "node_name": "Door to EMMI Zone Spinner (Middle)"
                     },
                     "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to White EMMI Arena (1)": {
+                        "Door to White EMMI Arena (Power)": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -8305,12 +8279,12 @@
                         }
                     }
                 },
-                "Door to White EMMI Arena (DoorFrame_011)": {
+                "Door to White EMMI Arena (Top)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 2656.4794192856552,
-                        "y": -2173.234760372845,
+                        "x": 2656.48,
+                        "y": -2173.23,
                         "z": 0.0
                     },
                     "description": "",
@@ -8329,13 +8303,13 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "White EMMI Arena",
-                        "node_name": "Door to EMMI Zone Spinner (DoorFrame_011)"
+                        "node_name": "Door to EMMI Zone Spinner (Top)"
                     },
                     "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to White EMMI Arena (1)": {
+                        "Door to White EMMI Arena (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8343,12 +8317,29 @@
                             }
                         },
                         "Pickup (Missile Tank)": {
-                            "type": "resource",
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "Grapple",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Grapple",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "ArtariaEmmiSpinnerRotated",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Door to White EMMI Introduction": {
@@ -8431,7 +8422,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to White EMMI Arena (DoorFrame_011)": {
+                        "Door to White EMMI Arena (Top)": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -8479,16 +8470,66 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to White EMMI Arena (1)": {
-                            "type": "resource",
+                        "Door to White EMMI Arena (Power)": {
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "Space",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Simple IBJ"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         },
-                        "Door to White EMMI Arena (DoorFrame_009)": {
+                        "Door to White EMMI Arena (Bottom)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8512,7 +8553,7 @@
                     "extra": {},
                     "event_name": "ArtariaEmmiMagnetPlatformLowered",
                     "connections": {
-                        "Door to White EMMI Arena (1)": {
+                        "Door to White EMMI Arena (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8536,7 +8577,7 @@
                     "extra": {},
                     "event_name": "ArtariaEmmiSpinnerRotated",
                     "connections": {
-                        "Door to White EMMI Arena (DoorFrame_011)": {
+                        "Door to White EMMI Arena (Top)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9240,7 +9281,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Spinner (DoorFrame_010)": {
+                        "Door to EMMI Zone Spinner (Middle)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -9264,10 +9305,6 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
@@ -9275,31 +9312,26 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Flash",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Walljump",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -9369,6 +9401,32 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SWJ",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -9382,7 +9440,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone Spinner (1)": {
+                "Door to EMMI Zone Spinner (Power)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -9406,7 +9464,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "EMMI Zone Spinner",
-                        "node_name": "Door to White EMMI Arena (1)"
+                        "node_name": "Door to White EMMI Arena (Power)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -9451,14 +9509,14 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Spinner (DoorFrame_010)": {
+                        "Door to EMMI Zone Spinner (Middle)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Door to EMMI Zone Spinner (DoorFrame_011)": {
+                        "Door to EMMI Zone Spinner (Top)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -9505,6 +9563,32 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SWJ",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -9541,7 +9625,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Spinner (DoorFrame_009)": {
+                        "Door to EMMI Zone Spinner (Bottom)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9557,7 +9641,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone Spinner (DoorFrame_009)": {
+                "Door to EMMI Zone Spinner (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -9581,7 +9665,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "EMMI Zone Spinner",
-                        "node_name": "Door to White EMMI Arena (DoorFrame_009)"
+                        "node_name": "Door to White EMMI Arena (Bottom)"
                     },
                     "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
@@ -9596,7 +9680,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone Spinner (DoorFrame_010)": {
+                "Door to EMMI Zone Spinner (Middle)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -9620,7 +9704,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "EMMI Zone Spinner",
-                        "node_name": "Door to White EMMI Arena (DoorFrame_010)"
+                        "node_name": "Door to White EMMI Arena (Middle)"
                     },
                     "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
@@ -9642,7 +9726,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone Spinner (DoorFrame_011)": {
+                "Door to EMMI Zone Spinner (Top)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -9666,7 +9750,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "EMMI Zone Spinner",
-                        "node_name": "Door to White EMMI Arena (DoorFrame_011)"
+                        "node_name": "Door to White EMMI Arena (Top)"
                     },
                     "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
@@ -9705,7 +9789,7 @@
                                 "items": []
                             }
                         },
-                        "Door to EMMI Zone Spinner (1)": {
+                        "Door to EMMI Zone Spinner (Power)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -9805,6 +9889,15 @@
                                         "data": {
                                             "type": "items",
                                             "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Flash",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -15486,29 +15579,12 @@
                             }
                         },
                         "Tunnel to Central Unit": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "ArtariaCU",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "ArtariaEmmiFirstChase",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "type": "events",
+                                "name": "ArtariaCU",
+                                "amount": 1,
+                                "negate": true
                             }
                         }
                     }
@@ -16418,28 +16494,6 @@
                             }
                         }
                     }
-                },
-                "Tile Group (POWERBEAM)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 2300.0,
-                        "y": 1000.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_062",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {}
                 },
                 "Start Point": {
                     "node_type": "generic",
@@ -20896,7 +20950,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Teleport to Dairon",
-                        "node_name": "Dock to Arbitrary Enky Room (DoorEmmy06)"
+                        "node_name": "Dock to Arbitrary Enky Room (Lower)"
                     },
                     "default_dock_weakness": "EMMI Door",
                     "override_default_open_requirement": null,
@@ -20945,7 +20999,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Teleport to Dairon",
-                        "node_name": "Dock to Arbitrary Enky Room (DoorEmmy07)"
+                        "node_name": "Dock to Arbitrary Enky Room (Upper)"
                     },
                     "default_dock_weakness": "EMMI Door",
                     "override_default_open_requirement": null,
@@ -21366,7 +21420,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Teleport to Dairon (DoorFrame_016)": {
+                        "Door to Teleport to Dairon (Bottom)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -21377,7 +21431,7 @@
                         }
                     }
                 },
-                "Door to Teleport to Dairon (DoorPowerPower_001)": {
+                "Door to Teleport to Dairon (Top)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -21401,13 +21455,13 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Teleport to Dairon",
-                        "node_name": "Door to EMMI First Chase End (DoorPowerPower_001)"
+                        "node_name": "Door to EMMI First Chase End (Top)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Teleport to Dairon (DoorFrame_015)": {
+                        "Door to Teleport to Dairon (Middle)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -21419,13 +21473,57 @@
                                     {
                                         "type": "template",
                                         "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Flash",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SWJ",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
                         }
                     }
                 },
-                "Door to Teleport to Dairon (DoorFrame_015)": {
+                "Door to Teleport to Dairon (Middle)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -21449,13 +21547,13 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Teleport to Dairon",
-                        "node_name": "Door to EMMI First Chase End (DoorFrame_015)"
+                        "node_name": "Door to EMMI First Chase End (Middle)"
                     },
                     "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Teleport to Dairon (DoorPowerPower_001)": {
+                        "Door to Teleport to Dairon (Top)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -21472,11 +21570,76 @@
                                     {
                                         "type": "template",
                                         "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Flash",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SWJ",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
                         },
-                        "Door to Teleport to Dairon (DoorFrame_016)": {
+                        "Door to Teleport to Dairon (Bottom)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -21485,7 +21648,7 @@
                         }
                     }
                 },
-                "Door to Teleport to Dairon (DoorFrame_016)": {
+                "Door to Teleport to Dairon (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -21509,7 +21672,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Teleport to Dairon",
-                        "node_name": "Door to EMMI First Chase End (DoorFrame_016)"
+                        "node_name": "Door to EMMI First Chase End (Bottom)"
                     },
                     "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
@@ -21519,7 +21682,7 @@
                             "type": "template",
                             "data": "Can Slide"
                         },
-                        "Door to Teleport to Dairon (DoorFrame_015)": {
+                        "Door to Teleport to Dairon (Middle)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -21542,7 +21705,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Door to Teleport to Dairon (DoorFrame_015)": {
+                        "Door to Teleport to Dairon (Middle)": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -559,9 +559,7 @@ Extra - asset_id: collision_camera_005
   > Door to White EMMI Arena
       Trivial
   > Dock to Early Cloak Room (Water Blob)
-      Any of the following:
-          Movement (Intermediate)
-          Movement (Beginner) and Lay Bomb
+      Morph Ball and Movement (Intermediate)
 
 > Door to White EMMI Arena; Heals? False
   * Layers: default
@@ -612,11 +610,9 @@ Extra - asset_id: collision_camera_005
   * EMMI Door to Early Cloak Room/Dock to EMMI Zone First Entrance (DoorEmmy10_000)
   * Extra - actor_name: DoorEmmy10_000
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Dock to Early Cloak Room (Water Blob)
-      After Artaria - EMMI Magnet Door Lock
   > Next to Pickup
-      All of the following:
-          Knowledge (Beginner) and Use Spin Boost
+      Any of the following:
+          # If this lock is unmoved, it can cause death if the room has been loaded
           After Artaria - EMMI Magnet Door Lock or Knowledge (Intermediate)
 
 > Start Point; Heals? False; Spawn Point
@@ -629,16 +625,13 @@ Extra - asset_id: collision_camera_005
       Trivial
   > Tile Group (POWERBEAM)
       Any of the following:
-          Spider Magnet or Space Jump or Simple IBJ
+          Grapple Beam or Spider Magnet or Space Jump or Simple IBJ
           All of the following:
-              Stand on Frozen Enemy (Intermediate) and Walljump (Beginner) and Shoot Ice Missile
+              Stand on Frozen Enemy (Intermediate) and Shoot Ice Missile
               After Artaria - Central Unit or After Elun - Release X Parasites
           All of the following:
               Walljump (Beginner)
               Flash Shift or Use Spin Boost
-          All of the following:
-              Grapple Beam
-              Movement (Beginner) or Walljump (Beginner)
 
 > Tile Group (POWERBEAM); Heals? False
   * Layers: default
@@ -688,17 +681,19 @@ Extra - asset_id: collision_camera_006
   > Door to Teleport to Dairon (Thermal)
       Any of the following:
           # Spider ceiling wall here. Probably don't need an event for it.
-          Spider Magnet or Simple IBJ or Use Spin Boost
+          Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
   > Door to EMMI Zone Ballspark Hallway
       Any of the following:
           Flash Shift or Speed Booster or Simple IBJ or Use Spin Boost
           All of the following:
               # Enemy that you freeze only spawns after White EMMI is defeated.
-              Stand on Frozen Enemy (Beginner) and Shoot Ice Missile
-              After Artaria - Central Unit or After Elun - Release X Parasites
+              After Artaria - Central Unit and Stand on Frozen Enemy (Beginner) and Shoot Ice Missile
+          Morph Ball and Single-wall Wall Jump (Intermediate)
   > Door to EMMI Zone First Entrance
-      After Artaria - EMMI First Chase
-  > Door to EMMI Zone Spinner
+      Flash Shift or Speed Booster or Walljump (Advanced) or Simple IBJ or Use Spin Boost
+  > Event - First Chase Blob
+      Pseudo-Wave Beam (Intermediate) or Shoot Diffusion or Wave
+  > Start Point
       After Artaria - First Chase Blob
 
 > Door to Teleport to Dairon (Thermal); Heals? False
@@ -735,13 +730,9 @@ Extra - asset_id: collision_camera_006
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to Teleport to Dairon (Lower)
-      All of the following:
-          After Artaria - EMMI First Chase
-          Simple IBJ or Use Spin Boost
-  > Door to EMMI Zone Spinner
-      After Artaria - EMMI First Chase and Can Slide
-  > Event - EMMI First Chase
-      Before Artaria - EMMI First Chase
+      Flash Shift or Speed Booster or Simple IBJ or Use Spin Boost
+  > Start Point
+      Can Slide
 
 > Door to EMMI Zone Spinner; Heals? False
   * Layers: default
@@ -752,27 +743,25 @@ Extra - asset_id: collision_camera_006
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Teleport to Dairon (Lower)
-      After Artaria - First Chase Blob
-  > Door to EMMI Zone First Entrance
-      Morph Ball and After Artaria - EMMI First Chase
+  > Start Point
+      Trivial
 
 > Event - First Chase Blob; Heals? False
   * Layers: default
   * Event Artaria - First Chase Blob
   * Extra - actor_name: PRP_DB_CV_002
   * Extra - actor_def: actordef:actors/props/breakablecave002/charclasses/breakablecave002.bmsad
+  > Start Point
+      Trivial
+
+> Start Point; Heals? False; Spawn Point
+  * Layers: default
+  > Door to Teleport to Dairon (Lower)
+      After Artaria - First Chase Blob
+  > Door to EMMI Zone First Entrance
+      Morph Ball
   > Door to EMMI Zone Spinner
       Trivial
-
-> Event - EMMI First Chase; Heals? False
-  * Layers: default
-  * Event Artaria - EMMI First Chase
-  > Warp from Entrance
-      Trivial
-
-> Warp from Entrance; Heals? False; Spawn Point
-  * Layers: default
   > Event - First Chase Blob
       Trivial
 
@@ -793,7 +782,7 @@ Extra - asset_id: collision_camera_008
   * Extra - right_shield_def: None
   > Door to White EMMI Introduction (Thermal)
       Trivial
-  > Teleporter to Dairon - Teleport to Artaria
+  > Door to EMMI Zone Exit North (Upper)
       Wave Beam
 
 > Door to White EMMI Introduction (Lower); Heals? False
@@ -805,9 +794,9 @@ Extra - asset_id: collision_camera_008
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI First Chase End (DoorFrame_015)
+  > Door to EMMI First Chase End (Middle)
       Trivial
-  > Door to EMMI First Chase End (DoorFrame_016)
+  > Door to EMMI First Chase End (Bottom)
       Can Slide
 
 > Door to White EMMI Introduction (Thermal); Heals? False
@@ -821,34 +810,34 @@ Extra - asset_id: collision_camera_008
   * Extra - right_shield_def: None
   > Door to EMMI Zone Exit North (Bottom)
       Trivial
-  > Door to EMMI First Chase End (DoorPowerPower_001)
+  > Door to EMMI First Chase End (Top)
       Trivial
 
-> Dock to Arbitrary Enky Room (DoorEmmy06); Heals? False
+> Dock to Arbitrary Enky Room (Lower); Heals? False
   * Layers: default
   * EMMI Door to Arbitrary Enky Room/Dock to Teleport to Dairon (DoorEmmy06)
   * Extra - actor_name: DoorEmmy06
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Dock to Arbitrary Enky Room (DoorEmmy07)
-      Morph Ball and Movement (Intermediate)
-  > Door to EMMI First Chase End (DoorPowerPower_001)
+  > Dock to Arbitrary Enky Room (Upper)
+      Morph Ball and Movement (Beginner)
+  > Door to EMMI First Chase End (Top)
       Trivial
   > Tunnel to EMMI Zone Exit North
-      Morph Ball and Speed Booster
+      Ballspark
 
-> Dock to Arbitrary Enky Room (DoorEmmy07); Heals? False
+> Dock to Arbitrary Enky Room (Upper); Heals? False
   * Layers: default
   * EMMI Door to Arbitrary Enky Room/Dock to Teleport to Dairon (DoorEmmy07)
   * Extra - actor_name: DoorEmmy07
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Dock to Arbitrary Enky Room (DoorEmmy06)
+  > Dock to Arbitrary Enky Room (Lower)
       Trivial
   > Tile Group (BOMB MISSILE)
       Trivial
 
-> Door to EMMI First Chase End (DoorPowerPower_001); Heals? False
+> Door to EMMI First Chase End (Top); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI First Chase End/Door to Teleport to Dairon (DoorPowerPower_001)
+  * Power Beam Door to EMMI First Chase End/Door to Teleport to Dairon (Top)
   * Extra - actor_name: DoorPowerPower_001
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -857,10 +846,12 @@ Extra - asset_id: collision_camera_008
   * Extra - right_shield_def: None
   > Door to White EMMI Introduction (Thermal)
       Trivial
+  > Dock to Arbitrary Enky Room (Lower)
+      Trivial
 
-> Door to EMMI First Chase End (DoorFrame_015); Heals? False
+> Door to EMMI First Chase End (Middle); Heals? False
   * Layers: default
-  * Access Open to EMMI First Chase End/Door to Teleport to Dairon (DoorFrame_015)
+  * Access Open to EMMI First Chase End/Door to Teleport to Dairon (Middle)
   * Extra - actor_name: DoorFrame_015
   * Extra - actor_def: actordef:actors/props/doorframe/charclasses/doorframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -870,9 +861,9 @@ Extra - asset_id: collision_camera_008
   > Door to White EMMI Introduction (Lower)
       Trivial
 
-> Door to EMMI First Chase End (DoorFrame_016); Heals? False
+> Door to EMMI First Chase End (Bottom); Heals? False
   * Layers: default
-  * Access Open to EMMI First Chase End/Door to Teleport to Dairon (DoorFrame_016)
+  * Access Open to EMMI First Chase End/Door to Teleport to Dairon (Bottom)
   * Extra - actor_name: DoorFrame_016
   * Extra - actor_def: actordef:actors/props/doorframe/charclasses/doorframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -913,7 +904,7 @@ Extra - asset_id: collision_camera_008
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB', 'MISSILE')
-  > Dock to Arbitrary Enky Room (DoorEmmy07)
+  > Dock to Arbitrary Enky Room (Upper)
       Trivial
   > Tile Group (BOMB) 1
       Morph Ball
@@ -936,7 +927,7 @@ Extra - asset_id: collision_camera_008
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('WEIGHT',)
-  > Dock to Arbitrary Enky Room (DoorEmmy07)
+  > Dock to Arbitrary Enky Room (Upper)
       Trivial
 
 > Tile Group (BOMB) 2; Heals? False
@@ -960,8 +951,8 @@ Extra - asset_id: collision_camera_008
 > Tunnel to EMMI Zone Exit North; Heals? False
   * Layers: default
   * Morph Ball Tunnel to EMMI Zone Exit North/Tunnel to Teleport to Dairon
-  > Dock to Arbitrary Enky Room (DoorEmmy07)
-      Movement (Beginner)
+  > Dock to Arbitrary Enky Room (Upper)
+      Trivial
 
 ----------------
 EMMI Zone Exit North
@@ -1715,19 +1706,21 @@ EMMI Zone Spinner
 Extra - total_boundings: {'x1': 700.0, 'x2': 2800.0, 'y1': -6450.0, 'y2': -800.0}
 Extra - polygon: [[2800.0, -800.0], [700.0, -800.0], [700.0, -6450.0], [2800.0, -6450.0]]
 Extra - asset_id: collision_camera_015
-> Door to White EMMI Arena (1); Heals? False
+> Door to White EMMI Arena (Power); Heals? False
   * Layers: default
-  * Power Beam Door to White EMMI Arena/Door to EMMI Zone Spinner (1)
+  * Power Beam Door to White EMMI Arena/Door to EMMI Zone Spinner (Power)
   * Extra - actor_name: Door016 (PW-PW)
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to White EMMI Arena (DoorFrame_010)
+  > Door to White EMMI Arena (Middle)
       After Artaria - EMMI Magnet Platform Lowered
-  > Door to White EMMI Arena (DoorFrame_011)
-      Space Jump
+  > Door to White EMMI Arena (Top)
+      Any of the following:
+          Space Jump
+          Movement (Beginner) and Use Spin Boost
   > Tunnel to White EMMI Arena
       Trivial
   > Event - EMMI Magnet Platform Lowered
@@ -1738,12 +1731,16 @@ Extra - asset_id: collision_camera_015
   * Pickup 5; Major Location? False
   * Extra - actor_name: Item_MissileTank002
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Door to White EMMI Arena (DoorFrame_011)
+  > Door to White EMMI Arena (Power)
       Trivial
+  > Door to White EMMI Arena (Top)
+      Any of the following:
+          Lay Cross Comb or Use Spin Boost
+          Slide and Slide Jump (Beginner)
 
-> Door to White EMMI Arena (DoorFrame_009); Heals? False
+> Door to White EMMI Arena (Bottom); Heals? False
   * Layers: default
-  * Access Open to White EMMI Arena/Door to EMMI Zone Spinner (DoorFrame_009)
+  * Access Open to White EMMI Arena/Door to EMMI Zone Spinner (Bottom)
   * Extra - actor_name: DoorFrame_009
   * Extra - actor_def: actordef:actors/props/doorframe/charclasses/doorframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1753,31 +1750,31 @@ Extra - asset_id: collision_camera_015
   > Tunnel to White EMMI Arena
       Trivial
 
-> Door to White EMMI Arena (DoorFrame_010); Heals? False
+> Door to White EMMI Arena (Middle); Heals? False
   * Layers: default
-  * Access Open to White EMMI Arena/Door to EMMI Zone Spinner (DoorFrame_010)
+  * Access Open to White EMMI Arena/Door to EMMI Zone Spinner (Middle)
   * Extra - actor_name: DoorFrame_010
   * Extra - actor_def: actordef:actors/props/doorframe/charclasses/doorframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to White EMMI Arena (1)
+  > Door to White EMMI Arena (Power)
       After Artaria - EMMI Magnet Platform Lowered
 
-> Door to White EMMI Arena (DoorFrame_011); Heals? False
+> Door to White EMMI Arena (Top); Heals? False
   * Layers: default
-  * Access Open to White EMMI Arena/Door to EMMI Zone Spinner (DoorFrame_011)
+  * Access Open to White EMMI Arena/Door to EMMI Zone Spinner (Top)
   * Extra - actor_name: DoorFrame_011
   * Extra - actor_def: actordef:actors/props/doorframe/charclasses/doorframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to White EMMI Arena (1)
+  > Door to White EMMI Arena (Power)
       Trivial
   > Pickup (Missile Tank)
-      Grapple Beam
+      Grapple Beam or Before Artaria - EMMI Spinner Rotated
   > Door to White EMMI Introduction
       After Artaria - EMMI Spinner Rotated
 
@@ -1802,7 +1799,7 @@ Extra - asset_id: collision_camera_015
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to White EMMI Arena (DoorFrame_011)
+  > Door to White EMMI Arena (Top)
       After Artaria - EMMI Spinner Rotated
   > Door to Wide Beam Block Room
       Trivial
@@ -1812,21 +1809,25 @@ Extra - asset_id: collision_camera_015
 > Tunnel to White EMMI Arena; Heals? False
   * Layers: default
   * Slide Tunnel to White EMMI Arena/Tunnel to EMMI Zone Spinner
-  > Door to White EMMI Arena (1)
-      Space Jump
-  > Door to White EMMI Arena (DoorFrame_009)
+  > Door to White EMMI Arena (Power)
+      Any of the following:
+          Space Jump
+          All of the following:
+              Movement (Beginner) and Use Spin Boost
+              Speed Booster or Simple IBJ
+  > Door to White EMMI Arena (Bottom)
       Trivial
 
 > Event - EMMI Magnet Platform Lowered; Heals? False
   * Layers: default
   * Event Artaria - EMMI Magnet Platform Lowered
-  > Door to White EMMI Arena (1)
+  > Door to White EMMI Arena (Power)
       Trivial
 
 > Event - EMMI Spinner Rotated; Heals? False
   * Layers: default
   * Event Artaria - EMMI Spinner Rotated
-  > Door to White EMMI Arena (DoorFrame_011)
+  > Door to White EMMI Arena (Top)
       Trivial
 
 > Start Point; Heals? False; Spawn Point
@@ -1941,20 +1942,22 @@ Extra - asset_id: collision_camera_017
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Spinner (DoorFrame_010)
+  > Door to EMMI Zone Spinner (Middle)
       Any of the following:
           Space Jump or Speed Booster or Simple IBJ
-          Walljump (Beginner) and Use Spin Boost
-          Flash Shift and Walljump (Beginner)
+          All of the following:
+              Walljump (Beginner)
+              Flash Shift or Use Spin Boost
           All of the following:
               Stand on Frozen Enemy (Intermediate) and Walljump (Advanced) and Shoot Ice Missile
               After Artaria - Central Unit or After Elun - Release X Parasites
+          Morph Ball and Single-wall Wall Jump (Intermediate)
   > Start Point
       Trivial
 
-> Door to EMMI Zone Spinner (1); Heals? False
+> Door to EMMI Zone Spinner (Power); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone Spinner/Door to White EMMI Arena (1)
+  * Power Beam Door to EMMI Zone Spinner/Door to White EMMI Arena (Power)
   * Extra - actor_name: Door016 (PW-PW)
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1973,12 +1976,13 @@ Extra - asset_id: collision_camera_017
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Spinner (DoorFrame_010)
+  > Door to EMMI Zone Spinner (Middle)
       Trivial
-  > Door to EMMI Zone Spinner (DoorFrame_011)
+  > Door to EMMI Zone Spinner (Top)
       Any of the following:
           Speed Booster or Simple IBJ or Use Spin Boost
           Flash Shift and Walljump (Intermediate)
+          Morph Ball and Single-wall Wall Jump (Intermediate)
 
 > Door to Central Unit Access (Power); Heals? False
   * Layers: default
@@ -1989,14 +1993,14 @@ Extra - asset_id: collision_camera_017
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Spinner (DoorFrame_009)
+  > Door to EMMI Zone Spinner (Bottom)
       Trivial
   > Start Point
       Trivial
 
-> Door to EMMI Zone Spinner (DoorFrame_009); Heals? False
+> Door to EMMI Zone Spinner (Bottom); Heals? False
   * Layers: default
-  * Access Open to EMMI Zone Spinner/Door to White EMMI Arena (DoorFrame_009)
+  * Access Open to EMMI Zone Spinner/Door to White EMMI Arena (Bottom)
   * Extra - actor_name: DoorFrame_009
   * Extra - actor_def: actordef:actors/props/doorframe/charclasses/doorframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2006,9 +2010,9 @@ Extra - asset_id: collision_camera_017
   > Door to Central Unit Access (Power)
       Trivial
 
-> Door to EMMI Zone Spinner (DoorFrame_010); Heals? False
+> Door to EMMI Zone Spinner (Middle); Heals? False
   * Layers: default
-  * Access Open to EMMI Zone Spinner/Door to White EMMI Arena (DoorFrame_010)
+  * Access Open to EMMI Zone Spinner/Door to White EMMI Arena (Middle)
   * Extra - actor_name: DoorFrame_010
   * Extra - actor_def: actordef:actors/props/doorframe/charclasses/doorframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2020,9 +2024,9 @@ Extra - asset_id: collision_camera_017
   > Door to EMMI Zone First Entrance
       Trivial
 
-> Door to EMMI Zone Spinner (DoorFrame_011); Heals? False
+> Door to EMMI Zone Spinner (Top); Heals? False
   * Layers: default
-  * Access Open to EMMI Zone Spinner/Door to White EMMI Arena (DoorFrame_011)
+  * Access Open to EMMI Zone Spinner/Door to White EMMI Arena (Top)
   * Extra - actor_name: DoorFrame_011
   * Extra - actor_def: actordef:actors/props/doorframe/charclasses/doorframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2038,9 +2042,9 @@ Extra - asset_id: collision_camera_017
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to Central Unit Access (Charge)
       Trivial
-  > Door to EMMI Zone Spinner (1)
+  > Door to EMMI Zone Spinner (Power)
       Any of the following:
-          Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
+          Flash Shift or Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
           All of the following:
               Stand on Frozen Enemy (Beginner) and Shoot Ice Missile
               After Artaria - Central Unit or After Elun - Release X Parasites
@@ -3229,7 +3233,7 @@ Extra - asset_id: collision_camera_049
   > Door to White EMMI Arena (Top)
       Trivial
   > Tunnel to Central Unit
-      Before Artaria - Central Unit and After Artaria - EMMI First Chase
+      Before Artaria - Central Unit
 
 > Tunnel to Central Unit; Heals? False
   * Layers: default
@@ -3433,14 +3437,6 @@ Extra - asset_id: collision_camera_053
   * Extra - right_shield_def: None
   > Door to White EMMI Introduction
       Trivial
-
-> Tile Group (POWERBEAM); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_062
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
 
 > Start Point; Heals? False; Spawn Point
   * Layers: default
@@ -4458,7 +4454,7 @@ Extra - asset_id: collision_camera_070
 
 > Dock to Teleport to Dairon (DoorEmmy06); Heals? False
   * Layers: default
-  * EMMI Door to Teleport to Dairon/Dock to Arbitrary Enky Room (DoorEmmy06)
+  * EMMI Door to Teleport to Dairon/Dock to Arbitrary Enky Room (Lower)
   * Extra - actor_name: DoorEmmy06
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Total Recharge
@@ -4466,7 +4462,7 @@ Extra - asset_id: collision_camera_070
 
 > Dock to Teleport to Dairon (DoorEmmy07); Heals? False
   * Layers: default
-  * EMMI Door to Teleport to Dairon/Dock to Arbitrary Enky Room (DoorEmmy07)
+  * EMMI Door to Teleport to Dairon/Dock to Arbitrary Enky Room (Upper)
   * Extra - actor_name: DoorEmmy07
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to Navigation Station North (Upper)
@@ -4544,38 +4540,43 @@ Extra - asset_id: collision_camera_071
   * EMMI Door to Invisible Corpius Room/Dock to EMMI First Chase End
   * Extra - actor_name: DoorEmmy08
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Door to Teleport to Dairon (DoorFrame_016)
+  > Door to Teleport to Dairon (Bottom)
       Morph Ball
 
-> Door to Teleport to Dairon (DoorPowerPower_001); Heals? False
+> Door to Teleport to Dairon (Top); Heals? False
   * Layers: default
-  * Power Beam Door to Teleport to Dairon/Door to EMMI First Chase End (DoorPowerPower_001)
+  * Power Beam Door to Teleport to Dairon/Door to EMMI First Chase End (Top)
   * Extra - actor_name: DoorPowerPower_001
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Teleport to Dairon (DoorFrame_015)
-      Simple IBJ or Use Spin Boost
+  > Door to Teleport to Dairon (Middle)
+      Any of the following:
+          Flash Shift or Speed Booster or Simple IBJ or Use Spin Boost
+          Morph Ball and Single-wall Wall Jump (Intermediate)
 
-> Door to Teleport to Dairon (DoorFrame_015); Heals? False
+> Door to Teleport to Dairon (Middle); Heals? False
   * Layers: default
-  * Access Open to Teleport to Dairon/Door to EMMI First Chase End (DoorFrame_015)
+  * Access Open to Teleport to Dairon/Door to EMMI First Chase End (Middle)
   * Extra - actor_name: DoorFrame_015
   * Extra - actor_def: actordef:actors/props/doorframe/charclasses/doorframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Teleport to Dairon (DoorPowerPower_001)
-      Space Jump or Simple IBJ
-  > Door to Teleport to Dairon (DoorFrame_016)
+  > Door to Teleport to Dairon (Top)
+      Any of the following:
+          Flash Shift or Space Jump or Speed Booster or Simple IBJ
+          Walljump (Beginner) and Use Spin Boost
+          Morph Ball and Single-wall Wall Jump (Intermediate)
+  > Door to Teleport to Dairon (Bottom)
       Trivial
 
-> Door to Teleport to Dairon (DoorFrame_016); Heals? False
+> Door to Teleport to Dairon (Bottom); Heals? False
   * Layers: default
-  * Access Open to Teleport to Dairon/Door to EMMI First Chase End (DoorFrame_016)
+  * Access Open to Teleport to Dairon/Door to EMMI First Chase End (Bottom)
   * Extra - actor_name: DoorFrame_016
   * Extra - actor_def: actordef:actors/props/doorframe/charclasses/doorframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -4584,12 +4585,12 @@ Extra - asset_id: collision_camera_071
   * Extra - right_shield_def: None
   > Dock to Invisible Corpius Room
       Can Slide
-  > Door to Teleport to Dairon (DoorFrame_015)
+  > Door to Teleport to Dairon (Middle)
       Trivial
 
 > Start Point; Heals? False; Spawn Point
   * Layers: default
-  > Door to Teleport to Dairon (DoorFrame_015)
+  > Door to Teleport to Dairon (Middle)
       Trivial
 
 ----------------

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -559,7 +559,11 @@ Extra - asset_id: collision_camera_005
   > Door to White EMMI Arena
       Trivial
   > Dock to Early Cloak Room (Water Blob)
-      Morph Ball and Movement (Intermediate)
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Movement (Intermediate)
+              Bomb and Movement (Beginner)
 
 > Door to White EMMI Arena; Heals? False
   * Layers: default

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -814,10 +814,6 @@
                 "long_name": "Artaria - EMMI Single Use Slide",
                 "extra": {}
             },
-            "ArtariaEmmiFirstChase": {
-                "long_name": "Artaria - EMMI First Chase",
-                "extra": {}
-            },
             "ArtariaProtoCU": {
                 "long_name": "Artaria - Proto Central Unit",
                 "extra": {}


### PR DESCRIPTION
This adds various method of getting around the rooms on the right half of the Artaria EMMI Zone. This includes:
- EMMI Zone Entrance Hallway
- EMMI Zone First Entrance
- White EMMI Introduction
- EMMI Zone Spinner
- White EMMI Arena
- Central Unit Access
- Central Unit
- EMMI Zone Ballspark Hallway
- Teleport to Dairon
- EMMI Zone First Chase End
- EMMI Zone Exit North

fixes #3548 