### PR TITLE
Dread: Add Misc. Resource for Door Lock Rando

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -1039,8 +1039,37 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Slide"
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Slide"
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Open Charge Door"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "DoorLocks",
+                                                                                "amount": 1,
+                                                                                "negate": true
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -1242,6 +1271,32 @@
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        },
+                        "Near Missile Tank 1": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "DoorLocks",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -3045,6 +3100,32 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "DoorLocks",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -3278,12 +3359,29 @@
                                         "data": "Simple IBJ"
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "DoorLocks",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -8827,6 +8925,32 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -10809,6 +10933,15 @@
                                                             {
                                                                 "type": "template",
                                                                 "data": "Open Charge Door"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
                                                             }
                                                         ]
                                                     }
@@ -11441,6 +11574,15 @@
                                                                                 "name": "Movement",
                                                                                 "amount": 1,
                                                                                 "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "DoorLocks",
+                                                                                "amount": 1,
+                                                                                "negate": true
                                                                             }
                                                                         }
                                                                     ]
@@ -21606,15 +21748,6 @@
                                         "data": "Simple IBJ"
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "and",
                                         "data": {
                                             "comment": null,
@@ -21665,6 +21798,32 @@
                                                         "name": "SWJ",
                                                         "amount": 2,
                                                         "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "DoorLocks",
+                                                        "amount": 1,
+                                                        "negate": true
                                                     }
                                                 }
                                             ]
@@ -22761,12 +22920,29 @@
                                         "data": "Simple IBJ"
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "DoorLocks",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -23593,12 +23769,46 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Movement",
-                                                        "amount": 2,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Morph",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "Avoid being pushed through the cloak door",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Movement",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "DoorLocks",
+                                                                                "amount": 1,
+                                                                                "negate": true
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -241,7 +241,11 @@ Extra - asset_id: collision_camera_002
   > Door to Navigation Station South
       Any of the following:
           Simple IBJ or Use Spin Boost
-          Speed Booster and Can Slide
+          All of the following:
+              Speed Booster
+              Any of the following:
+                  Can Slide
+                  Disabled Door Lock Randomizer and Open Charge Door
   > Tunnel to Melee Tutorial Room
       Trivial
 
@@ -287,6 +291,8 @@ Extra - asset_id: collision_camera_003
       Trivial
   > West of Blob
       Trivial
+  > Near Missile Tank 1
+      Speed Booster and Disabled Door Lock Randomizer
 
 > Door to Early Cloak Room; Heals? False
   * Layers: default
@@ -636,6 +642,7 @@ Extra - asset_id: collision_camera_005
           All of the following:
               Walljump (Beginner)
               Flash Shift or Use Spin Boost
+          Speed Booster and Disabled Door Lock Randomizer
 
 > Tile Group (POWERBEAM); Heals? False
   * Layers: default
@@ -688,7 +695,8 @@ Extra - asset_id: collision_camera_006
           Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
   > Door to EMMI Zone Ballspark Hallway
       Any of the following:
-          Flash Shift or Speed Booster or Simple IBJ or Use Spin Boost
+          Flash Shift or Simple IBJ or Use Spin Boost
+          Speed Booster and Disabled Door Lock Randomizer
           All of the following:
               # Enemy that you freeze only spawns after White EMMI is defeated.
               After Artaria - Central Unit and Stand on Frozen Enemy (Beginner) and Shoot Ice Missile
@@ -1873,6 +1881,7 @@ Extra - asset_id: collision_camera_016
           Any of the following:
               Flash Shift or Use Spin Boost
               After Elun - Release X Parasites and Stand on Frozen Enemy (Intermediate) and Shoot Ice Missile
+              Speed Booster and Disabled Door Lock Randomizer
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -2255,7 +2264,7 @@ Extra - asset_id: collision_camera_022
           Morph Ball
           Any of the following:
               Simple IBJ
-              Speed Booster and Open Charge Door
+              Speed Booster and Disabled Door Lock Randomizer and Open Charge Door
               Movement (Intermediate) and Use Spin Boost
 
 > Door to Thermal Device; Heals? False
@@ -2386,7 +2395,7 @@ Extra - asset_id: collision_camera_023_B
                   Heat/Cold Runs (Intermediate) and Heat Damage ≥ 200
               Any of the following:
                   Spider Magnet or Space Jump
-                  Speed Booster and Movement (Beginner) and Open Charge Door
+                  Speed Booster and Movement (Beginner) and Disabled Door Lock Randomizer and Open Charge Door
                   Grapple Beam and Movement (Intermediate)
 
 > Pickup (Missile Tank); Heals? False
@@ -4572,9 +4581,10 @@ Extra - asset_id: collision_camera_071
   * Extra - right_shield_def: None
   > Door to Teleport to Dairon (Top)
       Any of the following:
-          Flash Shift or Space Jump or Speed Booster or Simple IBJ
+          Flash Shift or Space Jump or Simple IBJ
           Walljump (Beginner) and Use Spin Boost
           Morph Ball and Single-wall Wall Jump (Intermediate)
+          Speed Booster and Disabled Door Lock Randomizer
   > Door to Teleport to Dairon (Bottom)
       Trivial
 
@@ -4830,8 +4840,9 @@ Extra - asset_id: collision_camera_077
   * Extra - right_shield_def: None
   > Elevator to Cataris - Transport to Artaria
       Any of the following:
-          Spider Magnet or Space Jump or Speed Booster or Walljump (Beginner) or Simple IBJ
+          Spider Magnet or Space Jump or Walljump (Beginner) or Simple IBJ
           Grapple Beam and Movement (Beginner)
+          Speed Booster and Disabled Door Lock Randomizer
 
 > Elevator to Cataris - Transport to Artaria; Heals? False; Spawn Point
   * Layers: default
@@ -4942,7 +4953,13 @@ Extra - asset_id: collision_camera_079
           Spider Magnet or Simple IBJ or Use Spin Boost
           Morph Ball and Damage Boost (Beginner)
           Missiles ≥ 2 and Stand on Frozen Enemy (Beginner) and Shoot Ice Missile
-          Speed Booster and Movement (Intermediate)
+          All of the following:
+              Speed Booster
+              Any of the following:
+                  Morph Ball
+                  All of the following:
+                      # Avoid being pushed through the cloak door
+                      Movement (Intermediate) and Disabled Door Lock Randomizer
           All of the following:
               Flash Shift
               Grapple Beam or Walljump (Beginner)

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -514,21 +514,38 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
                                                     "type": "template",
                                                     "data": "Use Spin Boost"
                                                 },
                                                 {
                                                     "type": "template",
                                                     "data": "Perform WBJ"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -628,6 +645,15 @@
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Movement",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
                                                                             "type": "and",
                                                                             "data": {
                                                                                 "comment": null,
@@ -635,46 +661,28 @@
                                                                                     {
                                                                                         "type": "resource",
                                                                                         "data": {
-                                                                                            "type": "tricks",
-                                                                                            "name": "Movement",
-                                                                                            "amount": 2,
+                                                                                            "type": "items",
+                                                                                            "name": "Speed",
+                                                                                            "amount": 1,
                                                                                             "negate": false
                                                                                         }
                                                                                     },
                                                                                     {
                                                                                         "type": "resource",
                                                                                         "data": {
-                                                                                            "type": "tricks",
-                                                                                            "name": "Walljump",
+                                                                                            "type": "misc",
+                                                                                            "name": "DoorLocks",
                                                                                             "amount": 1,
-                                                                                            "negate": false
+                                                                                            "negate": true
                                                                                         }
                                                                                     }
                                                                                 ]
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Movement",
-                                                                                "amount": 3,
-                                                                                "negate": false
                                                                             }
                                                                         }
                                                                     ]
                                                                 }
                                                             }
                                                         ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -1380,6 +1388,15 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "DoorLocks",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
                                     }
                                 ]
                             }
@@ -2053,6 +2070,54 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Slide"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Speedbooster",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "GhavoranRobotFight",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "DoorLocks",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -2223,13 +2288,8 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Ballspark"
                                     },
                                     {
                                         "type": "and",
@@ -3146,12 +3206,29 @@
                                         "data": "Use Spin Boost"
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "DoorLocks",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -3855,12 +3932,29 @@
                                                     "data": "Simple IBJ"
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
@@ -4137,6 +4231,15 @@
                                             "amount": 3,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "DoorLocks",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
                                     }
                                 ]
                             }
@@ -4350,6 +4453,15 @@
                                                         "amount": 3,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "DoorLocks",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
                                                 }
                                             ]
                                         }
@@ -4482,6 +4594,15 @@
                                                                 "data": "Lay Power Bomb"
                                                             }
                                                         ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "DoorLocks",
+                                                        "amount": 1,
+                                                        "negate": true
                                                     }
                                                 }
                                             ]
@@ -7698,8 +7819,25 @@
                                                                                 "comment": null,
                                                                                 "items": [
                                                                                     {
-                                                                                        "type": "template",
-                                                                                        "data": "Shoot Plasma Beam"
+                                                                                        "type": "and",
+                                                                                        "data": {
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "template",
+                                                                                                    "data": "Shoot Plasma Beam"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "misc",
+                                                                                                        "name": "DoorLocks",
+                                                                                                        "amount": 1,
+                                                                                                        "negate": true
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
                                                                                     },
                                                                                     {
                                                                                         "type": "resource",
@@ -7873,8 +8011,25 @@
                                                                             }
                                                                         },
                                                                         {
-                                                                            "type": "template",
-                                                                            "data": "Shoot Plasma Beam"
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Shoot Plasma Beam"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "misc",
+                                                                                            "name": "DoorLocks",
+                                                                                            "amount": 1,
+                                                                                            "negate": true
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
                                                                         }
                                                                     ]
                                                                 }
@@ -7937,8 +8092,25 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "template",
-                                                                "data": "Shoot Plasma Beam"
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Shoot Plasma Beam"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "DoorLocks",
+                                                                                "amount": 1,
+                                                                                "negate": true
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
                                                             }
                                                         ]
                                                     }
@@ -11005,6 +11177,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -12946,7 +13127,7 @@
                         "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
-                                "comment": "Temporary until door rando support",
+                                "comment": "Item logically unattainable if Door Lock Rando is enabled",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -12964,6 +13145,15 @@
                                             "name": "Grapple",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "DoorLocks",
+                                            "amount": 1,
+                                            "negate": true
                                         }
                                     }
                                 ]
@@ -15504,6 +15694,36 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Super Missile"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -15779,6 +15999,15 @@
                                             "name": "SSC",
                                             "amount": 4,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "DoorLocks",
+                                            "amount": 1,
+                                            "negate": true
                                         }
                                     }
                                 ]

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -112,18 +112,20 @@ Extra - asset_id: collision_camera_001
   > Tile Group (MISSILE)
       All of the following:
           Morph Ball
-          Gravity Suit or Speed Booster or Perform WBJ or Use Spin Boost
+          Any of the following:
+              Gravity Suit or Perform WBJ or Use Spin Boost
+              Speed Booster and Disabled Door Lock Randomizer
   > Grapple Block Alcove
       All of the following:
           Morph Ball and Before Ghavoran - Burenia Transport Grapple Box
           Any of the following:
-              Spider Magnet or Space Jump or Speed Booster
+              Spider Magnet or Space Jump
               Spin Boost and Movement (Beginner)
               All of the following:
                   Grapple Beam
                   Any of the following:
-                      Movement (Advanced)
-                      Movement (Intermediate) and Walljump (Beginner)
+                      Movement (Intermediate)
+                      Speed Booster and Disabled Door Lock Randomizer
 
 > Total Recharge; Heals? True
   * Layers: default
@@ -262,7 +264,7 @@ Extra - asset_id: collision_camera_003
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Dock to Blue EMMI Introduction
-      Speed Booster and After Ghavoran - Gold Robot Fight
+      Speed Booster and After Ghavoran - Gold Robot Fight and Disabled Door Lock Randomizer
   > Tile Group (BOMB)
       Can Slide
   > Floating Platform
@@ -380,6 +382,7 @@ Extra - asset_id: collision_camera_004
           All of the following:
               Walljump (Beginner)
               Flash Shift or Use Spin Boost
+          Speed Booster and After Ghavoran - Gold Robot Fight and Speedbooster Conservation (Intermediate) and Disabled Door Lock Randomizer and Can Slide
 
 > Door to EMMI Zone Exit Southeast; Heals? False
   * Layers: default
@@ -415,7 +418,7 @@ Extra - asset_id: collision_camera_004
   * Layers: default
   > Door to EMMI Zone Exit Southeast
       Any of the following:
-          Spider Magnet or Space Jump or Speed Booster or Simple IBJ
+          Spider Magnet or Space Jump or Ballspark or Simple IBJ
           Grapple Beam and Movement (Beginner)
           All of the following:
               Walljump (Beginner)
@@ -618,7 +621,9 @@ Extra - asset_id: collision_camera_008
   > Event - Breakable (grapplepulloff1x2_002)
       Grapple Beam
   > Tunnel to Super Missile Room Access
-      Speed Booster or Simple IBJ or Use Spin Boost
+      Any of the following:
+          Simple IBJ or Use Spin Boost
+          Speed Booster and Disabled Door Lock Randomizer
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -768,7 +773,8 @@ Extra - asset_id: collision_camera_010
       All of the following:
           Morph Ball
           Any of the following:
-              Speed Booster or Simple IBJ or Use Spin Boost
+              Simple IBJ or Use Spin Boost
+              Speed Booster and Disabled Door Lock Randomizer
               Flash Shift and Walljump (Beginner)
 
 > Door to Super Missile Room Access (Missile Lock); Heals? False
@@ -829,7 +835,7 @@ Extra - asset_id: collision_camera_011
   > Dock to EMMI Zone Exit West
       All of the following:
           # If you start in the room direclty below this one, you can carry a speed boost all the way to here
-          Morph Ball and Speed Booster and Speedbooster Conservation (Advanced) and Shoot Plasma Beam
+          Morph Ball and Speed Booster and Speedbooster Conservation (Advanced) and Disabled Door Lock Randomizer and Shoot Plasma Beam
 
 > Dock to Map Station Access (Lower); Heals? False
   * Layers: default
@@ -849,7 +855,7 @@ Extra - asset_id: collision_camera_011
               Bomb and Morph Ball and Infinite Bomb Jump (Intermediate)
           All of the following:
               # If you start in the room directly below this one, you can carry a speed boost all the way here
-              Morph Ball and Speed Booster and Speedbooster Conservation (Advanced) and Shoot Plasma Beam
+              Morph Ball and Speed Booster and Speedbooster Conservation (Advanced) and Disabled Door Lock Randomizer and Shoot Plasma Beam
 
 > Dock to Map Station Access (Upper); Heals? False
   * Layers: default
@@ -864,7 +870,7 @@ Extra - asset_id: collision_camera_011
           Slide and Slide Jump (Beginner)
           All of the following:
               # The boost must be charged from the map room
-              Speed Booster
+              Speed Booster and Disabled Door Lock Randomizer
               Lay Bomb or Lay Power Bomb
 
 > Dock to EMMI Zone Exit West; Heals? False
@@ -1489,7 +1495,9 @@ Extra - asset_id: collision_camera_021
                   Simple IBJ or Use Spin Boost
                   All of the following:
                       Speed Booster
-                      After Ghavoran - Super Missile Rotatable Enky or Shoot Plasma Beam
+                      Any of the following:
+                          After Ghavoran - Super Missile Rotatable Enky
+                          Disabled Door Lock Randomizer and Shoot Plasma Beam
                   Flash Shift and Spider Magnet
                   Spider Magnet and Slide and Slide Jump (Beginner) and Walljump (Beginner)
   > Tile Group (MISSILE)
@@ -1499,7 +1507,9 @@ Extra - asset_id: collision_camera_021
               Flash Shift or Spider Magnet or Simple IBJ or Use Spin Boost
               All of the following:
                   Speed Booster
-                  After Ghavoran - Super Missile Rotatable Enky or Shoot Plasma Beam
+                  Any of the following:
+                      After Ghavoran - Super Missile Rotatable Enky
+                      Disabled Door Lock Randomizer and Shoot Plasma Beam
   > Dock to Flipper Room
       Trivial
   > Upper Center Platform
@@ -1507,7 +1517,9 @@ Extra - asset_id: collision_camera_021
           Simple IBJ or Use Spin Boost
           All of the following:
               Speed Booster
-              After Ghavoran - Super Missile Rotatable Enky or Shoot Plasma Beam
+              Any of the following:
+                  After Ghavoran - Super Missile Rotatable Enky
+                  Disabled Door Lock Randomizer and Shoot Plasma Beam
 
 > Pickup (Power Bomb Tank); Heals? False
   * Layers: default
@@ -2126,7 +2138,7 @@ Extra - asset_id: collision_camera_025_B
           Grapple Beam or Spider Magnet or Space Jump or Speed Booster or Walljump (Beginner) or Simple IBJ
   > Door to Teleport to Burenia (Power Beam)
       Any of the following:
-          Use Spin Boost
+          Speed Booster or Use Spin Boost
           Infinite Bomb Jump (Intermediate) and Lay Bomb
 
 > Door to Teleport to Burenia (Missile); Heals? False
@@ -2519,8 +2531,8 @@ blast shields
       Trivial
   > Pickup (Missile Tank)
       All of the following:
-          # Temporary until door rando support
-          Grapple Beam and Speed Booster
+          # Item logically unattainable if Door Lock Rando is enabled
+          Grapple Beam and Speed Booster and Disabled Door Lock Randomizer
 
 ----------------
 Spin Boost Room
@@ -3037,6 +3049,7 @@ Extra - asset_id: collision_camera_035
           Any of the following:
               Grapple Beam or Single-wall Wall Jump (Beginner) or Simple IBJ or Use Spin Boost
               Flash Shift and Walljump (Beginner)
+              Speed Booster and Disabled Door Lock Randomizer and Shoot Super Missile
 
 > Tunnel to Super Missile Room Access; Heals? False
   * Layers: default
@@ -3083,7 +3096,7 @@ Extra - asset_id: collision_camera_036
   > Tunnel to Golzuna Arena
       Morph Ball
   > Dock to Golzuna Arena
-      Shinesink Clip (Expert) and Can SSC
+      Shinesink Clip (Expert) and Disabled Door Lock Randomizer and Can SSC
 
 > Door to Cross Bomb Tutorial; Heals? False
   * Layers: default

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1154,6 +1154,10 @@
             "SeparateBeams": {
                 "long_name": "Separate Beam Behaviors",
                 "extra": {}
+            },
+            "DoorLocks": {
+                "long_name": "Door Lock Randomizer",
+                "extra": {}
             }
         },
         "requirement_template": {


### PR DESCRIPTION
This adds the misc resource for door lock randomizer, and adds it being disabled as a requirement for all multi-room speedboosts that use doors and in rooms that have already been revised.