### PR TITLE
Improve Item Pool tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed: The multi-pickup placement, using the new weighting, is now the default mode. The old behavior has been removed.
 - Changed: Error messages when a permalink is incompatible have been improved with more details.
-- Changed: The Customize Preset dialog now creates each tab as you click then. This means the dialog is now faster to first open, but there's a short delay when opening certain tabs. 
+- Changed: The Customize Preset dialog now creates each tab as you click then. This means the dialog is now faster to first open, but there's a short delay when opening certain tabs.
+- Changed: Progressive items now have their proper count as the simplified shuffled option.
 - Fixed: Exceptions when exporting a game now use the improved error dialog.
 - Fixed: Gracefully handle unsupported old versions of the preferences file.
+- Fixed: Excluding all copies of a progressive item, or the non-progressive equivalent, no longer hides them from the editor.
 
 ### Cave Story
 

--- a/randovania/games/dread/item_database/item-database.json
+++ b/randovania/games/dread/item_database/item-database.json
@@ -257,7 +257,7 @@
             "progression": [
                 "Supers"
             ],
-            "default_shuffled_count": 0,
+            "default_shuffled_count": 1,
             "default_starting_count": 0,
             "ammo": [],
             "unlocks_ammo": false,
@@ -275,7 +275,7 @@
             "progression": [
                 "Ice"
             ],
-            "default_shuffled_count": 0,
+            "default_shuffled_count": 1,
             "default_starting_count": 0,
             "ammo": [],
             "unlocks_ammo": false,
@@ -382,7 +382,7 @@
             "progression": [
                 "Varia"
             ],
-            "default_shuffled_count": 0,
+            "default_shuffled_count": 1,
             "default_starting_count": 0,
             "ammo": [],
             "unlocks_ammo": false,
@@ -399,7 +399,7 @@
             "progression": [
                 "Gravity"
             ],
-            "default_shuffled_count": 0,
+            "default_shuffled_count": 1,
             "default_starting_count": 0,
             "ammo": [],
             "unlocks_ammo": false,
@@ -488,7 +488,7 @@
                 "Bomb",
                 "Cross"
             ],
-            "default_shuffled_count": 0,
+            "default_shuffled_count": 2,
             "default_starting_count": 0,
             "ammo": [],
             "unlocks_ammo": false,

--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -33,8 +33,7 @@ from randovania.resolver.exceptions import InvalidConfiguration
 _EXPECTED_COUNT_TEXT_TEMPLATE_EXACT = (
     "For a total of {total} from this source."
     "\n{from_items} will be provided from other sources."
-    "\n{maximum} is the maximum you can have at once.\n"
-    "\nResources from sources like this are only considered by logic when using 'multi-pickup placement'."
+    "\n{maximum} is the maximum you can have at once."
 )
 
 
@@ -398,17 +397,17 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
     def _create_progressive_widgets(self, item_database: ItemDatabase):
         self._progressive_widgets = []
 
-        all_progressive = self.game.gui.progressive_item_gui_tuples
+        all_progressive = list(self.game.gui.progressive_item_gui_tuples)
 
         layouts_with_lines: set[tuple[Foldable, QtWidgets.QGridLayout]] = {
             self._boxes_for_category[item_database.major_items[progressive_item_name].item_category.name][:2]
-            for (progressive_item_name, non_progressive_items) in all_progressive
+            for progressive_item_name, non_progressive_items in all_progressive
         }
 
         for box, layout in layouts_with_lines:
             layout.addWidget(_create_separator(box), layout.rowCount(), 0, 1, -1)
 
-        for (progressive_item_name, non_progressive_items) in all_progressive:
+        for progressive_item_name, non_progressive_items in all_progressive:
             progressive_item = item_database.major_items[progressive_item_name]
             parent, layout, _ = self._boxes_for_category[progressive_item.item_category.name]
 

--- a/randovania/gui/preset_settings/progressive_item_widget.py
+++ b/randovania/gui/preset_settings/progressive_item_widget.py
@@ -32,6 +32,10 @@ class ProgressiveItemWidget(QtWidgets.QCheckBox):
         has_non_progressive = any(_state_has_item(major_configuration.items_state[item])
                                   for item in self.non_progressive_items)
 
+        if not has_progressive and not has_non_progressive:
+            has_progressive = self.isChecked()
+            has_non_progressive = not has_progressive
+
         if has_non_progressive:
             new_state = Qt.PartiallyChecked if has_progressive else Qt.Unchecked
         else:

--- a/randovania/gui/ui_files/item_configuration_popup.ui
+++ b/randovania/gui/ui_files/item_configuration_popup.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>880</width>
-    <height>122</height>
+    <height>88</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -25,7 +25,7 @@
   <property name="windowTitle">
    <string>Item Configuration</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2">
+  <layout class="QGridLayout" name="root_layout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -38,27 +38,10 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0" colspan="5">
-    <widget class="Line" name="separator_line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="4">
-    <widget class="QLabel" name="warning_label">
+   <item row="3" column="2">
+    <widget class="QLabel" name="priority_label">
      <property name="text">
-      <string/>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="vanilla_check">
-     <property name="text">
-      <string>In Vanilla</string>
+      <string>Priority for placement</string>
      </property>
     </widget>
    </item>
@@ -72,7 +55,6 @@
      </property>
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -87,12 +69,6 @@
       <string>As starting</string>
      </property>
     </widget>
-   </item>
-   <item row="1" column="4">
-    <widget class="ScrollProtectedComboBox" name="state_case_combo"/>
-   </item>
-   <item row="1" column="3">
-    <widget class="ScrollProtectedSpinBox" name="provided_ammo_spinbox"/>
    </item>
    <item row="1" column="1" colspan="2">
     <widget class="QLabel" name="provided_ammo_label">
@@ -110,6 +86,13 @@
      </property>
     </widget>
    </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="vanilla_check">
+     <property name="text">
+      <string>In Vanilla</string>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="4">
     <widget class="ScrollProtectedSpinBox" name="shuffled_spinbox">
      <property name="suffix">
@@ -123,15 +106,21 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="0" colspan="5">
+    <widget class="Line" name="separator_line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="3">
     <widget class="ScrollProtectedComboBox" name="priority_combo"/>
    </item>
-   <item row="3" column="2">
-    <widget class="QLabel" name="priority_label">
-     <property name="text">
-      <string>Priority for placement</string>
-     </property>
-    </widget>
+   <item row="1" column="4">
+    <widget class="ScrollProtectedComboBox" name="state_case_combo"/>
+   </item>
+   <item row="1" column="3">
+    <widget class="ScrollProtectedSpinBox" name="provided_ammo_spinbox"/>
    </item>
   </layout>
  </widget>

--- a/randovania/layout/base/major_item_state.py
+++ b/randovania/layout/base/major_item_state.py
@@ -8,7 +8,6 @@ from randovania.bitpacking import bitpacking
 from randovania.bitpacking.bitpacking import BitPackDecoder
 from randovania.game_description import default_database
 from randovania.game_description.item.major_item import MajorItem
-from randovania.lib import enum_lib
 
 ENERGY_TANK_MAXIMUM_COUNT = 16
 DEFAULT_MAXIMUM_SHUFFLED = (2, 10, 99)
@@ -84,31 +83,6 @@ class MajorItemState:
             if ammo > db.get_item(ammo_index).max_capacity:
                 raise ValueError(
                     f"Including more than maximum capacity for ammo {ammo_index}. Included: {ammo}; Max: {db.get_item(ammo_index).max_capacity}")
-
-    @classmethod
-    def from_case(cls, case: MajorItemStateCase, included_ammo: tuple[int, ...]) -> MajorItemState | None:
-        if case == MajorItemStateCase.MISSING:
-            return MajorItemState(included_ammo=included_ammo)
-
-        elif case == MajorItemStateCase.VANILLA:
-            return MajorItemState(include_copy_in_original_location=True, included_ammo=included_ammo)
-
-        elif case == MajorItemStateCase.STARTING_ITEM:
-            return MajorItemState(num_included_in_starting_items=1, included_ammo=included_ammo)
-
-        elif case == MajorItemStateCase.SHUFFLED:
-            return MajorItemState(num_shuffled_pickups=1, included_ammo=included_ammo)
-
-        else:
-            return None
-
-    @property
-    def case(self) -> MajorItemStateCase:
-        for case in enum_lib.iterate_enum(MajorItemStateCase):
-            if self == MajorItemState.from_case(case, self.included_ammo):
-                return case
-
-        return MajorItemStateCase.CUSTOM
 
     @property
     def as_json(self) -> dict:


### PR DESCRIPTION
- Only create warning label for items that has it
- Handle warning label for items that must be starting
- Use custom shuffled count for simplified cases for progressive items
- Fix excluding all pickups of a progressive/non-progressive set
- Remove mention of multi-pickup for expansions