### PR TITLE
Dread: Begin Burenia Logic Revision

### DIFF
--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -2327,12 +2327,29 @@
                                         "data": "Simple IBJ"
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Grapple",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "GrappleMovement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -2363,6 +2380,15 @@
                                                                 "data": {
                                                                     "type": "items",
                                                                     "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Grapple",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
@@ -2939,7 +2965,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Movement",
+                                                        "name": "GrappleMovement",
                                                         "amount": 3,
                                                         "negate": false
                                                     }

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -215,7 +215,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Navigation Station North": {
+                        "Start Point": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -256,15 +256,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Burenia Hub to Dairon": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
                         "Door to Map Station": {
                             "type": "and",
                             "data": {
@@ -426,6 +417,10 @@
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
                     "connections": {
+                        "Door to Burenia Hub to Dairon": {
+                            "type": "template",
+                            "data": "Can Slide"
+                        },
                         "Door to Navigation Station North": {
                             "type": "and",
                             "data": {
@@ -2254,55 +2249,15 @@
                         "area_name": "Underneath Drogyga",
                         "node_name": "Tunnel to Drogyga Eyedoor (Upper)"
                     },
-                    "default_dock_weakness": "Morph Ball Tunnel",
+                    "default_dock_weakness": "Slide Tunnel",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Center Platform": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Grapple",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Walljump",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Ice Missile"
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }
@@ -2395,9 +2350,34 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
@@ -2406,6 +2386,10 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
                                                 }
                                             ]
                                         }
@@ -2493,7 +2477,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Pull Grapple Block (grapplepulloff1x2_004)": {
+                        "Event - Ghavoran Transport Grapple Block": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -2567,9 +2551,21 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Elevator Blob (db_reg_aq_008)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Elevator Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Elevator to Ghavoran - Transport to Burenia": {
                             "type": "resource",
@@ -2589,7 +2585,7 @@
                         }
                     }
                 },
-                "Event - Elevator Blob (db_reg_aq_008)": {
+                "Event - Elevator Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -2616,7 +2612,7 @@
                         }
                     }
                 },
-                "Event - Recharge Blob from left (db_reg_aq_011)": {
+                "Event - Recharge Blob from Left": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -2643,7 +2639,7 @@
                         }
                     }
                 },
-                "Event - Pull Grapple Block (grapplepulloff1x2_004)": {
+                "Event - Ghavoran Transport Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -2706,7 +2702,7 @@
                                 "negate": false
                             }
                         },
-                        "Event - Elevator Blob (db_reg_aq_008)": {
+                        "Event - Elevator Blob": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         }
@@ -2759,7 +2755,7 @@
                                 "items": []
                             }
                         },
-                        "Event - Recharge Blob from right (db_reg_aq_011)": {
+                        "Event - Recharge Blob from Right": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -2807,50 +2803,6 @@
                             }
                         }
                     }
-                },
-                "Tile Group (WEIGHT) 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 1200.0,
-                        "y": 10500.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_004",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {}
-                },
-                "Tile Group (WEIGHT) 2": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 1900.0,
-                        "y": 11400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_032",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {}
                 },
                 "Tunnel to Underneath Drogyga (Upper)": {
                     "node_type": "dock",
@@ -2920,6 +2872,10 @@
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Simple IBJ"
                                                             }
                                                         ]
                                                     }
@@ -2947,14 +2903,96 @@
                                                         "comment": null,
                                                         "items": [
                                                             {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Magnet",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
                                                                 "type": "template",
                                                                 "data": "Simple IBJ"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s040_aqua:default:db_reg_aq_011",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Slide"
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
-                                                                    "name": "Grapple",
+                                                                    "name": "Magnet",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
@@ -2964,13 +3002,55 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Cross Comb"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Bomb",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "IBJ",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
                         },
-                        "Event - Recharge Blob from left (db_reg_aq_011)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Recharge Blob from Left": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Energy Recharge": {
                             "type": "and",
@@ -3019,7 +3099,7 @@
                         "area_name": "Underneath Drogyga",
                         "node_name": "Tunnel to Transport to Ghavoran (Lower)"
                     },
-                    "default_dock_weakness": "Morph Ball Tunnel",
+                    "default_dock_weakness": "Slide Tunnel",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -3090,7 +3170,7 @@
                         }
                     }
                 },
-                "Event - Recharge Blob from right (db_reg_aq_011)": {
+                "Event - Recharge Blob from Right": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -3206,72 +3286,50 @@
                     "major_location": false,
                     "connections": {
                         "Water Bottom": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT) 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -599.5999755859375,
-                        "y": 10100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_002",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Left of Grapple Blocks": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT) 2": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -800.0,
-                        "y": 8900.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_035",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Water Bottom": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Perform WBJ"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "Drogyga",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -3299,12 +3357,9 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (WEIGHT) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                        "Left of Grapple Blocks": {
+                            "type": "template",
+                            "data": "Can Slide"
                         }
                     }
                 },
@@ -3353,6 +3408,49 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Gravity",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "Drogyga",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -3389,13 +3487,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (WEIGHT) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Left of Grapple Blocks": {
                             "type": "or",
                             "data": {
@@ -3430,6 +3521,13 @@
                                     }
                                 ]
                             }
+                        },
+                        "Water Bottom": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -3452,18 +3550,13 @@
                         "area_name": "Drogyga Eyedoor",
                         "node_name": "Tunnel to Underneath Drogyga (Upper)"
                     },
-                    "default_dock_weakness": "Morph Ball Tunnel",
+                    "default_dock_weakness": "Slide Tunnel",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Tunnel to Transport to Ghavoran (Lower)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
+                            "type": "template",
+                            "data": "Can Slide"
                         }
                     }
                 },
@@ -3518,18 +3611,13 @@
                         "area_name": "Transport to Ghavoran",
                         "node_name": "Tunnel to Underneath Drogyga (Lower)"
                     },
-                    "default_dock_weakness": "Morph Ball Tunnel",
+                    "default_dock_weakness": "Slide Tunnel",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Tunnel to Drogyga Eyedoor (Upper)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
+                            "type": "template",
+                            "data": "Can Slide"
                         }
                     }
                 },
@@ -3578,11 +3666,15 @@
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "WBJ",
+                                                        "type": "events",
+                                                        "name": "Drogyga",
                                                         "amount": 1,
-                                                        "negate": false
+                                                        "negate": true
                                                     }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Perform WBJ"
                                                 }
                                             ]
                                         }
@@ -3610,12 +3702,29 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Gravity",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "Drogyga",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
@@ -3639,6 +3748,15 @@
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             }
                                                         ]
                                                     }
@@ -3652,13 +3770,8 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "WBJ",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Perform WBJ"
                                                 },
                                                 {
                                                     "type": "or",
@@ -3679,6 +3792,15 @@
                                                                 "data": "Lay Cross Comb"
                                                             }
                                                         ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "Drogyga",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -3854,7 +3976,7 @@
                                 "items": []
                             }
                         },
-                        "Event - Pull Grapple Block (grapplepulloff1x2_001)": {
+                        "Event - Ferenia Teleport Grapple Block": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -3950,6 +4072,126 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Carry it from the Map Station, or alternatively from the suction enemy below",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "events",
+                                                                                "name": "s040_aqua:default:grapplepulloff1x2_001",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Morph",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Speedbooster",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Knowledge",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "You can stand on the edge of a flash gate without it closing",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Lay Cross Comb"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -3986,7 +4228,7 @@
                         }
                     }
                 },
-                "Event - Blob to Teleport (db_reg_aq_009)": {
+                "Event - Ferenia Teleport Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -4013,7 +4255,7 @@
                         }
                     }
                 },
-                "Event - Pull Grapple Block (grapplepulloff1x2_001)": {
+                "Event - Ferenia Teleport Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -4233,6 +4475,13 @@
                         ]
                     },
                     "connections": {
+                        "Door to Drogyga Eyedoor": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Tile Group (WEIGHT) 2": {
                             "type": "resource",
                             "data": {
@@ -4243,28 +4492,6 @@
                             }
                         }
                     }
-                },
-                "Tile Group (WEIGHT) 3": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -6500.0,
-                        "y": 8100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_030",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {}
                 },
                 "Tile Group (WEIGHT) 4": {
                     "node_type": "generic",
@@ -4363,18 +4590,120 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Ice",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Ice Missile"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "FrozenEnemy",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Use the suction enemy above to build the speed, or come from the Navigation Station",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Knowledge",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Slide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Slide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Diagonal WBJ",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Perform WBJ"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "WBJ",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
                             }
                         },
-                        "Event - Blob to Teleport (db_reg_aq_009)": {
+                        "Event - Ferenia Teleport Blob": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -13967,33 +14296,36 @@
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
                     "connections": {
-                        "After Fight": {
+                        "Event - Drogyga": {
                             "type": "and",
                             "data": {
-                                "comment": "TODO: Flesh out fight requirements",
+                                "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Methods of fighting; beam damage does not damage the core, even plasma and wave",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Missile"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Charge Beam"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Activate the switches",
                                             "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Magnetless",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -14015,41 +14347,63 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Gravityless",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Grapple",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Magnet",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Flash",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Space",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
                                     }
                                 ]
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT)": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -1800.0,
-                        "y": 11400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_031",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Before Fight": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }
@@ -14077,7 +14431,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (WEIGHT)": {
+                        "Before Fight": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14086,12 +14440,12 @@
                         }
                     }
                 },
-                "After Fight": {
-                    "node_type": "generic",
+                "Event - Drogyga": {
+                    "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": -147.1279373368145,
-                        "y": 10401.283724978242,
+                        "x": -147.13,
+                        "y": 10401.28,
                         "z": 0.0
                     },
                     "description": "",
@@ -14099,6 +14453,7 @@
                         "default"
                     ],
                     "extra": {},
+                    "event_name": "Drogyga",
                     "connections": {
                         "Pickup (Drogyga)": {
                             "type": "and",
@@ -14225,7 +14580,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Pull Grapple Block": {
+                        "Event - Drogyga Access Grapple Block": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -14262,7 +14617,7 @@
                         }
                     }
                 },
-                "Event - Pull Grapple Block": {
+                "Event - Drogyga Access Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -14311,34 +14666,7 @@
                     "default_dock_weakness": "Open Passage",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
-                    "connections": {
-                        "Door to Drogyga Eyedoor": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s040_aqua:default:grapplepulloff1x2_006",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
+                    "connections": {}
                 }
             }
         },

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -480,10 +480,11 @@ Extra - asset_id: collision_camera_005
   * Layers: default
   > Door to Drogyga Access
       Any of the following:
-          Grapple Beam or Space Jump or Simple IBJ
+          Space Jump or Simple IBJ
+          Grapple Beam and Grapple Movement (Beginner)
           All of the following:
               Spider Magnet
-              Flash Shift or Use Spin Boost
+              Flash Shift or Grapple Beam or Use Spin Boost
           Flash Shift and Use Spin Boost
   > Tunnel to Underneath Drogyga (Upper)
       Trivial
@@ -590,7 +591,7 @@ Extra - asset_id: collision_camera_006
           All of the following:
               Flash Shift
               Spider Magnet or Simple IBJ
-          Grapple Beam and Movement (Advanced)
+          Grapple Beam and Grapple Movement (Advanced)
           All of the following:
               Speed Booster and After Burenia - Recharge Blob and Can Slide
               Flash Shift or Spider Magnet

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -53,7 +53,7 @@ Extra - asset_id: collision_camera_001
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Navigation Station North
+  > Start Point
       Morph Ball
 
 > Door to Navigation Station North; Heals? False
@@ -65,8 +65,6 @@ Extra - asset_id: collision_camera_001
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Burenia Hub to Dairon
-      Morph Ball
   > Door to Map Station
       Morph Ball and After Quiet Robe
   > Start Point
@@ -98,6 +96,8 @@ Extra - asset_id: collision_camera_001
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_DoorProfessor
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
+  > Door to Burenia Hub to Dairon
+      Can Slide
   > Door to Navigation Station North
       Trivial
 
@@ -466,9 +466,9 @@ Extra - asset_id: collision_camera_005
 
 > Tunnel to Underneath Drogyga (Upper); Heals? False
   * Layers: default
-  * Morph Ball Tunnel to Underneath Drogyga/Tunnel to Drogyga Eyedoor (Upper)
+  * Slide Tunnel to Underneath Drogyga/Tunnel to Drogyga Eyedoor (Upper)
   > Center Platform
-      Grapple Beam or Morph Ball or Walljump (Beginner) or Shoot Ice Missile or Simple IBJ or Use Spin Boost
+      Trivial
 
 > Tunnel to Underneath Drogyga (Lower); Heals? False
   * Layers: default
@@ -481,7 +481,10 @@ Extra - asset_id: collision_camera_005
   > Door to Drogyga Access
       Any of the following:
           Grapple Beam or Space Jump or Simple IBJ
-          Flash Shift and Spider Magnet and Use Spin Boost
+          All of the following:
+              Spider Magnet
+              Flash Shift or Use Spin Boost
+          Flash Shift and Use Spin Boost
   > Tunnel to Underneath Drogyga (Upper)
       Trivial
 
@@ -499,12 +502,12 @@ Extra - asset_id: collision_camera_006
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Event - Pull Grapple Block (grapplepulloff1x2_004)
+  > Event - Ghavoran Transport Grapple Block
       Grapple Beam
   > Tunnel to Underneath Drogyga (Lower)
       Trivial
   > Tunnel to Upper Burenia Hub
-      Morph Ball and After Burenia - grapplepulloff1x2_004
+      Morph Ball and After Burenia - Ghavoran Transport Grapple Block
 
 > Door to Save Station North; Heals? False
   * Layers: default
@@ -515,32 +518,32 @@ Extra - asset_id: collision_camera_006
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Event - Elevator Blob (db_reg_aq_008)
-      Shoot Beam
+  > Event - Elevator Blob
+      Lay Bomb or Shoot Beam
   > Elevator to Ghavoran - Transport to Burenia
-      After Burenia - db_reg_aq_008
+      After Burenia - Elevator Blob
   > Tunnel to Underneath Drogyga (Upper)
       Trivial
 
-> Event - Elevator Blob (db_reg_aq_008); Heals? False
+> Event - Elevator Blob; Heals? False
   * Layers: default
-  * Event Burenia - db_reg_aq_008
+  * Event Burenia - Elevator Blob
   * Extra - actor_name: db_reg_aq_008
   * Extra - actor_def: actordef:actors/props/db_reg_aq_008/charclasses/db_reg_aq_008.bmsad
   > Door to Save Station North
       Trivial
 
-> Event - Recharge Blob from left (db_reg_aq_011); Heals? False
+> Event - Recharge Blob from Left; Heals? False
   * Layers: default
-  * Event Burenia - db_reg_aq_011
+  * Event Burenia - Recharge Blob
   * Extra - actor_name: db_reg_aq_011
   * Extra - actor_def: actordef:actors/props/db_reg_aq_010/charclasses/db_reg_aq_010.bmsad
   > Tunnel to Underneath Drogyga (Upper)
       Trivial
 
-> Event - Pull Grapple Block (grapplepulloff1x2_004); Heals? False
+> Event - Ghavoran Transport Grapple Block; Heals? False
   * Layers: default
-  * Event Burenia - grapplepulloff1x2_004
+  * Event Burenia - Ghavoran Transport Grapple Block
   * Extra - actor_name: grapplepulloff1x2_004
   * Extra - actor_def: actordef:actors/props/grapplepulloff1x2/charclasses/grapplepulloff1x2.bmsad
   > Door to Underneath Drogyga
@@ -556,8 +559,8 @@ Extra - asset_id: collision_camera_006
   * Extra - start_point_actor_name: elevator_forest_000_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad
   > Door to Save Station North
-      After Burenia - db_reg_aq_008
-  > Event - Elevator Blob (db_reg_aq_008)
+      After Burenia - Elevator Blob
+  > Event - Elevator Blob
       Shoot Diffusion or Wave
 
 > Energy Recharge; Heals? True
@@ -567,27 +570,13 @@ Extra - asset_id: collision_camera_006
   * Extra - start_point_actor_name: energyrecharge_000_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_energy/charclasses/weightactivatedplatform_energy.bmsad
   > Tunnel to Underneath Drogyga (Upper)
-      After Burenia - db_reg_aq_011 and Can Slide
+      After Burenia - Recharge Blob and Can Slide
   > Tunnel to Underneath Drogyga (Lower)
       Trivial
-  > Event - Recharge Blob from right (db_reg_aq_011)
+  > Event - Recharge Blob from Right
       Any of the following:
           Wave Beam or Pseudo-Wave Beam (Intermediate)
           Pseudo-Wave Beam (Beginner) and Shoot Diffusion Beam
-
-> Tile Group (WEIGHT) 1; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_004
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-
-> Tile Group (WEIGHT) 2; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_032
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
 
 > Tunnel to Underneath Drogyga (Upper); Heals? False
   * Layers: default
@@ -597,18 +586,23 @@ Extra - asset_id: collision_camera_006
           Space Jump
           All of the following:
               Spider Magnet
-              Grapple Beam or Use Spin Boost
+              Grapple Beam or Simple IBJ or Use Spin Boost
           All of the following:
               Flash Shift
-              Grapple Beam or Simple IBJ
-  > Event - Recharge Blob from left (db_reg_aq_011)
-      Shoot Beam
+              Spider Magnet or Simple IBJ
+          Grapple Beam and Movement (Advanced)
+          All of the following:
+              Speed Booster and After Burenia - Recharge Blob and Can Slide
+              Flash Shift or Spider Magnet
+          Bomb and Infinite Bomb Jump (Advanced) and Lay Cross Comb
+  > Event - Recharge Blob from Left
+      Lay Bomb or Shoot Beam
   > Energy Recharge
-      Morph Ball and After Burenia - db_reg_aq_011
+      Morph Ball and After Burenia - Recharge Blob
 
 > Tunnel to Underneath Drogyga (Lower); Heals? False
   * Layers: default
-  * Morph Ball Tunnel to Underneath Drogyga/Tunnel to Transport to Ghavoran (Lower)
+  * Slide Tunnel to Underneath Drogyga/Tunnel to Transport to Ghavoran (Lower)
   > Door to Underneath Drogyga
       Trivial
   > Energy Recharge
@@ -618,11 +612,11 @@ Extra - asset_id: collision_camera_006
   * Layers: default
   * Morph Ball Tunnel to Upper Burenia Hub/Tunnel to Transport to Ghavoran
   > Door to Underneath Drogyga
-      Morph Ball and After Burenia - grapplepulloff1x2_004
+      Morph Ball and After Burenia - Ghavoran Transport Grapple Block
 
-> Event - Recharge Blob from right (db_reg_aq_011); Heals? False
+> Event - Recharge Blob from Right; Heals? False
   * Layers: default
-  * Event Burenia - db_reg_aq_011
+  * Event Burenia - Recharge Blob
   > Energy Recharge
       Trivial
 
@@ -649,52 +643,40 @@ Extra - asset_id: collision_camera_007
   * Extra - actor_name: item_missiletank_000
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Water Bottom
-      Morph Ball
-
-> Tile Group (WEIGHT) 1; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_002
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Left of Grapple Blocks
-      Trivial
-
-> Tile Group (WEIGHT) 2; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_035
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Water Bottom
-      Trivial
+      All of the following:
+          Morph Ball
+          Gravity Suit or Before Drogyga or Perform WBJ
 
 > Dock to Drogyga Arena; Heals? False
   * Layers: default
   * Open Passage to Drogyga Arena/Dock to Underneath Drogyga
-  > Tile Group (WEIGHT) 1
-      Trivial
+  > Left of Grapple Blocks
+      Can Slide
 
 > Left of Grapple Blocks; Heals? False
   * Layers: default
   > Tunnel to Transport to Ghavoran (Upper)
-      Flash Shift or Grapple Beam or Space Jump
+      Any of the following:
+          Flash Shift or Grapple Beam or Space Jump
+          All of the following:
+              Speed Booster
+              Gravity Suit or Before Drogyga
   > Water Bottom
       Trivial
 
 > Tunnel to Transport to Ghavoran (Upper); Heals? False
   * Layers: default
   * Morph Ball Tunnel to Transport to Ghavoran/Tunnel to Underneath Drogyga (Upper)
-  > Tile Group (WEIGHT) 2
-      Trivial
   > Left of Grapple Blocks
       Flash Shift or Grapple Beam or Space Jump
+  > Water Bottom
+      Trivial
 
 > Tunnel to Drogyga Eyedoor (Upper); Heals? False
   * Layers: default
-  * Morph Ball Tunnel to Drogyga Eyedoor/Tunnel to Underneath Drogyga (Upper)
+  * Slide Tunnel to Drogyga Eyedoor/Tunnel to Underneath Drogyga (Upper)
   > Tunnel to Transport to Ghavoran (Lower)
-      Morph Ball
+      Can Slide
 
 > Tunnel to Drogyga Eyedoor (Lower); Heals? False
   * Layers: default
@@ -704,24 +686,24 @@ Extra - asset_id: collision_camera_007
 
 > Tunnel to Transport to Ghavoran (Lower); Heals? False
   * Layers: default
-  * Morph Ball Tunnel to Transport to Ghavoran/Tunnel to Underneath Drogyga (Lower)
+  * Slide Tunnel to Transport to Ghavoran/Tunnel to Underneath Drogyga (Lower)
   > Tunnel to Drogyga Eyedoor (Upper)
-      Morph Ball
+      Can Slide
 
 > Water Bottom; Heals? False
   * Layers: default
   > Pickup (Missile Tank)
       All of the following:
           Morph Ball
-          Gravity Suit or Water Bomb Jump (Beginner)
+          Gravity Suit or Before Drogyga or Perform WBJ
   > Left of Grapple Blocks
       Any of the following:
           Grapple Beam
           All of the following:
-              Gravity Suit
-              Spider Magnet or Simple IBJ or Use Spin Boost
+              Gravity Suit or Before Drogyga
+              Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
           All of the following:
-              Water Bomb Jump (Beginner)
+              After Drogyga and Perform WBJ
               Spider Magnet or Lay Cross Comb
 
 ----------------
@@ -767,10 +749,10 @@ Extra - asset_id: collision_camera_008
   * Extra - right_shield_def: None
   > Door to Drogyga Eyedoor
       Trivial
-  > Event - Pull Grapple Block (grapplepulloff1x2_001)
+  > Event - Ferenia Teleport Grapple Block
       Grapple Beam
   > Ammo Recharge Alcove
-      Morph Ball and After Burenia - grapplepulloff1x2_001
+      Morph Ball and After Burenia - Ferenia Teleport Grapple Block
 
 > Door to Drogyga Eyedoor; Heals? False
   * Layers: default
@@ -784,7 +766,18 @@ Extra - asset_id: collision_camera_008
   > Door to Map Station
       Trivial
   > Tile Group (MISSILE)
-      Flash Shift or Space Jump
+      Any of the following:
+          Flash Shift or Space Jump
+          All of the following:
+              # Carry it from the Map Station, or alternatively from the suction enemy below
+              Speed Booster
+              Any of the following:
+                  Disabled Door Lock Randomizer
+                  Morph Ball and After Burenia - Ferenia Teleport Grapple Block and Knowledge (Beginner) and Speedbooster Conservation (Intermediate)
+          All of the following:
+              # You can stand on the edge of a flash gate without it closing
+              Knowledge (Beginner)
+              Movement (Beginner) or Lay Cross Comb or Use Spin Boost
 
 > Pickup (Missile+ Tank); Heals? False
   * Layers: default
@@ -794,17 +787,17 @@ Extra - asset_id: collision_camera_008
   > Tile Group (WEIGHT) 1
       Morph Ball
 
-> Event - Blob to Teleport (db_reg_aq_009); Heals? False
+> Event - Ferenia Teleport Blob; Heals? False
   * Layers: default
-  * Event Burenia - db_reg_aq_009
+  * Event Burenia - Ferenia Teleport Blob
   * Extra - actor_name: db_reg_aq_009
   * Extra - actor_def: actordef:actors/props/db_reg_aq_009/charclasses/db_reg_aq_009.bmsad
   > Lower Left Ledge
       Trivial
 
-> Event - Pull Grapple Block (grapplepulloff1x2_001); Heals? False
+> Event - Ferenia Teleport Grapple Block; Heals? False
   * Layers: default
-  * Event Burenia - grapplepulloff1x2_001
+  * Event Burenia - Ferenia Teleport Grapple Block
   * Extra - actor_name: grapplepulloff1x2_001
   * Extra - actor_def: actordef:actors/props/grapplepulloff1x2/charclasses/grapplepulloff1x2.bmsad
   > Door to Map Station
@@ -870,15 +863,10 @@ Extra - asset_id: collision_camera_008
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('MISSILE',)
+  > Door to Drogyga Eyedoor
+      Trivial
   > Tile Group (WEIGHT) 2
       Morph Ball
-
-> Tile Group (WEIGHT) 3; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_030
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
 
 > Tile Group (WEIGHT) 4; Heals? False
   * Layers: default
@@ -894,13 +882,23 @@ Extra - asset_id: collision_camera_008
   > Door to Navigation Station North
       Trivial
   > Door to Main Hub Tower Top
-      Flash Shift or Grapple Beam or Gravity Suit or Ice Missile or Spider Magnet or Use Spin Boost
-  > Event - Blob to Teleport (db_reg_aq_009)
+      Any of the following:
+          Flash Shift or Grapple Beam or Gravity Suit or Spider Magnet or Use Spin Boost
+          Stand on Frozen Enemy (Beginner) and Shoot Ice Missile
+          All of the following:
+              # Use the suction enemy above to build the speed, or come from the Navigation Station
+              Speed Booster
+              Knowledge (Beginner) or Disabled Door Lock Randomizer
+          Slide and Slide Jump (Beginner)
+          All of the following:
+              # Diagonal WBJ
+              Water Bomb Jump (Intermediate) and Perform WBJ
+  > Event - Ferenia Teleport Blob
       Shoot Diffusion or Wave
   > Tile Group (BOMB)
       After Burenia - Storm Missile Gate for Teleport
   > Event - Storm Missile Gate
-      After Burenia - db_reg_aq_009 and Activate Storm Missile Locks
+      After Burenia - Ferenia Teleport Blob and Activate Storm Missile Locks
 
 > Event - Storm Missile Gate; Heals? False
   * Layers: default
@@ -913,7 +911,7 @@ Extra - asset_id: collision_camera_008
   > Door to Navigation Station North
       Can Slide
   > Door to Map Station
-      Morph Ball and After Burenia - grapplepulloff1x2_001
+      Morph Ball and After Burenia - Ferenia Teleport Grapple Block
   > Ammo Recharge
       Trivial
 
@@ -2850,31 +2848,30 @@ Extra - asset_id: collision_camera_028
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Hydrogiga_Dead
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > After Fight
+  > Event - Drogyga
       All of the following:
-          # TODO: Flesh out fight requirements
-          Shoot Beam
           Any of the following:
-              Grapple Beam
-              Gravity Suit and Space Jump
-
-> Tile Group (WEIGHT); Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_031
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Before Fight
-      Trivial
+              # Methods of fighting; beam damage does not damage the core, even plasma and wave
+              Shoot Charge Beam or Shoot Missile
+          Any of the following:
+              # Activate the switches
+              All of the following:
+                  # Magnetless
+                  Gravity Suit and Space Jump
+              All of the following:
+                  # Gravityless
+                  Grapple Beam
+                  Flash Shift or Spider Magnet or Space Jump
 
 > Dock to Drogyga Access; Heals? False
   * Layers: default
   * Open Passage to Drogyga Access/Dock to Drogyga Arena
-  > Tile Group (WEIGHT)
+  > Before Fight
       Trivial
 
-> After Fight; Heals? False
+> Event - Drogyga; Heals? False
   * Layers: default
+  * Event Drogyga
   > Pickup (Drogyga)
       Trivial
 
@@ -2905,12 +2902,12 @@ Extra - asset_id: collision_camera_029
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Event - Pull Grapple Block
+  > Event - Drogyga Access Grapple Block
       Grapple Beam
   > Dock to Drogyga Arena
       Morph Ball and After Burenia - Drogyga Access Grapple Block
 
-> Event - Pull Grapple Block; Heals? False
+> Event - Drogyga Access Grapple Block; Heals? False
   * Layers: default
   * Event Burenia - Drogyga Access Grapple Block
   * Extra - actor_name: grapplepulloff1x2_006
@@ -2921,8 +2918,6 @@ Extra - asset_id: collision_camera_029
 > Dock to Drogyga Arena; Heals? False
   * Layers: default
   * Open Passage to Drogyga Arena/Dock to Drogyga Access
-  > Door to Drogyga Eyedoor
-      Morph Ball and After Burenia - Drogyga Access Grapple Block
 
 ----------------
 Save Station North

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -551,7 +551,7 @@
                 "extra": {}
             },
             "s040_aqua:default:db_reg_aq_009": {
-                "long_name": "Burenia - db_reg_aq_009",
+                "long_name": "Burenia - Ferenia Teleport Blob",
                 "extra": {}
             },
             "s040_aqua:default:db_reg_aq_001": {
@@ -591,11 +591,11 @@
                 "extra": {}
             },
             "s040_aqua:default:db_reg_aq_008": {
-                "long_name": "Burenia - db_reg_aq_008",
+                "long_name": "Burenia - Elevator Blob",
                 "extra": {}
             },
             "s040_aqua:default:db_reg_aq_011": {
-                "long_name": "Burenia - db_reg_aq_011",
+                "long_name": "Burenia - Recharge Blob",
                 "extra": {}
             },
             "s040_aqua:default:db_reg_aq_012": {
@@ -711,7 +711,7 @@
                 "extra": {}
             },
             "s040_aqua:default:grapplepulloff1x2_004": {
-                "long_name": "Burenia - grapplepulloff1x2_004",
+                "long_name": "Burenia - Ghavoran Transport Grapple Block",
                 "extra": {}
             },
             "s040_aqua:default:grapplepulloff1x2_003": {
@@ -723,7 +723,7 @@
                 "extra": {}
             },
             "s040_aqua:default:grapplepulloff1x2_001": {
-                "long_name": "Burenia - grapplepulloff1x2_001",
+                "long_name": "Burenia - Ferenia Teleport Grapple Block",
                 "extra": {}
             },
             "s040_aqua:default:grapplepulloff1x2_006": {
@@ -1028,6 +1028,10 @@
             },
             "DaironFereniaTransportSpeedBlocks": {
                 "long_name": "Dairon - Ferenia Transport Speed Blocks Destroyed",
+                "extra": {}
+            },
+            "Drogyga": {
+                "long_name": "Drogyga",
                 "extra": {}
             }
         },


### PR DESCRIPTION
This PR begins the process of revising the logic for Burenia. This covers the upper portion of Burenia stretching from the Ghavoran Transport to the Ferenia Teleport.

- Added event for Drogyga to account for some logic in Underneath Drogyga
- Corrected the logic for fighting Drogyga
- Renamed various event nodes to make them easier to understand
- Removed some redundant WEIGHT tile nodes

Added various methods of traversing the following rooms:
- Transport to Ghavoran
- Teleport to Ferenia
- Drogyga Eyedoor