### PR TITLE
Use node identifier instead of raw indices in Dread Pool Creator

### DIFF
--- a/randovania/exporter/item_names.py
+++ b/randovania/exporter/item_names.py
@@ -1,3 +1,4 @@
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.game_description.resources.resource_info import ResourceInfo, ResourceCollection
 from randovania.generator.item_pool.pool_creator import calculate_pool_results
@@ -31,9 +32,9 @@ def resource_user_friendly_name(resource: ResourceInfo) -> str:
 
 
 def additional_starting_items(layout_configuration: BaseConfiguration,
-                              resource_database: ResourceDatabase,
+                              game: GameDescription,
                               starting_items: ResourceCollection) -> list[str]:
-    initial_items = calculate_pool_results(layout_configuration, resource_database).initial_resources
+    initial_items = calculate_pool_results(layout_configuration, game).initial_resources
 
     return [
         add_quantity_to_resource(resource_user_friendly_name(item), quantity)

--- a/randovania/game_description/game_patches.py
+++ b/randovania/game_description/game_patches.py
@@ -77,6 +77,7 @@ class GamePatches:
 
         for index, pickup in assignments:
             assert index not in new_pickup_assignment
+            assert self.game.world_list.node_from_pickup_index(index) is not None
             new_pickup_assignment[index] = pickup
 
         return dataclasses.replace(self, pickup_assignment=new_pickup_assignment)

--- a/randovania/games/blank/generator/pool_creator.py
+++ b/randovania/games/blank/generator/pool_creator.py
@@ -1,12 +1,12 @@
 from random import Random
 
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.game_patches import GamePatches
-from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.games.blank.layout.blank_configuration import BlankConfiguration
 from randovania.generator.item_pool import PoolResults
 from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def pool_creator(results: PoolResults, configuration: BaseConfiguration, db: ResourceDatabase,
+def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription,
                  base_patches: GamePatches, rng: Random) -> None:
     assert isinstance(configuration, BlankConfiguration)

--- a/randovania/games/cave_story/generator/pool_creator.py
+++ b/randovania/games/cave_story/generator/pool_creator.py
@@ -1,9 +1,9 @@
 from random import Random
 
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.pickup_entry import PickupEntry
 from randovania.game_description.resources.pickup_index import PickupIndex
-from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.game_description.resources.resource_type import ResourceType
 from randovania.games.cave_story.layout.cs_configuration import CSConfiguration
 from randovania.generator.base_patches_factory import MissingRng
@@ -13,7 +13,7 @@ from randovania.layout.base.base_configuration import BaseConfiguration
 
 def pool_creator(results: PoolResults,
                  configuration: BaseConfiguration,
-                 db: ResourceDatabase,
+                 game: GameDescription,
                  base_patches: GamePatches,
                  rng: Random) -> None:
     assert isinstance(configuration, CSConfiguration)
@@ -21,6 +21,8 @@ def pool_creator(results: PoolResults,
         raise MissingRng("Pool Creator")
     if base_patches is None:
         return
+
+    db = game.resource_database
 
     def get_valid_indices(indices):
         return [p for p in indices if p not in results.assignment.keys()]

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -74,7 +74,7 @@ class DreadPatchDataFactory(BasePatchDataFactory):
 
     def _starting_inventory_text(self, resources: ResourceCollection):
         result = [r"{c1}Random starting items:{c0}"]
-        items = item_names.additional_starting_items(self.configuration, self.game.resource_database, resources)
+        items = item_names.additional_starting_items(self.configuration, self.game, resources)
         if not items:
             return []
         result.extend(items)

--- a/randovania/games/dread/generator/pool_creator.py
+++ b/randovania/games/dread/generator/pool_creator.py
@@ -1,5 +1,6 @@
 from random import Random
 
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.pickup_entry import PickupEntry
 from randovania.game_description.resources.pickup_index import PickupIndex
@@ -12,20 +13,20 @@ from randovania.generator.item_pool.pool_creator import _extend_pool_results
 from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def pool_creator(results: PoolResults, configuration: BaseConfiguration, db: ResourceDatabase,
+def pool_creator(results: PoolResults, configuration: BaseConfiguration, game: GameDescription,
                  base_patches: GamePatches, rng: Random) -> None:
     assert isinstance(configuration, DreadConfiguration)
 
-    _extend_pool_results(results, artifact_pool(db, configuration, rng))
+    _extend_pool_results(results, artifact_pool(game, configuration, rng))
 
 
-def artifact_pool(resource_database: ResourceDatabase, configuration: DreadConfiguration, rng: Random) -> PoolResults:
+def artifact_pool(game: GameDescription, configuration: DreadConfiguration, rng: Random) -> PoolResults:
     config = configuration.artifacts
 
     new_assignment: dict[PickupIndex, PickupEntry] = {}
-    initial_resources = ResourceCollection.with_database(resource_database)
+    initial_resources = ResourceCollection.with_database(game.resource_database)
 
-    keys: list[PickupEntry] = [create_dread_artifact(i, resource_database) for i in range(12)]
+    keys: list[PickupEntry] = [create_dread_artifact(i, game.resource_database) for i in range(12)]
 
     keys_to_shuffle = keys[:config.required_artifacts]
     starting_keys = keys[config.required_artifacts:]

--- a/randovania/games/dread/generator/pool_creator.py
+++ b/randovania/games/dread/generator/pool_creator.py
@@ -4,8 +4,8 @@ from randovania.game_description.game_description import GameDescription
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.pickup_entry import PickupEntry
 from randovania.game_description.resources.pickup_index import PickupIndex
-from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.game_description.resources.resource_info import ResourceCollection
+from randovania.game_description.world.node_identifier import NodeIdentifier
 from randovania.games.dread.layout.dread_configuration import DreadConfiguration
 from randovania.generator.item_pool import PoolResults
 from randovania.generator.item_pool.pickup_creator import create_dread_artifact
@@ -34,7 +34,7 @@ def artifact_pool(game: GameDescription, configuration: DreadConfiguration, rng:
     for key in starting_keys:
         initial_resources.add_resource_gain(key.progression)
 
-    locations: list[PickupIndex] = []
+    locations: list[NodeIdentifier] = []
     if config.prefer_emmi:
         locations.extend(_EMMI_INDICES)
     if config.prefer_major_bosses:
@@ -44,26 +44,30 @@ def artifact_pool(game: GameDescription, configuration: DreadConfiguration, rng:
 
     if rng is not None:
         rng.shuffle(locations)
-        new_assignment = {location: key for location, key in zip(locations, keys_to_shuffle)}
+        new_assignment = {
+            game.world_list.get_pickup_node(location).pickup_index: key
+            for location, key in zip(locations, keys_to_shuffle)
+        }
         item_pool = [key for key in keys_to_shuffle if key not in new_assignment.values()]
 
     return PoolResults(item_pool, new_assignment, initial_resources)
 
 
+_c = NodeIdentifier.create
 _EMMI_INDICES = [
-    PickupIndex(139),  # Artaria
-    PickupIndex(144),  # Cataris
-    PickupIndex(147),  # Dairon
-    PickupIndex(143),  # Ferenia
-    PickupIndex(146),  # Ghavoran
-    PickupIndex(137),  # Hanubia
+    _c("Artaria", "Central Unit Access", "Pickup (Spider Magnet)"),
+    _c("Cataris", "Central Unit Access", "Pickup (Morph Ball)"),
+    _c("Dairon", "Central Unit Access", "Pickup (Speed Booster)"),
+    _c("Ferenia", "Purple EMMI Arena", "Pickup (Wave Beam)"),
+    _c("Ghavoran", "Central Unit Access", "Pickup (Ice Missile)"),
+    _c("Hanubia", "Orange EMMI Introduction", "Pickup (Power Bomb)"),
 ]
 
 _BOSS_INDICES = [
-    PickupIndex(138),  # Corpius
-    PickupIndex(142),  # Escue
-    PickupIndex(145),  # Golzuna
-    PickupIndex(150),  # Drogyga
-    PickupIndex(149),  # Experiment Z-57
-    PickupIndex(148),  # Kraid
+    _c("Artaria", "Corpius Arena", "Pickup (Phantom Cloak)"),
+    _c("Ferenia", "Escue Arena", "Pickup (Storm Missile)"),
+    _c("Ghavoran", "Golzuna Arena", "Pickup (Cross Bomb)"),
+    _c("Burenia", "Drogyga Arena", "Pickup (Drogyga)"),
+    _c("Cataris", "Above Z-57 Fight", "Pickup (Z-57)"),
+    _c("Cataris", "Kraid Arena", "Pickup (Kraid)"),
 ]

--- a/randovania/games/game.py
+++ b/randovania/games/game.py
@@ -15,18 +15,17 @@ if typing.TYPE_CHECKING:
     from randovania.exporter.game_exporter import GameExporter
     from randovania.exporter.patch_data_factory import BasePatchDataFactory
     from randovania.game_description.game_patches import GamePatches
-    from randovania.game_description.resources.resource_database import ResourceDatabase
+    from randovania.game_description.game_description import GameDescription
     from randovania.generator.base_patches_factory import BasePatchesFactory
     from randovania.generator.hint_distributor import HintDistributor
     from randovania.generator.item_pool import PoolResults
     from randovania.gui.dialog.base_cosmetic_patches_dialog import BaseCosmeticPatchesDialog
     from randovania.gui.dialog.game_export_dialog import GameExportDialog
     from randovania.gui.game_details.game_details_tab import GameDetailsTab
-    from randovania.gui.lib.background_task_mixin import BackgroundTaskMixin
     from randovania.gui.lib.window_manager import WindowManager
     from randovania.gui.preset_settings.preset_tab import PresetTab
     from randovania.gui.widgets.base_game_tab_widget import BaseGameTabWidget
-    from randovania.interface_common.options import PerGameOptions, Options
+    from randovania.interface_common.options import PerGameOptions
     from randovania.interface_common.preset_editor import PresetEditor
     from randovania.layout.base.base_configuration import BaseConfiguration
     from randovania.layout.base.cosmetic_patches import BaseCosmeticPatches
@@ -74,7 +73,7 @@ class GameGui:
 
 @dataclass(frozen=True)
 class GameGenerator:
-    item_pool_creator: Callable[[PoolResults, BaseConfiguration, ResourceDatabase, GamePatches, Random], None]
+    item_pool_creator: Callable[[PoolResults, BaseConfiguration, GameDescription, GamePatches, Random], None]
     """Extends the base item pools with any specific item pools such as Artifacts."""
 
     bootstrap: Bootstrap

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -706,7 +706,7 @@ class PrimePatchDataFactory(BasePatchDataFactory):
                 pass  # Skip making the hint if Phazon Suit is not in the seed
 
         starting_memo = None
-        extra_starting = item_names.additional_starting_items(self.configuration, db.resource_database,
+        extra_starting = item_names.additional_starting_items(self.configuration, db,
                                                               self.patches.starting_items)
         if extra_starting:
             starting_memo = ", ".join(extra_starting)

--- a/randovania/games/prime1/generator/item_pool/pool_creator.py
+++ b/randovania/games/prime1/generator/item_pool/pool_creator.py
@@ -1,5 +1,6 @@
 from random import Random
 
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.games.prime1.generator.item_pool.artifacts import add_artifacts
@@ -9,8 +10,9 @@ from randovania.generator.item_pool.pool_creator import _extend_pool_results
 from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def prime1_specific_pool(results: PoolResults, configuration: BaseConfiguration, db: ResourceDatabase,
+def prime1_specific_pool(results: PoolResults, configuration: BaseConfiguration, game: GameDescription,
                          patches: GamePatches, rng: Random):
     assert isinstance(configuration, PrimeConfiguration)
-    _extend_pool_results(results, add_artifacts(db, configuration.artifact_target,
+    _extend_pool_results(results, add_artifacts(game.resource_database,
+                                                configuration.artifact_target,
                                                 configuration.artifact_minimum_progression))

--- a/randovania/games/prime2/exporter/patch_data_factory.py
+++ b/randovania/games/prime2/exporter/patch_data_factory.py
@@ -377,9 +377,9 @@ def _create_string_patches(hint_config: HintConfiguration,
 
 
 def _create_starting_popup(layout_configuration: EchoesConfiguration,
-                           resource_database: ResourceDatabase,
+                           game_description: GameDescription,
                            starting_items: ResourceCollection) -> list:
-    extra_items = item_names.additional_starting_items(layout_configuration, resource_database, starting_items)
+    extra_items = item_names.additional_starting_items(layout_configuration, game_description, starting_items)
     if extra_items:
         return [
             "Extra starting items:",
@@ -525,7 +525,7 @@ class EchoesPatchDataFactory(BasePatchDataFactory):
         # Add Spawn Point
         result["spawn_point"] = _create_spawn_point_field(self.patches, self.game)
 
-        result["starting_popup"] = _create_starting_popup(self.configuration, self.game.resource_database,
+        result["starting_popup"] = _create_starting_popup(self.configuration, self.game,
                                                           self.patches.starting_items)
 
         # Add the pickups

--- a/randovania/games/prime2/generator/item_pool/pool_creator.py
+++ b/randovania/games/prime2/generator/item_pool/pool_creator.py
@@ -1,5 +1,6 @@
 from random import Random
 
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.games.prime2.generator.item_pool.dark_temple_keys import add_dark_temple_keys
@@ -10,11 +11,11 @@ from randovania.generator.item_pool.pool_creator import _extend_pool_results
 from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def echoes_specific_pool(results: PoolResults, configuration: BaseConfiguration, db: ResourceDatabase,
+def echoes_specific_pool(results: PoolResults, configuration: BaseConfiguration, game: GameDescription,
                          base_patches: GamePatches, rng: Random):
     assert isinstance(configuration, EchoesConfiguration)
     # Adding Dark Temple Keys to pool
-    _extend_pool_results(results, add_dark_temple_keys(db))
+    _extend_pool_results(results, add_dark_temple_keys(game.resource_database))
 
     # Adding Sky Temple Keys to pool
-    _extend_pool_results(results, add_sky_temple_key_distribution_logic(db, configuration.sky_temple_keys))
+    _extend_pool_results(results, add_sky_temple_key_distribution_logic(game, configuration.sky_temple_keys))

--- a/randovania/games/prime2/generator/item_pool/sky_temple_keys.py
+++ b/randovania/games/prime2/generator/item_pool/sky_temple_keys.py
@@ -1,3 +1,4 @@
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.resources.pickup_entry import PickupEntry
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.game_description.resources.resource_database import ResourceDatabase
@@ -8,16 +9,16 @@ from randovania.generator.item_pool.pickup_creator import create_sky_temple_key
 from randovania.resolver.exceptions import InvalidConfiguration
 
 
-def add_sky_temple_key_distribution_logic(resource_database: ResourceDatabase,
+def add_sky_temple_key_distribution_logic(game: GameDescription,
                                           mode: LayoutSkyTempleKeyMode,
                                           ) -> PoolResults:
     """
     Adds the given Sky Temple Keys to the item pool
-    :param resource_database:
+    :param game:
     :param mode:
     :return:
     """
-
+    resource_database = game.resource_database
     item_pool: list[PickupEntry] = []
     new_assignment: dict[PickupIndex, PickupEntry] = {}
     initial_resources = ResourceCollection.with_database(resource_database)
@@ -48,6 +49,7 @@ def add_sky_temple_key_distribution_logic(resource_database: ResourceDatabase,
     return PoolResults(item_pool, new_assignment, initial_resources)
 
 
+# FIXME: use node identifiers
 _GUARDIAN_INDICES = [
     PickupIndex(43),  # Dark Suit
     PickupIndex(79),  # Dark Visor

--- a/randovania/games/prime3/generator/item_pool/pool_creator.py
+++ b/randovania/games/prime3/generator/item_pool/pool_creator.py
@@ -1,5 +1,6 @@
 from random import Random
 
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.games.prime3.generator.item_pool.energy_cells import add_energy_cells
@@ -9,8 +10,8 @@ from randovania.generator.item_pool.pool_creator import _extend_pool_results
 from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def corruption_specific_pool(results: PoolResults, configuration: BaseConfiguration, db: ResourceDatabase,
+def corruption_specific_pool(results: PoolResults, configuration: BaseConfiguration, game: GameDescription,
                              base_patches: GamePatches, rng: Random):
     assert isinstance(configuration, CorruptionConfiguration)
     # Adding Energy Cells to pool
-    _extend_pool_results(results, add_energy_cells(db))
+    _extend_pool_results(results, add_energy_cells(game.resource_database))

--- a/randovania/games/super_metroid/generator/item_pool/pool_creator.py
+++ b/randovania/games/super_metroid/generator/item_pool/pool_creator.py
@@ -1,13 +1,13 @@
 from random import Random
 
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.game_patches import GamePatches
-from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.games.super_metroid.layout.super_metroid_configuration import SuperMetroidConfiguration
 from randovania.generator.item_pool import PoolResults
 from randovania.layout.base.base_configuration import BaseConfiguration
 
 
-def super_metroid_specific_pool(results: PoolResults, configuration: BaseConfiguration, db: ResourceDatabase,
+def super_metroid_specific_pool(results: PoolResults, configuration: BaseConfiguration, game: GameDescription,
                                 base_patches: GamePatches, rng: Random):
     assert isinstance(configuration, SuperMetroidConfiguration)
     pass

--- a/randovania/generator/filler/filler_logging.py
+++ b/randovania/generator/filler/filler_logging.py
@@ -72,9 +72,8 @@ def print_new_node_identifiers(game: GameDescription,
                 print(f"-> New {label}: {world_list.node_name(node, with_world=True)}")
 
 
-def print_new_pickup_index(player: int, game: GameDescription, reach: GeneratorReach,
-                           location: PickupIndex, count: int):
-    if debug.debug_level() > 1 and count == 1:
+def print_new_pickup_index(player: int, game: GameDescription, location: PickupIndex):
+    if debug.debug_level() > 1:
         world_list = game.world_list
         node = world_list.node_from_pickup_index(location)
         print(f"-> New Pickup Index: Player {player}'s {world_list.node_name(node, with_world=True)}")

--- a/randovania/generator/filler/player_state.py
+++ b/randovania/generator/filler/player_state.py
@@ -15,11 +15,10 @@ from randovania.game_description.world.teleporter_node import TeleporterNode
 from randovania.game_description.world.world import World
 from randovania.game_description.world.world_list import WorldList
 from randovania.generator import reach_lib
+from randovania.generator.filler import filler_logging
 from randovania.generator.filler.action import Action
 from randovania.generator.filler.filler_configuration import FillerConfiguration
 from randovania.generator.filler.filler_library import UncollectedState
-from randovania.generator.filler.filler_logging import print_new_resources, print_retcon_loop_start, \
-    print_new_node_identifiers
 from randovania.generator.filler.pickup_list import (
     get_pickups_that_solves_unreachable,
     interesting_resources_for_reach, PickupCombinations,
@@ -75,6 +74,7 @@ class PlayerState:
 
         self.advance_scan_asset_seen_count()
         self._advance_event_seen_count()
+        self._log_new_pickup_index()
         self._calculate_potential_actions()
 
     def advance_scan_asset_seen_count(self):
@@ -83,14 +83,20 @@ class PlayerState:
             if self.hint_seen_count[hint_identifier] == 1:
                 self.hint_initial_pickups[hint_identifier] = frozenset(self.reach.state.collected_pickup_indices)
 
-        print_new_node_identifiers(self.game, self.hint_seen_count, "Scan Asset")
+        filler_logging.print_new_node_identifiers(self.game, self.hint_seen_count, "Scan Asset")
 
     def _advance_event_seen_count(self):
         for resource, quantity in self.reach.state.resources.as_resource_gain():
             if resource.resource_type == ResourceType.EVENT and quantity > 0:
                 self.event_seen_count[resource] += 1
 
-        print_new_resources(self.game, self.reach, self.event_seen_count, "Events")
+        filler_logging.print_new_resources(self.game, self.reach, self.event_seen_count, "Events")
+
+    def _log_new_pickup_index(self):
+        for index in self.reach.state.collected_pickup_indices:
+            if index not in self.pickup_index_considered_count:
+                self.pickup_index_considered_count[index] = 0
+                filler_logging.print_new_pickup_index(self.index, self.game, index)
 
     def _calculate_potential_actions(self):
         uncollected_resource_nodes = reach_lib.get_collectable_resource_nodes_of_reach(self.reach)
@@ -98,7 +104,7 @@ class PlayerState:
         usable_pickups = [pickup for pickup in self.pickups_left
                           if self.num_actions >= pickup.required_progression]
         pickups = get_pickups_that_solves_unreachable(usable_pickups, self.reach, uncollected_resource_nodes)
-        print_retcon_loop_start(self.game, usable_pickups, self.reach, self.index)
+        filler_logging.print_retcon_loop_start(self.game, usable_pickups, self.reach, self.index)
 
         self._unfiltered_potential_actions = pickups, tuple(uncollected_resource_nodes)
 

--- a/randovania/generator/filler/retcon.py
+++ b/randovania/generator/filler/retcon.py
@@ -159,9 +159,11 @@ def select_weighted_action(rng: Random, weighted_actions: dict[Action, float]) -
 
 def increment_considered_count(locations_weighted: WeightedLocations):
     for player, location in locations_weighted.keys():
+        was_present = location in player.pickup_index_considered_count
         player.pickup_index_considered_count[location] += 1
-        filler_logging.print_new_pickup_index(player.index, player.game, player.reach, location,
-                                              player.pickup_index_considered_count[location])
+        if not was_present:
+            # if it wasn't present, thenwe get to log!
+            filler_logging.print_new_pickup_index(player.index, player.game, location)
 
 
 def retcon_playthrough_filler(rng: Random,

--- a/randovania/generator/filler/retcon.py
+++ b/randovania/generator/filler/retcon.py
@@ -166,17 +166,13 @@ def increment_considered_count(locations_weighted: WeightedLocations):
             filler_logging.print_new_pickup_index(player.index, player.game, location)
 
 
-def retcon_playthrough_filler(rng: Random,
-                              player_states: list[PlayerState],
-                              status_update: Callable[[str], None],
-                              ) -> tuple[dict[PlayerState, GamePatches], tuple[str, ...]]:
-    """
-    Runs the retcon logic.
-    :param rng:
-    :param player_states:
-    :param status_update:
-    :return: A GamePatches for each player and a sequence of placed items.
-    """
+def _print_header(player_states: list[PlayerState]):
+    def _name_for_index(state: PlayerState, index: PickupIndex):
+        return state.game.world_list.node_name(
+            state.game.world_list.node_from_pickup_index(index),
+            with_world=True,
+        )
+
     debug.debug_print("{}\nRetcon filler started with major items:\n{}".format(
         "*" * 100,
         "\n".join(
@@ -195,13 +191,27 @@ def retcon_playthrough_filler(rng: Random,
             "Player {}: {}".format(
                 player_state.index,
                 pprint.pformat({
-                    player_state.game.world_list.node_from_pickup_index(index).node_index: target.pickup.name
+                    _name_for_index(player_state, index): target.pickup.name
                     for index, target in player_state.reach.state.patches.pickup_assignment.items()
                 })
             )
             for player_state in player_states
         )
     ))
+
+
+def retcon_playthrough_filler(rng: Random,
+                              player_states: list[PlayerState],
+                              status_update: Callable[[str], None],
+                              ) -> tuple[dict[PlayerState, GamePatches], tuple[str, ...]]:
+    """
+    Runs the retcon logic.
+    :param rng:
+    :param player_states:
+    :param status_update:
+    :return: A GamePatches for each player and a sequence of placed items.
+    """
+    _print_header(player_states)
     last_message = "Starting."
 
     def action_report(message: str):

--- a/randovania/generator/filler/retcon.py
+++ b/randovania/generator/filler/retcon.py
@@ -190,6 +190,18 @@ def retcon_playthrough_filler(rng: Random,
             for player_state in player_states
         )
     ))
+    debug.debug_print("Static assignments:\n{}".format(
+        "\n".join(
+            "Player {}: {}".format(
+                player_state.index,
+                pprint.pformat({
+                    player_state.game.world_list.node_from_pickup_index(index).node_index: target.pickup.name
+                    for index, target in player_state.reach.state.patches.pickup_assignment.items()
+                })
+            )
+            for player_state in player_states
+        )
+    ))
     last_message = "Starting."
 
     def action_report(message: str):

--- a/randovania/generator/generator.py
+++ b/randovania/generator/generator.py
@@ -64,7 +64,7 @@ async def create_player_pool(rng: Random, configuration: BaseConfiguration,
     )
 
     pool_results = pool_creator.calculate_pool_results(configuration,
-                                                       game.resource_database,
+                                                       game,
                                                        base_patches,
                                                        rng,
                                                        rng_required=rng_required)

--- a/randovania/generator/item_pool/__init__.py
+++ b/randovania/generator/item_pool/__init__.py
@@ -14,3 +14,7 @@ class PoolResults:
     def __post_init__(self):
         if not isinstance(self.initial_resources, ResourceCollection):
             raise TypeError("initial_resources is not a ResourceCollection")
+
+        for key in self.assignment:
+            if not isinstance(key, PickupIndex):
+                raise TypeError(f"{key} is not a PickupIndex")

--- a/randovania/generator/item_pool/pool_creator.py
+++ b/randovania/generator/item_pool/pool_creator.py
@@ -1,5 +1,6 @@
 from random import Random
 
+from randovania.game_description.game_description import GameDescription
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.game_description.resources.resource_info import ResourceCollection
@@ -18,7 +19,7 @@ def _extend_pool_results(base_results: PoolResults, extension: PoolResults):
 
 
 def calculate_pool_results(layout_configuration: BaseConfiguration,
-                           resource_database: ResourceDatabase,
+                           game: GameDescription,
                            base_patches: GamePatches = None,
                            rng: Random = None,
                            rng_required: bool = False
@@ -27,26 +28,29 @@ def calculate_pool_results(layout_configuration: BaseConfiguration,
     Creates a PoolResults with all starting items and pickups in fixed locations, as well as a list of
     pickups we should shuffle.
     :param layout_configuration:
-    :param resource_database:
+    :param game:
+    :param base_patches
+    :param rng:
+    :param rng_required
     :return:
     """
-    base_results = PoolResults([], {}, ResourceCollection.with_database(resource_database))
+    base_results = PoolResults([], {}, ResourceCollection.with_database(game.resource_database))
 
     # Adding major items to the pool
-    _extend_pool_results(base_results, add_major_items(resource_database,
+    _extend_pool_results(base_results, add_major_items(game.resource_database,
                                                        layout_configuration.major_items_configuration,
                                                        layout_configuration.ammo_configuration))
 
     # Adding ammo to the pool
-    base_results.pickups.extend(add_ammo(resource_database,
+    base_results.pickups.extend(add_ammo(game.resource_database,
                                          layout_configuration.ammo_configuration))
     try:
         layout_configuration.game.generator.item_pool_creator(
-            base_results, layout_configuration, resource_database, base_patches, rng,
+            base_results, layout_configuration, game, base_patches, rng,
         )
-    except MissingRng as e:
+    except MissingRng:
         if rng_required:
-            raise e
+            raise
 
     return base_results
 
@@ -60,7 +64,7 @@ def calculate_pool_item_count(layout: BaseConfiguration) -> tuple[int, int]:
     game_description = filtered_database.game_description_for_layout(layout)
 
     num_pickup_nodes = game_description.world_list.num_pickup_nodes
-    pool_results = calculate_pool_results(layout, game_description.resource_database,
+    pool_results = calculate_pool_results(layout, game_description,
                                           rng_required=False)
     min_starting_items = layout.major_items_configuration.minimum_random_starting_items
 

--- a/randovania/gui/game_details/pickup_details_tab.py
+++ b/randovania/gui/game_details/pickup_details_tab.py
@@ -62,7 +62,7 @@ class PickupDetailsTab(GameDetailsTab, Ui_PickupDetailsTab):
         starting_area = game_description.world_list.area_by_area_location(patches.starting_location)
 
         extra_items = item_names.additional_starting_items(configuration,
-                                                           game_description.resource_database,
+                                                           game_description,
                                                            patches.starting_items)
 
         self.spoiler_starting_location_label.setText("Starting Location: {}".format(

--- a/randovania/layout/game_patches_serializer.py
+++ b/randovania/layout/game_patches_serializer.py
@@ -245,7 +245,7 @@ def decode(game_modifications: list[dict],
            ) -> dict[int, GamePatches]:
     all_games = {index: filtered_database.game_description_for_layout(configuration)
                  for index, configuration in layout_configurations.items()}
-    all_pools = {index: pool_creator.calculate_pool_results(configuration, all_games[index].resource_database)
+    all_pools = {index: pool_creator.calculate_pool_results(configuration, all_games[index])
                  for index, configuration in layout_configurations.items()}
     return {
         index: decode_single(index, all_pools, all_games[index], modifications, layout_configurations[index])

--- a/test/games/dread/generator/test_dread_pool_creator.py
+++ b/test/games/dread/generator/test_dread_pool_creator.py
@@ -1,0 +1,36 @@
+from random import Random
+
+from randovania.game_description.game_patches import GamePatches
+from randovania.game_description.world.node_identifier import NodeIdentifier
+from randovania.generator.item_pool import pool_creator
+
+
+def test_dread_pool_creator(dread_game_description, preset_manager):
+    # Setup
+    preset = preset_manager.default_preset_for_game(dread_game_description.game).get_preset()
+    patches = GamePatches.create_from_game(dread_game_description, 0, preset.configuration)
+
+    # Run
+    results = pool_creator.calculate_pool_results(
+        preset.configuration,
+        dread_game_description,
+        patches,
+        Random(5000),
+        True,
+    )
+
+    # Assert
+    wl = dread_game_description.world_list
+    c = NodeIdentifier.create
+
+    locations = [
+        wl.identifier_for_node(wl.node_from_pickup_index(index))
+        for index in results.assignment.keys()
+    ]
+    assert locations == [
+        c("Burenia", "Drogyga Arena", "Pickup (Drogyga)"),
+        c("Cataris", "Above Z-57 Fight", "Pickup (Z-57)"),
+        c("Ghavoran", "Golzuna Arena", "Pickup (Cross Bomb)"),
+    ]
+
+    assert len(results.pickups) == wl.num_pickup_nodes - 1 - len(results.assignment)

--- a/test/games/prime/patcher_file_lib/test_pickup_exporter.py
+++ b/test/games/prime/patcher_file_lib/test_pickup_exporter.py
@@ -1,3 +1,4 @@
+import dataclasses
 from random import Random
 from unittest.mock import MagicMock
 
@@ -93,6 +94,7 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
     has_scan_text = model_style in {PickupModelStyle.ALL_VISIBLE, PickupModelStyle.HIDE_MODEL}
     rng = Random(5000)
 
+    patches = dataclasses.replace(empty_patches, game=MagicMock())
     model_0 = MagicMock(spec=PickupModel)
     model_1 = MagicMock(spec=PickupModel)
     model_2 = MagicMock(spec=PickupModel)
@@ -118,7 +120,7 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
 
     useless_pickup = PickupEntry("P-Useless", model_0, USELESS_ITEM_CATEGORY, USELESS_ITEM_CATEGORY,
                                  progression=((useless_resource, 1),))
-    patches = empty_patches.assign_new_pickups([
+    patches = patches.assign_new_pickups([
         (PickupIndex(0), PickupTarget(pickup_a, 0)),
         (PickupIndex(2), PickupTarget(pickup_b, 0)),
         (PickupIndex(3), PickupTarget(pickup_a, 0)),

--- a/test/games/prime/patcher_file_lib/test_pickup_exporter.py
+++ b/test/games/prime/patcher_file_lib/test_pickup_exporter.py
@@ -226,7 +226,8 @@ def test_create_pickup_list_random_data_source(has_memo_data: bool, empty_patche
     useless_pickup = PickupEntry("Useless", useless_model, USELESS_ITEM_CATEGORY, USELESS_ITEM_CATEGORY,
                                  progression=tuple())
 
-    patches = empty_patches.assign_new_pickups([
+    patches = dataclasses.replace(empty_patches, game=MagicMock())
+    patches = patches.assign_new_pickups([
         (PickupIndex(0), PickupTarget(pickup_a, 0)),
         (PickupIndex(2), PickupTarget(pickup_b, 0)),
         (PickupIndex(3), PickupTarget(pickup_a, 0)),

--- a/test/games/prime/patcher_file_lib/test_sky_temple_key_hint.py
+++ b/test/games/prime/patcher_file_lib/test_sky_temple_key_hint.py
@@ -43,20 +43,23 @@ def make_useless_stk_hint(key_number: int) -> list[str]:
 
 @pytest.mark.parametrize("multiworld", [False, True])
 @pytest.mark.parametrize("hide_area", [False, True])
-def test_create_hints_all_placed(hide_area: bool, multiworld: bool, empty_patches, default_echoes_configuration,
+def test_create_hints_all_placed(hide_area: bool, multiworld: bool,
+                                 echoes_game_patches,
+                                 prime_game_patches,
+                                 default_echoes_configuration,
                                  default_prime_configuration):
     # Setup
     echoes_game = default_database.game_description_for(RandovaniaGame.METROID_PRIME_ECHOES)
     players_config = PlayersConfiguration(0, {0: "you", 1: "them"} if multiworld else {0: "you"})
 
-    patches = empty_patches.assign_new_pickups([
+    patches = echoes_game_patches.assign_new_pickups([
         (PickupIndex(17 + key),
          PickupTarget(pickup_creator.create_sky_temple_key(key, echoes_game.resource_database), 0))
         for key in range(5 if multiworld else 9)
     ])
     patches = dataclasses.replace(patches, configuration=default_echoes_configuration)
 
-    other_patches = empty_patches.assign_new_pickups([
+    other_patches = prime_game_patches.assign_new_pickups([
         (PickupIndex(17 + key),
          PickupTarget(pickup_creator.create_sky_temple_key(key, echoes_game.resource_database), 0))
         for key in range(5, 9)

--- a/test/games/prime2/patcher/test_patch_data_generator.py
+++ b/test/games/prime2/patcher/test_patch_data_generator.py
@@ -31,29 +31,30 @@ from randovania.layout.layout_description import LayoutDescription
 from randovania.layout.lib.teleporters import TeleporterShuffleMode
 
 
-def test_create_starting_popup_empty(default_echoes_configuration, echoes_resource_database):
-    starting_items = ResourceCollection.with_database(echoes_resource_database)
+def test_create_starting_popup_empty(default_echoes_configuration, echoes_game_description):
+    starting_items = ResourceCollection.with_database(echoes_game_description.resource_database)
 
     # Run
     result = patch_data_factory._create_starting_popup(default_echoes_configuration,
-                                                       echoes_resource_database,
+                                                       echoes_game_description,
                                                        starting_items)
 
     # Assert
     assert result == []
 
 
-def test_create_starting_popup_items(default_echoes_configuration, echoes_resource_database):
-    starting_items = ResourceCollection.from_dict(echoes_resource_database, {
-        echoes_resource_database.get_item_by_name("Missile"): 15,
-        echoes_resource_database.energy_tank: 3,
-        echoes_resource_database.get_item_by_name("Dark Beam"): 1,
-        echoes_resource_database.get_item_by_name("Screw Attack"): 1,
+def test_create_starting_popup_items(default_echoes_configuration, echoes_game_description):
+    db = echoes_game_description.resource_database
+    starting_items = ResourceCollection.from_dict(db, {
+        db.get_item_by_name("Missile"): 15,
+        db.energy_tank: 3,
+        db.get_item_by_name("Dark Beam"): 1,
+        db.get_item_by_name("Screw Attack"): 1,
     })
 
     # Run
     result = patch_data_factory._create_starting_popup(default_echoes_configuration,
-                                                       echoes_resource_database,
+                                                       echoes_game_description,
                                                        starting_items)
 
     # Assert
@@ -466,12 +467,12 @@ def test_pickup_data_for_pb_expansion_unlocked(echoes_item_database, echoes_reso
 
 
 @pytest.mark.parametrize("disable_hud_popup", [False, True])
-def test_create_pickup_all_from_pool(echoes_resource_database,
+def test_create_pickup_all_from_pool(echoes_game_description,
                                      default_echoes_configuration,
                                      disable_hud_popup: bool
                                      ):
     item_pool = pool_creator.calculate_pool_results(default_echoes_configuration,
-                                                    echoes_resource_database)
+                                                    echoes_game_description)
     index = PickupIndex(0)
     if disable_hud_popup:
         memo_data = patch_data_factory._simplified_memo_data()

--- a/test/generator/item_pool/test_pool_creator.py
+++ b/test/generator/item_pool/test_pool_creator.py
@@ -54,7 +54,7 @@ def test_cs_item_pool_creator(default_cs_configuration: CSConfiguration, puppies
 
     result = pool_creator.calculate_pool_results(
         default_cs_configuration,
-        game_description.resource_database,
+        game_description,
         base_patches,
         rng
     )

--- a/test/generator/test_generator_reach.py
+++ b/test/generator/test_generator_reach.py
@@ -118,8 +118,7 @@ def test_database_collectable(preset_manager, game_enum: RandovaniaGame,
     game, initial_state, permalink = run_bootstrap(
         preset_manager.default_preset_for_game(game_enum).get_preset())
     all_pickups = set(reach_lib.filter_pickup_nodes(game.world_list.iterate_nodes()))
-    pool_results = pool_creator.calculate_pool_results(permalink.get_preset(0).configuration,
-                                                       game.resource_database)
+    pool_results = pool_creator.calculate_pool_results(permalink.get_preset(0).configuration, game)
 
     initial_state.resources.add_resource_gain(pool_results.initial_resources.as_resource_gain())
     for pickup in pool_results.pickups:

--- a/test/layout/test_game_patches_serializer.py
+++ b/test/layout/test_game_patches_serializer.py
@@ -155,7 +155,7 @@ def test_decode(patches_with_data, default_echoes_configuration):
     encoded, expected = patches_with_data
 
     game = expected.game
-    pool = pool_creator.calculate_pool_results(default_echoes_configuration, game.resource_database)
+    pool = pool_creator.calculate_pool_results(default_echoes_configuration, game)
 
     # Run
     decoded = game_patches_serializer.decode_single(0, {0: pool}, game, encoded, default_echoes_configuration)

--- a/test/resolver/item_pool/test_sky_temple_key.py
+++ b/test/resolver/item_pool/test_sky_temple_key.py
@@ -8,45 +8,47 @@ from randovania.generator.item_pool import pickup_creator
 item_ids = [29, 30, 31, 101, 102, 103, 104, 105, 106]
 
 
-def test_sky_temple_key_distribution_logic_all_bosses_valid(echoes_resource_database):
+def test_sky_temple_key_distribution_logic_all_bosses_valid(echoes_game_description):
     # Run
-    results = sky_temple_keys.add_sky_temple_key_distribution_logic(echoes_resource_database,
+    results = sky_temple_keys.add_sky_temple_key_distribution_logic(echoes_game_description,
                                                                     LayoutSkyTempleKeyMode.ALL_BOSSES)
 
     # Assert
     assert results.pickups == []
-    assert results.initial_resources == ResourceCollection.from_dict(echoes_resource_database, {})
+    assert results.initial_resources == ResourceCollection.from_dict(echoes_game_description.resource_database, {})
     assert list(results.assignment.keys()) == sky_temple_keys._GUARDIAN_INDICES + sky_temple_keys._SUB_GUARDIAN_INDICES
 
 
-def test_sky_temple_key_distribution_logic_all_guardians_valid(echoes_resource_database):
+def test_sky_temple_key_distribution_logic_all_guardians_valid(echoes_game_description):
+    db = echoes_game_description.resource_database
     # Run
-    results = sky_temple_keys.add_sky_temple_key_distribution_logic(echoes_resource_database,
+    results = sky_temple_keys.add_sky_temple_key_distribution_logic(echoes_game_description,
                                                                     LayoutSkyTempleKeyMode.ALL_GUARDIANS)
 
     # Assert
     assert results.pickups == []
-    assert results.initial_resources == ResourceCollection.from_dict(echoes_resource_database, {
-        echoes_resource_database.get_item(f'TempleKey{i}'): 1
+    assert results.initial_resources == ResourceCollection.from_dict(db, {
+        db.get_item(f'TempleKey{i}'): 1
         for i in range(4, 10)
     })
     assert list(results.assignment.keys()) == sky_temple_keys._GUARDIAN_INDICES
 
 
 @pytest.mark.parametrize("quantity", list(range(10)))
-def test_sky_temple_key_distribution_logic_with_quantity(echoes_resource_database, quantity: int):
+def test_sky_temple_key_distribution_logic_with_quantity(echoes_game_description, quantity: int):
+    db = echoes_game_description.resource_database
     # Run
-    results = sky_temple_keys.add_sky_temple_key_distribution_logic(echoes_resource_database,
+    results = sky_temple_keys.add_sky_temple_key_distribution_logic(echoes_game_description,
                                                                     LayoutSkyTempleKeyMode(quantity))
 
     # ItemResourceInfo(f'Sky Temple Key {i}', , 1, frozendict({"item_id": item_ids[i - 1]})): 1
     # Assert
     assert results.pickups == [
-        pickup_creator.create_sky_temple_key(i, echoes_resource_database)
+        pickup_creator.create_sky_temple_key(i, db)
         for i in range(quantity)
     ]
     assert results.assignment == {}
-    assert results.initial_resources == ResourceCollection.from_dict(echoes_resource_database, {
-        echoes_resource_database.get_item(f'TempleKey{i}'): 1
+    assert results.initial_resources == ResourceCollection.from_dict(db, {
+        db.get_item(f'TempleKey{i}'): 1
         for i in range(quantity + 1, 10)
     })


### PR DESCRIPTION
In addition, GamePatches.assign_new_pickups now checks that the indices are known.