### PR TITLE
display the name of the preset on the quick generate button

### DIFF
--- a/randovania/gui/widgets/base_game_tab_widget.py
+++ b/randovania/gui/widgets/base_game_tab_widget.py
@@ -46,6 +46,7 @@ class BaseGameTabWidget(QtWidgets.QTabWidget):
             hints_text.update_hint_locations(game, self.hint_locations_tree_widget)
 
         self.tab_generate_game.setup_ui(game, window_manager, background_task, options)
+        self._update_quick_generate_text()
 
     def setup_ui(self):
         raise NotImplementedError()
@@ -53,12 +54,18 @@ class BaseGameTabWidget(QtWidgets.QTabWidget):
     @classmethod
     def game(cls) -> RandovaniaGame:
         raise NotImplementedError()
+    
+    def _update_quick_generate_text(self):
+        preset_name = self.tab_generate_game.preset.name
+        text = f"Quick Generate ({preset_name})"
+        self.quick_generate_button.setText(text)
 
     def _return_to_list(self):
         self._window_manager.set_games_selector_visible(True)
 
     def on_options_changed(self, options: Options):
         self.tab_generate_game.on_options_changed(options)
+        self._update_quick_generate_text()
 
     def on_quick_generate(self):
         self.tab_generate_game.generate_new_layout(spoiler=True)

--- a/randovania/gui/widgets/generate_game_widget.py
+++ b/randovania/gui/widgets/generate_game_widget.py
@@ -276,14 +276,18 @@ class GenerateGameWidget(QtWidgets.QWidget, Ui_GenerateGameWidget):
         self._preset_menu.set_preset(preset)
         self._preset_menu.exec_(QtGui.QCursor.pos())
 
+    @property
+    def preset(self) -> VersionedPreset:
+        preset = self._current_preset_data
+        if preset is None:
+            preset = self._window_manager.preset_manager.default_preset_for_game(self.game)
+        return preset
+    
     # Generate seed
 
     def generate_new_layout(self, spoiler: bool, retries: int | None = None):
-        preset = self._current_preset_data
+        preset = self.preset
         num_players = self.num_players_spin_box.value()
-
-        if preset is None:
-            preset = self._window_manager.preset_manager.default_preset_for_game(self.game)
 
         self.generate_layout_from_permalink(
             permalink=Permalink.from_parameters(GeneratorParameters(


### PR DESCRIPTION
since quick generate uses the most recent preset (or the default, if none were used yet) it's helpful to display the name of the preset it'll use
![image](https://user-images.githubusercontent.com/2979303/186042924-248f557a-a168-4393-841d-973059b4829c.png)
