### PR TITLE
ExportedPickupDetails: less prime-specific

### DIFF
--- a/randovania/exporter/pickup_exporter.py
+++ b/randovania/exporter/pickup_exporter.py
@@ -98,11 +98,11 @@ def _get_all_hud_text(conditionals: list[ConditionalResources],
     ]
 
 
-def _calculate_hud_text(pickup: PickupEntry,
-                        visual_pickup: PickupEntry,
-                        model_style: PickupModelStyle,
-                        memo_data: dict[str, str],
-                        ) -> list[str]:
+def _calculate_collection_text(pickup: PickupEntry,
+                               visual_pickup: PickupEntry,
+                               model_style: PickupModelStyle,
+                               memo_data: dict[str, str],
+                               ) -> list[str]:
     """
     Calculates what the hud_text for a pickup should be
     :param pickup:
@@ -127,8 +127,8 @@ def _calculate_hud_text(pickup: PickupEntry,
 @dataclasses.dataclass(frozen=True)
 class ExportedPickupDetails:
     index: PickupIndex
-    scan_text: str
-    hud_text: list[str]
+    description: str
+    collection_text: list[str]
     conditional_resources: list[ConditionalResources]
     conversion: list[ResourceConversion]
     model: PickupModel
@@ -172,13 +172,13 @@ class PickupExporterSolo(PickupExporter):
                        pickup_target: PickupTarget,
                        visual_pickup: PickupEntry,
                        model_style: PickupModelStyle,
-                       scan_text: str,
+                       description: str,
                        model: PickupModel) -> ExportedPickupDetails:
         pickup = pickup_target.pickup
         return ExportedPickupDetails(
             index=original_index,
-            scan_text=scan_text,
-            hud_text=_calculate_hud_text(pickup, visual_pickup, model_style, self.memo_data),
+            description=description,
+            collection_text=_calculate_collection_text(pickup, visual_pickup, model_style, self.memo_data),
             conditional_resources=_conditional_resources_for_pickup(pickup),
             conversion=list(pickup.convert_resources),
             model=model,
@@ -204,7 +204,7 @@ class PickupExporterMulti(PickupExporter):
         if pickup_target.player == self.players_config.player_index:
             details = self.solo_creator.create_details(original_index, pickup_target, visual_pickup,
                                                        model_style, scan_text, model)
-            return dataclasses.replace(details, scan_text=f"Your {details.scan_text}")
+            return dataclasses.replace(details, description=f"Your {details.description}")
         else:
             other_name = self.players_config.player_names[pickup_target.player]
             if self.multiworld_item is not None:
@@ -214,8 +214,8 @@ class PickupExporterMulti(PickupExporter):
 
             return ExportedPickupDetails(
                 index=original_index,
-                scan_text=f"{other_name}'s {scan_text}",
-                hud_text=[f"Sent {pickup_target.pickup.name} to {other_name}!"],
+                description=f"{other_name}'s {scan_text}",
+                collection_text=[f"Sent {pickup_target.pickup.name} to {other_name}!"],
                 conditional_resources=[ConditionalResources(
                     name=None,
                     item=None,

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -178,8 +178,8 @@ class DreadPatchDataFactory(BasePatchDataFactory):
         pickup_node = self.game.world_list.node_from_pickup_index(detail.index)
         pickup_type = pickup_node.extra.get("pickup_type", "actor")
 
-        hud_text = detail.hud_text[0]
-        if len(set(detail.hud_text)) > 1:
+        hud_text = detail.collection_text[0]
+        if len(set(detail.collection_text)) > 1:
             hud_text = self.memo_data[detail.original_pickup.name]
 
         details = {

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -106,8 +106,8 @@ def prime1_pickup_details_to_patcher(detail: pickup_exporter.ExportedPickupDetai
                                      rng: Random) -> dict:
     model = detail.model.as_json
 
-    scan_text = detail.description
-    hud_text = detail.collection_text[0]
+    name = detail.name
+    collection_text = detail.collection_text[0]
     pickup_type = "Nothing"
     count = 0
 
@@ -119,17 +119,17 @@ def prime1_pickup_details_to_patcher(detail: pickup_exporter.ExportedPickupDetai
         break
 
     if (model["name"] == "Missile" and not detail.other_player
-            and "Missile Expansion" in hud_text
+            and "Missile Expansion" in collection_text
             and rng.randint(0, _EASTER_EGG_SHINY_MISSILE) == 0):
         model["name"] = "Shiny Missile"
-        hud_text = hud_text.replace("Missile Expansion", "Shiny Missile Expansion")
-        scan_text = scan_text.replace("Missile Expansion", "Shiny Missile Expansion")
+        collection_text = collection_text.replace("Missile Expansion", "Shiny Missile Expansion")
+        name = name.replace("Missile Expansion", "Shiny Missile Expansion")
 
     result = {
         "type": pickup_type,
         "model": model,
-        "scanText": scan_text,
-        "hudmemoText": hud_text,
+        "scanText": f"{name}. {detail.description}".strip(),
+        "hudmemoText": collection_text,
         "currIncrease": count,
         "maxIncrease": count,
         "respawn": False,

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -106,8 +106,8 @@ def prime1_pickup_details_to_patcher(detail: pickup_exporter.ExportedPickupDetai
                                      rng: Random) -> dict:
     model = detail.model.as_json
 
-    scan_text = detail.scan_text
-    hud_text = detail.hud_text[0]
+    scan_text = detail.description
+    hud_text = detail.collection_text[0]
     pickup_type = "Nothing"
     count = 0
 

--- a/randovania/games/prime2/exporter/patch_data_factory.py
+++ b/randovania/games/prime2/exporter/patch_data_factory.py
@@ -666,7 +666,7 @@ def echoes_pickup_details_to_patcher(details: pickup_exporter.ExportedPickupDeta
         # If placing a missile expansion model, replace with Dark Missile Trooper model with a 1/8192 chance
         model["name"] = "MissileExpansionPrime1"
 
-    hud_text = details.hud_text
+    hud_text = details.collection_text
     if hud_text == ["Energy Transfer Module acquired!"] and (
             rng.randint(0, _EASTER_EGG_RUN_VALIDATED_CHANCE) == 0):
         hud_text = ["Run validated!"]
@@ -691,7 +691,7 @@ def echoes_pickup_details_to_patcher(details: pickup_exporter.ExportedPickupDeta
             for conversion in details.conversion
         ],
         "hud_text": hud_text,
-        "scan": details.scan_text,
+        "scan": details.description,
         "model": model,
     }
 

--- a/randovania/games/prime2/exporter/patch_data_factory.py
+++ b/randovania/games/prime2/exporter/patch_data_factory.py
@@ -691,7 +691,7 @@ def echoes_pickup_details_to_patcher(details: pickup_exporter.ExportedPickupDeta
             for conversion in details.conversion
         ],
         "hud_text": hud_text,
-        "scan": details.description,
+        "scan": f"{details.name}. {details.description}".strip(),
         "model": model,
     }
 

--- a/randovania/games/super_metroid/exporter/patch_data_factory.py
+++ b/randovania/games/super_metroid/exporter/patch_data_factory.py
@@ -55,8 +55,8 @@ def sm_pickup_details_to_patcher(detail: pickup_exporter.ExportedPickupDetails
     else:
         model_name = "Nothing"
 
-    scan_text = detail.scan_text
-    hud_text = detail.hud_text[0]
+    scan_text = detail.description
+    hud_text = detail.collection_text[0]
     pickup_type = "Nothing"
     count = 0
 

--- a/randovania/games/super_metroid/exporter/patch_data_factory.py
+++ b/randovania/games/super_metroid/exporter/patch_data_factory.py
@@ -50,13 +50,6 @@ _effect = {
 
 def sm_pickup_details_to_patcher(detail: pickup_exporter.ExportedPickupDetails
                                  ) -> dict:
-    if detail.model.game == RandovaniaGame.SUPER_METROID:
-        model_name = detail.model.name
-    else:
-        model_name = "Nothing"
-
-    scan_text = detail.description
-    hud_text = detail.collection_text[0]
     pickup_type = "Nothing"
     count = 0
 

--- a/test/games/prime/patcher_file_lib/test_pickup_exporter.py
+++ b/test/games/prime/patcher_file_lib/test_pickup_exporter.py
@@ -151,7 +151,8 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
     assert len(result) == 5
     assert result[0] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(0),
-        description="P-A" if has_scan_text else "Unknown item",
+        name="P-A" if has_scan_text else "Unknown item",
+        description="",
         collection_text=["A acquired!"] if model_style != PickupModelStyle.HIDE_ALL else ['Unknown item acquired!'],
         conditional_resources=[ConditionalResources("A", None, ((resource_a, 1),))],
         conversion=[],
@@ -161,7 +162,8 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
     )
     assert result[1] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(1),
-        description="P-Useless" if has_scan_text else "Unknown item",
+        name="P-Useless" if has_scan_text else "Unknown item",
+        description="",
         collection_text=["Useless acquired!"] if model_style != PickupModelStyle.HIDE_ALL else ['Unknown item acquired!'],
         conditional_resources=[ConditionalResources("Useless", None, ((useless_resource, 1),))],
         conversion=[],
@@ -171,7 +173,8 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
     )
     assert result[2] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(2),
-        description="P-B. Provides the following in order: B, A" if has_scan_text else "Unknown item",
+        name="P-B" if has_scan_text else "Unknown item",
+        description="Provides the following in order: B, A." if has_scan_text else "",
         collection_text=["B acquired!", "A acquired!"] if model_style != PickupModelStyle.HIDE_ALL else [
             'Unknown item acquired!', 'Unknown item acquired!'],
         conditional_resources=[
@@ -185,7 +188,8 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
     )
     assert result[3] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(3),
-        description="P-A" if has_scan_text else "Unknown item",
+        name="P-A" if has_scan_text else "Unknown item",
+        description="",
         collection_text=["A acquired!"] if model_style != PickupModelStyle.HIDE_ALL else ['Unknown item acquired!'],
         conditional_resources=[ConditionalResources("A", None, ((resource_a, 1),))],
         conversion=[],
@@ -195,7 +199,8 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
     )
     assert result[4] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(4),
-        description="P-C. Provides 2 B and 1 A" if has_scan_text else "Unknown item",
+        name="P-C" if has_scan_text else "Unknown item",
+        description="Provides 2 B and 1 A." if has_scan_text else "",
         collection_text=["P-C acquired!"] if model_style != PickupModelStyle.HIDE_ALL else ['Unknown item acquired!'],
         conditional_resources=[ConditionalResources("P-C", None, (
             (resource_b, 2), (resource_a, 1),
@@ -272,7 +277,8 @@ def test_create_pickup_list_random_data_source(has_memo_data: bool, empty_patche
     assert len(result) == 5
     assert result[0] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(0),
-        description="A",
+        name="A",
+        description="",
         collection_text=[memo_data["A"]],
         conditional_resources=[ConditionalResources("A", None, ())],
         conversion=[],
@@ -282,7 +288,8 @@ def test_create_pickup_list_random_data_source(has_memo_data: bool, empty_patche
     )
     assert result[1] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(1),
-        description="A",
+        name="A",
+        description="",
         collection_text=[memo_data["A"]],
         conditional_resources=[ConditionalResources("Useless", None, ())],
         conversion=[],
@@ -292,7 +299,8 @@ def test_create_pickup_list_random_data_source(has_memo_data: bool, empty_patche
     )
     assert result[2] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(2),
-        description="C",
+        name="C",
+        description="",
         collection_text=[memo_data["C"], memo_data["C"]],
         conditional_resources=[
             ConditionalResources("B", None, ((resource_b, 1),)),
@@ -305,7 +313,8 @@ def test_create_pickup_list_random_data_source(has_memo_data: bool, empty_patche
     )
     assert result[3] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(3),
-        description="B",
+        name="B",
+        description="",
         collection_text=[memo_data["B"]],
         conditional_resources=[ConditionalResources("A", None, ())],
         conversion=[],
@@ -315,7 +324,8 @@ def test_create_pickup_list_random_data_source(has_memo_data: bool, empty_patche
     )
     assert result[4] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(4),
-        description="A",
+        name="A",
+        description="",
         collection_text=[memo_data["A"]],
         conditional_resources=[ConditionalResources("C", None, ())],
         conversion=[],
@@ -332,10 +342,10 @@ def test_pickup_scan_for_progressive_suit(echoes_item_database, echoes_resource_
                                               None, False)
 
     # Run
-    result = pickup_exporter._pickup_scan(pickup)
+    result = pickup_exporter._pickup_description(pickup)
 
     # Assert
-    assert result == "Progressive Suit. Provides the following in order: Dark Suit, Light Suit"
+    assert result == "Provides the following in order: Dark Suit, Light Suit."
 
 
 @pytest.mark.parametrize(["item", "ammo", "result"], [
@@ -348,7 +358,7 @@ def test_pickup_scan_for_ammo_expansion(echoes_item_database, echoes_resource_da
     pickup = pickup_creator.create_ammo_expansion(expansion, ammo, False, echoes_resource_database)
 
     # Run
-    result = pickup_exporter._pickup_scan(pickup)
+    result = pickup_exporter._pickup_description(pickup)
 
     # Assert
     assert result == result
@@ -375,11 +385,12 @@ def test_solo_create_pickup_data(pickup_for_create_pickup_data):
     # Run
     data = creator.create_details(PickupIndex(10), PickupTarget(pickup_for_create_pickup_data, 0),
                                   pickup_for_create_pickup_data, PickupModelStyle.ALL_VISIBLE,
-                                  "Scan Text", model)
+                                  "The Name", "Scan Text", model)
 
     # Assert
     assert data == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(10),
+        name="The Name",
         description="Scan Text",
         collection_text=['A acquired!', 'B acquired!'],
         conditional_resources=[
@@ -404,12 +415,13 @@ def test_multi_create_pickup_data_for_self(pickup_for_create_pickup_data):
     # Run
     data = creator.create_details(PickupIndex(10), PickupTarget(pickup_for_create_pickup_data, 0),
                                   pickup_for_create_pickup_data, PickupModelStyle.ALL_VISIBLE,
-                                  "Scan Text", model)
+                                  "The Name", "Scan Text", model)
 
     # Assert
     assert data == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(10),
-        description="Your Scan Text",
+        name="Your The Name",
+        description="Scan Text",
         collection_text=['A acquired!', 'B acquired!'],
         conditional_resources=[
             ConditionalResources("A", None, ((resource_a, 1),)),
@@ -428,18 +440,17 @@ def test_multi_create_pickup_data_for_other(pickup_for_create_pickup_data):
     solo = pickup_exporter.PickupExporterSolo(pickup_exporter.GenericAcquiredMemo())
     creator = pickup_exporter.PickupExporterMulti(solo, multi, PlayersConfiguration(0, {0: "You", 1: "Someone"}))
     model = MagicMock()
-    resource_a = ItemResourceInfo("A", "A", 10, None)
-    resource_b = ItemResourceInfo("B", "B", 10, None)
 
     # Run
     data = creator.create_details(PickupIndex(10), PickupTarget(pickup_for_create_pickup_data, 1),
                                   pickup_for_create_pickup_data, PickupModelStyle.ALL_VISIBLE,
-                                  "Scan Text", model)
+                                  "The Name", "Scan Text", model)
 
     # Assert
     assert data == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(10),
-        description="Someone's Scan Text",
+        name="Someone's The Name",
+        description="Scan Text",
         collection_text=['Sent Cake to Someone!'],
         conditional_resources=[
             ConditionalResources(None, None, ((multi, 11),)),

--- a/test/games/prime/patcher_file_lib/test_pickup_exporter.py
+++ b/test/games/prime/patcher_file_lib/test_pickup_exporter.py
@@ -75,8 +75,8 @@ def test_calculate_hud_text(order: tuple[str, str], generic_item_category):
     }
 
     # Run
-    result = pickup_exporter._calculate_hud_text(pickups[order[0]], pickups[order[1]],
-                                                 PickupModelStyle.HIDE_ALL, memo_data)
+    result = pickup_exporter._calculate_collection_text(pickups[order[0]], pickups[order[1]],
+                                                        PickupModelStyle.HIDE_ALL, memo_data)
 
     # Assert
     if order[1] == "Y":
@@ -151,8 +151,8 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
     assert len(result) == 5
     assert result[0] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(0),
-        scan_text="P-A" if has_scan_text else "Unknown item",
-        hud_text=["A acquired!"] if model_style != PickupModelStyle.HIDE_ALL else ['Unknown item acquired!'],
+        description="P-A" if has_scan_text else "Unknown item",
+        collection_text=["A acquired!"] if model_style != PickupModelStyle.HIDE_ALL else ['Unknown item acquired!'],
         conditional_resources=[ConditionalResources("A", None, ((resource_a, 1),))],
         conversion=[],
         model=model_1 if model_style == PickupModelStyle.ALL_VISIBLE else useless_model,
@@ -161,8 +161,8 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
     )
     assert result[1] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(1),
-        scan_text="P-Useless" if has_scan_text else "Unknown item",
-        hud_text=["Useless acquired!"] if model_style != PickupModelStyle.HIDE_ALL else ['Unknown item acquired!'],
+        description="P-Useless" if has_scan_text else "Unknown item",
+        collection_text=["Useless acquired!"] if model_style != PickupModelStyle.HIDE_ALL else ['Unknown item acquired!'],
         conditional_resources=[ConditionalResources("Useless", None, ((useless_resource, 1),))],
         conversion=[],
         model=model_0 if model_style == PickupModelStyle.ALL_VISIBLE else useless_model,
@@ -171,8 +171,8 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
     )
     assert result[2] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(2),
-        scan_text="P-B. Provides the following in order: B, A" if has_scan_text else "Unknown item",
-        hud_text=["B acquired!", "A acquired!"] if model_style != PickupModelStyle.HIDE_ALL else [
+        description="P-B. Provides the following in order: B, A" if has_scan_text else "Unknown item",
+        collection_text=["B acquired!", "A acquired!"] if model_style != PickupModelStyle.HIDE_ALL else [
             'Unknown item acquired!', 'Unknown item acquired!'],
         conditional_resources=[
             ConditionalResources("B", None, ((resource_b, 1),)),
@@ -185,8 +185,8 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
     )
     assert result[3] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(3),
-        scan_text="P-A" if has_scan_text else "Unknown item",
-        hud_text=["A acquired!"] if model_style != PickupModelStyle.HIDE_ALL else ['Unknown item acquired!'],
+        description="P-A" if has_scan_text else "Unknown item",
+        collection_text=["A acquired!"] if model_style != PickupModelStyle.HIDE_ALL else ['Unknown item acquired!'],
         conditional_resources=[ConditionalResources("A", None, ((resource_a, 1),))],
         conversion=[],
         model=model_1 if model_style == PickupModelStyle.ALL_VISIBLE else useless_model,
@@ -195,8 +195,8 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
     )
     assert result[4] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(4),
-        scan_text="P-C. Provides 2 B and 1 A" if has_scan_text else "Unknown item",
-        hud_text=["P-C acquired!"] if model_style != PickupModelStyle.HIDE_ALL else ['Unknown item acquired!'],
+        description="P-C. Provides 2 B and 1 A" if has_scan_text else "Unknown item",
+        collection_text=["P-C acquired!"] if model_style != PickupModelStyle.HIDE_ALL else ['Unknown item acquired!'],
         conditional_resources=[ConditionalResources("P-C", None, (
             (resource_b, 2), (resource_a, 1),
         ))],
@@ -272,8 +272,8 @@ def test_create_pickup_list_random_data_source(has_memo_data: bool, empty_patche
     assert len(result) == 5
     assert result[0] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(0),
-        scan_text="A",
-        hud_text=[memo_data["A"]],
+        description="A",
+        collection_text=[memo_data["A"]],
         conditional_resources=[ConditionalResources("A", None, ())],
         conversion=[],
         model=model_1,
@@ -282,8 +282,8 @@ def test_create_pickup_list_random_data_source(has_memo_data: bool, empty_patche
     )
     assert result[1] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(1),
-        scan_text="A",
-        hud_text=[memo_data["A"]],
+        description="A",
+        collection_text=[memo_data["A"]],
         conditional_resources=[ConditionalResources("Useless", None, ())],
         conversion=[],
         model=model_1,
@@ -292,8 +292,8 @@ def test_create_pickup_list_random_data_source(has_memo_data: bool, empty_patche
     )
     assert result[2] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(2),
-        scan_text="C",
-        hud_text=[memo_data["C"], memo_data["C"]],
+        description="C",
+        collection_text=[memo_data["C"], memo_data["C"]],
         conditional_resources=[
             ConditionalResources("B", None, ((resource_b, 1),)),
             ConditionalResources("B", resource_b, ((resource_b, 1),)),
@@ -305,8 +305,8 @@ def test_create_pickup_list_random_data_source(has_memo_data: bool, empty_patche
     )
     assert result[3] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(3),
-        scan_text="B",
-        hud_text=[memo_data["B"]],
+        description="B",
+        collection_text=[memo_data["B"]],
         conditional_resources=[ConditionalResources("A", None, ())],
         conversion=[],
         model=model_2,
@@ -315,8 +315,8 @@ def test_create_pickup_list_random_data_source(has_memo_data: bool, empty_patche
     )
     assert result[4] == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(4),
-        scan_text="A",
-        hud_text=[memo_data["A"]],
+        description="A",
+        collection_text=[memo_data["A"]],
         conditional_resources=[ConditionalResources("C", None, ())],
         conversion=[],
         model=model_1,
@@ -380,8 +380,8 @@ def test_solo_create_pickup_data(pickup_for_create_pickup_data):
     # Assert
     assert data == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(10),
-        scan_text="Scan Text",
-        hud_text=['A acquired!', 'B acquired!'],
+        description="Scan Text",
+        collection_text=['A acquired!', 'B acquired!'],
         conditional_resources=[
             ConditionalResources("A", None, ((resource_a, 1),)),
             ConditionalResources("B", resource_a, ((resource_b, 1),)),
@@ -409,8 +409,8 @@ def test_multi_create_pickup_data_for_self(pickup_for_create_pickup_data):
     # Assert
     assert data == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(10),
-        scan_text="Your Scan Text",
-        hud_text=['A acquired!', 'B acquired!'],
+        description="Your Scan Text",
+        collection_text=['A acquired!', 'B acquired!'],
         conditional_resources=[
             ConditionalResources("A", None, ((resource_a, 1),)),
             ConditionalResources("B", resource_a, ((resource_b, 1),)),
@@ -439,8 +439,8 @@ def test_multi_create_pickup_data_for_other(pickup_for_create_pickup_data):
     # Assert
     assert data == pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(10),
-        scan_text="Someone's Scan Text",
-        hud_text=['Sent Cake to Someone!'],
+        description="Someone's Scan Text",
+        collection_text=['Sent Cake to Someone!'],
         conditional_resources=[
             ConditionalResources(None, None, ((multi, 11),)),
         ],

--- a/test/games/prime1/exporter/test_prime_patcher_data_factory.py
+++ b/test/games/prime1/exporter/test_prime_patcher_data_factory.py
@@ -21,8 +21,8 @@ def test_prime1_pickup_details_to_patcher_shiny_missile(prime1_resource_database
     rng.randint.return_value = 0
     detail = pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(15),
-        scan_text="Your Missile Expansion. Provides 5 Missiles",
-        hud_text=["Missile Expansion acquired!"],
+        description="Your Missile Expansion. Provides 5 Missiles",
+        collection_text=["Missile Expansion acquired!"],
         conditional_resources=[ConditionalResources(
             None, None, (
                 (prime1_resource_database.get_item_by_name("Missile"), 6),

--- a/test/games/prime1/exporter/test_prime_patcher_data_factory.py
+++ b/test/games/prime1/exporter/test_prime_patcher_data_factory.py
@@ -21,7 +21,8 @@ def test_prime1_pickup_details_to_patcher_shiny_missile(prime1_resource_database
     rng.randint.return_value = 0
     detail = pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(15),
-        description="Your Missile Expansion. Provides 5 Missiles",
+        name="Your Missile Expansion",
+        description="Provides 5 Missiles",
         collection_text=["Missile Expansion acquired!"],
         conditional_resources=[ConditionalResources(
             None, None, (

--- a/test/games/prime2/patcher/test_patch_data_generator.py
+++ b/test/games/prime2/patcher/test_patch_data_generator.py
@@ -482,7 +482,7 @@ def test_create_pickup_all_from_pool(echoes_game_description,
 
     for item in item_pool.pickups:
         data = creator.export(index, PickupTarget(item, 0), item, PickupModelStyle.ALL_VISIBLE)
-        for hud_text in data.hud_text:
+        for hud_text in data.collection_text:
             assert not hud_text.startswith("Locked")
 
 
@@ -492,8 +492,8 @@ def test_run_validated_hud_text():
     rng.randint.return_value = 0
     details = pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(0),
-        scan_text="scan",
-        hud_text=["Energy Transfer Module acquired!"],
+        description="scan",
+        collection_text=["Energy Transfer Module acquired!"],
         conditional_resources=[
             ConditionalResources(None, None, ()),
         ],

--- a/test/games/prime2/patcher/test_patch_data_generator.py
+++ b/test/games/prime2/patcher/test_patch_data_generator.py
@@ -376,7 +376,7 @@ def test_pickup_data_for_seeker_launcher(echoes_item_database, echoes_resource_d
     # Assert
     assert result == {
         "pickup_index": 0,
-        "scan": "Seeker Launcher",
+        "scan": "Seeker Launcher.",
         "model": {"game": "prime2", "name": "SeekerLauncher"},
         "hud_text": ["Seeker Launcher acquired, but the Missile Launcher is required to use it.",
                      "Seeker Launcher acquired!"],
@@ -425,7 +425,7 @@ def test_pickup_data_for_pb_expansion_locked(simplified, echoes_item_database, e
     # Assert
     assert result == {
         "pickup_index": 0,
-        "scan": "Power Bomb Expansion. Provides 2 Power Bombs and 1 Item Percentage",
+        "scan": "Power Bomb Expansion. Provides 2 Power Bombs and 1 Item Percentage.",
         "model": {"game": "prime2", "name": "PowerBombExpansion"},
         "hud_text": hud_text,
         'resources': [{'amount': 2, 'index': 72},
@@ -456,7 +456,7 @@ def test_pickup_data_for_pb_expansion_unlocked(echoes_item_database, echoes_reso
     # Assert
     assert result == {
         "pickup_index": 0,
-        "scan": "Power Bomb Expansion. Provides 2 Power Bombs and 1 Item Percentage",
+        "scan": "Power Bomb Expansion. Provides 2 Power Bombs and 1 Item Percentage.",
         "model": {"game": "prime2", "name": "PowerBombExpansion"},
         "hud_text": ["Power Bomb Expansion acquired!"],
         'resources': [{'amount': 2, 'index': 43},
@@ -492,6 +492,7 @@ def test_run_validated_hud_text():
     rng.randint.return_value = 0
     details = pickup_exporter.ExportedPickupDetails(
         index=PickupIndex(0),
+        name="Energy Transfer Module",
         description="scan",
         collection_text=["Energy Transfer Module acquired!"],
         conditional_resources=[

--- a/test/test_files/randomprime_expected_data.json
+++ b/test/test_files/randomprime_expected_data.json
@@ -34,7 +34,7 @@
         "forceFusion": false
     },
     "gameConfig": {
-        "resultsString": "4.6.0.dev240 | Seed Hash - Putrid Shriekbat Polluted (AAAAAAAA)",
+        "resultsString": "4.6.0.dev288 | Seed Hash - Putrid Shriekbat Polluted (AAAAAAAA)",
         "bossSizes": null,
         "noDoors": false,
         "shufflePickupPosition": false,
@@ -108,7 +108,7 @@
             "gameNameFull": "Metroid Prime: Randomizer - AAAAAAAA",
             "description": "Seed Hash: Putrid Shriekbat Polluted"
         },
-        "mainMenuMessage": "Randovania v4.6.0.dev240\nPutrid Shriekbat Polluted",
+        "mainMenuMessage": "Randovania v4.6.0.dev288\nPutrid Shriekbat Polluted",
         "creditsString": "&push;&font=C29C51F1;&main-color=#89D6FF;Major Item Locations&pop;\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Charge Beam&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Sanctuary Fortress - Sanctuary Energy Controller\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wave Beam&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Torvus Bog - Great Bridge\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Beam&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Temple Grounds - Temple Assembly Site\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Plasma Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Root Cave\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Grapple Beam&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Dark Agon Wastes - Junction Site\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Thermal Visor&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Torvus Bog - Torvus Energy Controller\n\n&push;&font=C29C51F1;&main-color=#33ffd6;X-Ray Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Alcove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Boost Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Life Grove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Spider Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Storage Depot A\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Power Bomb&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Main Plaza\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Varia Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Landing Site\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Gravity Suit&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Great Temple - Transport B Access\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Phazon Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Cargo Freight Lift to Deck Gamma\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Super Missile&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Temple Grounds - Windchamber Gateway\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wavebuster&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Sunchamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Spreader&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Sandcanyon\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Flamethrower&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Torvus Bog - Training Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Chozo&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Dark Agon Wastes - Ing Cache 1\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Elder&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Sand Cache\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Lifegiver&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Temple Grounds - Storage Cavern B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Nature&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Sanctuary Fortress - Hall of Combat Mastery\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Newborn&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Great Temple - Transport A Access\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Spirit&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Temple Grounds - Transport to Agon Wastes\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Strength&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Storage D\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Truth&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Mining Station Access\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Warrior&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Portal Access A\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Wild&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Transport Tunnel B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of World&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Ing Hive - Culling Chamber",
         "artifactHints": {
             "Artifact of Sun": "&push;&main-color=#c300ff;Artifact of Sun&pop; has no need to be located.",
@@ -240,7 +240,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -253,7 +253,7 @@
                                 "game": "prime2",
                                 "name": "LightBeamAmmoExpansion"
                             },
-                            "scanText": "Echoes's Light Ammo Expansion. Provides 20 Light Ammo and 1 Item Percentage",
+                            "scanText": "Echoes's Light Ammo Expansion. Provides 20 Light Ammo and 1 Item Percentage.",
                             "hudmemoText": "Sent Light Ammo Expansion to Echoes!",
                             "currIncrease": 37,
                             "maxIncrease": 37,
@@ -291,7 +291,7 @@
                                 "game": "prime2",
                                 "name": "EnergyTank"
                             },
-                            "scanText": "Echoes's Energy Tank",
+                            "scanText": "Echoes's Energy Tank.",
                             "hudmemoText": "Sent Energy Tank to Echoes!",
                             "currIncrease": 38,
                             "maxIncrease": 38,
@@ -309,7 +309,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 39,
                             "maxIncrease": 39,
@@ -327,7 +327,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -340,7 +340,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 41,
                             "maxIncrease": 41,
@@ -370,7 +370,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -388,7 +388,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -406,7 +406,7 @@
                                 "game": "prime2",
                                 "name": "EnergyTank"
                             },
-                            "scanText": "Echoes's Energy Tank",
+                            "scanText": "Echoes's Energy Tank.",
                             "hudmemoText": "Sent Energy Tank to Echoes!",
                             "currIncrease": 44,
                             "maxIncrease": 44,
@@ -452,7 +452,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -470,7 +470,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -492,7 +492,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 47,
                             "maxIncrease": 47,
@@ -518,7 +518,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -536,7 +536,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -582,7 +582,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 50,
                             "maxIncrease": 50,
@@ -600,7 +600,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -618,7 +618,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -672,7 +672,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 53,
                             "maxIncrease": 53,
@@ -686,7 +686,7 @@
                                 "game": "prime2",
                                 "name": "PowerBombExpansion"
                             },
-                            "scanText": "Echoes's Power Bomb Expansion. Provides 1 Power Bomb and 1 Item Percentage",
+                            "scanText": "Echoes's Power Bomb Expansion. Provides 1 Power Bomb and 1 Item Percentage.",
                             "hudmemoText": "Sent Power Bomb Expansion to Echoes!",
                             "currIncrease": 54,
                             "maxIncrease": 54,
@@ -709,7 +709,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -722,7 +722,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 56,
                             "maxIncrease": 56,
@@ -740,7 +740,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -758,7 +758,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 58,
                             "maxIncrease": 58,
@@ -922,7 +922,7 @@
                                 "game": "prime2",
                                 "name": "MorphBallBomb"
                             },
-                            "scanText": "Echoes's Morph Ball Bomb",
+                            "scanText": "Echoes's Morph Ball Bomb.",
                             "hudmemoText": "Sent Morph Ball Bomb to Echoes!",
                             "currIncrease": 91,
                             "maxIncrease": 91,
@@ -944,7 +944,7 @@
                                 "game": "prime2",
                                 "name": "PowerBombExpansion"
                             },
-                            "scanText": "Echoes's Power Bomb Expansion. Provides 1 Power Bomb and 1 Item Percentage",
+                            "scanText": "Echoes's Power Bomb Expansion. Provides 1 Power Bomb and 1 Item Percentage.",
                             "hudmemoText": "Sent Power Bomb Expansion to Echoes!",
                             "currIncrease": 92,
                             "maxIncrease": 92,
@@ -966,7 +966,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -988,7 +988,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1006,7 +1006,7 @@
                                 "game": "prime2",
                                 "name": "LightBeamAmmoExpansion"
                             },
-                            "scanText": "Echoes's Light Ammo Expansion. Provides 20 Light Ammo and 1 Item Percentage",
+                            "scanText": "Echoes's Light Ammo Expansion. Provides 20 Light Ammo and 1 Item Percentage.",
                             "hudmemoText": "Sent Light Ammo Expansion to Echoes!",
                             "currIncrease": 95,
                             "maxIncrease": 95,
@@ -1024,7 +1024,7 @@
                                 "game": "prime2",
                                 "name": "DarkBeamAmmoExpansion"
                             },
-                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage",
+                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage.",
                             "hudmemoText": "Sent Dark Ammo Expansion to Echoes!",
                             "currIncrease": 96,
                             "maxIncrease": 96,
@@ -1046,7 +1046,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 97,
                             "maxIncrease": 97,
@@ -1059,7 +1059,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1101,7 +1101,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 99,
                             "maxIncrease": 99,
@@ -1123,7 +1123,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1177,7 +1177,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1203,7 +1203,7 @@
                                 "game": "prime2",
                                 "name": "EnergyTank"
                             },
-                            "scanText": "Echoes's Energy Tank",
+                            "scanText": "Echoes's Energy Tank.",
                             "hudmemoText": "Sent Energy Tank to Echoes!",
                             "currIncrease": 75,
                             "maxIncrease": 75,
@@ -1233,7 +1233,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1259,7 +1259,7 @@
                                 "game": "prime1",
                                 "name": "Spider Ball"
                             },
-                            "scanText": "Your Spider Ball",
+                            "scanText": "Your Spider Ball.",
                             "hudmemoText": "Spider Ball acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1277,7 +1277,7 @@
                                 "game": "prime2",
                                 "name": "SonicBoom"
                             },
-                            "scanText": "Echoes's Sonic Boom",
+                            "scanText": "Echoes's Sonic Boom.",
                             "hudmemoText": "Sent Sonic Boom to Echoes!",
                             "currIncrease": 78,
                             "maxIncrease": 78,
@@ -1290,7 +1290,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1312,7 +1312,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 80,
                             "maxIncrease": 80,
@@ -1338,7 +1338,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1356,7 +1356,7 @@
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
                             },
-                            "scanText": "Your Power Bomb Expansion. Provides 1 Power Bomb",
+                            "scanText": "Your Power Bomb Expansion. Provides 1 Power Bomb.",
                             "hudmemoText": "Power Bomb Expansion acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1382,7 +1382,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1412,7 +1412,7 @@
                                 "game": "prime2",
                                 "name": "LightBeamAmmoExpansion"
                             },
-                            "scanText": "Echoes's Light Ammo Expansion. Provides 20 Light Ammo and 1 Item Percentage",
+                            "scanText": "Echoes's Light Ammo Expansion. Provides 20 Light Ammo and 1 Item Percentage.",
                             "hudmemoText": "Sent Light Ammo Expansion to Echoes!",
                             "currIncrease": 84,
                             "maxIncrease": 84,
@@ -1430,7 +1430,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1460,7 +1460,7 @@
                                 "game": "prime2",
                                 "name": "Darkburst"
                             },
-                            "scanText": "Echoes's Darkburst",
+                            "scanText": "Echoes's Darkburst.",
                             "hudmemoText": "Sent Darkburst to Echoes!",
                             "currIncrease": 86,
                             "maxIncrease": 86,
@@ -1478,7 +1478,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 87,
                             "maxIncrease": 87,
@@ -1508,7 +1508,7 @@
                                 "game": "prime2",
                                 "name": "LightBeamAmmoExpansion"
                             },
-                            "scanText": "Echoes's Light Ammo Expansion. Provides 20 Light Ammo and 1 Item Percentage",
+                            "scanText": "Echoes's Light Ammo Expansion. Provides 20 Light Ammo and 1 Item Percentage.",
                             "hudmemoText": "Sent Light Ammo Expansion to Echoes!",
                             "currIncrease": 88,
                             "maxIncrease": 88,
@@ -1534,7 +1534,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1552,7 +1552,7 @@
                                 "game": "prime2",
                                 "name": "EnergyTank"
                             },
-                            "scanText": "Echoes's Energy Tank",
+                            "scanText": "Echoes's Energy Tank.",
                             "hudmemoText": "Sent Energy Tank to Echoes!",
                             "currIncrease": 90,
                             "maxIncrease": 90,
@@ -1586,7 +1586,7 @@
                                 "game": "prime1",
                                 "name": "Varia Suit"
                             },
-                            "scanText": "Your Varia Suit",
+                            "scanText": "Your Varia Suit.",
                             "hudmemoText": "Varia Suit acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1616,7 +1616,7 @@
                                 "game": "prime1",
                                 "name": "X-Ray Visor"
                             },
-                            "scanText": "Your X-Ray Visor",
+                            "scanText": "Your X-Ray Visor.",
                             "hudmemoText": "X-Ray Visor acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1646,7 +1646,7 @@
                                 "game": "prime2",
                                 "name": "EmeraldTranslator"
                             },
-                            "scanText": "Echoes's Emerald Translator",
+                            "scanText": "Echoes's Emerald Translator.",
                             "hudmemoText": "Sent Emerald Translator to Echoes!",
                             "currIncrease": 61,
                             "maxIncrease": 61,
@@ -1680,7 +1680,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1702,7 +1702,7 @@
                                 "game": "prime1",
                                 "name": "Plasma Beam"
                             },
-                            "scanText": "Your Plasma Beam",
+                            "scanText": "Your Plasma Beam.",
                             "hudmemoText": "Plasma Beam acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1720,7 +1720,7 @@
                                 "game": "prime2",
                                 "name": "VioletTranslator"
                             },
-                            "scanText": "Echoes's Violet Translator",
+                            "scanText": "Echoes's Violet Translator.",
                             "hudmemoText": "Sent Violet Translator to Echoes!",
                             "currIncrease": 64,
                             "maxIncrease": 64,
@@ -1747,7 +1747,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Wild"
                             },
-                            "scanText": "Your Artifact of Wild",
+                            "scanText": "Your Artifact of Wild.",
                             "hudmemoText": "Artifact of Wild acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1765,7 +1765,7 @@
                                 "game": "prime2",
                                 "name": "ScrewAttack"
                             },
-                            "scanText": "Echoes's Screw Attack",
+                            "scanText": "Echoes's Screw Attack.",
                             "hudmemoText": "Sent Screw Attack to Echoes!",
                             "currIncrease": 66,
                             "maxIncrease": 66,
@@ -1807,7 +1807,7 @@
                                 "game": "prime1",
                                 "name": "Phazon Suit"
                             },
-                            "scanText": "Your Phazon Suit",
+                            "scanText": "Your Phazon Suit.",
                             "hudmemoText": "Phazon Suit acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1833,7 +1833,7 @@
                                 "game": "prime2",
                                 "name": "DarkBeamAmmoExpansion"
                             },
-                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage",
+                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage.",
                             "hudmemoText": "Sent Dark Ammo Expansion to Echoes!",
                             "currIncrease": 68,
                             "maxIncrease": 68,
@@ -1867,7 +1867,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1889,7 +1889,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1911,7 +1911,7 @@
                                 "game": "prime2",
                                 "name": "LightBeamAmmoExpansion"
                             },
-                            "scanText": "Echoes's Light Ammo Expansion. Provides 20 Light Ammo and 1 Item Percentage",
+                            "scanText": "Echoes's Light Ammo Expansion. Provides 20 Light Ammo and 1 Item Percentage.",
                             "hudmemoText": "Sent Light Ammo Expansion to Echoes!",
                             "currIncrease": 71,
                             "maxIncrease": 71,
@@ -1937,7 +1937,7 @@
                                 "game": "prime1",
                                 "name": "Boost Ball"
                             },
-                            "scanText": "Your Boost Ball",
+                            "scanText": "Your Boost Ball.",
                             "hudmemoText": "Boost Ball acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1950,7 +1950,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1990,7 +1990,7 @@
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
                             },
-                            "scanText": "Your Power Bomb Expansion. Provides 1 Power Bomb",
+                            "scanText": "Your Power Bomb Expansion. Provides 1 Power Bomb.",
                             "hudmemoText": "Power Bomb Expansion acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -2003,7 +2003,7 @@
                                 "game": "prime1",
                                 "name": "Power Bomb"
                             },
-                            "scanText": "Your Power Bomb",
+                            "scanText": "Your Power Bomb.",
                             "hudmemoText": "Main Power Bomb acquired!",
                             "currIncrease": 4,
                             "maxIncrease": 4,
@@ -2016,7 +2016,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2029,7 +2029,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2067,7 +2067,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2085,7 +2085,7 @@
                                 "game": "prime2",
                                 "name": "DarkBeamAmmoExpansion"
                             },
-                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage",
+                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage.",
                             "hudmemoText": "Sent Dark Ammo Expansion to Echoes!",
                             "currIncrease": 6,
                             "maxIncrease": 6,
@@ -2099,7 +2099,7 @@
                                 "game": "prime2",
                                 "name": "PowerBombExpansion"
                             },
-                            "scanText": "Echoes's Power Bomb Expansion. Provides 1 Power Bomb and 1 Item Percentage",
+                            "scanText": "Echoes's Power Bomb Expansion. Provides 1 Power Bomb and 1 Item Percentage.",
                             "hudmemoText": "Sent Power Bomb Expansion to Echoes!",
                             "currIncrease": 7,
                             "maxIncrease": 7,
@@ -2113,7 +2113,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 8,
                             "maxIncrease": 8,
@@ -2136,7 +2136,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 9,
                             "maxIncrease": 9,
@@ -2154,7 +2154,7 @@
                                 "game": "prime2",
                                 "name": "EnergyTank"
                             },
-                            "scanText": "Echoes's Energy Tank",
+                            "scanText": "Echoes's Energy Tank.",
                             "hudmemoText": "Sent Energy Tank to Echoes!",
                             "currIncrease": 10,
                             "maxIncrease": 10,
@@ -2184,7 +2184,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2206,7 +2206,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 12,
                             "maxIncrease": 12,
@@ -2228,7 +2228,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -2246,7 +2246,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 14,
                             "maxIncrease": 14,
@@ -2284,7 +2284,7 @@
                                 "game": "prime2",
                                 "name": "PowerBombExpansion"
                             },
-                            "scanText": "Echoes's Power Bomb Expansion. Provides 1 Power Bomb and 1 Item Percentage",
+                            "scanText": "Echoes's Power Bomb Expansion. Provides 1 Power Bomb and 1 Item Percentage.",
                             "hudmemoText": "Sent Power Bomb Expansion to Echoes!",
                             "currIncrease": 15,
                             "maxIncrease": 15,
@@ -2302,7 +2302,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2315,7 +2315,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 17,
                             "maxIncrease": 17,
@@ -2337,7 +2337,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 18,
                             "maxIncrease": 18,
@@ -2360,7 +2360,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2390,7 +2390,7 @@
                                 "game": "prime2",
                                 "name": "DarkBeamAmmoExpansion"
                             },
-                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage",
+                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage.",
                             "hudmemoText": "Sent Dark Ammo Expansion to Echoes!",
                             "currIncrease": 20,
                             "maxIncrease": 20,
@@ -2409,7 +2409,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2422,7 +2422,7 @@
                                 "game": "prime1",
                                 "name": "Wavebuster"
                             },
-                            "scanText": "Your Wavebuster",
+                            "scanText": "Your Wavebuster.",
                             "hudmemoText": "Wavebuster acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -2440,7 +2440,7 @@
                                 "game": "prime2",
                                 "name": "DarkBeamAmmoExpansion"
                             },
-                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage",
+                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage.",
                             "hudmemoText": "Sent Dark Ammo Expansion to Echoes!",
                             "currIncrease": 23,
                             "maxIncrease": 23,
@@ -2466,7 +2466,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -2479,7 +2479,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -2509,7 +2509,7 @@
                                 "game": "prime2",
                                 "name": "DarkBeamAmmoExpansion"
                             },
-                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage",
+                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage.",
                             "hudmemoText": "Sent Dark Ammo Expansion to Echoes!",
                             "currIncrease": 26,
                             "maxIncrease": 26,
@@ -2522,7 +2522,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2548,7 +2548,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2561,7 +2561,7 @@
                                 "game": "prime2",
                                 "name": "EnergyTank"
                             },
-                            "scanText": "Echoes's Energy Tank",
+                            "scanText": "Echoes's Energy Tank.",
                             "hudmemoText": "Sent Energy Tank to Echoes!",
                             "currIncrease": 29,
                             "maxIncrease": 29,
@@ -2579,7 +2579,7 @@
                                 "game": "prime2",
                                 "name": "LightBeamAmmoExpansion"
                             },
-                            "scanText": "Echoes's Light Ammo Expansion. Provides 20 Light Ammo and 1 Item Percentage",
+                            "scanText": "Echoes's Light Ammo Expansion. Provides 20 Light Ammo and 1 Item Percentage.",
                             "hudmemoText": "Sent Light Ammo Expansion to Echoes!",
                             "currIncrease": 30,
                             "maxIncrease": 30,
@@ -2592,7 +2592,7 @@
                                 "game": "prime2",
                                 "name": "EnergyTank"
                             },
-                            "scanText": "Echoes's Energy Tank",
+                            "scanText": "Echoes's Energy Tank.",
                             "hudmemoText": "Sent Energy Tank to Echoes!",
                             "currIncrease": 31,
                             "maxIncrease": 31,
@@ -2618,7 +2618,7 @@
                                 "game": "prime2",
                                 "name": "MissileExpansion"
                             },
-                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage",
+                            "scanText": "Echoes's Missile Expansion. Provides 5 Missiles and 1 Item Percentage.",
                             "hudmemoText": "Sent Missile Expansion to Echoes!",
                             "currIncrease": 32,
                             "maxIncrease": 32,
@@ -2636,7 +2636,7 @@
                                 "game": "prime2",
                                 "name": "DarkBeamAmmoExpansion"
                             },
-                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage",
+                            "scanText": "Echoes's Dark Ammo Expansion. Provides 20 Dark Ammo and 1 Item Percentage.",
                             "hudmemoText": "Sent Dark Ammo Expansion to Echoes!",
                             "currIncrease": 33,
                             "maxIncrease": 33,
@@ -2666,7 +2666,7 @@
                                 "game": "prime2",
                                 "name": "EnergyTank"
                             },
-                            "scanText": "Echoes's Energy Tank",
+                            "scanText": "Echoes's Energy Tank.",
                             "hudmemoText": "Sent Energy Tank to Echoes!",
                             "currIncrease": 34,
                             "maxIncrease": 34,
@@ -2696,7 +2696,7 @@
                                 "game": "prime2",
                                 "name": "PowerBombExpansion"
                             },
-                            "scanText": "Echoes's Power Bomb Expansion. Provides 1 Power Bomb and 1 Item Percentage",
+                            "scanText": "Echoes's Power Bomb Expansion. Provides 1 Power Bomb and 1 Item Percentage.",
                             "hudmemoText": "Sent Power Bomb Expansion to Echoes!",
                             "currIncrease": 35,
                             "maxIncrease": 35,

--- a/test/test_files/randomprime_expected_data_crazy.json
+++ b/test/test_files/randomprime_expected_data_crazy.json
@@ -34,7 +34,7 @@
         "forceFusion": false
     },
     "gameConfig": {
-        "resultsString": "4.6.0.dev240 | Seed Hash - Geemer Shriekbat Fission (AAAAAAAA)",
+        "resultsString": "4.6.0.dev288 | Seed Hash - Geemer Shriekbat Fission (AAAAAAAA)",
         "bossSizes": null,
         "noDoors": true,
         "shufflePickupPosition": true,
@@ -108,7 +108,7 @@
             "gameNameFull": "Metroid Prime: Randomizer - AAAAAAAA",
             "description": "Seed Hash: Geemer Shriekbat Fission"
         },
-        "mainMenuMessage": "Randovania v4.6.0.dev240\nGeemer Shriekbat Fission",
+        "mainMenuMessage": "Randovania v4.6.0.dev288\nGeemer Shriekbat Fission",
         "creditsString": "&push;&font=C29C51F1;&main-color=#89D6FF;Major Item Locations&pop;\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Charge Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ice Ruins East\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wave Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Arbor Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Ruined Fountain\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Plasma Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Central Dynamo\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Missile Launcher&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Alcove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Grapple Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Ruined Gallery\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Combat Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Landing Site\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Thermal Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Ventilation Shaft\n\n&push;&font=C29C51F1;&main-color=#33ffd6;X-Ray Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Furnace\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Space Jump Boots&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Hall of the Elders\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Boost Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Main Plaza\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Spider Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Watery Hall\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Power Bomb&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Transport Access North\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Varia Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Main Plaza\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Gravity Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Fungal Hall B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Phazon Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Burn Dome\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Super Missile&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Warrior Shrine\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wavebuster&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Phendrana Canyon\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Spreader&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Life Grove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Flamethrower&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ice Ruins East\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Chozo&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Triclops Pit\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Elder&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Storage Cavern\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Lifegiver&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Chapel of the Elders\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Nature&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Phendrana Shorelines\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Strength&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Magma Pool\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Sun&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Lava Lake\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Truth&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ice Ruins West\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Warrior&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Elder Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Wild&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ruined Courtyard",
         "artifactHints": {
             "Artifact of World": "&push;&main-color=#c300ff;Artifact of World&pop; has no need to be located.",
@@ -164,7 +164,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -212,7 +212,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -251,7 +251,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -296,7 +296,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -329,7 +329,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -368,7 +368,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -401,7 +401,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -427,7 +427,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -453,7 +453,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -479,7 +479,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -505,7 +505,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -531,7 +531,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -565,7 +565,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -598,7 +598,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -637,7 +637,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -650,7 +650,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Nature"
                             },
-                            "scanText": "Your Artifact of Nature",
+                            "scanText": "Your Artifact of Nature.",
                             "hudmemoText": "Artifact of Nature acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -707,7 +707,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -746,7 +746,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -779,7 +779,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -818,7 +818,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -857,7 +857,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -896,7 +896,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -929,7 +929,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Truth"
                             },
-                            "scanText": "Your Artifact of Truth",
+                            "scanText": "Your Artifact of Truth.",
                             "hudmemoText": "Artifact of Truth acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -968,7 +968,7 @@
                                 "game": "prime1",
                                 "name": "Charge Beam"
                             },
-                            "scanText": "Your Charge Beam",
+                            "scanText": "Your Charge Beam.",
                             "hudmemoText": "Charge Beam acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -981,7 +981,7 @@
                                 "game": "prime1",
                                 "name": "Flamethrower"
                             },
-                            "scanText": "Your Flamethrower",
+                            "scanText": "Your Flamethrower.",
                             "hudmemoText": "Flamethrower acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1014,7 +1014,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1053,7 +1053,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1092,7 +1092,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1131,7 +1131,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Lifegiver"
                             },
-                            "scanText": "Your Artifact of Lifegiver",
+                            "scanText": "Your Artifact of Lifegiver.",
                             "hudmemoText": "Artifact of Lifegiver acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1158,7 +1158,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Wild"
                             },
-                            "scanText": "Your Artifact of Wild",
+                            "scanText": "Your Artifact of Wild.",
                             "hudmemoText": "Artifact of Wild acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1203,7 +1203,7 @@
                                 "game": "prime1",
                                 "name": "Wavebuster"
                             },
-                            "scanText": "Your Wavebuster",
+                            "scanText": "Your Wavebuster.",
                             "hudmemoText": "Wavebuster acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1230,7 +1230,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1263,7 +1263,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1302,7 +1302,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1341,7 +1341,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1386,7 +1386,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1425,7 +1425,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1458,7 +1458,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1497,7 +1497,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1536,7 +1536,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1569,7 +1569,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1608,7 +1608,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1635,7 +1635,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1674,7 +1674,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1713,7 +1713,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1752,7 +1752,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1785,7 +1785,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1824,7 +1824,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1857,7 +1857,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1908,7 +1908,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1947,7 +1947,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1986,7 +1986,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2025,7 +2025,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2064,7 +2064,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2097,7 +2097,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -2130,7 +2130,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2169,7 +2169,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2220,7 +2220,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2259,7 +2259,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2298,7 +2298,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2331,7 +2331,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2370,7 +2370,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2409,7 +2409,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2448,7 +2448,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2487,7 +2487,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2526,7 +2526,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -2539,7 +2539,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2572,7 +2572,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2623,7 +2623,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2636,7 +2636,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2669,7 +2669,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2696,7 +2696,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2730,7 +2730,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2756,7 +2756,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2789,7 +2789,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2828,7 +2828,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2854,7 +2854,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2893,7 +2893,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2926,7 +2926,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2965,7 +2965,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3004,7 +3004,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3043,7 +3043,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3082,7 +3082,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3121,7 +3121,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3160,7 +3160,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3199,7 +3199,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3238,7 +3238,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3283,7 +3283,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3322,7 +3322,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3361,7 +3361,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3400,7 +3400,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3433,7 +3433,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3472,7 +3472,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3511,7 +3511,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3550,7 +3550,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3583,7 +3583,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3616,7 +3616,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3655,7 +3655,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3694,7 +3694,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3733,7 +3733,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3783,7 +3783,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3816,7 +3816,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3861,7 +3861,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3900,7 +3900,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3933,7 +3933,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Sun"
                             },
-                            "scanText": "Your Artifact of Sun",
+                            "scanText": "Your Artifact of Sun.",
                             "hudmemoText": "Artifact of Sun acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -3966,7 +3966,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4005,7 +4005,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Chozo"
                             },
-                            "scanText": "Your Artifact of Chozo",
+                            "scanText": "Your Artifact of Chozo.",
                             "hudmemoText": "Artifact of Chozo acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -4044,7 +4044,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4083,7 +4083,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Elder"
                             },
-                            "scanText": "Your Artifact of Elder",
+                            "scanText": "Your Artifact of Elder.",
                             "hudmemoText": "Artifact of Elder acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -4110,7 +4110,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4161,7 +4161,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -4194,7 +4194,7 @@
                                 "game": "prime1",
                                 "name": "Super Missile"
                             },
-                            "scanText": "Your Super Missile",
+                            "scanText": "Your Super Missile.",
                             "hudmemoText": "Super Missile acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -4227,7 +4227,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -4260,7 +4260,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4293,7 +4293,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -4306,7 +4306,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -4345,7 +4345,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4384,7 +4384,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4423,7 +4423,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4462,7 +4462,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4501,7 +4501,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4540,7 +4540,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4585,7 +4585,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -4612,7 +4612,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4651,7 +4651,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -4690,7 +4690,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4729,7 +4729,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4768,7 +4768,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4801,7 +4801,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4840,7 +4840,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4881,7 +4881,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4914,7 +4914,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4953,7 +4953,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -4998,7 +4998,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5037,7 +5037,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5070,7 +5070,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5103,7 +5103,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5154,7 +5154,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5199,7 +5199,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5238,7 +5238,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5265,7 +5265,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5304,7 +5304,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5343,7 +5343,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5370,7 +5370,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5383,7 +5383,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5416,7 +5416,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5455,7 +5455,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5488,7 +5488,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5533,7 +5533,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5572,7 +5572,7 @@
                                 "game": "prime1",
                                 "name": "Thermal Visor"
                             },
-                            "scanText": "Your Thermal Visor",
+                            "scanText": "Your Thermal Visor.",
                             "hudmemoText": "Thermal Visor acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -5605,7 +5605,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -5644,7 +5644,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5689,7 +5689,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5728,7 +5728,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5761,7 +5761,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5794,7 +5794,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5833,7 +5833,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5866,7 +5866,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5899,7 +5899,7 @@
                                 "game": "prime1",
                                 "name": "Plasma Beam"
                             },
-                            "scanText": "Your Plasma Beam",
+                            "scanText": "Your Plasma Beam.",
                             "hudmemoText": "Plasma Beam acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -5938,7 +5938,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5977,7 +5977,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6016,7 +6016,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6049,7 +6049,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -6088,7 +6088,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -6121,7 +6121,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6160,7 +6160,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6193,7 +6193,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6232,7 +6232,7 @@
                                 "game": "prime1",
                                 "name": "Gravity Suit"
                             },
-                            "scanText": "Your Gravity Suit",
+                            "scanText": "Your Gravity Suit.",
                             "hudmemoText": "Gravity Suit acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -6271,7 +6271,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6310,7 +6310,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6343,7 +6343,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -6376,7 +6376,7 @@
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
                             },
-                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb",
+                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb.",
                             "hudmemoText": "Power Bomb Expansion acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6409,7 +6409,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6460,7 +6460,7 @@
                                 "game": "prime1",
                                 "name": "Combat Visor"
                             },
-                            "scanText": "Your Combat Visor",
+                            "scanText": "Your Combat Visor.",
                             "hudmemoText": "Combat Visor acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -6511,7 +6511,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6550,7 +6550,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6589,7 +6589,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6628,7 +6628,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Launcher",
+                            "scanText": "Your Missile Launcher.",
                             "hudmemoText": "Missile Launcher acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -6655,7 +6655,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6694,7 +6694,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6745,7 +6745,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6784,7 +6784,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -6823,7 +6823,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6862,7 +6862,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6901,7 +6901,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6934,7 +6934,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6973,7 +6973,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -7006,7 +7006,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7039,7 +7039,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -7078,7 +7078,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -7098,7 +7098,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7137,7 +7137,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7176,7 +7176,7 @@
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
                             },
-                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb",
+                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb.",
                             "hudmemoText": "Power Bomb Expansion acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7209,7 +7209,7 @@
                                 "game": "prime1",
                                 "name": "Wave Beam"
                             },
-                            "scanText": "Your Wave Beam",
+                            "scanText": "Your Wave Beam.",
                             "hudmemoText": "Wave Beam acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -7236,7 +7236,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7275,7 +7275,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7308,7 +7308,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7341,7 +7341,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7380,7 +7380,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7419,7 +7419,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7464,7 +7464,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -7497,7 +7497,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7530,7 +7530,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7569,7 +7569,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -7602,7 +7602,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7641,7 +7641,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7680,7 +7680,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7719,7 +7719,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7758,7 +7758,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -7791,7 +7791,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7848,7 +7848,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -7875,7 +7875,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7914,7 +7914,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -7947,7 +7947,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7986,7 +7986,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8019,7 +8019,7 @@
                                 "game": "prime1",
                                 "name": "Ice Spreader"
                             },
-                            "scanText": "Your Ice Spreader",
+                            "scanText": "Your Ice Spreader.",
                             "hudmemoText": "Ice Spreader acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8032,7 +8032,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -8059,7 +8059,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8102,7 +8102,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8135,7 +8135,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8174,7 +8174,7 @@
                                 "game": "prime1",
                                 "name": "Varia Suit"
                             },
-                            "scanText": "Your Varia Suit",
+                            "scanText": "Your Varia Suit.",
                             "hudmemoText": "Varia Suit acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8187,7 +8187,7 @@
                                 "game": "prime1",
                                 "name": "Boost Ball"
                             },
-                            "scanText": "Your Boost Ball",
+                            "scanText": "Your Boost Ball.",
                             "hudmemoText": "Boost Ball acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8200,7 +8200,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8213,7 +8213,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8270,7 +8270,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8309,7 +8309,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8348,7 +8348,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8387,7 +8387,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8426,7 +8426,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8465,7 +8465,7 @@
                                 "game": "prime1",
                                 "name": "Ice Beam"
                             },
-                            "scanText": "Your Ice Beam",
+                            "scanText": "Your Ice Beam.",
                             "hudmemoText": "Ice Beam acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8504,7 +8504,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8517,7 +8517,7 @@
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
                             },
-                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb",
+                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb.",
                             "hudmemoText": "Power Bomb Expansion acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8530,7 +8530,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -8563,7 +8563,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8602,7 +8602,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8635,7 +8635,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -8668,7 +8668,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8707,7 +8707,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8746,7 +8746,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8785,7 +8785,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -8824,7 +8824,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8863,7 +8863,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -8896,7 +8896,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8941,7 +8941,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Strength"
                             },
-                            "scanText": "Your Artifact of Strength",
+                            "scanText": "Your Artifact of Strength.",
                             "hudmemoText": "Artifact of Strength acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8974,7 +8974,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9007,7 +9007,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9040,7 +9040,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9079,7 +9079,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9124,7 +9124,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9163,7 +9163,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9202,7 +9202,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -9229,7 +9229,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9242,7 +9242,7 @@
                                 "game": "prime1",
                                 "name": "Grapple Beam"
                             },
-                            "scanText": "Your Grapple Beam",
+                            "scanText": "Your Grapple Beam.",
                             "hudmemoText": "Grapple Beam acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -9281,7 +9281,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9320,7 +9320,7 @@
                                 "game": "prime1",
                                 "name": "Power Bomb"
                             },
-                            "scanText": "Your Power Bomb",
+                            "scanText": "Your Power Bomb.",
                             "hudmemoText": "Main Power Bomb acquired!",
                             "currIncrease": 8,
                             "maxIncrease": 8,
@@ -9353,7 +9353,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9386,7 +9386,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9431,7 +9431,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9470,7 +9470,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9503,7 +9503,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9536,7 +9536,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9569,7 +9569,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -9582,7 +9582,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9602,7 +9602,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9635,7 +9635,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9668,7 +9668,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9707,7 +9707,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -9720,7 +9720,7 @@
                                 "game": "prime1",
                                 "name": "Spider Ball"
                             },
-                            "scanText": "Your Spider Ball",
+                            "scanText": "Your Spider Ball.",
                             "hudmemoText": "Spider Ball acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -9753,7 +9753,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9792,7 +9792,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9831,7 +9831,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9876,7 +9876,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9889,7 +9889,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9916,7 +9916,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9955,7 +9955,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9994,7 +9994,7 @@
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
                             },
-                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb",
+                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb.",
                             "hudmemoText": "Power Bomb Expansion acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10007,7 +10007,7 @@
                                 "game": "prime1",
                                 "name": "Phazon Suit"
                             },
-                            "scanText": "Your Phazon Suit",
+                            "scanText": "Your Phazon Suit.",
                             "hudmemoText": "Phazon Suit acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -10034,7 +10034,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -10047,7 +10047,7 @@
                                 "game": "prime1",
                                 "name": "X-Ray Visor"
                             },
-                            "scanText": "Your X-Ray Visor",
+                            "scanText": "Your X-Ray Visor.",
                             "hudmemoText": "X-Ray Visor acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -10086,7 +10086,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10125,7 +10125,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10164,7 +10164,7 @@
                                 "game": "prime1",
                                 "name": "Space Jump Boots"
                             },
-                            "scanText": "Your Space Jump Boots",
+                            "scanText": "Your Space Jump Boots.",
                             "hudmemoText": "Space Jump Boots acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -10215,7 +10215,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -10254,7 +10254,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10293,7 +10293,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10332,7 +10332,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10371,7 +10371,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Warrior"
                             },
-                            "scanText": "Your Artifact of Warrior",
+                            "scanText": "Your Artifact of Warrior.",
                             "hudmemoText": "Artifact of Warrior acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -10398,7 +10398,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10449,7 +10449,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10488,7 +10488,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10527,7 +10527,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -10554,7 +10554,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10587,7 +10587,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,

--- a/test/test_files/randomprime_expected_data_one_way_door.json
+++ b/test/test_files/randomprime_expected_data_one_way_door.json
@@ -34,7 +34,7 @@
         "forceFusion": false
     },
     "gameConfig": {
-        "resultsString": "4.6.0.dev240 | Seed Hash - Geemer Shriekbat Fission (AAAAAAAA)",
+        "resultsString": "4.6.0.dev288 | Seed Hash - Geemer Shriekbat Fission (AAAAAAAA)",
         "bossSizes": {
             "parasiteQueen": 0.44977572662984067,
             "incineratorDrone": 0.5455729671029474,
@@ -124,7 +124,7 @@
             "gameNameFull": "Metroid Prime: Randomizer - AAAAAAAA",
             "description": "Seed Hash: Geemer Shriekbat Fission"
         },
-        "mainMenuMessage": "Randovania v4.6.0.dev240\nGeemer Shriekbat Fission",
+        "mainMenuMessage": "Randovania v4.6.0.dev288\nGeemer Shriekbat Fission",
         "creditsString": "&push;&font=C29C51F1;&main-color=#89D6FF;Major Item Locations&pop;\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Charge Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ice Ruins East\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wave Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Arbor Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Ruined Fountain\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Plasma Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Central Dynamo\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Missile Launcher&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Alcove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Grapple Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Ruined Gallery\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Combat Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Landing Site\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Thermal Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Ventilation Shaft\n\n&push;&font=C29C51F1;&main-color=#33ffd6;X-Ray Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Furnace\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Space Jump Boots&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Hall of the Elders\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Boost Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Main Plaza\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Spider Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Watery Hall\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Power Bomb&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Transport Access North\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Varia Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Main Plaza\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Gravity Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Fungal Hall B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Phazon Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Burn Dome\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Super Missile&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Warrior Shrine\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wavebuster&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Phendrana Canyon\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Spreader&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Life Grove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Flamethrower&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ice Ruins East\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Chozo&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Triclops Pit\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Elder&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Storage Cavern\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Lifegiver&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Chapel of the Elders\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Nature&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Phendrana Shorelines\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Strength&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Magma Pool\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Sun&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Lava Lake\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Truth&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ice Ruins West\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Warrior&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Elder Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Wild&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ruined Courtyard",
         "artifactHints": {
             "Artifact of World": "&push;&main-color=#c300ff;Artifact of World&pop; has no need to be located.",
@@ -180,7 +180,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -213,7 +213,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -252,7 +252,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -297,7 +297,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -330,7 +330,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -369,7 +369,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -402,7 +402,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -428,7 +428,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -454,7 +454,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -480,7 +480,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -506,7 +506,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -532,7 +532,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -566,7 +566,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -599,7 +599,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -638,7 +638,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -651,7 +651,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Nature"
                             },
-                            "scanText": "Your Artifact of Nature",
+                            "scanText": "Your Artifact of Nature.",
                             "hudmemoText": "Artifact of Nature acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -708,7 +708,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -747,7 +747,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -780,7 +780,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -819,7 +819,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -858,7 +858,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -897,7 +897,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -930,7 +930,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Truth"
                             },
-                            "scanText": "Your Artifact of Truth",
+                            "scanText": "Your Artifact of Truth.",
                             "hudmemoText": "Artifact of Truth acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -969,7 +969,7 @@
                                 "game": "prime1",
                                 "name": "Charge Beam"
                             },
-                            "scanText": "Your Charge Beam",
+                            "scanText": "Your Charge Beam.",
                             "hudmemoText": "Charge Beam acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -982,7 +982,7 @@
                                 "game": "prime1",
                                 "name": "Flamethrower"
                             },
-                            "scanText": "Your Flamethrower",
+                            "scanText": "Your Flamethrower.",
                             "hudmemoText": "Flamethrower acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1015,7 +1015,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1054,7 +1054,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1093,7 +1093,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1132,7 +1132,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Lifegiver"
                             },
-                            "scanText": "Your Artifact of Lifegiver",
+                            "scanText": "Your Artifact of Lifegiver.",
                             "hudmemoText": "Artifact of Lifegiver acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1159,7 +1159,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Wild"
                             },
-                            "scanText": "Your Artifact of Wild",
+                            "scanText": "Your Artifact of Wild.",
                             "hudmemoText": "Artifact of Wild acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1204,7 +1204,7 @@
                                 "game": "prime1",
                                 "name": "Wavebuster"
                             },
-                            "scanText": "Your Wavebuster",
+                            "scanText": "Your Wavebuster.",
                             "hudmemoText": "Wavebuster acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1231,7 +1231,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1264,7 +1264,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1303,7 +1303,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1342,7 +1342,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1387,7 +1387,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1426,7 +1426,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1459,7 +1459,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1498,7 +1498,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -1537,7 +1537,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1570,7 +1570,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1609,7 +1609,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1636,7 +1636,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1675,7 +1675,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1714,7 +1714,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -1753,7 +1753,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1786,7 +1786,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1825,7 +1825,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1858,7 +1858,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1909,7 +1909,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1948,7 +1948,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -1987,7 +1987,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2026,7 +2026,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2065,7 +2065,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2098,7 +2098,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -2131,7 +2131,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2170,7 +2170,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2221,7 +2221,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2260,7 +2260,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2299,7 +2299,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2332,7 +2332,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2371,7 +2371,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2410,7 +2410,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2449,7 +2449,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2488,7 +2488,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2527,7 +2527,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -2540,7 +2540,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2573,7 +2573,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2624,7 +2624,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2637,7 +2637,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2670,7 +2670,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2697,7 +2697,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -2731,7 +2731,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2757,7 +2757,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2790,7 +2790,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2829,7 +2829,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2855,7 +2855,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2894,7 +2894,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2927,7 +2927,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -2966,7 +2966,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3005,7 +3005,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3044,7 +3044,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3083,7 +3083,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3122,7 +3122,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3161,7 +3161,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3200,7 +3200,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3239,7 +3239,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3284,7 +3284,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3323,7 +3323,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3362,7 +3362,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3401,7 +3401,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3434,7 +3434,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3473,7 +3473,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3512,7 +3512,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3551,7 +3551,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3584,7 +3584,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3617,7 +3617,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3656,7 +3656,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3695,7 +3695,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3734,7 +3734,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3784,7 +3784,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3817,7 +3817,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3862,7 +3862,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3901,7 +3901,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -3934,7 +3934,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Sun"
                             },
-                            "scanText": "Your Artifact of Sun",
+                            "scanText": "Your Artifact of Sun.",
                             "hudmemoText": "Artifact of Sun acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -3967,7 +3967,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4006,7 +4006,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Chozo"
                             },
-                            "scanText": "Your Artifact of Chozo",
+                            "scanText": "Your Artifact of Chozo.",
                             "hudmemoText": "Artifact of Chozo acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -4045,7 +4045,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4084,7 +4084,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Elder"
                             },
-                            "scanText": "Your Artifact of Elder",
+                            "scanText": "Your Artifact of Elder.",
                             "hudmemoText": "Artifact of Elder acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -4111,7 +4111,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4162,7 +4162,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -4195,7 +4195,7 @@
                                 "game": "prime1",
                                 "name": "Super Missile"
                             },
-                            "scanText": "Your Super Missile",
+                            "scanText": "Your Super Missile.",
                             "hudmemoText": "Super Missile acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -4228,7 +4228,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -4261,7 +4261,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4294,7 +4294,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -4307,7 +4307,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -4346,7 +4346,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4385,7 +4385,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4424,7 +4424,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4463,7 +4463,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4502,7 +4502,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4541,7 +4541,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4586,7 +4586,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -4613,7 +4613,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4652,7 +4652,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -4691,7 +4691,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4730,7 +4730,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4769,7 +4769,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4802,7 +4802,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4841,7 +4841,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4882,7 +4882,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4915,7 +4915,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -4954,7 +4954,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -4999,7 +4999,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5038,7 +5038,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5071,7 +5071,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5104,7 +5104,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5155,7 +5155,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5200,7 +5200,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5239,7 +5239,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5266,7 +5266,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5305,7 +5305,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5344,7 +5344,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5371,7 +5371,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5384,7 +5384,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5417,7 +5417,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5456,7 +5456,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5489,7 +5489,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5534,7 +5534,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5573,7 +5573,7 @@
                                 "game": "prime1",
                                 "name": "Thermal Visor"
                             },
-                            "scanText": "Your Thermal Visor",
+                            "scanText": "Your Thermal Visor.",
                             "hudmemoText": "Thermal Visor acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -5606,7 +5606,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -5645,7 +5645,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5690,7 +5690,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5729,7 +5729,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5762,7 +5762,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5795,7 +5795,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5834,7 +5834,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5867,7 +5867,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -5900,7 +5900,7 @@
                                 "game": "prime1",
                                 "name": "Plasma Beam"
                             },
-                            "scanText": "Your Plasma Beam",
+                            "scanText": "Your Plasma Beam.",
                             "hudmemoText": "Plasma Beam acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -5939,7 +5939,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -5978,7 +5978,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6017,7 +6017,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6050,7 +6050,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -6089,7 +6089,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -6122,7 +6122,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6161,7 +6161,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6194,7 +6194,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6233,7 +6233,7 @@
                                 "game": "prime1",
                                 "name": "Gravity Suit"
                             },
-                            "scanText": "Your Gravity Suit",
+                            "scanText": "Your Gravity Suit.",
                             "hudmemoText": "Gravity Suit acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -6272,7 +6272,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6311,7 +6311,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6344,7 +6344,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -6377,7 +6377,7 @@
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
                             },
-                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb",
+                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb.",
                             "hudmemoText": "Power Bomb Expansion acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6410,7 +6410,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6461,7 +6461,7 @@
                                 "game": "prime1",
                                 "name": "Combat Visor"
                             },
-                            "scanText": "Your Combat Visor",
+                            "scanText": "Your Combat Visor.",
                             "hudmemoText": "Combat Visor acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -6512,7 +6512,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6551,7 +6551,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6590,7 +6590,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6629,7 +6629,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Launcher",
+                            "scanText": "Your Missile Launcher.",
                             "hudmemoText": "Missile Launcher acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -6656,7 +6656,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6695,7 +6695,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6746,7 +6746,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6785,7 +6785,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -6824,7 +6824,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6863,7 +6863,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6902,7 +6902,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6935,7 +6935,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -6974,7 +6974,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -7007,7 +7007,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7040,7 +7040,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -7079,7 +7079,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -7099,7 +7099,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7138,7 +7138,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7177,7 +7177,7 @@
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
                             },
-                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb",
+                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb.",
                             "hudmemoText": "Power Bomb Expansion acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7210,7 +7210,7 @@
                                 "game": "prime1",
                                 "name": "Wave Beam"
                             },
-                            "scanText": "Your Wave Beam",
+                            "scanText": "Your Wave Beam.",
                             "hudmemoText": "Wave Beam acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -7237,7 +7237,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7276,7 +7276,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7309,7 +7309,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7342,7 +7342,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7381,7 +7381,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7420,7 +7420,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7465,7 +7465,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -7498,7 +7498,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7531,7 +7531,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7570,7 +7570,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -7603,7 +7603,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7642,7 +7642,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7681,7 +7681,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7720,7 +7720,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7759,7 +7759,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -7792,7 +7792,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7849,7 +7849,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -7876,7 +7876,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7915,7 +7915,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -7948,7 +7948,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -7987,7 +7987,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8020,7 +8020,7 @@
                                 "game": "prime1",
                                 "name": "Ice Spreader"
                             },
-                            "scanText": "Your Ice Spreader",
+                            "scanText": "Your Ice Spreader.",
                             "hudmemoText": "Ice Spreader acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8033,7 +8033,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -8060,7 +8060,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8103,7 +8103,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8136,7 +8136,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8175,7 +8175,7 @@
                                 "game": "prime1",
                                 "name": "Varia Suit"
                             },
-                            "scanText": "Your Varia Suit",
+                            "scanText": "Your Varia Suit.",
                             "hudmemoText": "Varia Suit acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8188,7 +8188,7 @@
                                 "game": "prime1",
                                 "name": "Boost Ball"
                             },
-                            "scanText": "Your Boost Ball",
+                            "scanText": "Your Boost Ball.",
                             "hudmemoText": "Boost Ball acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8201,7 +8201,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8214,7 +8214,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8271,7 +8271,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8310,7 +8310,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8349,7 +8349,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8388,7 +8388,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8427,7 +8427,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8466,7 +8466,7 @@
                                 "game": "prime1",
                                 "name": "Ice Beam"
                             },
-                            "scanText": "Your Ice Beam",
+                            "scanText": "Your Ice Beam.",
                             "hudmemoText": "Ice Beam acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8505,7 +8505,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8518,7 +8518,7 @@
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
                             },
-                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb",
+                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb.",
                             "hudmemoText": "Power Bomb Expansion acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8531,7 +8531,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -8564,7 +8564,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8603,7 +8603,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8636,7 +8636,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -8669,7 +8669,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8708,7 +8708,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8747,7 +8747,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8786,7 +8786,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -8825,7 +8825,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8864,7 +8864,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -8897,7 +8897,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -8942,7 +8942,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Strength"
                             },
-                            "scanText": "Your Artifact of Strength",
+                            "scanText": "Your Artifact of Strength.",
                             "hudmemoText": "Artifact of Strength acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -8975,7 +8975,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9008,7 +9008,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9041,7 +9041,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9080,7 +9080,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9125,7 +9125,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9164,7 +9164,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9203,7 +9203,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -9230,7 +9230,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9243,7 +9243,7 @@
                                 "game": "prime1",
                                 "name": "Grapple Beam"
                             },
-                            "scanText": "Your Grapple Beam",
+                            "scanText": "Your Grapple Beam.",
                             "hudmemoText": "Grapple Beam acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -9282,7 +9282,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9321,7 +9321,7 @@
                                 "game": "prime1",
                                 "name": "Power Bomb"
                             },
-                            "scanText": "Your Power Bomb",
+                            "scanText": "Your Power Bomb.",
                             "hudmemoText": "Main Power Bomb acquired!",
                             "currIncrease": 8,
                             "maxIncrease": 8,
@@ -9354,7 +9354,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9387,7 +9387,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9432,7 +9432,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9471,7 +9471,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9504,7 +9504,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9537,7 +9537,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9570,7 +9570,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -9583,7 +9583,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9603,7 +9603,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9636,7 +9636,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9669,7 +9669,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9708,7 +9708,7 @@
                                 "game": "prime1",
                                 "name": "Energy Tank"
                             },
-                            "scanText": "Your Energy Tank",
+                            "scanText": "Your Energy Tank.",
                             "hudmemoText": "Energy Tank acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -9721,7 +9721,7 @@
                                 "game": "prime1",
                                 "name": "Spider Ball"
                             },
-                            "scanText": "Your Spider Ball",
+                            "scanText": "Your Spider Ball.",
                             "hudmemoText": "Spider Ball acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -9754,7 +9754,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9793,7 +9793,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9832,7 +9832,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9877,7 +9877,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9890,7 +9890,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -9917,7 +9917,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9956,7 +9956,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -9995,7 +9995,7 @@
                                 "game": "prime1",
                                 "name": "Power Bomb Expansion"
                             },
-                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb",
+                            "scanText": "Your Power Bomb Expansion. Provides 0 Power Bomb.",
                             "hudmemoText": "Power Bomb Expansion acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10008,7 +10008,7 @@
                                 "game": "prime1",
                                 "name": "Phazon Suit"
                             },
-                            "scanText": "Your Phazon Suit",
+                            "scanText": "Your Phazon Suit.",
                             "hudmemoText": "Phazon Suit acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -10035,7 +10035,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -10048,7 +10048,7 @@
                                 "game": "prime1",
                                 "name": "X-Ray Visor"
                             },
-                            "scanText": "Your X-Ray Visor",
+                            "scanText": "Your X-Ray Visor.",
                             "hudmemoText": "X-Ray Visor acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -10087,7 +10087,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10126,7 +10126,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10165,7 +10165,7 @@
                                 "game": "prime1",
                                 "name": "Space Jump Boots"
                             },
-                            "scanText": "Your Space Jump Boots",
+                            "scanText": "Your Space Jump Boots.",
                             "hudmemoText": "Space Jump Boots acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -10216,7 +10216,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -10255,7 +10255,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10294,7 +10294,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10333,7 +10333,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10372,7 +10372,7 @@
                                 "game": "prime1",
                                 "name": "Artifact of Warrior"
                             },
-                            "scanText": "Your Artifact of Warrior",
+                            "scanText": "Your Artifact of Warrior.",
                             "hudmemoText": "Artifact of Warrior acquired!",
                             "currIncrease": 1,
                             "maxIncrease": 1,
@@ -10399,7 +10399,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10450,7 +10450,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10489,7 +10489,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10528,7 +10528,7 @@
                                 "game": "prime1",
                                 "name": "Missile"
                             },
-                            "scanText": "Your Missile Expansion. Provides 5 Missiles",
+                            "scanText": "Your Missile Expansion. Provides 5 Missiles.",
                             "hudmemoText": "Missile Expansion acquired!",
                             "currIncrease": 5,
                             "maxIncrease": 5,
@@ -10555,7 +10555,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,
@@ -10588,7 +10588,7 @@
                                 "game": "prime1",
                                 "name": "Nothing"
                             },
-                            "scanText": "Your Nothing",
+                            "scanText": "Your Nothing.",
                             "hudmemoText": "Nothing acquired!",
                             "currIncrease": 0,
                             "maxIncrease": 0,


### PR DESCRIPTION
Split scan_text into name and description. Rename `hud_text` into `collection_text`.