### PR TITLE
Artaria waterfall Allow rotatable to be activated with wave beam

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -18156,6 +18156,15 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Event - Waterfall Rotatable": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Wave",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
                         "Right of Rotatable": {
                             "type": "resource",
                             "data": {
@@ -18476,6 +18485,15 @@
                     ],
                     "extra": {},
                     "connections": {
+                        "Event - Waterfall Rotatable": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Wave",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
                         "Door to Shortcut to Screw Attack": {
                             "type": "resource",
                             "data": {

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -18207,25 +18207,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Event - Waterfall Rotatable": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Diffusion Beam"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Wave",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Shoot Diffusion or Wave"
                         },
                         "Start Point": {
                             "type": "resource",

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -3733,7 +3733,7 @@ Extra - asset_id: collision_camera_056
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:door_shield_plasma_001
   * Extra - right_shield_def: actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad
   > Event - Waterfall Rotatable
-      Wave Beam or Shoot Diffusion Beam
+      Shoot Diffusion or Wave
   > Start Point
       After Artaria - Waterfall Rotatable
 

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -3718,6 +3718,8 @@ Extra - asset_id: collision_camera_056
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  > Event - Waterfall Rotatable
+      Wave Beam
   > Right of Rotatable
       After Artaria - Waterfall Rotatable
 
@@ -3775,6 +3777,8 @@ Extra - asset_id: collision_camera_056
 
 > Right of Rotatable; Heals? False
   * Layers: default
+  > Event - Waterfall Rotatable
+      Wave Beam
   > Door to Shortcut to Screw Attack
       After Artaria - Waterfall Rotatable
   > Dock to Water Tunnel under Map


### PR DESCRIPTION
If you have wave beam here, you can shoot the blob to rotate the flipper
and walk between the shortcut to screw attack and waterfall rooms.

![image](https://user-images.githubusercontent.com/6470224/187088937-ed462c3a-6e57-4036-acb2-7c140d3de284.png)
