### PR TITLE
Fixed incorrect actors being randomized, released GIL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -255,7 +255,7 @@ pywin32-ctypes==0.2.0
     # via pyinstaller
 qasync==0.23.0
     # via randovania (setup.py)
-random-enemy-attributes==1.0.1
+random-enemy-attributes==1.0.3
     # via randovania (setup.py)
 requests==2.28.1
     # via

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     open-prime-rando>=0.1.0
     cave-story-randomizer>=1.0.0
     tsc-utils>=0.2.0
-    random-enemy-attributes>=1.0.1
+    random-enemy-attributes>=1.0.3
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
I fixed 4 actors being scaled that shouldn't of been scaled due to them having the same instance ID as another actor in another PAK (Ex: Two of the pistons in Research Entrance were being randomized instead of some Elite Pirate Actors in the tubes) I also released the GIL.

I was wanting to wait on this pull request until I got the callback thing done, but I ended up getting sick so its quite unlikely that I'll get that done before next month rolls around.

Idk why the 8 commits from my last pull request are showing up but since they don't change anything, I suppose it doesn't matter.

Also this won't make any previous test of this null or anything, cause if my changes broke anything, it would cause an exception.