### PR TITLE
Remove impossible Walljump from Itorash

### DIFF
--- a/randovania/games/dread/json_data/Itorash.json
+++ b/randovania/games/dread/json_data/Itorash.json
@@ -418,15 +418,6 @@
                                                 }
                                             ]
                                         }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Walljump",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
                                     }
                                 ]
                             }
@@ -513,15 +504,6 @@
                                                     }
                                                 }
                                             ]
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Walljump",
-                                            "amount": 2,
-                                            "negate": false
                                         }
                                     }
                                 ]

--- a/randovania/games/dread/json_data/Itorash.txt
+++ b/randovania/games/dread/json_data/Itorash.txt
@@ -69,7 +69,7 @@ Extra - asset_id: collision_camera_001
       Metroid DNA 1 and Metroid DNA 10 and Metroid DNA 11 and Metroid DNA 12 and Metroid DNA 2 and Metroid DNA 3 and Metroid DNA 4 and Metroid DNA 5 and Metroid DNA 6 and Metroid DNA 7 and Metroid DNA 8 and Metroid DNA 9
   > Artifact Gate
       Any of the following:
-          Speed Booster or Walljump (Intermediate) or Simple IBJ or Use Spin Boost
+          Speed Booster or Simple IBJ or Use Spin Boost
           Flash Shift and Walljump (Beginner)
 
 > Elevator to Hanubia; Heals? False; Spawn Point
@@ -85,7 +85,7 @@ Extra - asset_id: collision_camera_001
       Trivial
   > Artifact Gate
       Any of the following:
-          Speed Booster or Walljump (Intermediate) or Simple IBJ or Use Spin Boost
+          Speed Booster or Simple IBJ or Use Spin Boost
           Flash Shift and Walljump (Beginner)
 
 > Artifact Gate; Heals? False


### PR DESCRIPTION
This has been confirmed to only be possible if you have space jump for the extra walljump height.