### PR TITLE
Dread: Final Burenia Revision

### DIFF
--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -1965,12 +1965,55 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "HighDanger",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Use Spin Boost"
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Simple IBJ"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "s040_aqua:default:db_reg_aq_002",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "s040_aqua:default:db_reg_aq_001",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -8038,6 +8038,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -8505,12 +8514,64 @@
                                                     "data": "Use Spin Boost"
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "events",
-                                                        "name": "BureniaPrepareSpeedSave",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "BureniaPrepareSpeedSave",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Gravity",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Speedbooster",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
@@ -11902,7 +11963,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "name": "BureniaDestroyGravitySuitFloor",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -12002,7 +12063,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "name": "BureniaDestroyGravitySuitFloor",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -12180,7 +12241,7 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "events",
-                                                                    "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                                                    "name": "BureniaDestroyGravitySuitFloor",
                                                                     "amount": 1,
                                                                     "negate": true
                                                                 }
@@ -12198,7 +12259,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                "name": "BureniaDestroyGravitySuitFloor",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -12239,7 +12300,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                "name": "BureniaDestroyGravitySuitFloor",
                                 "amount": 1,
                                 "negate": true
                             }
@@ -12248,7 +12309,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                "name": "BureniaDestroyGravitySuitFloor",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -12350,7 +12411,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "name": "BureniaDestroyGravitySuitFloor",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -12509,7 +12570,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "name": "BureniaDestroyGravitySuitFloor",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -13214,7 +13275,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                "name": "BureniaDestroyGravitySuitFloor",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -13237,7 +13298,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "name": "BureniaDestroyGravitySuitFloor",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -13301,7 +13362,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "name": "BureniaDestroyGravitySuitFloor",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -13484,7 +13545,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                "name": "BureniaDestroyGravitySuitFloor",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -13493,7 +13554,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                "name": "BureniaDestroyGravitySuitFloor",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -13507,7 +13568,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "name": "BureniaDestroyGravitySuitFloor",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -13534,7 +13595,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "event_name": "s040_aqua:default:grapplepulloff1x2_003",
+                    "event_name": "BureniaDestroyGravitySuitFloor",
                     "connections": {
                         "Blob Alcove": {
                             "type": "and",
@@ -13624,7 +13685,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "name": "BureniaDestroyGravitySuitFloor",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -13847,7 +13908,7 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "events",
-                                                                    "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                                                    "name": "BureniaDestroyGravitySuitFloor",
                                                                     "amount": 1,
                                                                     "negate": true
                                                                 }

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -7871,6 +7871,32 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Event - Prepare Speedboost in Save Station": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "DoorLocks",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -8479,29 +8505,12 @@
                                                     "data": "Use Spin Boost"
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Speed",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "misc",
-                                                                    "name": "DoorLocks",
-                                                                    "amount": 1,
-                                                                    "negate": true
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "events",
+                                                        "name": "BureniaPrepareSpeedSave",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 },
                                                 {
@@ -9061,6 +9070,30 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Energy Recharge South": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Prepare Speedboost in Save Station": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -4250.0,
+                        "y": -8100.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "BureniaPrepareSpeedSave",
+                    "connections": {
+                        "Door to Save Station South Access (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -7344,6 +7344,15 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "BureniaHubMagnetPlatform",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
                                                 }
                                             ]
                                         }
@@ -7799,7 +7808,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Alcove across grapple block": {
+                        "Alcove Across Grapple Block": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -7815,7 +7824,7 @@
                                 "items": []
                             }
                         },
-                        "Event - Shoot Blob from above (db_reg_aq_003)": {
+                        "Event - Main Hub Bottom Blob, Above": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -7826,13 +7835,13 @@
                         }
                     }
                 },
-                "Door to Save Station South Access (doorpowerpower_022)": {
+                "Door to Save Station South Access (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
                         "x": -4950.0,
                         "y": -8100.0,
-                        "z": -0.006835999898612499
+                        "z": -0.01
                     },
                     "description": "",
                     "layers": [
@@ -7850,13 +7859,13 @@
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Save Station South Access",
-                        "node_name": "Door to Main Hub Tower Bottom (doorpowerpower_022)"
+                        "node_name": "Door to Main Hub Tower Bottom (Upper)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Alcove across grapple block": {
+                        "Alcove Across Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7865,13 +7874,13 @@
                         }
                     }
                 },
-                "Door to Save Station South Access (doorpowerpower_023)": {
+                "Door to Save Station South Access (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
                         "x": -4950.0,
                         "y": -9200.0,
-                        "z": -0.006835999898612499
+                        "z": -0.01
                     },
                     "description": "",
                     "layers": [
@@ -7889,7 +7898,7 @@
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Save Station South Access",
-                        "node_name": "Door to Main Hub Tower Bottom (doorpowerpower_023)"
+                        "node_name": "Door to Main Hub Tower Bottom (Lower)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -7903,8 +7912,13 @@
                             }
                         },
                         "Water Space Jump Platform": {
-                            "type": "template",
-                            "data": "Horizontal Water Movement"
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Space",
+                                "amount": 1,
+                                "negate": false
+                            }
                         }
                     }
                 },
@@ -7938,7 +7952,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Alcove across grapple block": {
+                        "Alcove Across Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7956,14 +7970,48 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "name": "s040_aqua:default:db_reg_aq_003",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Horizontal Water Movement"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Gravity",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -8031,7 +8079,7 @@
                         }
                     }
                 },
-                "Event - Shoot Blob from alcove (db_reg_aq_003)": {
+                "Event - Main Hub Bottom Blob, Left": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -8049,7 +8097,7 @@
                     },
                     "event_name": "s040_aqua:default:db_reg_aq_003",
                     "connections": {
-                        "Alcove across grapple block": {
+                        "Alcove Across Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8058,7 +8106,7 @@
                         }
                     }
                 },
-                "Event - Pull Lower-Right Grapple Block (grapplepulloff1x2_003)": {
+                "Event - Main Hub Bottom Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -8076,7 +8124,7 @@
                     },
                     "event_name": "s040_aqua:default:grapplepulloff1x2_003",
                     "connections": {
-                        "Alcove across grapple block": {
+                        "Alcove Across Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8106,7 +8154,7 @@
                         ]
                     },
                     "connections": {
-                        "Door to Save Station South Access (doorpowerpower_023)": {
+                        "Door to Save Station South Access (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8132,6 +8180,15 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Simple IBJ"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -8170,24 +8227,12 @@
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -8257,6 +8302,36 @@
                                                         "name": "Speed",
                                                         "amount": 1,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -8348,7 +8423,7 @@
                         }
                     }
                 },
-                "Alcove across grapple block": {
+                "Alcove Across Grapple Block": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -8362,7 +8437,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Door to Save Station South Access (doorpowerpower_022)": {
+                        "Door to Save Station South Access (Upper)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -8395,17 +8470,89 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Horizontal Water Movement"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Gravity",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
                         },
-                        "Event - Shoot Blob from alcove (db_reg_aq_003)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Main Hub Bottom Blob, Left": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
-                        "Event - Pull Lower-Right Grapple Block (grapplepulloff1x2_003)": {
+                        "Event - Main Hub Bottom Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8429,6 +8576,50 @@
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Ledge above Grapple Block": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Flash",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s040_aqua:default:db_reg_aq_003",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Water Space Jump Platform": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "s040_aqua:default:db_reg_aq_003",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -8475,29 +8666,12 @@
                                                     "data": "Simple IBJ"
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Flash",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Walljump",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "items",
+                                                        "name": "Flash",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -8532,7 +8706,7 @@
                                 ]
                             }
                         },
-                        "Alcove across grapple block": {
+                        "Alcove Across Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8547,13 +8721,30 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
                         },
-                        "Event - Shoot Blob from right (db_reg_aq_003)": {
+                        "Event - Main Hub Bottom Blob, Right": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -8566,7 +8757,7 @@
                         }
                     }
                 },
-                "Event - Shoot Blob from above (db_reg_aq_003)": {
+                "Event - Main Hub Bottom Blob, Above": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -8590,7 +8781,7 @@
                         }
                     }
                 },
-                "Event - Shoot Blob from right (db_reg_aq_003)": {
+                "Event - Main Hub Bottom Blob, Right": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -8628,15 +8819,135 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Door to Save Station South Access (doorpowerpower_023)": {
+                        "Door to Save Station South Access (Lower)": {
                             "type": "template",
                             "data": "Horizontal Water Movement"
+                        },
+                        "Door to Storm Missile Gate Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SWJ",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Tile Group (SCREWATTACK)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        },
+                        "Alcove Across Grapple Block": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Flash",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s040_aqua:default:db_reg_aq_003",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Ledge above Grapple Block": {
@@ -8665,6 +8976,58 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Morph",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "SWJ",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Flash",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -9211,12 +9574,29 @@
                             "data": "Can Slide Underwater"
                         },
                         "Tile Group (BOMB) 1": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -10467,51 +10847,10 @@
                     "editable": true,
                     "connections": {
                         "Door to Navigation Station South": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Flash",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "WBJ",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
-                                    }
-                                ]
-                            }
-                        },
-                        "Tile Group (SCREWATTACK) 1": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "items": []
                             }
                         }
                     }
@@ -10552,50 +10891,6 @@
                             }
                         }
                     }
-                },
-                "Tile Group (POWERBEAM) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 11300.0,
-                        "y": -7600.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_038",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {}
-                },
-                "Tile Group (POWERBEAM) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 11500.0,
-                        "y": -7600.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_039",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {}
                 },
                 "Tile Group (SCREWATTACK) 2": {
                     "node_type": "configurable_node",
@@ -11574,7 +11869,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "BureniaDestroyGravitySuitFloor",
+                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -11588,18 +11883,68 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Gravity",
+                                                        "name": "Space",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Space",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Gravity",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Use Spin Boost"
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Simple IBJ"
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Speed",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "misc",
+                                                                                            "name": "DoorLocks",
+                                                                                            "amount": 1,
+                                                                                            "negate": true
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -11624,7 +11969,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "BureniaDestroyGravitySuitFloor",
+                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -11641,6 +11986,58 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Simple IBJ"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Slide",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Slide",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -11719,12 +12116,46 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -11734,7 +12165,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "BureniaDestroyGravitySuitFloor",
+                                "name": "s040_aqua:default:grapplepulloff1x2_003",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -11765,7 +12196,7 @@
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Ammo Recharge South",
-                        "node_name": "Door to Gravity Suit Tower (Upper)"
+                        "node_name": "Door to Gravity Suit Tower (Lower)"
                     },
                     "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
@@ -11775,7 +12206,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "BureniaDestroyGravitySuitFloor",
+                                "name": "s040_aqua:default:grapplepulloff1x2_003",
                                 "amount": 1,
                                 "negate": true
                             }
@@ -11784,7 +12215,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "BureniaDestroyGravitySuitFloor",
+                                "name": "s040_aqua:default:grapplepulloff1x2_003",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -11886,7 +12317,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "BureniaDestroyGravitySuitFloor",
+                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -12023,7 +12454,7 @@
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Ammo Recharge South",
-                        "node_name": "Door to Gravity Suit Tower (Lower)"
+                        "node_name": "Door to Gravity Suit Tower (Upper)"
                     },
                     "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
@@ -12037,12 +12468,24 @@
                             }
                         },
                         "Breakable Floor": {
-                            "type": "resource",
+                            "type": "or",
                             "data": {
-                                "type": "events",
-                                "name": "BureniaDestroyGravitySuitFloor",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Horizontal Water Movement"
+                                    }
+                                ]
                             }
                         },
                         "Tunnel to Ammo Recharge South": {
@@ -12053,10 +12496,31 @@
                                 "amount": 1,
                                 "negate": false
                             }
+                        },
+                        "Blob Alcove": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Horizontal Water Movement"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
-                "Event - Blob #1 (ev_demolition_db_001)": {
+                "Event - Break Floor Blob 1": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12083,7 +12547,7 @@
                         }
                     }
                 },
-                "Event - Blob #2 (ev_demolition_db_002)": {
+                "Event - Break Floor Blob 2": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12110,7 +12574,7 @@
                         }
                     }
                 },
-                "Event - Blob #3 (ev_demolition_db_003)": {
+                "Event - Break Floor Blob 3": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12137,7 +12601,7 @@
                         }
                     }
                 },
-                "Event - Early Gravity Blob (db_reg_aq_005)": {
+                "Event - Early Gravity Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12213,9 +12677,18 @@
                                 "comment": null,
                                 "items": [
                                     {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
                                         "type": "or",
                                         "data": {
-                                            "comment": "ways to get up",
+                                            "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -12229,97 +12702,6 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Simple IBJ"
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": "Combat tricks",
-                                            "items": [
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": "Max difficulty",
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Combat",
-                                                                    "amount": 3,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": "less than vanilla requirements",
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Shoot Wide Beam"
-                                                            },
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Shoot Super Missile"
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Combat",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Shoot Charge Beam"
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": "Vanilla requirements",
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Shoot Plasma Beam"
-                                                            },
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Shoot Ice Missile"
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": "PB cheese",
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Lay Power Bomb"
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Combat",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
                                                 }
                                             ]
                                         }
@@ -12354,14 +12736,16 @@
                     },
                     "connections": {
                         "Door to Teleport to Ghavoran": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "events",
+                                "name": "BureniaRobots",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Start Point 2": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -12369,17 +12753,47 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "Space",
+                                            "name": "Morph",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "BureniaRobots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Space",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
+                        },
+                        "Event - Twin Robot Fight": {
+                            "type": "template",
+                            "data": "Fight Twin Robots"
                         }
                     }
                 },
@@ -12408,28 +12822,6 @@
                             }
                         }
                     }
-                },
-                "Tile Group (SCREWATTACK) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 6700.0,
-                        "y": -4500.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SCREWATTACK"
-                        ]
-                    },
-                    "connections": {}
                 },
                 "Tile Group (POWERBOMB)": {
                     "node_type": "configurable_node",
@@ -12489,7 +12881,7 @@
                         ]
                     },
                     "connections": {
-                        "Event - Early Gravity Blob (db_reg_aq_005)": {
+                        "Event - Early Gravity Blob": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -12569,51 +12961,24 @@
                             }
                         },
                         "Tile Group (POWERBEAM) 1": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
-                                    }
-                                ]
+                                "items": []
                             }
                         },
                         "Tile Group (POWERBEAM) 2": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
-                                    }
-                                ]
+                                "items": []
                             }
                         },
                         "Tile Group (SCREWATTACK) 4": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }
@@ -12654,28 +13019,6 @@
                             }
                         }
                     }
-                },
-                "Tile Group (SCREWATTACK) 3": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 6100.0,
-                        "y": -4500.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_021",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SCREWATTACK"
-                        ]
-                    },
-                    "connections": {}
                 },
                 "Tile Group (MISSILE)": {
                     "node_type": "configurable_node",
@@ -12838,7 +13181,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "BureniaDestroyGravitySuitFloor",
+                                "name": "s040_aqua:default:grapplepulloff1x2_003",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -12861,7 +13204,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "BureniaDestroyGravitySuitFloor",
+                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -12881,12 +13224,29 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
@@ -12908,7 +13268,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "BureniaDestroyGravitySuitFloor",
+                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -12964,10 +13324,66 @@
                             }
                         },
                         "Blob Alcove": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Perform WBJ"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s040_aqua:default:db_reg_aq_005",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DBoost",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Early Gravity Blob through Wall": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
-                                "name": "Morph",
+                                "name": "Wave",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -13035,7 +13451,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "BureniaDestroyGravitySuitFloor",
+                                "name": "s040_aqua:default:grapplepulloff1x2_003",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -13044,18 +13460,30 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "BureniaDestroyGravitySuitFloor",
+                                "name": "s040_aqua:default:grapplepulloff1x2_003",
                                 "amount": 1,
                                 "negate": false
                             }
                         },
                         "Breakable Floor": {
-                            "type": "resource",
+                            "type": "or",
                             "data": {
-                                "type": "events",
-                                "name": "BureniaDestroyGravitySuitFloor",
-                                "amount": 1,
-                                "negate": true
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Horizontal Water Movement"
+                                    }
+                                ]
                             }
                         }
                     }
@@ -13073,7 +13501,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "event_name": "BureniaDestroyGravitySuitFloor",
+                    "event_name": "s040_aqua:default:grapplepulloff1x2_003",
                     "connections": {
                         "Blob Alcove": {
                             "type": "and",
@@ -13098,11 +13526,96 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Event - Blob #1 (ev_demolition_db_001)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Door to Navigation Station South": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Flash",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         },
-                        "Event - Blob #2 (ev_demolition_db_002)": {
+                        "Event - Break Floor Blob 1": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Break Floor Blob 2": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13123,7 +13636,7 @@
                                 ]
                             }
                         },
-                        "Event - Blob #3 (ev_demolition_db_003)": {
+                        "Event - Break Floor Blob 3": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13210,12 +13723,106 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "IBJ",
-                                            "amount": 2,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Bomb"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "IBJ",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Flash",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Speedbooster",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "s040_aqua:default:grapplepulloff1x2_003",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -13236,6 +13843,54 @@
                             }
                         },
                         "Tile Group (SCREWATTACK) 4": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Early Gravity Blob through Wall": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 5000.0,
+                        "y": -10200.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "s040_aqua:default:db_reg_aq_005",
+                    "connections": {
+                        "Breakable Floor": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Twin Robot Fight": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 4500.0,
+                        "y": -3100.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "BureniaRobots",
+                    "connections": {
+                        "Start Point 3": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13277,7 +13932,7 @@
                 "asset_id": "collision_camera_022"
             },
             "nodes": {
-                "Door to Gravity Suit Tower (Upper)": {
+                "Door to Gravity Suit Tower (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13307,7 +13962,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Gravity Suit Tower (Lower)": {
+                        "Door to Gravity Suit Tower (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13323,7 +13978,7 @@
                         }
                     }
                 },
-                "Door to Gravity Suit Tower (Lower)": {
+                "Door to Gravity Suit Tower (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13353,7 +14008,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Gravity Suit Tower (Upper)": {
+                        "Door to Gravity Suit Tower (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13381,7 +14036,7 @@
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_ammo/charclasses/weightactivatedplatform_ammo.bmsad"
                     },
                     "connections": {
-                        "Door to Gravity Suit Tower (Upper)": {
+                        "Door to Gravity Suit Tower (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13529,7 +14184,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Blob from above (db_reg_aq_004)": {
+                        "Event - Gravity Suit Blob, Above": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -13657,7 +14312,7 @@
                                 ]
                             }
                         },
-                        "Event - Blob from right (db_reg_aq_004)": {
+                        "Event - Gravity Suit Blob, Right": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -13675,7 +14330,7 @@
                         }
                     }
                 },
-                "Event - Blob from above (db_reg_aq_004)": {
+                "Event - Gravity Suit Blob, Above": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -13818,7 +14473,7 @@
                                 "negate": false
                             }
                         },
-                        "Event - Blob from below (db_reg_aq_004)": {
+                        "Event - Gravity Suit Blob, Below": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         }
@@ -13878,39 +14533,13 @@
                                             "amount": 1,
                                             "negate": false
                                         }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "WBJ",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
                                     }
                                 ]
                             }
                         }
                     }
                 },
-                "Event - Blob from right (db_reg_aq_004)": {
+                "Event - Gravity Suit Blob, Right": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -13934,7 +14563,7 @@
                         }
                     }
                 },
-                "Event - Blob from below (db_reg_aq_004)": {
+                "Event - Gravity Suit Blob, Below": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -14194,12 +14823,29 @@
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "resource",
+                                                                "type": "or",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "Flash",
-                                                                    "amount": 1,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Flash",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Space",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             {
@@ -14232,12 +14878,37 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "template",
+                                                    "data": "Perform WBJ"
+                                                },
+                                                {
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "WBJ",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Grapple",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "GrappleMovement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -14453,7 +15124,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Main Hub Tower Bottom (doorpowerpower_022)": {
+                        "Door to Main Hub Tower Bottom (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14462,13 +15133,13 @@
                         }
                     }
                 },
-                "Door to Main Hub Tower Bottom (doorpowerpower_022)": {
+                "Door to Main Hub Tower Bottom (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
                         "x": -4950.0,
                         "y": -8100.0,
-                        "z": -0.006835999898612499
+                        "z": -0.01
                     },
                     "description": "",
                     "layers": [
@@ -14486,7 +15157,7 @@
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Main Hub Tower Bottom",
-                        "node_name": "Door to Save Station South Access (doorpowerpower_022)"
+                        "node_name": "Door to Save Station South Access (Upper)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -14499,19 +15170,19 @@
                                 "items": []
                             }
                         },
-                        "Door to Main Hub Tower Bottom (doorpowerpower_023)": {
+                        "Door to Main Hub Tower Bottom (Lower)": {
                             "type": "template",
                             "data": "Can Slide Underwater"
                         }
                     }
                 },
-                "Door to Main Hub Tower Bottom (doorpowerpower_023)": {
+                "Door to Main Hub Tower Bottom (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
                         "x": -4950.0,
                         "y": -9200.0,
-                        "z": -0.006835999898612499
+                        "z": -0.01
                     },
                     "description": "",
                     "layers": [
@@ -14529,13 +15200,13 @@
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Main Hub Tower Bottom",
-                        "node_name": "Door to Save Station South Access (doorpowerpower_023)"
+                        "node_name": "Door to Save Station South Access (Lower)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Main Hub Tower Bottom (doorpowerpower_022)": {
+                        "Door to Main Hub Tower Bottom (Upper)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -8528,24 +8528,6 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Speed",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "misc",
-                                                                    "name": "DoorLocks",
-                                                                    "amount": 1,
-                                                                    "negate": true
-                                                                }
-                                                            },
-                                                            {
                                                                 "type": "or",
                                                                 "data": {
                                                                     "comment": null,

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -1426,14 +1426,14 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   * Extra - right_shield_def: None
   > Alcove Across Grapple Block
       All of the following:
-          Morph Ball and After Burenia - Main Hub Bottom Blob
+          Morph Ball and After Burenia - Main Hub Bottom Blob and After Burenia - Main Hub Bottom Grapple Block
           Any of the following:
               Use Spin Boost
               Flash Shift and Gravity Suit
   > Ledge above Grapple Block
-      Gravity Suit and Morph Ball and After Burenia - Destroy Gravity Suit Floor
+      Gravity Suit and Morph Ball and After Burenia - Main Hub Bottom Grapple Block
   > Water Space Jump Platform
-      Morph Ball and After Burenia - Destroy Gravity Suit Floor
+      Morph Ball and After Burenia - Main Hub Bottom Grapple Block
 
 > Event - Main Hub Bottom Blob, Left; Heals? False
   * Layers: default
@@ -1445,7 +1445,7 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
 
 > Event - Main Hub Bottom Grapple Block; Heals? False
   * Layers: default
-  * Event Burenia - Destroy Gravity Suit Floor
+  * Event Burenia - Main Hub Bottom Grapple Block
   * Extra - actor_name: grapplepulloff1x2_003
   * Extra - actor_def: actordef:actors/props/grapplepulloff1x2/charclasses/grapplepulloff1x2.bmsad
   > Alcove Across Grapple Block
@@ -1495,9 +1495,12 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
       Gravity Suit
   > Door to Storm Missile Gate Room
       All of the following:
-          Morph Ball and After Burenia - Destroy Gravity Suit Floor
+          Morph Ball and After Burenia - Main Hub Bottom Grapple Block
           Any of the following:
-              After Burenia - Prepare Speedboost in Save Station or Use Spin Boost
+              Use Spin Boost
+              All of the following:
+                  Speed Booster and After Burenia - Prepare Speedboost in Save Station and Disabled Door Lock Randomizer
+                  Gravity Suit or Speedbooster Conservation (Intermediate)
               Flash Shift and Gravity Suit
   > Event - Main Hub Bottom Blob, Left
       Lay Bomb or Shoot Beam
@@ -1515,7 +1518,7 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
           Gravity Suit
           Flash Shift or Simple IBJ or Use Spin Boost
   > Door to Storm Missile Gate Room
-      Morph Ball and After Burenia - Destroy Gravity Suit Floor
+      Morph Ball and After Burenia - Main Hub Bottom Grapple Block
   > Alcove Across Grapple Block
       All of the following:
           After Burenia - Main Hub Bottom Blob
@@ -1543,7 +1546,7 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
       Horizontal Water Movement
   > Door to Storm Missile Gate Room
       All of the following:
-          Gravity Suit and Morph Ball and After Burenia - Destroy Gravity Suit Floor
+          Gravity Suit and Morph Ball and After Burenia - Main Hub Bottom Grapple Block
           Speed Booster or Single-wall Wall Jump (Beginner) or Simple IBJ or Use Spin Boost
   > Tile Group (SCREWATTACK)
       Trivial

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -1298,7 +1298,7 @@ Extra - asset_id: collision_camera_010
   > Missile Tank Plus Platform
       Any of the following:
           Gravity Suit
-          Grapple Beam and Grapple Movement (Beginner)
+          Grapple Beam and Before Burenia - Hub Magnet Wall and Grapple Movement (Beginner)
   > Upper Water Ledge - Left
       All of the following:
           Gravity Suit
@@ -1380,28 +1380,28 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Alcove across grapple block
-      After Burenia - db_reg_aq_003
+  > Alcove Across Grapple Block
+      After Burenia - Main Hub Bottom Blob
   > Ledge above Grapple Block
       Trivial
-  > Event - Shoot Blob from above (db_reg_aq_003)
+  > Event - Main Hub Bottom Blob, Above
       Wave Beam
 
-> Door to Save Station South Access (doorpowerpower_022); Heals? False
+> Door to Save Station South Access (Upper); Heals? False
   * Layers: default
-  * Power Beam Door to Save Station South Access/Door to Main Hub Tower Bottom (doorpowerpower_022)
+  * Power Beam Door to Save Station South Access/Door to Main Hub Tower Bottom (Upper)
   * Extra - actor_name: doorpowerpower_022
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Alcove across grapple block
+  > Alcove Across Grapple Block
       Trivial
 
-> Door to Save Station South Access (doorpowerpower_023); Heals? False
+> Door to Save Station South Access (Lower); Heals? False
   * Layers: default
-  * Power Beam Door to Save Station South Access/Door to Main Hub Tower Bottom (doorpowerpower_023)
+  * Power Beam Door to Save Station South Access/Door to Main Hub Tower Bottom (Lower)
   * Extra - actor_name: doorpowerpower_023
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1411,7 +1411,7 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   > Tile Group (SCREWATTACK)
       Trivial
   > Water Space Jump Platform
-      Horizontal Water Movement
+      Space Jump
 
 > Door to Storm Missile Gate Room; Heals? False
   * Layers: default
@@ -1422,27 +1422,31 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Alcove across grapple block
-      Morph Ball and After Burenia - grapplepulloff1x2_003 and Horizontal Water Movement
+  > Alcove Across Grapple Block
+      All of the following:
+          Morph Ball and After Burenia - Main Hub Bottom Blob
+          Any of the following:
+              Use Spin Boost
+              Flash Shift and Gravity Suit
   > Ledge above Grapple Block
-      Gravity Suit and Morph Ball and After Burenia - grapplepulloff1x2_003
+      Gravity Suit and Morph Ball and After Burenia - Destroy Gravity Suit Floor
   > Water Space Jump Platform
-      Morph Ball and After Burenia - grapplepulloff1x2_003
+      Morph Ball and After Burenia - Destroy Gravity Suit Floor
 
-> Event - Shoot Blob from alcove (db_reg_aq_003); Heals? False
+> Event - Main Hub Bottom Blob, Left; Heals? False
   * Layers: default
-  * Event Burenia - db_reg_aq_003
+  * Event Burenia - Main Hub Bottom Blob
   * Extra - actor_name: db_reg_aq_003
   * Extra - actor_def: actordef:actors/props/db_reg_aq_003/charclasses/db_reg_aq_003.bmsad
-  > Alcove across grapple block
+  > Alcove Across Grapple Block
       Trivial
 
-> Event - Pull Lower-Right Grapple Block (grapplepulloff1x2_003); Heals? False
+> Event - Main Hub Bottom Grapple Block; Heals? False
   * Layers: default
-  * Event Burenia - grapplepulloff1x2_003
+  * Event Burenia - Destroy Gravity Suit Floor
   * Extra - actor_name: grapplepulloff1x2_003
   * Extra - actor_def: actordef:actors/props/grapplepulloff1x2/charclasses/grapplepulloff1x2.bmsad
-  > Alcove across grapple block
+  > Alcove Across Grapple Block
       Trivial
 
 > Tile Group (SCREWATTACK); Heals? False
@@ -1452,18 +1456,16 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('SCREWATTACK',)
-  > Door to Save Station South Access (doorpowerpower_023)
+  > Door to Save Station South Access (Lower)
       All of the following:
           Gravity Suit
-          Simple IBJ or Use Spin Boost
+          Speed Booster or Simple IBJ or Use Spin Boost
   > Dock to Gravity Suit Room Access
       Trivial
   > Tunnel to Storm Missile Gate Room
       Morph Ball
   > Water Space Jump Platform
-      Any of the following:
-          Morph Ball
-          Gravity Suit and Use Spin Boost
+      Gravity Suit or Morph Ball
 
 > Dock to Gravity Suit Room Access; Heals? False
   * Layers: default
@@ -1471,7 +1473,9 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   > Tile Group (SCREWATTACK)
       All of the following:
           Gravity Suit
-          Space Jump or Speed Booster or Simple IBJ
+          Any of the following:
+              Space Jump or Speed Booster or Simple IBJ
+              Flash Shift and Walljump (Beginner) and Use Spin Boost
   > Tunnel to Storm Missile Gate Room
       All of the following:
           Gravity Suit
@@ -1483,56 +1487,76 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   > Tile Group (SCREWATTACK)
       Morph Ball
 
-> Alcove across grapple block; Heals? False
+> Alcove Across Grapple Block; Heals? False
   * Layers: default
-  > Door to Save Station South Access (doorpowerpower_022)
+  > Door to Save Station South Access (Upper)
       Gravity Suit
   > Door to Storm Missile Gate Room
-      Morph Ball and After Burenia - grapplepulloff1x2_003 and Horizontal Water Movement
-  > Event - Shoot Blob from alcove (db_reg_aq_003)
-      Shoot Beam
-  > Event - Pull Lower-Right Grapple Block (grapplepulloff1x2_003)
-      Grapple Beam and After Burenia - db_reg_aq_003
+      All of the following:
+          Morph Ball and After Burenia - Destroy Gravity Suit Floor
+          Any of the following:
+              Use Spin Boost
+              Speed Booster and Disabled Door Lock Randomizer
+              Flash Shift and Gravity Suit
+  > Event - Main Hub Bottom Blob, Left
+      Lay Bomb or Shoot Beam
+  > Event - Main Hub Bottom Grapple Block
+      Grapple Beam and After Burenia - Main Hub Bottom Blob
+  > Ledge above Grapple Block
+      Flash Shift and Gravity Suit and After Burenia - Main Hub Bottom Blob
+  > Water Space Jump Platform
+      After Burenia - Main Hub Bottom Blob
 
 > Ledge above Grapple Block; Heals? False
   * Layers: default
   > Door to Energy Recharge South
       All of the following:
           Gravity Suit
-          Any of the following:
-              Simple IBJ or Use Spin Boost
-              Flash Shift and Walljump (Beginner)
+          Flash Shift or Simple IBJ or Use Spin Boost
   > Door to Storm Missile Gate Room
-      Morph Ball and After Burenia - grapplepulloff1x2_003
-  > Alcove across grapple block
-      After Burenia - db_reg_aq_003 and Use Spin Boost
-  > Event - Shoot Blob from right (db_reg_aq_003)
+      Morph Ball and After Burenia - Destroy Gravity Suit Floor
+  > Alcove Across Grapple Block
+      All of the following:
+          After Burenia - Main Hub Bottom Blob
+          Gravity Suit or Use Spin Boost
+  > Event - Main Hub Bottom Blob, Right
       Shoot Diffusion or Wave
   > Water Space Jump Platform
       Trivial
 
-> Event - Shoot Blob from above (db_reg_aq_003); Heals? False
+> Event - Main Hub Bottom Blob, Above; Heals? False
   * Layers: default
-  * Event Burenia - db_reg_aq_003
+  * Event Burenia - Main Hub Bottom Blob
   > Door to Energy Recharge South
       Trivial
 
-> Event - Shoot Blob from right (db_reg_aq_003); Heals? False
+> Event - Main Hub Bottom Blob, Right; Heals? False
   * Layers: default
-  * Event Burenia - db_reg_aq_003
+  * Event Burenia - Main Hub Bottom Blob
   > Ledge above Grapple Block
       Trivial
 
 > Water Space Jump Platform; Heals? False
   * Layers: default
-  > Door to Save Station South Access (doorpowerpower_023)
+  > Door to Save Station South Access (Lower)
       Horizontal Water Movement
+  > Door to Storm Missile Gate Room
+      All of the following:
+          Gravity Suit and Morph Ball and After Burenia - Destroy Gravity Suit Floor
+          Speed Booster or Single-wall Wall Jump (Beginner) or Simple IBJ or Use Spin Boost
   > Tile Group (SCREWATTACK)
       Trivial
+  > Alcove Across Grapple Block
+      All of the following:
+          Gravity Suit and After Burenia - Main Hub Bottom Blob
+          Flash Shift or Simple IBJ or Use Spin Boost
   > Ledge above Grapple Block
       All of the following:
           Gravity Suit
-          Simple IBJ or Use Spin Boost
+          Any of the following:
+              Simple IBJ or Use Spin Boost
+              Morph Ball and Single-wall Wall Jump (Intermediate)
+              Flash Shift and Walljump (Intermediate)
 
 > Dock from Main Hub Tower Middle; Heals? False
   * Layers: default
@@ -1673,7 +1697,7 @@ Extra - asset_id: collision_camera_013
   > Pickup (Missile Tank)
       Can Slide Underwater
   > Tile Group (BOMB) 1
-      Morph Ball
+      Gravity Suit and Morph Ball
 
 ----------------
 Flash Shift Room
@@ -1972,9 +1996,7 @@ Extra - asset_id: collision_camera_017
   * Extra - start_point_actor_name: elevator_cave_000_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad
   > Door to Navigation Station South
-      Flash Shift or Gravity Suit or Water Bomb Jump (Beginner) or Use Spin Boost
-  > Tile Group (SCREWATTACK) 1
-      Morph Ball
+      Trivial
 
 > Tile Group (SCREWATTACK) 1; Heals? False
   * Layers: default
@@ -1987,22 +2009,6 @@ Extra - asset_id: collision_camera_017
       Trivial
   > Tile Group (SCREWATTACK) 2
       Trivial
-
-> Tile Group (POWERBEAM) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_038
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-
-> Tile Group (POWERBEAM) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_039
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
 
 > Tile Group (SCREWATTACK) 2; Heals? False
   * Layers: default
@@ -2194,13 +2200,22 @@ Extra - asset_id: collision_camera_021
   > Door to Ammo Recharge South (Lower)
       All of the following:
           After Burenia - Destroy Gravity Suit Floor
-          Gravity Suit or Space Jump
+          Any of the following:
+              Space Jump
+              All of the following:
+                  Gravity Suit
+                  Any of the following:
+                      Simple IBJ or Use Spin Boost
+                      Speed Booster and Disabled Door Lock Randomizer
   > Tile Group (POWERBOMB)
       Trivial
   > Breakable Floor
       All of the following:
           Gravity Suit and After Burenia - Destroy Gravity Suit Floor
-          Simple IBJ or Use Spin Boost
+          Any of the following:
+              Simple IBJ or Use Spin Boost
+              Speed Booster and Disabled Door Lock Randomizer
+              Slide and Slide Jump (Beginner)
 
 > Door to Navigation Station South; Heals? False
   * Layers: default
@@ -2214,13 +2229,17 @@ Extra - asset_id: collision_camera_021
   > Start Point 4
       Trivial
   > Tile Group (SCREWATTACK) 2
-      Flash Shift or Speed Booster or Simple IBJ or Use Spin Boost
+      Any of the following:
+          Flash Shift or Simple IBJ or Use Spin Boost
+          All of the following:
+              Speed Booster
+              Before Burenia - Destroy Gravity Suit Floor or Disabled Door Lock Randomizer
   > Breakable Floor
       After Burenia - Destroy Gravity Suit Floor
 
 > Door to Ammo Recharge South (Lower); Heals? False
   * Layers: default
-  * Access Open to Ammo Recharge South/Door to Gravity Suit Tower (Upper)
+  * Access Open to Ammo Recharge South/Door to Gravity Suit Tower (Lower)
   * Extra - actor_name: doorframepresence
   * Extra - actor_def: actordef:actors/props/doorframepresence/charclasses/doorframepresence.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2284,7 +2303,7 @@ Extra - asset_id: collision_camera_021
 
 > Door to Ammo Recharge South (Upper); Heals? False
   * Layers: default
-  * Access Open to Ammo Recharge South/Door to Gravity Suit Tower (Lower)
+  * Access Open to Ammo Recharge South/Door to Gravity Suit Tower (Upper)
   * Extra - actor_name: doorframepresence_000
   * Extra - actor_def: actordef:actors/props/doorframepresence/charclasses/doorframepresence.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2294,37 +2313,39 @@ Extra - asset_id: collision_camera_021
   > Start Point 1
       Trivial
   > Breakable Floor
-      After Burenia - Destroy Gravity Suit Floor
+      Before Burenia - Destroy Gravity Suit Floor or Horizontal Water Movement
   > Tunnel to Ammo Recharge South
       Morph Ball
+  > Blob Alcove
+      Morph Ball and Horizontal Water Movement
 
-> Event - Blob #1 (ev_demolition_db_001); Heals? False
+> Event - Break Floor Blob 1; Heals? False
   * Layers: default
-  * Event Burenia - ev_demolition_db_001
+  * Event Burenia - Break Floor Blob 1
   * Extra - actor_name: ev_demolition_db_001
   * Extra - actor_def: actordef:actors/props/ev_demolition_db_001/charclasses/ev_demolition_db_001.bmsad
   > Blob Alcove
       Trivial
 
-> Event - Blob #2 (ev_demolition_db_002); Heals? False
+> Event - Break Floor Blob 2; Heals? False
   * Layers: default
-  * Event Burenia - ev_demolition_db_002
+  * Event Burenia - Break Floor Blob 2
   * Extra - actor_name: ev_demolition_db_002
   * Extra - actor_def: actordef:actors/props/ev_demolition_db_002/charclasses/ev_demolition_db_002.bmsad
   > Blob Alcove
       Trivial
 
-> Event - Blob #3 (ev_demolition_db_003); Heals? False
+> Event - Break Floor Blob 3; Heals? False
   * Layers: default
-  * Event Burenia - ev_demolition_db_003
+  * Event Burenia - Break Floor Blob 3
   * Extra - actor_name: ev_demolition_db_003
   * Extra - actor_def: actordef:actors/props/ev_demolition_db_003/charclasses/ev_demolition_db_003.bmsad
   > Blob Alcove
       Trivial
 
-> Event - Early Gravity Blob (db_reg_aq_005); Heals? False
+> Event - Early Gravity Blob; Heals? False
   * Layers: default
-  * Event Burenia - db_reg_aq_005
+  * Event Burenia - Early Gravity Blob
   * Extra - actor_name: db_reg_aq_005
   * Extra - actor_def: actordef:actors/props/db_reg_aq_005/charclasses/db_reg_aq_005.bmsad
   > Tile Group (WEIGHT)
@@ -2343,23 +2364,8 @@ Extra - asset_id: collision_camera_021
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Start Point 3
       All of the following:
-          Any of the following:
-              # ways to get up
-              Space Jump or Simple IBJ
-          Any of the following:
-              # Combat tricks
-              All of the following:
-                  # Max difficulty
-                  Combat (Advanced)
-              All of the following:
-                  # less than vanilla requirements
-                  Combat (Intermediate) and Shoot Charge Beam and Shoot Super Missile and Shoot Wide Beam
-              All of the following:
-                  # Vanilla requirements
-                  Shoot Ice Missile and Shoot Plasma Beam
-              All of the following:
-                  # PB cheese
-                  Combat (Beginner) and Lay Power Bomb
+          Morph Ball
+          Space Jump or Simple IBJ
   > Shaft Base
       Trivial
 
@@ -2368,9 +2374,13 @@ Extra - asset_id: collision_camera_021
   * Extra - start_point_actor_name: SP_Checkpoint_Dead_2RCW
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to Teleport to Ghavoran
-      Trivial
+      After Burenia - Twin Robot Fight
   > Start Point 2
-      Space Jump or Simple IBJ
+      All of the following:
+          Morph Ball and After Burenia - Twin Robot Fight
+          Space Jump or Simple IBJ
+  > Event - Twin Robot Fight
+      Fight Twin Robots
 
 > Start Point 4; Heals? False; Spawn Point
   * Layers: default
@@ -2378,14 +2388,6 @@ Extra - asset_id: collision_camera_021
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to Navigation Station South
       Trivial
-
-> Tile Group (SCREWATTACK) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SCREWATTACK',)
 
 > Tile Group (POWERBOMB); Heals? False
   * Layers: default
@@ -2405,10 +2407,10 @@ Extra - asset_id: collision_camera_021
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('WEIGHT',)
-  > Event - Early Gravity Blob (db_reg_aq_005)
+  > Event - Early Gravity Blob
       Lay Bomb or Shoot Beam
   > Breakable Floor
-      Morph Ball and After Burenia - db_reg_aq_005
+      Morph Ball and After Burenia - Early Gravity Blob
 
 > Tile Group (SCREWATTACK) 2; Heals? False
   * Layers: default
@@ -2422,11 +2424,11 @@ Extra - asset_id: collision_camera_021
   > Pickup (Missile+ Tank)
       Trivial
   > Tile Group (POWERBEAM) 1
-      Simple IBJ or Use Spin Boost
+      Trivial
   > Tile Group (POWERBEAM) 2
-      Simple IBJ or Use Spin Boost
+      Trivial
   > Tile Group (SCREWATTACK) 4
-      Simple IBJ or Use Spin Boost
+      Trivial
 
 > Tile Group (POWERBEAM) 1; Heals? False
   * Layers: default
@@ -2439,14 +2441,6 @@ Extra - asset_id: collision_camera_021
       Trivial
   > Shaft Base
       Trivial
-
-> Tile Group (SCREWATTACK) 3; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_021
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SCREWATTACK',)
 
 > Tile Group (MISSILE); Heals? False
   * Layers: default
@@ -2497,7 +2491,9 @@ Extra - asset_id: collision_camera_021
   > Door to Navigation Station South
       All of the following:
           Gravity Suit and After Burenia - Destroy Gravity Suit Floor
-          Space Jump or Speed Booster or Simple IBJ
+          Any of the following:
+              Space Jump or Simple IBJ
+              Speed Booster and Disabled Door Lock Randomizer
   > Dock to Ammo Recharge South
       Any of the following:
           Space Jump or Before Burenia - Destroy Gravity Suit Floor
@@ -2505,7 +2501,11 @@ Extra - asset_id: collision_camera_021
               Gravity Suit
               Flash Shift or Use Spin Boost
   > Blob Alcove
-      Morph Ball
+      All of the following:
+          Morph Ball
+          Gravity Suit or After Burenia - Early Gravity Blob or Damage Boost (Advanced) or Perform WBJ
+  > Event - Early Gravity Blob through Wall
+      Wave Beam
 
 > Tunnel to Ammo Recharge South; Heals? False
   * Layers: default
@@ -2521,7 +2521,7 @@ Extra - asset_id: collision_camera_021
   > Door to Ammo Recharge South (Lower)
       After Burenia - Destroy Gravity Suit Floor
   > Breakable Floor
-      Before Burenia - Destroy Gravity Suit Floor
+      Before Burenia - Destroy Gravity Suit Floor or Horizontal Water Movement
 
 > Event - Break Floor; Heals? False
   * Layers: default
@@ -2531,21 +2531,33 @@ Extra - asset_id: collision_camera_021
 
 > Blob Alcove; Heals? False
   * Layers: default
-  > Event - Blob #1 (ev_demolition_db_001)
-      Shoot Beam
-  > Event - Blob #2 (ev_demolition_db_002)
-      After Burenia - ev_demolition_db_001 and Shoot Beam
-  > Event - Blob #3 (ev_demolition_db_003)
-      After Burenia - ev_demolition_db_002 and Shoot Diffusion or Wave
+  > Door to Navigation Station South
+      All of the following:
+          Flash Shift and Gravity Suit and After Burenia - Destroy Gravity Suit Floor
+          Any of the following:
+              Walljump (Advanced)
+              Walljump (Intermediate) and Use Spin Boost
+  > Event - Break Floor Blob 1
+      Lay Bomb or Shoot Beam
+  > Event - Break Floor Blob 2
+      After Burenia - Break Floor Blob 1 and Shoot Beam
+  > Event - Break Floor Blob 3
+      After Burenia - Break Floor Blob 2 and Shoot Diffusion or Wave
   > Breakable Floor
       Morph Ball
   > Event - Break Floor
-      Grapple Beam and After Burenia - ev_demolition_db_003
+      Grapple Beam and After Burenia - Break Floor Blob 3
 
 > Shaft Base; Heals? False
   * Layers: default
   > Start Point 2
-      Space Jump or Infinite Bomb Jump (Intermediate)
+      Any of the following:
+          Space Jump
+          Infinite Bomb Jump (Intermediate) and Lay Bomb
+          Flash Shift and Walljump (Intermediate) and Use Spin Boost
+          All of the following:
+              Speed Booster and Speedbooster Conservation (Intermediate)
+              Before Burenia - Destroy Gravity Suit Floor or Disabled Door Lock Randomizer
   > Tile Group (POWERBEAM) 1
       Trivial
   > Tile Group (POWERBEAM) 2
@@ -2553,12 +2565,24 @@ Extra - asset_id: collision_camera_021
   > Tile Group (SCREWATTACK) 4
       Trivial
 
+> Event - Early Gravity Blob through Wall; Heals? False
+  * Layers: default
+  * Event Burenia - Early Gravity Blob
+  > Breakable Floor
+      Trivial
+
+> Event - Twin Robot Fight; Heals? False
+  * Layers: default
+  * Event Burenia - Twin Robot Fight
+  > Start Point 3
+      Trivial
+
 ----------------
 Ammo Recharge South
 Extra - total_boundings: {'x1': 9000.0, 'x2': 11100.0, 'y1': -10900.0, 'y2': -8800.0}
 Extra - polygon: [[11100.0, -8800.0], [9000.0, -8800.0], [9000.0, -10900.0], [11100.0, -10900.0]]
 Extra - asset_id: collision_camera_022
-> Door to Gravity Suit Tower (Upper); Heals? False
+> Door to Gravity Suit Tower (Lower); Heals? False
   * Layers: default
   * Sensor Lock Door to Gravity Suit Tower/Door to Ammo Recharge South (Lower)
   * Extra - actor_name: doorframepresence
@@ -2567,12 +2591,12 @@ Extra - asset_id: collision_camera_022
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Gravity Suit Tower (Lower)
+  > Door to Gravity Suit Tower (Upper)
       Trivial
   > Ammo Recharge
       Trivial
 
-> Door to Gravity Suit Tower (Lower); Heals? False
+> Door to Gravity Suit Tower (Upper); Heals? False
   * Layers: default
   * Sensor Lock Door to Gravity Suit Tower/Door to Ammo Recharge South (Upper)
   * Extra - actor_name: doorframepresence_000
@@ -2581,7 +2605,7 @@ Extra - asset_id: collision_camera_022
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Gravity Suit Tower (Upper)
+  > Door to Gravity Suit Tower (Lower)
       Trivial
 
 > Ammo Recharge; Heals? False; Spawn Point
@@ -2590,7 +2614,7 @@ Extra - asset_id: collision_camera_022
   * Extra - actor_def: actordef:actors/props/ammorecharge/charclasses/ammorecharge.bmsad
   * Extra - start_point_actor_name: ammorecharge_001_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_ammo/charclasses/weightactivatedplatform_ammo.bmsad
-  > Door to Gravity Suit Tower (Upper)
+  > Door to Gravity Suit Tower (Lower)
       Trivial
 
 > Tunnel to Gravity Suit Tower; Heals? False
@@ -2624,7 +2648,7 @@ the blast shield issue.
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorshieldmissile_001
   * Extra - right_shield_def: actordef:actors/props/doorshieldmissile/charclasses/doorshieldmissile.bmsad
-  > Event - Blob from above (db_reg_aq_004)
+  > Event - Gravity Suit Blob, Above
       Shoot Diffusion or Wave
   > Start Point
       Trivial
@@ -2656,13 +2680,13 @@ the blast shield issue.
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Tunnel to Gravity Suit Room Access (Upper)
-      Morph Ball and After Burenia - db_reg_aq_004
-  > Event - Blob from right (db_reg_aq_004)
+      Morph Ball and After Burenia - Gravity Suit Blob
+  > Event - Gravity Suit Blob, Right
       Lay Bomb or Shoot Beam
 
-> Event - Blob from above (db_reg_aq_004); Heals? False
+> Event - Gravity Suit Blob, Above; Heals? False
   * Layers: default
-  * Event Burenia - db_reg_aq_004
+  * Event Burenia - Gravity Suit Blob
   * Extra - actor_name: db_reg_aq_004
   * Extra - actor_def: actordef:actors/props/db_reg_aq_004/charclasses/db_reg_aq_004.bmsad
   > Door to Gravity Suit Tower (Upper)
@@ -2681,14 +2705,14 @@ the blast shield issue.
   * Layers: default
   * Morph Ball Tunnel to Gravity Suit Room Access/Tunnel to Gravity Suit Room (Upper)
   > Door to Gravity Suit Tower (Lower)
-      Morph Ball and After Burenia - db_reg_aq_004
+      Morph Ball and After Burenia - Gravity Suit Blob
 
 > Tunnel to Gravity Suit Room Access (Lower); Heals? False
   * Layers: default
   * Morph Ball Tunnel to Gravity Suit Room Access/Tunnel to Gravity Suit Room (Lower)
   > Tile Group (POWERBOMB)
       Morph Ball
-  > Event - Blob from below (db_reg_aq_004)
+  > Event - Gravity Suit Blob, Below
       Shoot Diffusion or Wave
 
 > Tile Group (POWERBOMB); Heals? False
@@ -2700,19 +2724,17 @@ the blast shield issue.
   > Pickup (Power Bomb Tank)
       Gravity Suit and Ballspark
   > Tunnel to Gravity Suit Room Access (Lower)
-      All of the following:
-          Morph Ball
-          Gravity Suit or Water Bomb Jump (Beginner)
+      Morph Ball
 
-> Event - Blob from right (db_reg_aq_004); Heals? False
+> Event - Gravity Suit Blob, Right; Heals? False
   * Layers: default
-  * Event Burenia - db_reg_aq_004
+  * Event Burenia - Gravity Suit Blob
   > Door to Gravity Suit Tower (Lower)
       Trivial
 
-> Event - Blob from below (db_reg_aq_004); Heals? False
+> Event - Gravity Suit Blob, Below; Heals? False
   * Layers: default
-  * Event Burenia - db_reg_aq_004
+  * Event Burenia - Gravity Suit Blob
   > Tunnel to Gravity Suit Room Access (Lower)
       Trivial
 
@@ -2759,10 +2781,11 @@ Extra - asset_id: collision_camera_025
       All of the following:
           After Burenia - Storm Missile Gate for Etank
           Any of the following:
-              Gravity Suit or Water Bomb Jump (Beginner)
+              Gravity Suit or Perform WBJ
               All of the following:
-                  Flash Shift
+                  Flash Shift or Space Jump
                   Grapple Beam or Spider Magnet
+              Grapple Beam and Grapple Movement (Beginner) and Use Spin Boost
   > Tile Group (POWERBEAM)
       Morph Ball
   > Event - Storm Missile Gate
@@ -2814,12 +2837,12 @@ Extra - asset_id: collision_camera_026
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Main Hub Tower Bottom (doorpowerpower_022)
+  > Door to Main Hub Tower Bottom (Upper)
       Trivial
 
-> Door to Main Hub Tower Bottom (doorpowerpower_022); Heals? False
+> Door to Main Hub Tower Bottom (Upper); Heals? False
   * Layers: default
-  * Power Beam Door to Main Hub Tower Bottom/Door to Save Station South Access (doorpowerpower_022)
+  * Power Beam Door to Main Hub Tower Bottom/Door to Save Station South Access (Upper)
   * Extra - actor_name: doorpowerpower_022
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2828,19 +2851,19 @@ Extra - asset_id: collision_camera_026
   * Extra - right_shield_def: None
   > Door to Save Station South
       Trivial
-  > Door to Main Hub Tower Bottom (doorpowerpower_023)
+  > Door to Main Hub Tower Bottom (Lower)
       Can Slide Underwater
 
-> Door to Main Hub Tower Bottom (doorpowerpower_023); Heals? False
+> Door to Main Hub Tower Bottom (Lower); Heals? False
   * Layers: default
-  * Power Beam Door to Main Hub Tower Bottom/Door to Save Station South Access (doorpowerpower_023)
+  * Power Beam Door to Main Hub Tower Bottom/Door to Save Station South Access (Lower)
   * Extra - actor_name: doorpowerpower_023
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Main Hub Tower Bottom (doorpowerpower_022)
+  > Door to Main Hub Tower Bottom (Upper)
       Morph Ball
 
 ----------------

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -1499,7 +1499,7 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
           Any of the following:
               Use Spin Boost
               All of the following:
-                  Speed Booster and After Burenia - Prepare Speedboost in Save Station and Disabled Door Lock Randomizer
+                  After Burenia - Prepare Speedboost in Save Station
                   Gravity Suit or Speedbooster Conservation (Intermediate)
               Flash Shift and Gravity Suit
   > Event - Main Hub Bottom Blob, Left

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -345,8 +345,10 @@ Extra - asset_id: collision_camera_002
       All of the following:
           Gravity Suit and After Burenia - Dairon Hub Transport Blob
           Any of the following:
-              Simple IBJ or Use Spin Boost
               After Burenia - Dairon Hub Water Blob Right and After Burenia - Dairon Hub Water Blob Left
+              All of the following:
+                  Before Burenia - Dairon Hub Water Blob Right and Before Burenia - Dairon Hub Water Blob Left and Enabled Highly Dangerous Logic
+                  Simple IBJ or Use Spin Boost
   > Tile Group (BOMB)
       Morph Ball
   > Bottom-left Corner

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -1398,6 +1398,8 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   * Extra - right_shield_def: None
   > Alcove Across Grapple Block
       Trivial
+  > Event - Prepare Speedboost in Save Station
+      Speed Booster and Disabled Door Lock Randomizer
 
 > Door to Save Station South Access (Lower); Heals? False
   * Layers: default
@@ -1495,8 +1497,7 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
       All of the following:
           Morph Ball and After Burenia - Destroy Gravity Suit Floor
           Any of the following:
-              Use Spin Boost
-              Speed Booster and Disabled Door Lock Randomizer
+              After Burenia - Prepare Speedboost in Save Station or Use Spin Boost
               Flash Shift and Gravity Suit
   > Event - Main Hub Bottom Blob, Left
       Lay Bomb or Shoot Beam
@@ -1562,6 +1563,12 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   * Layers: default
   * Blocked Passage to Main Hub Tower Middle/Dock to Main Hub Tower Bottom
   > Door to Energy Recharge South
+      Trivial
+
+> Event - Prepare Speedboost in Save Station; Heals? False
+  * Layers: default
+  * Event Burenia - Prepare Speedboost in Save Station
+  > Door to Save Station South Access (Upper)
       Trivial
 
 ----------------

--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -12571,7 +12571,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "misc",
-                                            "name": "DisabledFreezer",
+                                            "name": "HighDanger",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -12928,7 +12928,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "misc",
-                                            "name": "DisabledFreezer",
+                                            "name": "HighDanger",
                                             "amount": 1,
                                             "negate": false
                                         }

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -2285,7 +2285,7 @@ Extra - asset_id: collision_camera_025
                   Flash Shift and Walljump (Beginner)
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
   > Freezer Navigation
-      After Dairon - Power Switch 2 or Enabled Allow Disabled Freezer
+      After Dairon - Power Switch 2 or Enabled Highly Dangerous Logic
 
 > Beside the Blob; Heals? False
   * Layers: default
@@ -2329,7 +2329,7 @@ while disabled
   > Event - Hidden Blob, Outside
       Wave Beam
   > Freezer Center
-      After Dairon - Power Switch 2 or Enabled Allow Disabled Freezer
+      After Dairon - Power Switch 2 or Enabled Highly Dangerous Logic
   > Event - Freezer Speed Blocks Destroyed
       All of the following:
           Speed Booster

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -1390,11 +1390,11 @@ Extra - asset_id: collision_camera_017
   * Extra - start_point_actor_name: SP_Checkpoint_Dead_2ChozoRobots
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to Teleport to Burenia (Cyan)
-      No Storm Missile or After  Ferenia - Twin Robot Fight
+      No Storm Missile or After Ferenia - Twin Robot Fight
   > Door to Energy Recharge Station (Gate)
-      No Storm Missile or After  Ferenia - Twin Robot Fight
+      No Storm Missile or After Ferenia - Twin Robot Fight
   > Door to Navigation Station
-      No Storm Missile or After  Ferenia - Twin Robot Fight
+      No Storm Missile or After Ferenia - Twin Robot Fight
   > Event - Twin Robot Fight
       Storm Missile and Fight Twin Robots
 
@@ -1426,7 +1426,7 @@ Extra - asset_id: collision_camera_017
 
 > Event - Twin Robot Fight; Heals? False
   * Layers: default
-  * Event  Ferenia - Twin Robot Fight
+  * Event Ferenia - Twin Robot Fight
   > Start Point 1
       Trivial
 

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1013,6 +1013,10 @@
             "BureniaRobots": {
                 "long_name": "Burenia - Twin Robot Fight",
                 "extra": {}
+            },
+            "BureniaPrepareSpeedSave": {
+                "long_name": "Burenia - Prepare Speedboost in Save Station",
+                "extra": {}
             }
         },
         "tricks": {

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -563,27 +563,27 @@
                 "extra": {}
             },
             "s040_aqua:default:db_reg_aq_003": {
-                "long_name": "Burenia - db_reg_aq_003",
+                "long_name": "Burenia - Main Hub Bottom Blob",
                 "extra": {}
             },
             "s040_aqua:default:db_reg_aq_004": {
-                "long_name": "Burenia - db_reg_aq_004",
+                "long_name": "Burenia - Gravity Suit Blob",
                 "extra": {}
             },
             "s040_aqua:default:ev_demolition_db_001": {
-                "long_name": "Burenia - ev_demolition_db_001",
+                "long_name": "Burenia - Break Floor Blob 1",
                 "extra": {}
             },
             "s040_aqua:default:ev_demolition_db_002": {
-                "long_name": "Burenia - ev_demolition_db_002",
+                "long_name": "Burenia - Break Floor Blob 2",
                 "extra": {}
             },
             "s040_aqua:default:ev_demolition_db_003": {
-                "long_name": "Burenia - ev_demolition_db_003",
+                "long_name": "Burenia - Break Floor Blob 3",
                 "extra": {}
             },
             "s040_aqua:default:db_reg_aq_005": {
-                "long_name": "Burenia - db_reg_aq_005",
+                "long_name": "Burenia - Early Gravity Blob",
                 "extra": {}
             },
             "s040_aqua:default:db_reg_aq_007": {
@@ -695,7 +695,7 @@
                 "extra": {}
             },
             "s040_aqua:default:grapplepulloff1x2_003": {
-                "long_name": "Burenia - grapplepulloff1x2_003",
+                "long_name": "Burenia - Destroy Gravity Suit Floor",
                 "extra": {}
             },
             "s040_aqua:default:grapplepulloff1x2_000": {
@@ -930,10 +930,6 @@
                 "long_name": "Burenia - Hub Magnet Wall",
                 "extra": {}
             },
-            "BureniaDestroyGravitySuitFloor": {
-                "long_name": "Burenia - Destroy Gravity Suit Floor",
-                "extra": {}
-            },
             "Quiet Robe": {
                 "long_name": "Quiet Robe",
                 "extra": {}
@@ -1011,7 +1007,11 @@
                 "extra": {}
             },
             "FereniaRobots": {
-                "long_name": " Ferenia - Twin Robot Fight",
+                "long_name": "Ferenia - Twin Robot Fight",
+                "extra": {}
+            },
+            "BureniaRobots": {
+                "long_name": "Burenia - Twin Robot Fight",
                 "extra": {}
             }
         },

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -695,7 +695,7 @@
                 "extra": {}
             },
             "s040_aqua:default:grapplepulloff1x2_003": {
-                "long_name": "Burenia - Destroy Gravity Suit Floor",
+                "long_name": "Burenia - Main Hub Bottom Grapple Block",
                 "extra": {}
             },
             "s040_aqua:default:grapplepulloff1x2_000": {
@@ -924,6 +924,10 @@
             },
             "BureniaHubMagnetPlatform": {
                 "long_name": "Burenia - Hub Magnet Wall",
+                "extra": {}
+            },
+            "BureniaDestroyGravitySuitFloor": {
+                "long_name": "Burenia - Destroy Gravity Suit Floor",
                 "extra": {}
             },
             "Quiet Robe": {

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1167,8 +1167,8 @@
                 "long_name": "Door Lock Randomizer",
                 "extra": {}
             },
-            "DisabledFreezer": {
-                "long_name": "Allow Disabled Freezer",
+            "HighDanger": {
+                "long_name": "Highly Dangerous Logic",
                 "extra": {}
             }
         },


### PR DESCRIPTION
This should finish off the logic revision for Burenia. Fixed a few things from the previous PR as well.

- Added various methods of traversing "Main Hub Tower Bottom"
- Added various methods of traversing "Gravity Suit Tower"
- Corrected some logic in "Gravity Suit Tower"
- Corrected some logic in "Gravity Suit Room"
- Corrected some logic in "Transport to Artaria"
- Fixed the connection between the bomb blocks in "Energy Recharge South"
- Accounted for the magnet wall event when choosing to grapple it to reach the item in "Main Hub Tower Middle"
- Added event for the Twin Robot Fight
- Added event for a speedboost in "Main Hub Tower Bottom"
- Corrected minor typo in the event long name for the Ferenia Twin Robot Fight
- Renamed "Allow Disabled Freezer" to "Highly Dangerous Logic", allowing for many forms of dangerous logic that is not entirely obvious to be covered
- Applied "Highly Dangerous Logic" to the connection from "Water Bottom" to "Door to Lower Transport to Dairon" in "Burenia Hub to Dairon"

fixes #3558 