### PR TITLE
Dread: Revise the Freezer to make it less dangerous

### DIFF
--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -10993,6 +10993,147 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Door to Power Switch 2": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Magnet",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spin Boost"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "GrappleMovement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Flash",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Slide"
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Wave",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Shoot Diffusion Beam"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Pseudo",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Freezer Center": {
                             "type": "or",
                             "data": {
@@ -11031,15 +11172,6 @@
                                                     }
                                                 }
                                             ]
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s030_baselab:default:powergenerator_002",
-                                            "amount": 1,
-                                            "negate": true
                                         }
                                     }
                                 ]
@@ -11098,15 +11230,6 @@
                                                             }
                                                         ]
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
                                                 }
                                             ]
                                         }
@@ -11114,7 +11237,7 @@
                                 ]
                             }
                         },
-                        "Event - Right Blob from above (db_reg_b1_002)": {
+                        "Event - Freezer Right Blob, Above": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11169,15 +11292,6 @@
                                                         "name": "Gravity",
                                                         "amount": 1,
                                                         "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
                                                     }
                                                 },
                                                 {
@@ -11283,15 +11397,6 @@
                                                 }
                                             ]
                                         }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s030_baselab:default:powergenerator_002",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
                                     }
                                 ]
                             }
@@ -11349,15 +11454,6 @@
                                                             }
                                                         ]
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
                                                 }
                                             ]
                                         }
@@ -11397,7 +11493,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Energy Recharge Station West (Lower)": {
+                        "Freezer Center": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11405,8 +11501,8 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Morph",
+                                            "type": "events",
+                                            "name": "DaironFreezerSpeedBlocks",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -11433,18 +11529,87 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 30,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Left Blob Alcove": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "DaironFreezerSpeedBlocks",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
                                                                     "type": "damage",
                                                                     "name": "Cold",
                                                                     "amount": 120,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -11458,61 +11623,9 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s030_baselab:default:powergenerator_002",
+                                            "name": "s030_baselab:default:db_reg_b1_001",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Freezer Center": {
-                            "type": "or",
-                            "data": {
-                                "comment": "TODO? Add event for destroying speed blocks for room rando",
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s030_baselab:default:powergenerator_002",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Suitless",
-                                                        "amount": 2,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "damage",
-                                                        "name": "Cold",
-                                                        "amount": 30,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
                                         }
                                     }
                                 ]
@@ -11550,231 +11663,11 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Pickup (Missile Tank - Upper)": {
+                        "Left Blob Alcove": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:db_reg_b1_001",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can Slide"
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 30,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Event - Hidden Blob from left (db_reg_b1_001)": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 30,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Freezer Center": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 100,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s030_baselab:default:db_reg_b1_001",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }
@@ -11851,15 +11744,6 @@
                                                             }
                                                         ]
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
                                                 }
                                             ]
                                         }
@@ -11888,20 +11772,11 @@
                     "pickup_index": 76,
                     "major_location": false,
                     "connections": {
-                        "Door to Energy Recharge Station West (Lower)": {
+                        "Left Blob Alcove": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s030_baselab:default:powergenerator_002",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
                                     {
                                         "type": "or",
                                         "data": {
@@ -11935,7 +11810,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "Suitless",
-                                                                    "amount": 2,
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -11943,32 +11818,6 @@
                                                     }
                                                 }
                                             ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Freezer Center": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s030_baselab:default:db_reg_b1_001",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
                                         }
                                     },
                                     {
@@ -11980,7 +11829,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Gravity",
+                                                        "name": "Morph",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -11989,35 +11838,9 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "name": "s030_baselab:default:db_reg_b1_001",
                                                         "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 30,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -12028,7 +11851,7 @@
                         }
                     }
                 },
-                "Event - Hidden Blob from left (db_reg_b1_001)": {
+                "Event - Freezer Hidden Blob, Adjacent": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12046,18 +11869,16 @@
                     },
                     "event_name": "s030_baselab:default:db_reg_b1_001",
                     "connections": {
-                        "Door to Energy Recharge Station West (Lower)": {
-                            "type": "resource",
+                        "Left Blob Alcove": {
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "s030_baselab:default:powergenerator_002",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
                 },
-                "Event - Right Blob from right (db_reg_b1_002)": {
+                "Event - Freezer Right Blob, Adjacent": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12134,15 +11955,6 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
                                                     "type": "and",
                                                     "data": {
                                                         "comment": null,
@@ -12203,15 +12015,6 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
                                                     "type": "and",
                                                     "data": {
                                                         "comment": null,
@@ -12255,15 +12058,6 @@
                                             "name": "Gravity",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s030_baselab:default:powergenerator_002",
-                                            "amount": 1,
-                                            "negate": true
                                         }
                                     },
                                     {
@@ -12371,15 +12165,6 @@
                                                             }
                                                         ]
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
                                                 }
                                             ]
                                         }
@@ -12456,15 +12241,6 @@
                                                             }
                                                         ]
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
                                                 }
                                             ]
                                         }
@@ -12501,15 +12277,6 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
                                                     "type": "and",
                                                     "data": {
                                                         "comment": null,
@@ -12534,36 +12301,6 @@
                                                             }
                                                         ]
                                                     }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Space",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Walljump",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
                                                 }
                                             ]
                                         }
@@ -12592,15 +12329,6 @@
                                                         "name": "Gravity",
                                                         "amount": 1,
                                                         "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
                                                     }
                                                 },
                                                 {
@@ -12637,7 +12365,7 @@
                         }
                     }
                 },
-                "Event - Hidden Blob through wall (db_reg_b1_001)": {
+                "Event - Freezer Hidden Blob through Wall": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12719,15 +12447,6 @@
                                                             }
                                                         ]
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
                                                 }
                                             ]
                                         }
@@ -12760,12 +12479,67 @@
                                                     "data": "Simple IBJ"
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Walljump",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Flash",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Use Spin Boost"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Morph",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "SWJ",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -12780,63 +12554,12 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "and",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Gravity",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Suitless",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Cold",
-                                                                                "amount": 200,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     },
                                     {
@@ -12847,144 +12570,19 @@
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
+                                                        "type": "damage",
+                                                        "name": "Cold",
+                                                        "amount": 200,
+                                                        "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "or",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Space",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Magnet",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Speed",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Grapple",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Movement",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Gravity",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "or",
-                                                                            "data": {
-                                                                                "comment": null,
-                                                                                "items": [
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "items",
-                                                                                            "name": "Spin",
-                                                                                            "amount": 1,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "tricks",
-                                                                                            "name": "Walljump",
-                                                                                            "amount": 1,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "template",
-                                                                                        "data": "Simple IBJ"
-                                                                                    }
-                                                                                ]
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Flash",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Walljump",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
+                                                        "amount": 2,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -13001,8 +12599,8 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Speed",
+                                            "type": "events",
+                                            "name": "DaironFreezerSpeedBlocks",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -13051,6 +12649,32 @@
                                         }
                                     },
                                     {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:powergenerator_002",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tile Group (SCREWATTACK)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
                                         "type": "or",
                                         "data": {
                                             "comment": null,
@@ -13059,7 +12683,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Space",
+                                                        "name": "Gravity",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -13073,8 +12697,17 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Movement",
+                                                                    "name": "Suitless",
                                                                     "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 50,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -13083,20 +12716,20 @@
                                                 }
                                             ]
                                         }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s030_baselab:default:powergenerator_002",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
                                     }
                                 ]
                             }
                         },
-                        "Pickup (Missile Tank - Upper)": {
+                        "Event - Freezer Hidden Blob through Wall": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Wave",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Left Blob Alcove": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13134,12 +12767,89 @@
                                                     }
                                                 },
                                                 {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 200,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Freezer Speed Blocks Destroyed": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "type": "items",
+                                                        "name": "Space",
                                                         "amount": 1,
-                                                        "negate": true
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 },
                                                 {
@@ -13172,84 +12882,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        },
-                        "Tile Group (SCREWATTACK)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 50,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Event - Hidden Blob through wall (db_reg_b1_001)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Wave",
-                                "amount": 1,
-                                "negate": false
                             }
                         }
                     }
@@ -13294,15 +12926,6 @@
                                                         "name": "Gravity",
                                                         "amount": 1,
                                                         "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
                                                     }
                                                 },
                                                 {
@@ -13385,15 +13008,6 @@
                                                             }
                                                         ]
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
                                                 }
                                             ]
                                         }
@@ -13401,7 +13015,7 @@
                                 ]
                             }
                         },
-                        "Event - Right Blob from right (db_reg_b1_002)": {
+                        "Event - Freezer Right Blob, Adjacent": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13422,15 +13036,6 @@
                                                         "name": "Gravity",
                                                         "amount": 1,
                                                         "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
                                                     }
                                                 },
                                                 {
@@ -13467,7 +13072,7 @@
                         }
                     }
                 },
-                "Event - Right Blob from above (db_reg_b1_002)": {
+                "Event - Freezer Right Blob, Above": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -13487,6 +13092,265 @@
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        }
+                    }
+                },
+                "Left Blob Alcove": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -13500.0,
+                        "y": 5500.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "connections": {
+                        "Door to Energy Recharge Station West (Lower)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "s030_baselab:default:powergenerator_002",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Pickup (Missile Tank - Upper)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:db_reg_b1_001",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Slide"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 30,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Freezer Hidden Blob, Adjacent": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Beam"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Bomb"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 30,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Freezer Center": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:db_reg_b1_001",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 30,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Event - Freezer Speed Blocks Destroyed": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -13050.0,
+                        "y": 7200.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "DaironFreezerSpeedBlocks",
+                    "connections": {
+                        "Door to Energy Recharge Station West (Upper)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "s030_baselab:default:powergenerator_002",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -582,7 +582,7 @@ Extra - asset_id: collision_camera_007
 
 > Event - Electric Generator; Heals? False; Spawn Point
   * Layers: default
-  * Event Dairon - powergenerator_001
+  * Event Dairon - Power Switch 1
   * Extra - actor_name: powergenerator_001
   * Extra - actor_def: actordef:actors/props/powergenerator/charclasses/powergenerator.bmsad
   * Extra - start_point_actor_name: powergenerator_001_platform
@@ -2061,7 +2061,7 @@ Extra - asset_id: collision_camera_024
 
 > Event - Electric Generator; Heals? False; Spawn Point
   * Layers: default
-  * Event Dairon - powergenerator_002
+  * Event Dairon - Power Switch 2
   * Extra - actor_name: powergenerator_002
   * Extra - actor_def: actordef:actors/props/powergenerator/charclasses/powergenerator.bmsad
   * Extra - start_point_actor_name: powergenerator_002_platform
@@ -2094,23 +2094,33 @@ Extra - asset_id: collision_camera_025
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  > Door to Power Switch 2
+      Any of the following:
+          Gravity Suit or Spider Magnet or Speed Booster or Use Spin Boost
+          Grapple Beam and Grapple Movement (Beginner)
+          Flash Shift and Walljump (Beginner)
+          All of the following:
+              Can Slide
+              Any of the following:
+                  Wave Beam
+                  Pseudo-Wave Beam (Beginner) and Shoot Diffusion Beam
   > Freezer Center
       Any of the following:
-          Gravity Suit or Before Dairon - powergenerator_002
+          Gravity Suit
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
   > Beside the Blob
       All of the following:
           After Dairon - db_reg_b1_002
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
-  > Event - Right Blob from above (db_reg_b1_002)
+  > Event - Freezer Right Blob, Above
       All of the following:
           Any of the following:
               Wave Beam
               Pseudo-Wave Beam (Beginner) and Shoot Diffusion Beam
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
 
 > Door to Power Switch 2; Heals? False
@@ -2124,13 +2134,13 @@ Extra - asset_id: collision_camera_025
   * Extra - right_shield_def: None
   > Freezer Center
       Any of the following:
-          Gravity Suit or Before Dairon - powergenerator_002
+          Gravity Suit
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
   > Beside the Blob
       All of the following:
           Morph Ball
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
 
 > Door to Energy Recharge Station West (Upper); Heals? False
@@ -2142,17 +2152,18 @@ Extra - asset_id: collision_camera_025
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Energy Recharge Station West (Lower)
+  > Freezer Center
       All of the following:
-          Morph Ball and After Dairon - powergenerator_002
+          After Dairon - Freezer Speed Blocks Destroyed
+          Any of the following:
+              Gravity Suit
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
+  > Left Blob Alcove
+      All of the following:
+          Morph Ball and After Dairon - Freezer Speed Blocks Destroyed and After Dairon - Freezer Hidden Blob
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 120
-  > Freezer Center
-      Any of the following:
-          # TODO? Add event for destroying speed blocks for room rando
-          Gravity Suit or Before Dairon - powergenerator_002
-          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
 
 > Door to Energy Recharge Station West (Lower); Heals? False
   * Layers: default
@@ -2163,22 +2174,8 @@ Extra - asset_id: collision_camera_025
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Pickup (Missile Tank - Upper)
-      All of the following:
-          After Dairon - Freezer Hidden Left Blob or Can Slide
-          Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
-  > Event - Hidden Blob from left (db_reg_b1_001)
-      Any of the following:
-          Gravity Suit or Before Dairon - powergenerator_002 or Lay Bomb or Shoot Beam
-          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
-  > Freezer Center
-      All of the following:
-          Morph Ball and After Dairon - Freezer Hidden Left Blob
-          Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
+  > Left Blob Alcove
+      Trivial
 
 > Pickup (Missile Tank - Lower); Heals? False
   * Layers: default
@@ -2189,7 +2186,7 @@ Extra - asset_id: collision_camera_025
       All of the following:
           Morph Ball
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
 
 > Pickup (Missile Tank - Upper); Heals? False
@@ -2197,30 +2194,24 @@ Extra - asset_id: collision_camera_025
   * Pickup 76; Major Location? False
   * Extra - actor_name: item_missiletank_006
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Door to Energy Recharge Station West (Lower)
+  > Left Blob Alcove
       All of the following:
-          After Dairon - powergenerator_002
           Any of the following:
               Gravity Suit
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 20
-  > Freezer Center
-      All of the following:
-          Morph Ball and After Dairon - Freezer Hidden Left Blob
-          Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
+              Heat/Cold Runs (Beginner) and Cold Damage ≥ 20
+          Morph Ball or After Dairon - Freezer Hidden Left Blob
 
-> Event - Hidden Blob from left (db_reg_b1_001); Heals? False
+> Event - Freezer Hidden Blob, Adjacent; Heals? False
   * Layers: default
-  * Event Dairon - Freezer Hidden Left Blob
+  * Event Dairon - Freezer Hidden Blob
   * Extra - actor_name: db_reg_b1_001
   * Extra - actor_def: actordef:actors/props/db_reg_b1_001/charclasses/db_reg_b1_001.bmsad
-  > Door to Energy Recharge Station West (Lower)
-      After Dairon - powergenerator_002
+  > Left Blob Alcove
+      Trivial
 
-> Event - Right Blob from right (db_reg_b1_002); Heals? False
+> Event - Freezer Right Blob, Adjacent; Heals? False
   * Layers: default
-  * Event Dairon - db_reg_b1_002
+  * Event Dairon - Freezer Right Blob
   * Extra - actor_name: db_reg_b1_002
   * Extra - actor_def: actordef:actors/props/db_reg_b1_002/charclasses/db_reg_b1_002.bmsad
   > Beside the Blob
@@ -2237,17 +2228,17 @@ Extra - asset_id: collision_camera_025
       All of the following:
           Morph Ball
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 70
   > Bottom-Left Corner
       All of the following:
           Speed Booster
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
   > Freezer Center
       Any of the following:
-          Gravity Suit or Before Dairon - powergenerator_002
+          Gravity Suit
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
 
 > Tile Group (WEIGHT); Heals? False
@@ -2260,7 +2251,7 @@ Extra - asset_id: collision_camera_025
       All of the following:
           Speed Booster
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
 
 > Bottom-Left Corner; Heals? False
@@ -2269,25 +2260,24 @@ Extra - asset_id: collision_camera_025
       All of the following:
           Morph Ball
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
   > Tile Group (SCREWATTACK)
       All of the following:
           Speed Booster
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
-          Space Jump or Walljump (Beginner) or Simple IBJ
   > Tile Group (WEIGHT)
       All of the following:
           Ballspark
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 70
 
-> Event - Hidden Blob through wall (db_reg_b1_001); Heals? False
+> Event - Freezer Hidden Blob through Wall; Heals? False
   * Layers: default
-  * Event Dairon - Freezer Hidden Left Blob
+  * Event Dairon - Freezer Hidden Blob
   > Freezer Center
       Trivial
 
@@ -2296,46 +2286,45 @@ Extra - asset_id: collision_camera_025
   > Door to Map Station
       All of the following:
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 150
-          Space Jump or Speed Booster or Walljump (Beginner) or Simple IBJ
+          Any of the following:
+              Space Jump or Speed Booster or Simple IBJ
+              All of the following:
+                  Walljump (Beginner)
+                  Flash Shift or Use Spin Boost
+              Morph Ball and Single-wall Wall Jump (Intermediate)
   > Door to Power Switch 2
       Any of the following:
-          All of the following:
-              After Dairon - powergenerator_002
-              Any of the following:
-                  Gravity Suit
-                  Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
-          All of the following:
-              Before Dairon - powergenerator_002
-              Any of the following:
-                  Spider Magnet or Space Jump or Speed Booster
-                  Grapple Beam and Movement (Beginner)
-                  All of the following:
-                      Gravity Suit
-                      Spin Boost or Walljump (Beginner) or Simple IBJ
-                  Flash Shift and Walljump (Beginner)
+          Gravity Suit
+          Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
   > Door to Energy Recharge Station West (Upper)
       All of the following:
-          Speed Booster and After Dairon - powergenerator_002
+          After Dairon - Freezer Speed Blocks Destroyed and After Dairon - Power Switch 2
           Any of the following:
               Gravity Suit
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
-          Space Jump or Movement (Intermediate)
-  > Pickup (Missile Tank - Upper)
-      All of the following:
-          Morph Ball and After Dairon - Freezer Hidden Left Blob
-          Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
   > Tile Group (SCREWATTACK)
       All of the following:
           Speed Booster
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
-  > Event - Hidden Blob through wall (db_reg_b1_001)
+  > Event - Freezer Hidden Blob through Wall
       Wave Beam
+  > Left Blob Alcove
+      All of the following:
+          Morph Ball and After Dairon - Freezer Hidden Left Blob
+          Any of the following:
+              Gravity Suit
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
+  > Event - Freezer Speed Blocks Destroyed
+      All of the following:
+          Speed Booster
+          Space Jump or Movement (Intermediate)
+          Any of the following:
+              Gravity Suit
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
 
 > Beside the Blob; Heals? False
   * Layers: default
@@ -2343,26 +2332,55 @@ Extra - asset_id: collision_camera_025
       All of the following:
           After Dairon - db_reg_b1_002
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
   > Door to Power Switch 2
       All of the following:
           Can Slide
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
-  > Event - Right Blob from right (db_reg_b1_002)
+  > Event - Freezer Right Blob, Adjacent
       All of the following:
           Shoot Beam
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
 
-> Event - Right Blob from above (db_reg_b1_002); Heals? False
+> Event - Freezer Right Blob, Above; Heals? False
   * Layers: default
-  * Event Dairon - db_reg_b1_002
+  * Event Dairon - Freezer Right Blob
   > Door to Map Station
       Trivial
+
+> Left Blob Alcove; Heals? False
+  * Layers: default
+  > Door to Energy Recharge Station West (Lower)
+      After Dairon - powergenerator_002
+  > Pickup (Missile Tank - Upper)
+      All of the following:
+          After Dairon - Freezer Hidden Left Blob or Can Slide
+          Any of the following:
+              Gravity Suit
+              Heat/Cold Runs (Beginner) and Cold Damage ≥ 30
+  > Event - Freezer Hidden Blob, Adjacent
+      All of the following:
+          Lay Bomb or Shoot Beam
+          Any of the following:
+              Gravity Suit
+              Heat/Cold Runs (Beginner) and Cold Damage ≥ 30
+  > Freezer Center
+      All of the following:
+          Morph Ball and After Dairon - Freezer Hidden Left Blob
+          Any of the following:
+              Gravity Suit
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
+
+> Event - Freezer Speed Blocks Destroyed; Heals? False
+  * Layers: default
+  * Event Dairon - Freezer Speed Blocks Destroyed
+  > Door to Energy Recharge Station West (Upper)
+      After Dairon - Power Switch 2
 
 ----------------
 Test Chamber Access

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -511,7 +511,7 @@ Extra - asset_id: collision_camera_006
   > Pickup (Wide Beam)
       Trivial
   > Door to Teleport to Cataris
-      Morph Ball and After Dairon - powergenerator_001
+      Morph Ball and After Dairon - Power Switch 1
   > Tile Group (POWERBEAM) 4
       Trivial
 
@@ -595,7 +595,7 @@ Extra - asset_id: collision_camera_007
   * Extra - start_point_actor_name: powergeneratorengine_001
   * Extra - start_point_actor_def: actordef:actors/props/powergeneratorengine/charclasses/powergeneratorengine.bmsad
   > Door to Teleport to Cataris
-      After Dairon - powergenerator_001
+      After Dairon - Power Switch 1
   > Event - Electric Generator
       Trivial
   > Tunnel to Teleport to Cataris
@@ -635,7 +635,7 @@ Extra - asset_id: collision_camera_008
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to Wide Beam Room
-      After Dairon - powergenerator_001
+      After Dairon - Power Switch 1
   > Tile Group (POWERBEAM) 1
       Trivial
   > Tile Group (POWERBEAM) 2
@@ -653,7 +653,7 @@ Extra - asset_id: collision_camera_008
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to Wide Beam Room
-      After Dairon - powergenerator_001
+      After Dairon - Power Switch 1
   > Tile Group (POWERBEAM) 1
       Trivial
 
@@ -669,7 +669,7 @@ Extra - asset_id: collision_camera_008
   > Door to Total Recharge Station East
       Trivial
   > Door to Power Switch 1
-      After Dairon - powergenerator_001
+      After Dairon - Power Switch 1
 
 > Event - Blob from shaft (db_dif_b1_001); Heals? False
   * Layers: default
@@ -703,7 +703,7 @@ Extra - asset_id: collision_camera_008
   > Door to Total Recharge Station East
       Trivial
   > Door to Power Switch 1
-      After Dairon - powergenerator_001
+      After Dairon - Power Switch 1
   > Tunnel to Power Switch 1
       Can Slide
 
@@ -728,7 +728,7 @@ Extra - asset_id: collision_camera_008
 > Bottom-Left Corner; Heals? False
   * Layers: default
   > Door to Early Grapple Access
-      Morph Ball and After Dairon - powergenerator_001
+      Morph Ball and After Dairon - Power Switch 1
   > Event - Blob from shaft (db_dif_b1_001)
       Shoot Diffusion or Wave
   > Teleporter to Cataris - Teleport to Dairon
@@ -917,7 +917,7 @@ Extra - asset_id: collision_camera_010
   * Layers: default
   > Door to Teleport to Cataris
       All of the following:
-          Morph Ball and After Dairon - powergenerator_001
+          Morph Ball and After Dairon - Power Switch 1
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 120
@@ -1954,7 +1954,7 @@ Extra - asset_id: collision_camera_022
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to Bomb Room
-      Morph Ball and After Dairon - powergenerator_002
+      Morph Ball and After Dairon - Power Switch 2
   > Center
       Trivial
 
@@ -2007,7 +2007,7 @@ Extra - asset_id: collision_camera_023
   > Door to Freezer
       Trivial
   > Map Station
-      After Dairon - powergenerator_002
+      After Dairon - Power Switch 2
 
 > Door to Freezer; Heals? False
   * Layers: default
@@ -2110,7 +2110,7 @@ Extra - asset_id: collision_camera_025
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
   > Beside the Blob
       All of the following:
-          After Dairon - db_reg_b1_002
+          After Dairon - Freezer Right Blob
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
@@ -2199,7 +2199,7 @@ Extra - asset_id: collision_camera_025
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Beginner) and Cold Damage ≥ 20
-          Morph Ball or After Dairon - Freezer Hidden Left Blob
+          Morph Ball or After Dairon - Freezer Hidden Blob
 
 > Event - Freezer Hidden Blob, Adjacent; Heals? False
   * Layers: default
@@ -2314,7 +2314,7 @@ Extra - asset_id: collision_camera_025
       Wave Beam
   > Left Blob Alcove
       All of the following:
-          Morph Ball and After Dairon - Freezer Hidden Left Blob
+          Morph Ball and After Dairon - Freezer Hidden Blob
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
@@ -2330,7 +2330,7 @@ Extra - asset_id: collision_camera_025
   * Layers: default
   > Door to Map Station
       All of the following:
-          After Dairon - db_reg_b1_002
+          After Dairon - Freezer Right Blob
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
@@ -2356,10 +2356,10 @@ Extra - asset_id: collision_camera_025
 > Left Blob Alcove; Heals? False
   * Layers: default
   > Door to Energy Recharge Station West (Lower)
-      After Dairon - powergenerator_002
+      After Dairon - Power Switch 2
   > Pickup (Missile Tank - Upper)
       All of the following:
-          After Dairon - Freezer Hidden Left Blob or Can Slide
+          After Dairon - Freezer Hidden Blob or Can Slide
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Beginner) and Cold Damage ≥ 30
@@ -2371,7 +2371,7 @@ Extra - asset_id: collision_camera_025
               Heat/Cold Runs (Beginner) and Cold Damage ≥ 30
   > Freezer Center
       All of the following:
-          Morph Ball and After Dairon - Freezer Hidden Left Blob
+          Morph Ball and After Dairon - Freezer Hidden Blob
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
@@ -3270,7 +3270,7 @@ Extra - asset_id: collision_camera_042
   * Extra - start_point_actor_name: energyrecharge_001_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_energy/charclasses/weightactivatedplatform_energy.bmsad
   > Door to Freezer (Lower)
-      After Dairon - powergenerator_002
+      After Dairon - Power Switch 2
   > Dock to Transport to Ghavoran
       Can Slide
 
@@ -3287,7 +3287,7 @@ Extra - asset_id: collision_camera_042
   * Layers: default
   * Open Passage to Transport to Ghavoran/Dock to Energy Recharge Station West
   > Door to Freezer (Lower)
-      Morph Ball and After Dairon - powergenerator_002
+      Morph Ball and After Dairon - Power Switch 2
   > Life Recharge
       Morph Ball
 

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -515,11 +515,11 @@
                 "extra": {}
             },
             "s030_baselab:default:powergenerator_002": {
-                "long_name": "Dairon - powergenerator_002",
+                "long_name": "Dairon - Power Switch 2",
                 "extra": {}
             },
             "s030_baselab:default:powergenerator_001": {
-                "long_name": "Dairon - powergenerator_001",
+                "long_name": "Dairon - Power Switch 1",
                 "extra": {}
             },
             "s030_baselab:default:db_hdoor_b1_001": {
@@ -535,11 +535,11 @@
                 "extra": {}
             },
             "s030_baselab:default:db_reg_b1_001": {
-                "long_name": "Dairon - Freezer Hidden Left Blob",
+                "long_name": "Dairon - Freezer Hidden Blob",
                 "extra": {}
             },
             "s030_baselab:default:db_reg_b1_002": {
-                "long_name": "Dairon - db_reg_b1_002",
+                "long_name": "Dairon - Freezer Right Blob",
                 "extra": {}
             },
             "s030_baselab:default:db_reg_b1_003": {
@@ -1012,6 +1012,10 @@
             },
             "ArtariaMapSpeed": {
                 "long_name": "Artaria - Prepare Speedboost in Map Station",
+                "extra": {}
+            },
+            "DaironFreezerSpeedBlocks": {
+                "long_name": "Dairon - Freezer Speed Blocks Destroyed",
                 "extra": {}
             }
         },


### PR DESCRIPTION
- Added a new node, "Left Blob Alcove", to allow grabbing the item without the power switch event
- Added a new event, "Freezer Speed Blocks Destroyed", in case the player somehow enters from the upper door first
- Renamed various nodes and events
- Added connection from Map Station to Power Switch 2 to make activating the switch non-dangerous
- Every other connection now forces Gravity or damage run tricks