### PR TITLE
Add misc resource for navigating unpowered freezer

### DIFF
--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -11114,7 +11114,7 @@
                                 ]
                             }
                         },
-                        "Event - Right Blob from above (db_reg_b1_002)": {
+                        "Event - Right Blob, Above": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11466,7 +11466,7 @@
                                 ]
                             }
                         },
-                        "Freezer Center": {
+                        "Freezer Navigation": {
                             "type": "or",
                             "data": {
                                 "comment": "TODO? Add event for destroying speed blocks for room rando",
@@ -11524,8 +11524,8 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -13950.0,
-                        "y": 5300.0,
+                        "x": -13967.319908905669,
+                        "y": 5406.915977466138,
                         "z": 0.0
                     },
                     "description": "",
@@ -11631,7 +11631,7 @@
                                 ]
                             }
                         },
-                        "Event - Hidden Blob from left (db_reg_b1_001)": {
+                        "Event - Hidden Blob, Inside": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -11699,7 +11699,7 @@
                                 ]
                             }
                         },
-                        "Freezer Center": {
+                        "Freezer Navigation": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11948,7 +11948,7 @@
                                 ]
                             }
                         },
-                        "Freezer Center": {
+                        "Freezer Navigation": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12028,7 +12028,7 @@
                         }
                     }
                 },
-                "Event - Hidden Blob from left (db_reg_b1_001)": {
+                "Event - Hidden Blob, Inside": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12057,7 +12057,7 @@
                         }
                     }
                 },
-                "Event - Right Blob from right (db_reg_b1_002)": {
+                "Event - Right Blob, Below": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12243,7 +12243,7 @@
                                 ]
                             }
                         },
-                        "Freezer Center": {
+                        "Freezer Navigation": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -12637,7 +12637,7 @@
                         }
                     }
                 },
-                "Event - Hidden Blob through wall (db_reg_b1_001)": {
+                "Event - Hidden Blob, Outside": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12652,7 +12652,7 @@
                     "extra": {},
                     "event_name": "s030_baselab:default:db_reg_b1_001",
                     "connections": {
-                        "Freezer Center": {
+                        "Freezer Navigation": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12665,8 +12665,8 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": -12149.642021203359,
-                        "y": 4819.964202120336,
+                        "x": -11816.039759135529,
+                        "y": 4788.039264208529,
                         "z": 0.0
                     },
                     "description": "",
@@ -12993,6 +12993,285 @@
                                 ]
                             }
                         },
+                        "Freezer Navigation": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "DisabledFreezer",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:powergenerator_002",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Beside the Blob": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -10436.713479278535,
+                        "y": 6097.6731378218365,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "connections": {
+                        "Door to Map Station": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s030_baselab:default:db_reg_b1_002",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 30,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Door to Power Switch 2": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 200,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Right Blob, Below": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 30,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Event - Right Blob, Above": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -10828.01,
+                        "y": 6744.51,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "s030_baselab:default:db_reg_b1_002",
+                    "connections": {
+                        "Door to Map Station": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Freezer Navigation": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -12399.72,
+                        "y": 4941.14,
+                        "z": 0.0
+                    },
+                    "description": "Helper node to connect to the parts of the Freezer we don't want to access\nwhile disabled\n\n",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "connections": {
                         "Door to Energy Recharge Station West (Upper)": {
                             "type": "and",
                             "data": {
@@ -13243,7 +13522,7 @@
                                 ]
                             }
                         },
-                        "Event - Hidden Blob through wall (db_reg_b1_001)": {
+                        "Event - Hidden Blob, Outside": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -13251,242 +13530,31 @@
                                 "amount": 1,
                                 "negate": false
                             }
-                        }
-                    }
-                },
-                "Beside the Blob": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -10436.713479278535,
-                        "y": 6097.6731378218365,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "connections": {
-                        "Door to Map Station": {
-                            "type": "and",
+                        },
+                        "Freezer Center": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "events",
-                                            "name": "s030_baselab:default:db_reg_b1_002",
+                                            "type": "misc",
+                                            "name": "DisabledFreezer",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 30,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
+                                            "type": "events",
+                                            "name": "s030_baselab:default:powergenerator_002",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
-                            }
-                        },
-                        "Door to Power Switch 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Slide"
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 200,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Event - Right Blob from right (db_reg_b1_002)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "s030_baselab:default:powergenerator_002",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 30,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "Event - Right Blob from above (db_reg_b1_002)": {
-                    "node_type": "event",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -10828.01,
-                        "y": 6744.51,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "event_name": "s030_baselab:default:db_reg_b1_002",
-                    "connections": {
-                        "Door to Map Station": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -511,7 +511,7 @@ Extra - asset_id: collision_camera_006
   > Pickup (Wide Beam)
       Trivial
   > Door to Teleport to Cataris
-      Morph Ball and After Dairon - powergenerator_001
+      Morph Ball and After Dairon - Power Switch 1
   > Tile Group (POWERBEAM) 4
       Trivial
 
@@ -582,7 +582,7 @@ Extra - asset_id: collision_camera_007
 
 > Event - Electric Generator; Heals? False; Spawn Point
   * Layers: default
-  * Event Dairon - powergenerator_001
+  * Event Dairon - Power Switch 1
   * Extra - actor_name: powergenerator_001
   * Extra - actor_def: actordef:actors/props/powergenerator/charclasses/powergenerator.bmsad
   * Extra - start_point_actor_name: powergenerator_001_platform
@@ -595,7 +595,7 @@ Extra - asset_id: collision_camera_007
   * Extra - start_point_actor_name: powergeneratorengine_001
   * Extra - start_point_actor_def: actordef:actors/props/powergeneratorengine/charclasses/powergeneratorengine.bmsad
   > Door to Teleport to Cataris
-      After Dairon - powergenerator_001
+      After Dairon - Power Switch 1
   > Event - Electric Generator
       Trivial
   > Tunnel to Teleport to Cataris
@@ -635,7 +635,7 @@ Extra - asset_id: collision_camera_008
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to Wide Beam Room
-      After Dairon - powergenerator_001
+      After Dairon - Power Switch 1
   > Tile Group (POWERBEAM) 1
       Trivial
   > Tile Group (POWERBEAM) 2
@@ -653,7 +653,7 @@ Extra - asset_id: collision_camera_008
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to Wide Beam Room
-      After Dairon - powergenerator_001
+      After Dairon - Power Switch 1
   > Tile Group (POWERBEAM) 1
       Trivial
 
@@ -669,7 +669,7 @@ Extra - asset_id: collision_camera_008
   > Door to Total Recharge Station East
       Trivial
   > Door to Power Switch 1
-      After Dairon - powergenerator_001
+      After Dairon - Power Switch 1
 
 > Event - Blob from shaft (db_dif_b1_001); Heals? False
   * Layers: default
@@ -703,7 +703,7 @@ Extra - asset_id: collision_camera_008
   > Door to Total Recharge Station East
       Trivial
   > Door to Power Switch 1
-      After Dairon - powergenerator_001
+      After Dairon - Power Switch 1
   > Tunnel to Power Switch 1
       Can Slide
 
@@ -728,7 +728,7 @@ Extra - asset_id: collision_camera_008
 > Bottom-Left Corner; Heals? False
   * Layers: default
   > Door to Early Grapple Access
-      Morph Ball and After Dairon - powergenerator_001
+      Morph Ball and After Dairon - Power Switch 1
   > Event - Blob from shaft (db_dif_b1_001)
       Shoot Diffusion or Wave
   > Teleporter to Cataris - Teleport to Dairon
@@ -917,7 +917,7 @@ Extra - asset_id: collision_camera_010
   * Layers: default
   > Door to Teleport to Cataris
       All of the following:
-          Morph Ball and After Dairon - powergenerator_001
+          Morph Ball and After Dairon - Power Switch 1
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 120
@@ -1954,7 +1954,7 @@ Extra - asset_id: collision_camera_022
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to Bomb Room
-      Morph Ball and After Dairon - powergenerator_002
+      Morph Ball and After Dairon - Power Switch 2
   > Center
       Trivial
 
@@ -2007,7 +2007,7 @@ Extra - asset_id: collision_camera_023
   > Door to Freezer
       Trivial
   > Map Station
-      After Dairon - powergenerator_002
+      After Dairon - Power Switch 2
 
 > Door to Freezer; Heals? False
   * Layers: default
@@ -2061,7 +2061,7 @@ Extra - asset_id: collision_camera_024
 
 > Event - Electric Generator; Heals? False; Spawn Point
   * Layers: default
-  * Event Dairon - powergenerator_002
+  * Event Dairon - Power Switch 2
   * Extra - actor_name: powergenerator_002
   * Extra - actor_def: actordef:actors/props/powergenerator/charclasses/powergenerator.bmsad
   * Extra - start_point_actor_name: powergenerator_002_platform
@@ -2096,21 +2096,21 @@ Extra - asset_id: collision_camera_025
   * Extra - right_shield_def: None
   > Freezer Center
       Any of the following:
-          Gravity Suit or Before Dairon - powergenerator_002
+          Gravity Suit or Before Dairon - Power Switch 2
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
   > Beside the Blob
       All of the following:
-          After Dairon - db_reg_b1_002
+          After Dairon - Freezer Right Blob
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
-  > Event - Right Blob from above (db_reg_b1_002)
+  > Event - Right Blob, Above
       All of the following:
           Any of the following:
               Wave Beam
               Pseudo-Wave Beam (Beginner) and Shoot Diffusion Beam
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
 
 > Door to Power Switch 2; Heals? False
@@ -2124,13 +2124,13 @@ Extra - asset_id: collision_camera_025
   * Extra - right_shield_def: None
   > Freezer Center
       Any of the following:
-          Gravity Suit or Before Dairon - powergenerator_002
+          Gravity Suit or Before Dairon - Power Switch 2
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
   > Beside the Blob
       All of the following:
           Morph Ball
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
 
 > Door to Energy Recharge Station West (Upper); Heals? False
@@ -2144,14 +2144,14 @@ Extra - asset_id: collision_camera_025
   * Extra - right_shield_def: None
   > Door to Energy Recharge Station West (Lower)
       All of the following:
-          Morph Ball and After Dairon - powergenerator_002
+          Morph Ball and After Dairon - Power Switch 2
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 120
-  > Freezer Center
+  > Freezer Navigation
       Any of the following:
           # TODO? Add event for destroying speed blocks for room rando
-          Gravity Suit or Before Dairon - powergenerator_002
+          Gravity Suit or Before Dairon - Power Switch 2
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
 
 > Door to Energy Recharge Station West (Lower); Heals? False
@@ -2165,19 +2165,19 @@ Extra - asset_id: collision_camera_025
   * Extra - right_shield_def: None
   > Pickup (Missile Tank - Upper)
       All of the following:
-          After Dairon - Freezer Hidden Left Blob or Can Slide
+          After Dairon - Freezer Hidden Blob or Can Slide
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
-  > Event - Hidden Blob from left (db_reg_b1_001)
+  > Event - Hidden Blob, Inside
       Any of the following:
-          Gravity Suit or Before Dairon - powergenerator_002 or Lay Bomb or Shoot Beam
+          Gravity Suit or Before Dairon - Power Switch 2 or Lay Bomb or Shoot Beam
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
-  > Freezer Center
+  > Freezer Navigation
       All of the following:
-          Morph Ball and After Dairon - Freezer Hidden Left Blob
+          Morph Ball and After Dairon - Freezer Hidden Blob
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
 
 > Pickup (Missile Tank - Lower); Heals? False
@@ -2189,7 +2189,7 @@ Extra - asset_id: collision_camera_025
       All of the following:
           Morph Ball
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
 
 > Pickup (Missile Tank - Upper); Heals? False
@@ -2199,28 +2199,28 @@ Extra - asset_id: collision_camera_025
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Door to Energy Recharge Station West (Lower)
       All of the following:
-          After Dairon - powergenerator_002
+          After Dairon - Power Switch 2
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 20
-  > Freezer Center
+  > Freezer Navigation
       All of the following:
-          Morph Ball and After Dairon - Freezer Hidden Left Blob
+          Morph Ball and After Dairon - Freezer Hidden Blob
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
 
-> Event - Hidden Blob from left (db_reg_b1_001); Heals? False
+> Event - Hidden Blob, Inside; Heals? False
   * Layers: default
-  * Event Dairon - Freezer Hidden Left Blob
+  * Event Dairon - Freezer Hidden Blob
   * Extra - actor_name: db_reg_b1_001
   * Extra - actor_def: actordef:actors/props/db_reg_b1_001/charclasses/db_reg_b1_001.bmsad
   > Door to Energy Recharge Station West (Lower)
-      After Dairon - powergenerator_002
+      After Dairon - Power Switch 2
 
-> Event - Right Blob from right (db_reg_b1_002); Heals? False
+> Event - Right Blob, Below; Heals? False
   * Layers: default
-  * Event Dairon - db_reg_b1_002
+  * Event Dairon - Freezer Right Blob
   * Extra - actor_name: db_reg_b1_002
   * Extra - actor_def: actordef:actors/props/db_reg_b1_002/charclasses/db_reg_b1_002.bmsad
   > Beside the Blob
@@ -2237,17 +2237,17 @@ Extra - asset_id: collision_camera_025
       All of the following:
           Morph Ball
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 70
   > Bottom-Left Corner
       All of the following:
           Speed Booster
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
-  > Freezer Center
+  > Freezer Navigation
       Any of the following:
-          Gravity Suit or Before Dairon - powergenerator_002
+          Gravity Suit or Before Dairon - Power Switch 2
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
 
 > Tile Group (WEIGHT); Heals? False
@@ -2260,7 +2260,7 @@ Extra - asset_id: collision_camera_025
       All of the following:
           Speed Booster
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
 
 > Bottom-Left Corner; Heals? False
@@ -2269,26 +2269,26 @@ Extra - asset_id: collision_camera_025
       All of the following:
           Morph Ball
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
   > Tile Group (SCREWATTACK)
       All of the following:
           Speed Booster
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
           Space Jump or Walljump (Beginner) or Simple IBJ
   > Tile Group (WEIGHT)
       All of the following:
           Ballspark
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 70
 
-> Event - Hidden Blob through wall (db_reg_b1_001); Heals? False
+> Event - Hidden Blob, Outside; Heals? False
   * Layers: default
-  * Event Dairon - Freezer Hidden Left Blob
-  > Freezer Center
+  * Event Dairon - Freezer Hidden Blob
+  > Freezer Navigation
       Trivial
 
 > Freezer Center; Heals? False
@@ -2296,18 +2296,18 @@ Extra - asset_id: collision_camera_025
   > Door to Map Station
       All of the following:
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 150
           Space Jump or Speed Booster or Walljump (Beginner) or Simple IBJ
   > Door to Power Switch 2
       Any of the following:
           All of the following:
-              After Dairon - powergenerator_002
+              After Dairon - Power Switch 2
               Any of the following:
                   Gravity Suit
                   Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
           All of the following:
-              Before Dairon - powergenerator_002
+              Before Dairon - Power Switch 2
               Any of the following:
                   Spider Magnet or Space Jump or Speed Booster
                   Grapple Beam and Movement (Beginner)
@@ -2315,54 +2315,65 @@ Extra - asset_id: collision_camera_025
                       Gravity Suit
                       Spin Boost or Walljump (Beginner) or Simple IBJ
                   Flash Shift and Walljump (Beginner)
+  > Freezer Navigation
+      After Dairon - Power Switch 2 or Enabled Allow Disabled Freezer
+
+> Beside the Blob; Heals? False
+  * Layers: default
+  > Door to Map Station
+      All of the following:
+          After Dairon - Freezer Right Blob
+          Any of the following:
+              Gravity Suit or Before Dairon - Power Switch 2
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
+  > Door to Power Switch 2
+      All of the following:
+          Can Slide
+          Any of the following:
+              Gravity Suit or Before Dairon - Power Switch 2
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
+  > Event - Right Blob, Below
+      All of the following:
+          Shoot Beam
+          Any of the following:
+              Gravity Suit or Before Dairon - Power Switch 2
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
+
+> Event - Right Blob, Above; Heals? False
+  * Layers: default
+  * Event Dairon - Freezer Right Blob
+  > Door to Map Station
+      Trivial
+
+> Freezer Navigation; Heals? False
+  * Layers: default
+  * Helper node to connect to the parts of the Freezer we don't want to access
+while disabled
+
+
   > Door to Energy Recharge Station West (Upper)
       All of the following:
-          Speed Booster and After Dairon - powergenerator_002
+          Speed Booster and After Dairon - Power Switch 2
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
           Space Jump or Movement (Intermediate)
   > Pickup (Missile Tank - Upper)
       All of the following:
-          Morph Ball and After Dairon - Freezer Hidden Left Blob
+          Morph Ball and After Dairon - Freezer Hidden Blob
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
   > Tile Group (SCREWATTACK)
       All of the following:
           Speed Booster
           Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
+              Gravity Suit or Before Dairon - Power Switch 2
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
-  > Event - Hidden Blob through wall (db_reg_b1_001)
+  > Event - Hidden Blob, Outside
       Wave Beam
-
-> Beside the Blob; Heals? False
-  * Layers: default
-  > Door to Map Station
-      All of the following:
-          After Dairon - db_reg_b1_002
-          Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
-  > Door to Power Switch 2
-      All of the following:
-          Can Slide
-          Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 200
-  > Event - Right Blob from right (db_reg_b1_002)
-      All of the following:
-          Shoot Beam
-          Any of the following:
-              Gravity Suit or Before Dairon - powergenerator_002
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 30
-
-> Event - Right Blob from above (db_reg_b1_002); Heals? False
-  * Layers: default
-  * Event Dairon - db_reg_b1_002
-  > Door to Map Station
-      Trivial
+  > Freezer Center
+      After Dairon - Power Switch 2 or Enabled Allow Disabled Freezer
 
 ----------------
 Test Chamber Access
@@ -3252,7 +3263,7 @@ Extra - asset_id: collision_camera_042
   * Extra - start_point_actor_name: energyrecharge_001_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_energy/charclasses/weightactivatedplatform_energy.bmsad
   > Door to Freezer (Lower)
-      After Dairon - powergenerator_002
+      After Dairon - Power Switch 2
   > Dock to Transport to Ghavoran
       Can Slide
 
@@ -3269,7 +3280,7 @@ Extra - asset_id: collision_camera_042
   * Layers: default
   * Open Passage to Transport to Ghavoran/Dock to Energy Recharge Station West
   > Door to Freezer (Lower)
-      Morph Ball and After Dairon - powergenerator_002
+      Morph Ball and After Dairon - Power Switch 2
   > Life Recharge
       Morph Ball
 

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -515,11 +515,11 @@
                 "extra": {}
             },
             "s030_baselab:default:powergenerator_002": {
-                "long_name": "Dairon - powergenerator_002",
+                "long_name": "Dairon - Power Switch 2",
                 "extra": {}
             },
             "s030_baselab:default:powergenerator_001": {
-                "long_name": "Dairon - powergenerator_001",
+                "long_name": "Dairon - Power Switch 1",
                 "extra": {}
             },
             "s030_baselab:default:db_hdoor_b1_001": {
@@ -535,11 +535,11 @@
                 "extra": {}
             },
             "s030_baselab:default:db_reg_b1_001": {
-                "long_name": "Dairon - Freezer Hidden Left Blob",
+                "long_name": "Dairon - Freezer Hidden Blob",
                 "extra": {}
             },
             "s030_baselab:default:db_reg_b1_002": {
-                "long_name": "Dairon - db_reg_b1_002",
+                "long_name": "Dairon - Freezer Right Blob",
                 "extra": {}
             },
             "s030_baselab:default:db_reg_b1_003": {
@@ -1153,6 +1153,10 @@
             },
             "DoorLocks": {
                 "long_name": "Door Lock Randomizer",
+                "extra": {}
+            },
+            "DisabledFreezer": {
+                "long_name": "Allow Disabled Freezer",
                 "extra": {}
             }
         },


### PR DESCRIPTION
- Always allow navigation on the right side of the freezer when unpowered
- The left side of the freezer (pickups, both doors) are blocked by the misc resource
- Rename a few resources and events