### PR TITLE
Dread: Cataris Revision, West Side

### DIFF
--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -9644,7 +9644,7 @@
                 "asset_id": "collision_camera_023"
             },
             "nodes": {
-                "Dock to EMMI Zone Exits West (dooremmy_008)": {
+                "Dock to EMMI Zone Exits West (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -9670,7 +9670,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (WEIGHT) 1": {
+                        "Dock to EMMI Zone Exits West (Lower)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -9681,7 +9681,7 @@
                         }
                     }
                 },
-                "Dock to EMMI Zone Exits West (dooremmy_009)": {
+                "Dock to EMMI Zone Exits West (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -9755,7 +9755,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to EMMI Zone Exits West (dooremmy_009)": {
+                        "Dock to EMMI Zone Exits West (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9790,6 +9790,15 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Simple IBJ"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Flash",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -9797,7 +9806,7 @@
                                 ]
                             }
                         },
-                        "Event - Ledge Blob (db_reg_mg_017)": {
+                        "Event - Path to Kraid Blob": {
                             "type": "template",
                             "data": "Shoot Beam"
                         },
@@ -9854,7 +9863,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to EMMI Zone Exits West (dooremmy_009)": {
+                        "Dock to EMMI Zone Exits West (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9863,7 +9872,7 @@
                         }
                     }
                 },
-                "Event - Ledge Blob (db_reg_mg_017)": {
+                "Event - Path to Kraid Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -9918,38 +9927,6 @@
                         }
                     }
                 },
-                "Tile Group (WEIGHT) 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -11400.0,
-                        "y": 2400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_015",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (WEIGHT) 2": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
                 "Tile Group (POWERBEAM) 1": {
                     "node_type": "configurable_node",
                     "heal": false,
@@ -9971,7 +9948,7 @@
                         ]
                     },
                     "connections": {
-                        "Dock to EMMI Zone Exits West (dooremmy_009)": {
+                        "Dock to EMMI Zone Exits West (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -10052,70 +10029,6 @@
                         }
                     }
                 },
-                "Tile Group (WEIGHT) 2": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -11800.0,
-                        "y": 2200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_031",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (WEIGHT) 3": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT) 3": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -11900.0,
-                        "y": 1600.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_032",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Dock to EMMI Zone Exits West (dooremmy_009)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
                 "Tunnel to Path to Kraid Entryway": {
                     "node_type": "dock",
                     "heal": false,
@@ -10135,7 +10048,7 @@
                         "area_name": "Path to Kraid Entryway",
                         "node_name": "Tunnel to Long Mouth Statue Room"
                     },
-                    "default_dock_weakness": "Morph Ball Tunnel",
+                    "default_dock_weakness": "Slide Tunnel",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -10229,8 +10142,20 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Event - Blob above Kraid, from below": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Dock to Kraid Arena": {
                             "type": "and",
@@ -10367,7 +10292,7 @@
                         }
                     }
                 },
-                "Event - Ceiling Blob": {
+                "Event - Above Kraid Ceiling Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -10532,7 +10457,7 @@
                         ]
                     },
                     "connections": {
-                        "Event - Ceiling Blob": {
+                        "Event - Above Kraid Ceiling Blob": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11549,21 +11474,41 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "or",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "Spin",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Walljump",
-                                                                    "amount": 1,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Walljump",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Use Spin Boost"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Walljump",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -11629,6 +11574,15 @@
                                                         "amount": 1,
                                                         "negate": true
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Speedbooster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -11636,9 +11590,21 @@
                                 ]
                             }
                         },
-                        "Event - Morph Tunnel Blob": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Ghavoran Teleport Lower Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Tile Group (BOMB)": {
                             "type": "and",
@@ -11766,7 +11732,7 @@
                         }
                     }
                 },
-                "Event - Morph Tunnel Blob": {
+                "Event - Ghavoran Teleport Lower Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -11820,21 +11786,16 @@
                     "keep_name_when_vanilla": true,
                     "editable": true,
                     "connections": {
-                        "Tile Group (BOMB)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Tile Group (WEIGHT) 2": {
+                        "Door to Save Station West": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Tile Group (BOMB)": {
+                            "type": "template",
+                            "data": "Can Slide"
                         }
                     }
                 },
@@ -11875,69 +11836,13 @@
                                 "items": []
                             }
                         },
+                        "Pickup (Missile+ Tank)": {
+                            "type": "template",
+                            "data": "Can Slide"
+                        },
                         "Teleporter to Artaria - Teleport to Cataris": {
                             "type": "template",
                             "data": "Can Slide"
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT) 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -18300.0,
-                        "y": -300.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_021",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Save Station West": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT) 2": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -18300.0,
-                        "y": 200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_022",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (WEIGHT) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
                         }
                     }
                 },
@@ -12121,7 +12026,7 @@
                         }
                     }
                 },
-                "Event - Lower-left Tunnel Blob": {
+                "Event - Ghavoran Teleport Lower Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12148,7 +12053,7 @@
                         }
                     }
                 },
-                "Event - Upper-right Tunnel Blob (db_dside_mg_002)": {
+                "Event - Ghavoran Teleport Upper Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12175,7 +12080,7 @@
                         }
                     }
                 },
-                "Event - Green Teleport Grapple Block": {
+                "Event - Ghavoran Teleport Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12229,7 +12134,7 @@
                     "keep_name_when_vanilla": true,
                     "editable": true,
                     "connections": {
-                        "Event - Green Teleport Grapple Block": {
+                        "Event - Ghavoran Teleport Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12295,13 +12200,8 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Can Slide"
                                     },
                                     {
                                         "type": "or",
@@ -12441,6 +12341,66 @@
                         ]
                     },
                     "connections": {
+                        "Pickup (Missile Tank - Top)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 50,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Top room": {
                             "type": "and",
                             "data": {
@@ -12484,10 +12444,6 @@
                                             "amount": 1,
                                             "negate": false
                                         }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Can Slide"
                                     },
                                     {
                                         "type": "resource",
@@ -12614,9 +12570,21 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Event - Lower-left Tunnel Blob": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Ghavoran Teleport Lower Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Tile Group (POWERBEAM) 2": {
                             "type": "resource",
@@ -12638,12 +12606,46 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Grapple",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Magnet",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "GrappleMovement",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
@@ -12651,10 +12653,74 @@
                                                     "data": "Use Spin Boost"
                                                 },
                                                 {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Gravity",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Speedbooster",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "misc",
+                                                                                            "name": "DoorLocks",
+                                                                                            "amount": 1,
+                                                                                            "negate": true
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "IBJ",
+                                                        "type": "items",
+                                                        "name": "Flash",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -12860,9 +12926,21 @@
                                 ]
                             }
                         },
-                        "Event - Upper-right Tunnel Blob (db_dside_mg_002)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Ghavoran Teleport Upper Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Teleporter to Ghavoran - Teleport to Cataris": {
                             "type": "and",
@@ -13237,9 +13315,21 @@
                                 "items": []
                             }
                         },
-                        "Event - Morph Tunnel Blob (db_dside_mg_002)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Ghavoran Teleport Upper Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Tunnel to Teleport to Ghavoran": {
                             "type": "resource",
@@ -13287,7 +13377,7 @@
                         }
                     }
                 },
-                "Event - Morph Tunnel Blob (db_dside_mg_002)": {
+                "Event - Ghavoran Teleport Upper Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -13518,7 +13608,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Long Mouth Statue Room",
-                        "node_name": "Dock to EMMI Zone Exits West (dooremmy_008)"
+                        "node_name": "Dock to EMMI Zone Exits West (Upper)"
                     },
                     "default_dock_weakness": "EMMI Door",
                     "override_default_open_requirement": null,
@@ -13557,7 +13647,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Long Mouth Statue Room",
-                        "node_name": "Dock to EMMI Zone Exits West (dooremmy_009)"
+                        "node_name": "Dock to EMMI Zone Exits West (Lower)"
                     },
                     "default_dock_weakness": "EMMI Door",
                     "override_default_open_requirement": null,
@@ -18011,13 +18101,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Tile Group (POWERBEAM) 1": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
+                            "type": "template",
+                            "data": "Can Slide"
                         }
                     }
                 },
@@ -18109,7 +18194,7 @@
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
@@ -18123,29 +18208,56 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Heat",
-                                                                    "amount": 100,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Lava",
+                                                        "amount": 100,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Heat",
+                                                        "amount": 100,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
+                                                        "amount": 2,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -18178,13 +18290,8 @@
                     },
                     "connections": {
                         "Door to Teleport to Artaria (Red)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
+                            "type": "template",
+                            "data": "Can Slide"
                         },
                         "Tunnel to Long Mouth Statue Room": {
                             "type": "and",
@@ -18356,29 +18463,56 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Heat",
-                                                                    "amount": 100,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Lava",
+                                                        "amount": 100,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Heat",
+                                                        "amount": 100,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
+                                                        "amount": 2,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -18451,7 +18585,7 @@
                         "area_name": "Long Mouth Statue Room",
                         "node_name": "Tunnel to Path to Kraid Entryway"
                     },
-                    "default_dock_weakness": "Morph Ball Tunnel",
+                    "default_dock_weakness": "Slide Tunnel",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -18570,7 +18704,7 @@
                                 ]
                             }
                         },
-                        "Event - Diffusion Tutorial Blob (db_dif_mg_002)": {
+                        "Event - Diffusion Tutorial Blob": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -18757,7 +18891,7 @@
                         }
                     }
                 },
-                "Event - Diffusion Tutorial Blob (db_dif_mg_002)": {
+                "Event - Diffusion Tutorial Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -18784,7 +18918,7 @@
                         }
                     }
                 },
-                "Event - PB Tank Grapple Block (grapplepulloff1x2)": {
+                "Event - PB Tank Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -19225,7 +19359,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Diffusion Tutorial Blob (db_dif_mg_002)": {
+                        "Event - Diffusion Tutorial Blob": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -19527,7 +19661,7 @@
                                 ]
                             }
                         },
-                        "Event - PB Tank Grapple Block (grapplepulloff1x2)": {
+                        "Event - PB Tank Grapple Block": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -22122,7 +22256,7 @@
                     "pickup_index": 39,
                     "major_location": false,
                     "connections": {
-                        "Event - Missile Tank Blob (breakablemag009)": {
+                        "Event - Missile Tank Blob": {
                             "type": "template",
                             "data": "Lay Bomb"
                         },
@@ -22383,7 +22517,7 @@
                         }
                     }
                 },
-                "Event - Missile Tank Blob (breakablemag009)": {
+                "Event - Missile Tank Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -22446,7 +22580,7 @@
                         }
                     }
                 },
-                "Event - Diffusion Tutorial Blob from below (db_dif_mg_001)": {
+                "Event - Diffusion Tutorial Blob 2, below": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -22983,7 +23117,7 @@
                                 ]
                             }
                         },
-                        "Event - Diffusion Tutorial Blob from below (db_dif_mg_001)": {
+                        "Event - Diffusion Tutorial Blob 2, below": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -23256,7 +23390,7 @@
                         }
                     }
                 },
-                "Event - Wave Beam Blob (db_reg_mg_021)": {
+                "Event - Kraid Eyedoor Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -23280,7 +23414,7 @@
                         }
                     }
                 },
-                "Event - Diffusion Tutorial Blob from above (db_dif_mg_001)": {
+                "Event - Diffusion Tutorial Blob 2, above": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -23412,7 +23546,7 @@
                                 ]
                             }
                         },
-                        "Event - Missile Tank Blob (breakablemag009)": {
+                        "Event - Missile Tank Blob": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -23578,19 +23712,14 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s020_magma:default:db_reg_mg_021",
+                                            "name": "s020_magma:default:db_dif_mg_001",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Can Slide"
                                     },
                                     {
                                         "type": "or",
@@ -23670,7 +23799,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Morph",
+                                                        "name": "Varia",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -23707,7 +23836,7 @@
                                 ]
                             }
                         },
-                        "Event - Wave Beam Blob (db_reg_mg_021)": {
+                        "Event - Kraid Eyedoor Blob": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -23716,7 +23845,7 @@
                                 "negate": false
                             }
                         },
-                        "Event - Diffusion Tutorial Blob from above (db_dif_mg_001)": {
+                        "Event - Diffusion Tutorial Blob 2, above": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -23851,9 +23980,21 @@
                                 "items": []
                             }
                         },
-                        "Event - Breakable (db_hdoor_mg_002)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Green EMMI Access Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -23949,7 +24090,7 @@
                         }
                     }
                 },
-                "Event - Breakable (db_hdoor_mg_002)": {
+                "Event - Green EMMI Access Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -25822,6 +25963,19 @@
                                                         "amount": 10,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Cross Comb"
                                                 }
                                             ]
                                         }
@@ -25874,7 +26028,7 @@
                         }
                     }
                 },
-                "Event - Blob to Teleport to Dairon (db_reg_mg_021)": {
+                "Event - Kraid Eyedoor Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -25901,7 +26055,7 @@
                         }
                     }
                 },
-                "Event - Top Blob (db_reg_mg_020)": {
+                "Event - Kraid Eyedoor Ceiling Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -26177,6 +26331,19 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Cross Comb"
                                                 }
                                             ]
                                         }
@@ -26227,7 +26394,7 @@
                                 ]
                             }
                         },
-                        "Event - Blob to Teleport to Dairon (db_reg_mg_021)": {
+                        "Event - Kraid Eyedoor Blob": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -26432,13 +26599,8 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "IBJ",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
                                                 }
                                             ]
                                         }
@@ -26547,7 +26709,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Event - Top Blob (db_reg_mg_020)": {
+                        "Event - Kraid Eyedoor Ceiling Blob": {
                             "type": "template",
                             "data": "Shoot Beam"
                         },

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -1429,7 +1429,7 @@ Extra - asset_id: collision_camera_019
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:db_hdoor_mg_002b_000
   * Extra - right_shield_def: actordef:actors/props/db_hdoor_mg_002b/charclasses/db_hdoor_mg_002b.bmsad
   > Top Ledge
-      After Cataris - Ghavoran Teleporter Upper-right Tunnel Blob
+      After Cataris - Green EMMI Access Blob
 
 > Event - First Tunnel Blob (breakablemag004); Heals? False
   * Layers: default
@@ -1513,14 +1513,14 @@ Extra - asset_id: collision_camera_019
 
 > Event - Door Blob (db_hdoor_mg_002); Heals? False
   * Layers: default
-  * Event Cataris - Ghavoran Teleporter Upper-right Tunnel Blob
+  * Event Cataris - Green EMMI Access Blob
   > Top Ledge
       Trivial
 
 > Top Ledge; Heals? False
   * Layers: default
   > Door to Green EMMI Introduction Access
-      After Cataris - Ghavoran Teleporter Upper-right Tunnel Blob
+      After Cataris - Green EMMI Access Blob
   > Left Platform
       Any of the following:
           Varia Suit
@@ -1787,15 +1787,15 @@ Long Mouth Statue Room
 Extra - total_boundings: {'x1': -14500.0, 'x2': -10400.0, 'y1': -1000.0, 'y2': 3100.0}
 Extra - polygon: [[-10400.0, 3100.0], [-12500.0, 3100.0], [-12500.0, 1100.0], [-14500.0, 1100.0], [-14500.0, -1000.0], [-10400.0, -1000.0]]
 Extra - asset_id: collision_camera_023
-> Dock to EMMI Zone Exits West (dooremmy_008); Heals? False
+> Dock to EMMI Zone Exits West (Upper); Heals? False
   * Layers: default
   * EMMI Door to EMMI Zone Exits West/Dock to Long Mouth Statue Room (dooremmy_008)
   * Extra - actor_name: dooremmy_008
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Tile Group (WEIGHT) 1
+  > Dock to EMMI Zone Exits West (Lower)
       Morph Ball
 
-> Dock to EMMI Zone Exits West (dooremmy_009); Heals? False
+> Dock to EMMI Zone Exits West (Lower); Heals? False
   * Layers: default
   * EMMI Door to EMMI Zone Exits West/Dock to Long Mouth Statue Room (dooremmy_009)
   * Extra - actor_name: dooremmy_009
@@ -1814,11 +1814,11 @@ Extra - asset_id: collision_camera_023
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Dock to EMMI Zone Exits West (dooremmy_009)
+  > Dock to EMMI Zone Exits West (Lower)
       All of the following:
           Morph Ball
-          After Cataris - db_reg_mg_017 or Simple IBJ or Use Spin Boost
-  > Event - Ledge Blob (db_reg_mg_017)
+          Flash Shift or After Cataris - Path to Kraid Blob or Simple IBJ or Use Spin Boost
+  > Event - Path to Kraid Blob
       Shoot Beam
   > Ammo Recharge
       Trivial
@@ -1836,12 +1836,12 @@ Extra - asset_id: collision_camera_023
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Dock to EMMI Zone Exits West (dooremmy_009)
+  > Dock to EMMI Zone Exits West (Lower)
       Trivial
 
-> Event - Ledge Blob (db_reg_mg_017); Heals? False
+> Event - Path to Kraid Blob; Heals? False
   * Layers: default
-  * Event Cataris - db_reg_mg_017
+  * Event Cataris - Path to Kraid Blob
   * Extra - actor_name: db_reg_mg_017
   * Extra - actor_def: actordef:actors/props/db_reg_mg_016/charclasses/db_reg_mg_016.bmsad
   > Door to Path to Kraid Entryway
@@ -1856,15 +1856,6 @@ Extra - asset_id: collision_camera_023
   > Door to Path to Kraid Entryway
       Trivial
 
-> Tile Group (WEIGHT) 1; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_015
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Tile Group (WEIGHT) 2
-      Morph Ball
-
 > Tile Group (POWERBEAM) 1; Heals? False
   * Layers: default
   * Configurable Node
@@ -1872,7 +1863,7 @@ Extra - asset_id: collision_camera_023
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
-  > Dock to EMMI Zone Exits West (dooremmy_009)
+  > Dock to EMMI Zone Exits West (Lower)
       Flash Shift and Morph Ball
   > Door to Path to Kraid Entryway
       Trivial
@@ -1891,27 +1882,9 @@ Extra - asset_id: collision_camera_023
   > Tunnel to Path to Kraid Entryway
       Trivial
 
-> Tile Group (WEIGHT) 2; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_031
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Tile Group (WEIGHT) 3
-      Morph Ball
-
-> Tile Group (WEIGHT) 3; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_032
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Dock to EMMI Zone Exits West (dooremmy_009)
-      Morph Ball
-
 > Tunnel to Path to Kraid Entryway; Heals? False
   * Layers: default
-  * Morph Ball Tunnel to Path to Kraid Entryway/Tunnel to Long Mouth Statue Room
+  * Slide Tunnel to Path to Kraid Entryway/Tunnel to Long Mouth Statue Room
   > Tile Group (POWERBEAM) 1
       Morph Ball
   > Tile Group (POWERBEAM) 2
@@ -1932,7 +1905,7 @@ Extra - asset_id: collision_camera_024
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Event - Blob above Kraid, from below
-      Shoot Beam
+      Lay Bomb or Shoot Beam
   > Dock to Kraid Arena
       All of the following:
           Before Kraid and Can Slide
@@ -1941,14 +1914,14 @@ Extra - asset_id: collision_camera_024
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
   > Center Room
       All of the following:
-          Morph Ball and After Cataris - db_reg_mg_019
+          Morph Ball and After Cataris - Blob above Kraid
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
-> Event - Ceiling Blob; Heals? False
+> Event - Above Kraid Ceiling Blob; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag010
+  * Event Cataris - Above Kraid Ceiling Blob
   * Extra - actor_name: breakablemag010
   * Extra - actor_def: actordef:actors/props/breakablemag010/charclasses/breakablemag010.bmsad
   > Right Tile Barrier
@@ -1956,7 +1929,7 @@ Extra - asset_id: collision_camera_024
 
 > Event - Blob above Kraid, from below; Heals? False
   * Layers: default
-  * Event Cataris - db_reg_mg_019
+  * Event Cataris - Blob above Kraid
   * Extra - actor_name: db_reg_mg_019
   * Extra - actor_def: actordef:actors/props/db_reg_mg_018/charclasses/db_reg_mg_018.bmsad
   > Door to Kraid Eyedoor Room
@@ -1985,7 +1958,7 @@ Extra - asset_id: collision_camera_024
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
-  > Event - Ceiling Blob
+  > Event - Above Kraid Ceiling Blob
       Morph Ball and Shoot Beam
   > Left Tile Barrier
       All of the following:
@@ -1995,7 +1968,7 @@ Extra - asset_id: collision_camera_024
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
   > Tunnel to Kraid Eyedoor Room
       All of the following:
-          Morph Ball and After Cataris - breakablemag010
+          Morph Ball and After Cataris - Above Kraid Ceiling Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
@@ -2046,7 +2019,7 @@ Extra - asset_id: collision_camera_024
   * Morph Ball Tunnel to Kraid Eyedoor Room/Tunnel to Above Kraid
   > Right Tile Barrier
       All of the following:
-          Morph Ball and After Cataris - breakablemag010
+          Morph Ball and After Cataris - Above Kraid Ceiling Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
@@ -2065,7 +2038,7 @@ Extra - asset_id: collision_camera_024
   * Layers: default
   > Door to Kraid Eyedoor Room
       All of the following:
-          After Cataris - db_reg_mg_019 and Can Slide
+          After Cataris - Blob above Kraid and Can Slide
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
@@ -2082,7 +2055,7 @@ Extra - asset_id: collision_camera_024
 
 > Event - Blob above Kraid, from left; Heals? False
   * Layers: default
-  * Event Cataris - db_reg_mg_019
+  * Event Cataris - Blob above Kraid
   > Center Room
       Trivial
 
@@ -2120,15 +2093,19 @@ Extra - asset_id: collision_camera_025
   > Door to Navigation Station Northwest
       Any of the following:
           Spider Magnet or Space Jump
-          Flash Shift and Spin Boost and Walljump (Beginner)
+          All of the following:
+              Flash Shift
+              Any of the following:
+                  Walljump (Intermediate)
+                  Walljump (Beginner) and Use Spin Boost
           Bomb and Morph Ball and Infinite Bomb Jump (Advanced)
-          Speed Booster and Disabled Door Lock Randomizer
-  > Event - Morph Tunnel Blob
-      Shoot Beam
+          Speed Booster and Speedbooster Conservation (Beginner) and Disabled Door Lock Randomizer
+  > Event - Ghavoran Teleport Lower Blob
+      Lay Bomb or Shoot Beam
   > Tile Group (BOMB)
       Trivial
   > Tunnel to Teleport to Ghavoran
-      After Cataris - Ghavoran Teleporter Lower-left Tunnel Blob
+      After Cataris - Ghavoran Teleport Lower Blob
 
 > Door to Navigation Station Northwest; Heals? False
   * Layers: default
@@ -2162,9 +2139,9 @@ Extra - asset_id: collision_camera_025
   > Door to Path to Kraid Entryway
       Morph Ball
 
-> Event - Morph Tunnel Blob; Heals? False
+> Event - Ghavoran Teleport Lower Blob; Heals? False
   * Layers: default
-  * Event Cataris - Ghavoran Teleporter Lower-left Tunnel Blob
+  * Event Cataris - Ghavoran Teleport Lower Blob
   * Extra - actor_name: db_dside_mg_002b_000
   * Extra - actor_def: actordef:actors/props/db_dside_mg_002b/charclasses/db_dside_mg_002b.bmsad
   > Door to West Teleport Access
@@ -2179,10 +2156,10 @@ Extra - asset_id: collision_camera_025
   * Extra - target_spawn_point: LE_Platform_Teleport_FromMagma
   * Extra - start_point_actor_name: LE_Platform_Teleport_FromCave
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad
-  > Tile Group (BOMB)
-      Morph Ball
-  > Tile Group (WEIGHT) 2
+  > Door to Save Station West
       Trivial
+  > Tile Group (BOMB)
+      Can Slide
 
 > Tile Group (BOMB); Heals? False
   * Layers: default
@@ -2195,32 +2172,16 @@ Extra - asset_id: collision_camera_025
       Morph Ball
   > Door to West Teleport Access
       Trivial
+  > Pickup (Missile+ Tank)
+      Can Slide
   > Teleporter to Artaria - Teleport to Cataris
       Can Slide
-
-> Tile Group (WEIGHT) 1; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_021
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Door to Save Station West
-      Trivial
-
-> Tile Group (WEIGHT) 2; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_022
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Tile Group (WEIGHT) 1
-      Trivial
 
 > Tunnel to Teleport to Ghavoran; Heals? False
   * Layers: default
   * Slide Tunnel to Teleport to Ghavoran/Tunnel to Teleport to Artaria (Red)
   > Door to West Teleport Access
-      After Cataris - Ghavoran Teleporter Lower-left Tunnel Blob
+      After Cataris - Ghavoran Teleport Lower Blob
 
 ----------------
 Teleport to Ghavoran
@@ -2248,25 +2209,25 @@ Extra - asset_id: collision_camera_026
   > Lower Center
       Trivial
 
-> Event - Lower-left Tunnel Blob; Heals? False
+> Event - Ghavoran Teleport Lower Blob; Heals? False
   * Layers: default
-  * Event Cataris - Ghavoran Teleporter Lower-left Tunnel Blob
+  * Event Cataris - Ghavoran Teleport Lower Blob
   * Extra - actor_name: db_dside_mg_003
   * Extra - actor_def: actordef:actors/props/db_dside_mg_002/charclasses/db_dside_mg_002.bmsad
   > Lower Center
       Trivial
 
-> Event - Upper-right Tunnel Blob (db_dside_mg_002); Heals? False
+> Event - Ghavoran Teleport Upper Blob; Heals? False
   * Layers: default
-  * Event Cataris - db_dside_mg_002
+  * Event Cataris - Ghavoran Teleport Upper Blob
   * Extra - actor_name: db_dside_mg_001b_000
   * Extra - actor_def: actordef:actors/props/db_dside_mg_001b/charclasses/db_dside_mg_001b.bmsad
   > Top room
       Trivial
 
-> Event - Green Teleport Grapple Block; Heals? False
+> Event - Ghavoran Teleport Grapple Block; Heals? False
   * Layers: default
-  * Event Cataris - Green Teleport Grapple Block
+  * Event Cataris - Ghavoran Teleport Grapple Block
   * Extra - actor_name: grapplepulloff1x2_001
   * Extra - actor_def: actordef:actors/props/grapplepulloff1x2/charclasses/grapplepulloff1x2.bmsad
   > Teleporter to Ghavoran - Teleport to Cataris
@@ -2281,7 +2242,7 @@ Extra - asset_id: collision_camera_026
   * Extra - target_spawn_point: teleporter_magma_000_platform
   * Extra - start_point_actor_name: teleporter_forest_000_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad
-  > Event - Green Teleport Grapple Block
+  > Event - Ghavoran Teleport Grapple Block
       All of the following:
           Grapple Beam
           Any of the following:
@@ -2289,13 +2250,13 @@ Extra - asset_id: collision_camera_026
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
   > Tile Group (POWERBEAM) 3
       All of the following:
-          Morph Ball
+          Can Slide
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
   > Top room
       All of the following:
-          Morph Ball and After Cataris - Green Teleport Grapple Block
+          Morph Ball and After Cataris - Ghavoran Teleport Grapple Block
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
@@ -2307,6 +2268,12 @@ Extra - asset_id: collision_camera_026
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
+  > Pickup (Missile Tank - Top)
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Varia Suit
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
   > Top room
       Trivial
 
@@ -2318,7 +2285,7 @@ Extra - asset_id: collision_camera_026
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
   > Pickup (Missile Tank - Bottom)
-      Gravity Suit and Speed Booster and Can Slide
+      Gravity Suit and Speed Booster
   > Lower Center
       Trivial
 
@@ -2340,19 +2307,28 @@ Extra - asset_id: collision_camera_026
 
 > Lower Center; Heals? False
   * Layers: default
-  > Event - Lower-left Tunnel Blob
-      Shoot Beam
+  > Event - Ghavoran Teleport Lower Blob
+      Lay Bomb or Shoot Beam
   > Tile Group (POWERBEAM) 2
       Gravity Suit
   > Tile Group (POWERBEAM) 3
       All of the following:
-          Grapple Beam or Infinite Bomb Jump (Beginner) or Use Spin Boost
+          Any of the following:
+              Flash Shift or Simple IBJ or Use Spin Boost
+              All of the following:
+                  Grapple Beam
+                  Spider Magnet or Grapple Movement (Beginner)
+              All of the following:
+                  Speed Booster
+                  Any of the following:
+                      Gravity Suit
+                      Speedbooster Conservation (Beginner) and Disabled Door Lock Randomizer
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage
   > Tunnel to Teleport to Artaria (Red)
       All of the following:
-          After Cataris - Ghavoran Teleporter Lower-left Tunnel Blob
+          After Cataris - Ghavoran Teleport Lower Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
@@ -2366,11 +2342,11 @@ Extra - asset_id: collision_camera_026
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
-  > Event - Upper-right Tunnel Blob (db_dside_mg_002)
-      Shoot Beam
+  > Event - Ghavoran Teleport Upper Blob
+      Lay Bomb or Shoot Beam
   > Teleporter to Ghavoran - Teleport to Cataris
       All of the following:
-          After Cataris - Green Teleport Grapple Block and Can Slide
+          After Cataris - Ghavoran Teleport Grapple Block and Can Slide
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
@@ -2378,7 +2354,7 @@ Extra - asset_id: collision_camera_026
       Trivial
   > Tunnel to Ghavoran Teleport Access
       All of the following:
-          After Cataris - db_dside_mg_002
+          After Cataris - Ghavoran Teleport Upper Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
@@ -2388,7 +2364,7 @@ Extra - asset_id: collision_camera_026
   * Slide Tunnel to Teleport to Artaria (Red)/Tunnel to Teleport to Ghavoran
   > Lower Center
       All of the following:
-          After Cataris - Ghavoran Teleporter Lower-left Tunnel Blob
+          After Cataris - Ghavoran Teleport Lower Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
@@ -2398,7 +2374,7 @@ Extra - asset_id: collision_camera_026
   * Slide Tunnel to Ghavoran Teleport Access/Tunnel to Teleport to Ghavoran
   > Top room
       All of the following:
-          After Cataris - db_dside_mg_002
+          After Cataris - Ghavoran Teleport Upper Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
@@ -2419,10 +2395,10 @@ Extra - asset_id: collision_camera_027
   * Extra - right_shield_def: None
   > Dock to EMMI Zone Exits West
       Trivial
-  > Event - Morph Tunnel Blob (db_dside_mg_002)
-      Shoot Beam
+  > Event - Ghavoran Teleport Upper Blob
+      Lay Bomb or Shoot Beam
   > Tunnel to Teleport to Ghavoran
-      After Cataris - db_dside_mg_002
+      After Cataris - Ghavoran Teleport Upper Blob
 
 > Dock to EMMI Zone Exits West; Heals? False
   * Layers: default
@@ -2432,9 +2408,9 @@ Extra - asset_id: collision_camera_027
   > Door to Navigation Station Northwest
       Trivial
 
-> Event - Morph Tunnel Blob (db_dside_mg_002); Heals? False
+> Event - Ghavoran Teleport Upper Blob; Heals? False
   * Layers: default
-  * Event Cataris - db_dside_mg_002
+  * Event Cataris - Ghavoran Teleport Upper Blob
   * Extra - actor_name: db_dside_mg_002
   * Extra - actor_def: actordef:actors/props/db_dside_mg_001/charclasses/db_dside_mg_001.bmsad
   > Door to Navigation Station Northwest
@@ -2444,7 +2420,7 @@ Extra - asset_id: collision_camera_027
   * Layers: default
   * Slide Tunnel to Teleport to Ghavoran/Tunnel to Ghavoran Teleport Access
   > Door to Navigation Station Northwest
-      After Cataris - db_dside_mg_002
+      After Cataris - Ghavoran Teleport Upper Blob
 
 ----------------
 EMMI Zone Exits West
@@ -2479,7 +2455,7 @@ Extra - asset_id: collision_camera_028
 
 > Dock to Long Mouth Statue Room (dooremmy_008); Heals? False
   * Layers: default
-  * EMMI Door to Long Mouth Statue Room/Dock to EMMI Zone Exits West (dooremmy_008)
+  * EMMI Door to Long Mouth Statue Room/Dock to EMMI Zone Exits West (Upper)
   * Extra - actor_name: dooremmy_008
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to EMMI Zone Item Tunnel
@@ -2489,7 +2465,7 @@ Extra - asset_id: collision_camera_028
 
 > Dock to Long Mouth Statue Room (dooremmy_009); Heals? False
   * Layers: default
-  * EMMI Door to Long Mouth Statue Room/Dock to EMMI Zone Exits West (dooremmy_009)
+  * EMMI Door to Long Mouth Statue Room/Dock to EMMI Zone Exits West (Lower)
   * Extra - actor_name: dooremmy_009
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Upper Ledge
@@ -3411,7 +3387,7 @@ Extra - asset_id: collision_camera_043
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Tile Group (POWERBEAM) 1
-      Morph Ball
+      Can Slide
 
 > Door to Long Mouth Statue Room; Heals? False
   * Layers: default
@@ -3428,8 +3404,12 @@ Extra - asset_id: collision_camera_043
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
   > Dock to Above Kraid
       Any of the following:
-          Gravity Suit or Lava Damage ≥ 100
-          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
+          Gravity Suit
+          All of the following:
+              Lava Damage ≥ 100
+              Any of the following:
+                  Varia Suit and Heat/Cold Runs (Beginner)
+                  Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
 > Tile Group (POWERBEAM) 1; Heals? False
   * Layers: default
@@ -3439,7 +3419,7 @@ Extra - asset_id: collision_camera_043
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
   > Door to Teleport to Artaria (Red)
-      Morph Ball
+      Can Slide
   > Tunnel to Long Mouth Statue Room
       Trivial
 
@@ -3465,7 +3445,11 @@ Extra - asset_id: collision_camera_043
   > Door to Long Mouth Statue Room
       Any of the following:
           Gravity Suit
-          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100 and Lava Damage ≥ 100
+          All of the following:
+              Lava Damage ≥ 100
+              Any of the following:
+                  Varia Suit and Heat/Cold Runs (Beginner)
+                  Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
   > Tile Group (POWERBEAM) 2
       Any of the following:
           Varia Suit
@@ -3473,7 +3457,7 @@ Extra - asset_id: collision_camera_043
 
 > Tunnel to Long Mouth Statue Room; Heals? False
   * Layers: default
-  * Morph Ball Tunnel to Long Mouth Statue Room/Tunnel to Path to Kraid Entryway
+  * Slide Tunnel to Long Mouth Statue Room/Tunnel to Path to Kraid Entryway
   > Tile Group (POWERBEAM) 1
       Trivial
 
@@ -3496,11 +3480,11 @@ Extra - asset_id: collision_camera_044
       Any of the following:
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
-  > Event - Diffusion Tutorial Blob (db_dif_mg_002)
+  > Event - Diffusion Tutorial Blob
       Shoot Diffusion or Wave
   > Tunnel to Teleport to Dairon
       All of the following:
-          Morph Ball and After Cataris - db_dif_mg_002
+          Morph Ball and After Cataris - Diffusion Tutorial Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
@@ -3522,19 +3506,19 @@ Extra - asset_id: collision_camera_044
   * Extra - actor_name: item_powerbombtank_001
   * Extra - actor_def: actordef:actors/items/item_powerbombtank/charclasses/item_powerbombtank.bmsad
   > Alcove
-      Morph Ball and After Cataris - grapplepulloff1x2
+      Morph Ball and After Cataris - PB Tank Grapple Block
 
-> Event - Diffusion Tutorial Blob (db_dif_mg_002); Heals? False
+> Event - Diffusion Tutorial Blob; Heals? False
   * Layers: default
-  * Event Cataris - db_dif_mg_002
+  * Event Cataris - Diffusion Tutorial Blob
   * Extra - actor_name: db_dif_mg_002
   * Extra - actor_def: actordef:actors/props/db_dif_mg_002/charclasses/db_dif_mg_002.bmsad
   > Door from Teleport to Dairon
       Trivial
 
-> Event - PB Tank Grapple Block (grapplepulloff1x2); Heals? False
+> Event - PB Tank Grapple Block; Heals? False
   * Layers: default
-  * Event Cataris - grapplepulloff1x2
+  * Event Cataris - PB Tank Grapple Block
   * Extra - actor_name: grapplepulloff1x2
   * Extra - actor_def: actordef:actors/props/grapplepulloff1x2/charclasses/grapplepulloff1x2.bmsad
   > Alcove
@@ -3654,7 +3638,7 @@ Extra - asset_id: collision_camera_044
 > Tunnel to Kraid Arena (top); Heals? False
   * Layers: default
   * Morph Ball Tunnel to Kraid Arena/Tunnel to Diffusion Beam Room (Top)
-  > Event - Diffusion Tutorial Blob (db_dif_mg_002)
+  > Event - Diffusion Tutorial Blob
       Morph Ball and Shoot Diffusion or Wave
   > Tunnel to Teleport to Dairon
       All of the following:
@@ -3674,7 +3658,7 @@ Extra - asset_id: collision_camera_044
   * Morph Ball Tunnel to Teleport to Dairon/Tunnel to Diffusion Beam Room
   > Door from Teleport to Dairon
       All of the following:
-          After Cataris - db_dif_mg_002
+          After Cataris - Diffusion Tutorial Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
@@ -3688,8 +3672,8 @@ Extra - asset_id: collision_camera_044
 > Alcove; Heals? False
   * Layers: default
   > Pickup (Power Bomb Tank)
-      Morph Ball and After Cataris - grapplepulloff1x2
-  > Event - PB Tank Grapple Block (grapplepulloff1x2)
+      Morph Ball and After Cataris - PB Tank Grapple Block
+  > Event - PB Tank Grapple Block
       Grapple Beam
   > Tile Group (WEIGHT) 4
       Trivial
@@ -4162,7 +4146,7 @@ Extra - asset_id: collision_camera_051
   * Pickup 39; Major Location? False
   * Extra - actor_name: item_missiletank_003
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Event - Missile Tank Blob (breakablemag009)
+  > Event - Missile Tank Blob
       Lay Bomb
   > Ledge above Teleport
       All of the following:
@@ -4170,7 +4154,7 @@ Extra - asset_id: collision_camera_051
           Any of the following:
               Gravity Suit
               All of the following:
-                  After Cataris - breakablemag009
+                  After Cataris - Missile Tank Blob
                   Any of the following:
                       Varia Suit
                       Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
@@ -4197,9 +4181,9 @@ Extra - asset_id: collision_camera_051
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
-> Event - Missile Tank Blob (breakablemag009); Heals? False
+> Event - Missile Tank Blob; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag009
+  * Event Cataris - Missile Tank Blob
   * Extra - actor_name: breakablemag009
   * Extra - actor_def: actordef:actors/props/breakablemag009/charclasses/breakablemag009.bmsad
   > Ledge above Teleport
@@ -4207,9 +4191,9 @@ Extra - asset_id: collision_camera_051
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
 
-> Event - Diffusion Tutorial Blob from below (db_dif_mg_001); Heals? False
+> Event - Diffusion Tutorial Blob 2, below; Heals? False
   * Layers: default
-  * Event Cataris - db_dif_mg_001
+  * Event Cataris - Diffusion Tutorial Blob 2
   * Extra - actor_name: db_dif_mg_001
   * Extra - actor_def: actordef:actors/props/db_dif_mg_001/charclasses/db_dif_mg_001.bmsad
   > Tunnel to Diffusion Beam Room
@@ -4286,11 +4270,11 @@ Extra - asset_id: collision_camera_051
       Any of the following:
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
-  > Event - Diffusion Tutorial Blob from below (db_dif_mg_001)
+  > Event - Diffusion Tutorial Blob 2, below
       Shoot Diffusion or Wave
   > Above Tutorial Blob
       All of the following:
-          Morph Ball and After Cataris - db_dif_mg_001
+          Morph Ball and After Cataris - Diffusion Tutorial Blob 2
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 120
@@ -4300,7 +4284,7 @@ Extra - asset_id: collision_camera_051
   * Morph Ball Tunnel to Kraid Eyedoor Room/Tunnel to Teleport to Dairon
   > Above Tutorial Blob
       All of the following:
-          Morph Ball and After Cataris - db_reg_mg_021
+          Morph Ball and After Cataris - Kraid Eyedoor Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
@@ -4315,15 +4299,15 @@ Extra - asset_id: collision_camera_051
           Gravity Suit and Can Slide
           Morph Ball and Heat/Cold Runs (Intermediate) and Lava Damage ≥ 600
 
-> Event - Wave Beam Blob (db_reg_mg_021); Heals? False
+> Event - Kraid Eyedoor Blob; Heals? False
   * Layers: default
-  * Event Cataris - db_reg_mg_021
+  * Event Cataris - Kraid Eyedoor Blob
   > Above Tutorial Blob
       Trivial
 
-> Event - Diffusion Tutorial Blob from above (db_dif_mg_001); Heals? False
+> Event - Diffusion Tutorial Blob 2, above; Heals? False
   * Layers: default
-  * Event Cataris - db_dif_mg_001
+  * Event Cataris - Diffusion Tutorial Blob 2
   > Above Tutorial Blob
       Trivial
 
@@ -4335,11 +4319,11 @@ Extra - asset_id: collision_camera_051
           Any of the following:
               Gravity Suit
               All of the following:
-                  After Cataris - breakablemag009
+                  After Cataris - Missile Tank Blob
                   Any of the following:
                       Varia Suit
                       Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
-  > Event - Missile Tank Blob (breakablemag009)
+  > Event - Missile Tank Blob
       All of the following:
           Shoot Diffusion or Wave
           Any of the following:
@@ -4358,19 +4342,19 @@ Extra - asset_id: collision_camera_051
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
   > Tunnel to Diffusion Beam Room
       All of the following:
-          Morph Ball and After Cataris - db_reg_mg_021
+          After Cataris - Diffusion Tutorial Blob 2 and Can Slide
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
   > Tunnel to Kraid Eyedoor Room
       All of the following:
-          Morph Ball and After Cataris - db_reg_mg_021
+          Morph Ball and After Cataris - Kraid Eyedoor Blob
           Any of the following:
-              Morph Ball
+              Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
-  > Event - Wave Beam Blob (db_reg_mg_021)
+  > Event - Kraid Eyedoor Blob
       Wave Beam
-  > Event - Diffusion Tutorial Blob from above (db_dif_mg_001)
+  > Event - Diffusion Tutorial Blob 2, above
       Wave Beam
 
 ----------------
@@ -4389,7 +4373,7 @@ Extra - asset_id: collision_camera_052
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:db_hdoor_mg_002b_000
   * Extra - right_shield_def: actordef:actors/props/db_hdoor_mg_002b/charclasses/db_hdoor_mg_002b.bmsad
   > Dock to Green EMMI Introduction
-      After Cataris - Ghavoran Teleporter Upper-right Tunnel Blob
+      After Cataris - Green EMMI Access Blob
 
 > Dock to Green EMMI Introduction; Heals? False
   * Layers: default
@@ -4397,11 +4381,11 @@ Extra - asset_id: collision_camera_052
   * Extra - actor_name: dooremmy_003
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to Z-57 Heat Room West (Left)
-      After Cataris - Ghavoran Teleporter Upper-right Tunnel Blob
+      After Cataris - Green EMMI Access Blob
   > Door to Teleport to Dairon
       Trivial
-  > Event - Breakable (db_hdoor_mg_002)
-      Shoot Beam
+  > Event - Green EMMI Access Blob
+      Lay Bomb or Shoot Beam
 
 > Door from Underlava Puzzle Room 2; Heals? False
   * Layers: default
@@ -4431,9 +4415,9 @@ Extra - asset_id: collision_camera_052
   > Tunnel to Underlava Puzzle Room 2
       Trivial
 
-> Event - Breakable (db_hdoor_mg_002); Heals? False
+> Event - Green EMMI Access Blob; Heals? False
   * Layers: default
-  * Event Cataris - Ghavoran Teleporter Upper-right Tunnel Blob
+  * Event Cataris - Green EMMI Access Blob
   * Extra - actor_name: db_hdoor_mg_002
   * Extra - actor_def: actordef:actors/props/db_hdoor_mg_002/charclasses/db_hdoor_mg_002.bmsad
   > Dock to Green EMMI Introduction
@@ -4776,22 +4760,22 @@ Extra - asset_id: collision_camera_061
   * Extra - right_shield_def: None
   > Safe Ledge
       All of the following:
-          Flash Shift or Gravity Suit or Spider Magnet or Lava Damage ≥ 10 or Use Spin Boost
+          Flash Shift or Gravity Suit or Spider Magnet or Movement (Beginner) or Lava Damage ≥ 10 or Lay Cross Comb or Use Spin Boost
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
-> Event - Blob to Teleport to Dairon (db_reg_mg_021); Heals? False
+> Event - Kraid Eyedoor Blob; Heals? False
   * Layers: default
-  * Event Cataris - db_reg_mg_021
+  * Event Cataris - Kraid Eyedoor Blob
   * Extra - actor_name: db_reg_mg_021
   * Extra - actor_def: actordef:actors/props/db_reg_mg_020/charclasses/db_reg_mg_020.bmsad
   > Safe Ledge
       Trivial
 
-> Event - Top Blob (db_reg_mg_020); Heals? False
+> Event - Kraid Eyedoor Ceiling Blob; Heals? False
   * Layers: default
-  * Event Cataris - db_reg_mg_020
+  * Event Cataris - Kraid Eyedoor Ceiling Blob
   * Extra - actor_name: db_reg_mg_020
   * Extra - actor_def: actordef:actors/props/db_reg_mg_019/charclasses/db_reg_mg_019.bmsad
   > Ledge below blob
@@ -4832,11 +4816,11 @@ Extra - asset_id: collision_camera_061
   * Layers: default
   > Door to Above Kraid
       All of the following:
-          Flash Shift or Grapple Beam or Gravity Suit or Spider Magnet or Use Spin Boost
+          Flash Shift or Grapple Beam or Gravity Suit or Spider Magnet or Movement (Beginner) or Lay Cross Comb or Use Spin Boost
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
-  > Event - Blob to Teleport to Dairon (db_reg_mg_021)
+  > Event - Kraid Eyedoor Blob
       Shoot Diffusion or Wave
   > Tile Group (BOMB)
       All of the following:
@@ -4846,31 +4830,31 @@ Extra - asset_id: collision_camera_061
               Heat/Cold Runs (Beginner) and Lava Damage ≥ 400
   > Tunnel to Teleport to Dairon
       All of the following:
-          After Cataris - db_reg_mg_021
+          After Cataris - Kraid Eyedoor Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 10
   > Ledge below blob
       All of the following:
-          Morph Ball and After Cataris - db_reg_mg_020
+          Morph Ball and After Cataris - Kraid Eyedoor Ceiling Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 200
-          Space Jump or Infinite Bomb Jump (Beginner)
+          Space Jump or Simple IBJ
 
 > Tunnel to Teleport to Dairon; Heals? False
   * Layers: default
   * Morph Ball Tunnel to Teleport to Dairon/Tunnel to Kraid Eyedoor Room
   > Safe Ledge
       All of the following:
-          After Cataris - db_reg_mg_021
+          After Cataris - Kraid Eyedoor Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 10
 
 > Ledge below blob; Heals? False
   * Layers: default
-  > Event - Top Blob (db_reg_mg_020)
+  > Event - Kraid Eyedoor Ceiling Blob
       Shoot Beam
   > Tunnel to Above Kraid
       Any of the following:
@@ -4878,7 +4862,7 @@ Extra - asset_id: collision_camera_061
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
   > Safe Ledge
       All of the following:
-          Morph Ball and After Cataris - db_reg_mg_020
+          Morph Ball and After Cataris - Kraid Eyedoor Ceiling Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -447,11 +447,11 @@
                 "extra": {}
             },
             "s020_magma:default:breakablemag009": {
-                "long_name": "Cataris - breakablemag009",
+                "long_name": "Cataris - Missile Tank Blob",
                 "extra": {}
             },
             "s020_magma:default:breakablemag010": {
-                "long_name": "Cataris - breakablemag010",
+                "long_name": "Cataris - Above Kraid Ceiling Blob",
                 "extra": {}
             },
             "s020_magma:default:breakablemag012": {
@@ -459,15 +459,15 @@
                 "extra": {}
             },
             "s020_magma:default:db_hdoor_mg_002": {
-                "long_name": "Cataris - Ghavoran Teleporter Upper-right Tunnel Blob",
+                "long_name": "Cataris - Green EMMI Access Blob",
                 "extra": {}
             },
             "s020_magma:default:db_dside_mg_003": {
-                "long_name": "Cataris - Ghavoran Teleporter Lower-left Tunnel Blob",
+                "long_name": "Cataris - Ghavoran Teleport Lower Blob",
                 "extra": {}
             },
             "s020_magma:default:db_dside_mg_002": {
-                "long_name": "Cataris - db_dside_mg_002",
+                "long_name": "Cataris - Ghavoran Teleport Upper Blob",
                 "extra": {}
             },
             "s020_magma:default:db_hdoor_mg_001": {
@@ -483,11 +483,11 @@
                 "extra": {}
             },
             "s020_magma:default:db_dif_mg_002": {
-                "long_name": "Cataris - db_dif_mg_002",
+                "long_name": "Cataris - Diffusion Tutorial Blob",
                 "extra": {}
             },
             "s020_magma:default:db_dif_mg_001": {
-                "long_name": "Cataris - db_dif_mg_001",
+                "long_name": "Cataris - Diffusion Tutorial Blob 2",
                 "extra": {}
             },
             "s020_magma:default:deviceheat_camerafar_000": {
@@ -495,11 +495,11 @@
                 "extra": {}
             },
             "s020_magma:default:db_reg_mg_017": {
-                "long_name": "Cataris - db_reg_mg_017",
+                "long_name": "Cataris - Path to Kraid Blob",
                 "extra": {}
             },
             "s020_magma:default:db_reg_mg_019": {
-                "long_name": "Cataris - db_reg_mg_019",
+                "long_name": "Cataris - Blob above Kraid",
                 "extra": {}
             },
             "s020_magma:default:db_dside_mg_004": {
@@ -507,11 +507,11 @@
                 "extra": {}
             },
             "s020_magma:default:db_reg_mg_021": {
-                "long_name": "Cataris - db_reg_mg_021",
+                "long_name": "Cataris - Kraid Eyedoor Blob",
                 "extra": {}
             },
             "s020_magma:default:db_reg_mg_020": {
-                "long_name": "Cataris - db_reg_mg_020",
+                "long_name": "Cataris - Kraid Eyedoor Ceiling Blob",
                 "extra": {}
             },
             "s030_baselab:default:powergenerator_002": {
@@ -647,7 +647,7 @@
                 "extra": {}
             },
             "s020_magma:default:grapplepulloff1x2": {
-                "long_name": "Cataris - grapplepulloff1x2",
+                "long_name": "Cataris - PB Tank Grapple Block",
                 "extra": {}
             },
             "s020_magma:default:grapplepulloff1x2_000": {
@@ -655,7 +655,7 @@
                 "extra": {}
             },
             "s020_magma:default:grapplepulloff1x2_001": {
-                "long_name": "Cataris - Green Teleport Grapple Block",
+                "long_name": "Cataris - Ghavoran Teleport Grapple Block",
                 "extra": {}
             },
             "s030_baselab:default:grapplepulloff1x2_007": {


### PR DESCRIPTION
Looking over the Cataris logic and adding anything I see that is missing from trickless and changing things to be tricks if needed. I am also renaming all the events and nodes as I go through. This affects the following rooms on the west side of Cataris:

- Path to Kraid Entryway
- Above Kraid
- Heated U-Turn
- Kraid Eyedoor Room
- Diffusion Beam Room
- Teleport to Dairon
- Green EMMI Introduction
- Long Mouth Statue Room
- Teleport to Artaria (Red)
- Teleport to Ghavoran
- Ghavoran Teleport Access