### PR TITLE
Dread: Fix up the logic around getting the Thermal Device item without Morph

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -21014,12 +21014,10 @@
                             }
                         },
                         "Door to Thermal Device (Upper)": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "ArtariaThermalItemDoor",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -21273,9 +21271,21 @@
                                 "items": []
                             }
                         },
-                        "Tile Group (MISSILE)": {
-                            "type": "template",
-                            "data": "Can Slide"
+                        "Start Point": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Missile"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -21367,23 +21377,7 @@
                                 "items": []
                             }
                         },
-                        "Event - Thermal Device": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (MISSILE)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Event - Open Item Door": {
+                        "Door to Path to Thermal Device (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -21398,16 +21392,50 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Shoot Beam"
-                                                },
-                                                {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "MissileAmmo",
-                                                        "amount": 2,
+                                                        "name": "Morph",
+                                                        "amount": 1,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "MissileAmmo",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Shoot Beam"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -21415,61 +21443,8 @@
                                     }
                                 ]
                             }
-                        }
-                    }
-                },
-                "Tile Group (MISSILE)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 19200.0,
-                        "y": 1600.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_049",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "MISSILE"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Path to Thermal Device (Upper)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
                         },
-                        "Start Point": {
-                            "type": "template",
-                            "data": "Can Slide"
-                        }
-                    }
-                },
-                "Event - Open Item Door": {
-                    "node_type": "event",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 18900.4,
-                        "y": 1600.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "event_name": "ArtariaThermalItemDoor",
-                    "connections": {
-                        "Start Point": {
+                        "Event - Thermal Device": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -4232,7 +4232,7 @@ Extra - asset_id: collision_camera_066
   > Door to Save Station East
       Trivial
   > Door to Thermal Device (Upper)
-      After Artaria - Open Thermal Device Item Door
+      Trivial
 
 > Door to Save Station East; Heals? False
   * Layers: default
@@ -4304,8 +4304,8 @@ Extra - asset_id: collision_camera_067
   * Extra - right_shield_def: None
   > Pickup (Missile Tank)
       Trivial
-  > Tile Group (MISSILE)
-      Can Slide
+  > Start Point
+      Can Slide and Shoot Missile
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -4333,31 +4333,15 @@ Extra - asset_id: collision_camera_067
       Trivial
   > Door to Thermal Door Tutorial
       Trivial
-  > Event - Thermal Device
-      Trivial
-  > Tile Group (MISSILE)
-      Morph Ball
-  > Event - Open Item Door
+  > Door to Path to Thermal Device (Upper)
       All of the following:
           Shoot Missile
-          Missiles ≥ 2 or Shoot Beam
-
-> Tile Group (MISSILE); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_049
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('MISSILE',)
-  > Door to Path to Thermal Device (Upper)
-      Morph Ball
-  > Start Point
-      Can Slide
-
-> Event - Open Item Door; Heals? False
-  * Layers: default
-  * Event Artaria - Open Thermal Device Item Door
-  > Start Point
+          Any of the following:
+              Morph Ball
+              All of the following:
+                  Disabled Door Lock Randomizer
+                  Missiles ≥ 2 or Shoot Beam
+  > Event - Thermal Device
       Trivial
 
 ----------------

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -970,10 +970,6 @@
                 "long_name": "Dairon - Teleport To Artaria Speed Blocks Destroyed",
                 "extra": {}
             },
-            "ArtariaThermalItemDoor": {
-                "long_name": "Artaria - Open Thermal Device Item Door",
-                "extra": {}
-            },
             "GhavoranRobotFight": {
                 "long_name": "Ghavoran - Gold Robot Fight",
                 "extra": {}


### PR DESCRIPTION
- Removed the event for opening the upper door
- Added a direct connection to the door if Door Rando is disabled