### PR TITLE
Dread: Cataris Revision Part 2

### DIFF
--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -147,7 +147,7 @@
                                 ]
                             }
                         },
-                        "Event - Missile Tank Blob through wall (breakablemag002)": {
+                        "Event - Artaria Transport Blob through Wall": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -188,7 +188,7 @@
                         }
                     }
                 },
-                "Event - Missile Tank Blob (breakablemag002)": {
+                "Event - Artaria Transport Blob, adjacent": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -388,13 +388,25 @@
                                 "items": []
                             }
                         },
-                        "Event - Missile Tank Blob (breakablemag002)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Artaria Transport Blob, adjacent": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
-                "Event - Missile Tank Blob through wall (breakablemag002)": {
+                "Event - Artaria Transport Blob through Wall": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -1075,12 +1087,29 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Start Point": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s020_magma:default:deviceheat",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -1415,14 +1444,9 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Breakable (breakablemag001)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Wave",
-                                "amount": 1,
-                                "negate": false
-                            }
+                        "Event - First Device Blob": {
+                            "type": "template",
+                            "data": "Shoot Diffusion or Wave"
                         },
                         "Tunnel to Transport to Artaria": {
                             "type": "resource",
@@ -1435,7 +1459,7 @@
                         }
                     }
                 },
-                "Event - Breakable (breakablemag001)": {
+                "Event - First Device Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -1553,9 +1577,21 @@
                                 "negate": false
                             }
                         },
-                        "Event - Breakable (breakablemag001)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - First Device Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Total Recharge": {
                             "type": "and",
@@ -1565,11 +1601,8 @@
                             }
                         },
                         "Tile Group (POWERBEAM)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                            "type": "template",
+                            "data": "Can Slide"
                         }
                     }
                 },
@@ -1757,9 +1790,21 @@
                                 "items": []
                             }
                         },
-                        "Event - Blob (breakablemag003)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Z-57 Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Tunnel to Dropdown Pit": {
                             "type": "and",
@@ -1804,15 +1849,17 @@
                     "major_location": false,
                     "connections": {
                         "Pickup Corner": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
                 },
-                "Event - Blob (breakablemag003)": {
+                "Event - Z-57 Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -2034,10 +2081,12 @@
                             }
                         },
                         "Between Thermal Gates": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "events",
+                                "name": "s020_magma:default:deviceheat",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -2382,10 +2431,12 @@
                             }
                         },
                         "Center Hall": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "events",
+                                "name": "s020_magma:default:deviceheat",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Z-57 Room": {
@@ -2461,7 +2512,7 @@
                 "asset_id": "collision_camera_010"
             },
             "nodes": {
-                "Door to EMMI Zone Tower East (doorpowerpower_016)": {
+                "Door to EMMI Zone Tower East (Power)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2491,7 +2542,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (doorclosedcharge_001)": {
+                        "Door to EMMI Zone Tower East (Charge)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2517,10 +2568,49 @@
                                         }
                                     },
                                     {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
+                                    },
+                                    {
                                         "type": "resource",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "IBJ",
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "GrappleMovement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Flash",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -2556,7 +2646,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (doorclosedcharge_001)": {
+                        "Door to EMMI Zone Tower East (Charge)": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -2567,7 +2657,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone Tower East (doorclosedcharge_001)": {
+                "Door to EMMI Zone Tower East (Charge)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2597,7 +2687,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (doorpowerpower_016)": {
+                        "Door to EMMI Zone Tower East (Power)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -2620,6 +2710,23 @@
                                         "data": {
                                             "type": "items",
                                             "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Comb"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spin Boost"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Movement",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -2661,7 +2768,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (doorpowerpower_016)": {
+                        "Door to EMMI Zone Tower East (Power)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7503,12 +7610,12 @@
                         }
                     }
                 },
-                "Event - First Tunnel Blob (breakablemag004)": {
+                "Event - First Tunnel Blob, in tunnel": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
                         "x": -2300.0,
-                        "y": -2200.0,
+                        "y": -2300.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -7521,7 +7628,7 @@
                     },
                     "event_name": "s020_magma:default:breakablemag004",
                     "connections": {
-                        "Right Platform": {
+                        "Tiny Alcove": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7530,7 +7637,7 @@
                         }
                     }
                 },
-                "Event - Second Tunnel Blob (breakablemag014)": {
+                "Event - Second Tunnel Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -7557,7 +7664,7 @@
                         }
                     }
                 },
-                "Event - Open Passage Blob (breakablemag013)": {
+                "Event - Open Passage Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -7753,82 +7860,40 @@
                             }
                         },
                         "Top Ledge": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "or",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Magnet",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "Varia",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Varia",
-                                                        "amount": 1,
+                                                        "type": "damage",
+                                                        "name": "Heat",
+                                                        "amount": 50,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Heat",
-                                                                    "amount": 50,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
+                                                        "amount": 2,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -7990,9 +8055,21 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Event - Second Tunnel Blob (breakablemag014)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Second Tunnel Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Tunnel to Z-57 Heat Room West (Right)": {
                             "type": "and",
@@ -8129,7 +8206,7 @@
                         }
                     }
                 },
-                "Event - Door Blob (db_hdoor_mg_002)": {
+                "Event - Green EMMI Access Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -8219,9 +8296,21 @@
                                 ]
                             }
                         },
-                        "Event - Door Blob (db_hdoor_mg_002)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Green EMMI Access Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -8239,42 +8328,30 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Event - First Tunnel Blob (breakablemag004)": {
-                            "type": "or",
+                        "Event - First Tunnel Blob, in tunnel": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Shoot Diffusion or Wave"
+                                        "data": "Lay Bomb"
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Simple IBJ"
-                                                            },
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Use Spin Boost"
-                                                            }
-                                                        ]
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
                                                 },
                                                 {
                                                     "type": "template",
-                                                    "data": "Lay Bomb"
+                                                    "data": "Simple IBJ"
                                                 },
                                                 {
-                                                    "type": "or",
+                                                    "type": "and",
                                                     "data": {
                                                         "comment": null,
                                                         "items": [
@@ -8282,35 +8359,82 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
-                                                                    "name": "Varia",
+                                                                    "name": "Slide",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
-                                                                "type": "and",
+                                                                "type": "resource",
                                                                 "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Heat",
-                                                                                "amount": 100,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Suitless",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
+                                                                    "type": "tricks",
+                                                                    "name": "Slide",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Ice Missile"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "FrozenEnemy",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 100,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]
@@ -8322,7 +8446,7 @@
                                 ]
                             }
                         },
-                        "Event - Open Passage Blob (breakablemag013)": {
+                        "Event - Open Passage Blob": {
                             "type": "template",
                             "data": "Shoot Beam"
                         },
@@ -8428,6 +8552,34 @@
                                     }
                                 ]
                             }
+                        },
+                        "Event - First Tunnel Blob, below": {
+                            "type": "template",
+                            "data": "Shoot Diffusion or Wave"
+                        }
+                    }
+                },
+                "Event - First Tunnel Blob, below": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -2300.0,
+                        "y": -2500.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "s020_magma:default:breakablemag004",
+                    "connections": {
+                        "Right Platform": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 }
@@ -8490,14 +8642,14 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone East Tower Access (doorchargecharge_005)": {
+                        "Door to EMMI Zone East Tower Access (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Event - Lower-left Blob (breakablemag005)": {
+                        "Event - Green EMMI Blob": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -8558,7 +8710,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone East Tower Access (doorchargecharge_005)": {
+                "Door to EMMI Zone East Tower Access (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8582,7 +8734,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone East Tower Access",
-                        "node_name": "Door to Green EMMI Introduction (doorchargecharge_005)"
+                        "node_name": "Door to Green EMMI Introduction (Lower)"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -8671,6 +8823,32 @@
                                                     }
                                                 },
                                                 {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Grapple",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "GrappleMovement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
@@ -8698,7 +8876,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone East Tower Access (doorshutter_001)": {
+                "Door to EMMI Zone East Tower Access (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8722,7 +8900,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone East Tower Access",
-                        "node_name": "Door to Green EMMI Introduction (doorshutter_001)"
+                        "node_name": "Door to Green EMMI Introduction (Upper)"
                     },
                     "default_dock_weakness": "Phase Shift Door",
                     "override_default_open_requirement": null,
@@ -8737,7 +8915,7 @@
                         }
                     }
                 },
-                "Event - Lower-left Blob (breakablemag005)": {
+                "Event - Green EMMI Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -8823,18 +9001,12 @@
                     },
                     "connections": {
                         "Tile Group (POWERBEAM) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                            "type": "template",
+                            "data": "Can Slide"
                         },
                         "Tile Group (POWERBEAM) 3": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                            "type": "template",
+                            "data": "Can Slide"
                         }
                     }
                 },
@@ -8859,7 +9031,7 @@
                         ]
                     },
                     "connections": {
-                        "Door to EMMI Zone East Tower Access (doorshutter_001)": {
+                        "Door to EMMI Zone East Tower Access (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9105,9 +9277,21 @@
                                 ]
                             }
                         },
-                        "Event - Lower-left Blob (breakablemag005)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Green EMMI Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 }
@@ -9234,9 +9418,21 @@
                                 ]
                             }
                         },
-                        "Event - Open Passage Blob (breakablemag013)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Open Passage Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -9355,7 +9551,7 @@
                         }
                     }
                 },
-                "Event - Open Passage Blob (breakablemag013)": {
+                "Event - Open Passage Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -9565,6 +9761,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -9664,7 +9869,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone Exits West",
-                        "node_name": "Dock to Long Mouth Statue Room (dooremmy_008)"
+                        "node_name": "Dock to Long Mouth Statue Room (Upper)"
                     },
                     "default_dock_weakness": "EMMI Door",
                     "override_default_open_requirement": null,
@@ -9701,7 +9906,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone Exits West",
-                        "node_name": "Dock to Long Mouth Statue Room (dooremmy_009)"
+                        "node_name": "Dock to Long Mouth Statue Room (Lower)"
                     },
                     "default_dock_weakness": "EMMI Door",
                     "override_default_open_requirement": null,
@@ -13502,43 +13707,10 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Dock to Ghavoran Teleport Access": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Slide"
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Slide"
                         },
-                        "Dock to Long Mouth Statue Room (dooremmy_008)": {
+                        "Dock to Long Mouth Statue Room (Upper)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -13588,7 +13760,7 @@
                         }
                     }
                 },
-                "Dock to Long Mouth Statue Room (dooremmy_008)": {
+                "Dock to Long Mouth Statue Room (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13627,7 +13799,7 @@
                         }
                     }
                 },
-                "Dock to Long Mouth Statue Room (dooremmy_009)": {
+                "Dock to Long Mouth Statue Room (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13720,7 +13892,7 @@
                     "pickup_index": 40,
                     "major_location": false,
                     "connections": {
-                        "Dock to Long Mouth Statue Room (dooremmy_008)": {
+                        "Dock to Long Mouth Statue Room (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13853,7 +14025,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Dock to Long Mouth Statue Room (dooremmy_009)": {
+                        "Dock to Long Mouth Statue Room (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14020,13 +14192,8 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Can Slide"
                                     },
                                     {
                                         "type": "resource",
@@ -14063,62 +14230,6 @@
                         ]
                     },
                     "connections": {
-                        "Tile Group (POWERBOMB)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT)": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -6300.0,
-                        "y": 1400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_017",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {}
-                },
-                "Tile Group (POWERBOMB)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -6500.0,
-                        "y": 1500.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_076",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBOMB"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Power Bomb Tank)": {
-                            "type": "template",
-                            "data": "Ballspark"
-                        },
                         "Center of Tunnel": {
                             "type": "resource",
                             "data": {
@@ -14212,6 +14323,45 @@
                     ],
                     "extra": {},
                     "connections": {
+                        "Pickup (Power Bomb Tank)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Power Bomb"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisCU",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "DoorLocks",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Door to EMMI Zone Exit to Map Station": {
                             "type": "and",
                             "data": {
@@ -14236,15 +14386,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        },
-                        "Tile Group (POWERBOMB)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
                             }
                         },
                         "Tunnel to Green EMMI Introduction": {
@@ -14491,7 +14632,7 @@
                                         "data": "Simple IBJ"
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
@@ -14505,7 +14646,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "or",
                                                     "data": {
                                                         "comment": null,
                                                         "items": [
@@ -14521,8 +14662,8 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "events",
-                                                                    "name": "CatarisThermalLowerLava",
+                                                                    "type": "tricks",
+                                                                    "name": "GrappleMovement",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
@@ -14540,6 +14681,32 @@
                                             "name": "Speed",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Magnet",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "CatarisThermalLowerLava",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -14573,29 +14740,12 @@
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Knowledge",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     },
                                     {
@@ -14657,12 +14807,21 @@
                                         "data": "Simple IBJ"
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "and",
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
                                                     "data": {
                                                         "comment": null,
                                                         "items": [
@@ -14678,22 +14837,13 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "events",
-                                                                    "name": "CatarisThermalLowerLava",
+                                                                    "type": "tricks",
+                                                                    "name": "GrappleMovement",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             }
                                                         ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -14720,6 +14870,32 @@
                                                         "name": "DoorLocks",
                                                         "amount": 1,
                                                         "negate": true
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Magnet",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "CatarisThermalLowerLava",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -14798,7 +14974,7 @@
                 "asset_id": "collision_camera_032"
             },
             "nodes": {
-                "Door to EMMI Zone East Tower Access (doorpowerpower_015)": {
+                "Door to EMMI Zone East Tower Access (Middle)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -14861,13 +15037,13 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone Exit East",
-                        "node_name": "Door to EMMI Zone Tower East (doorpowerpower_016)"
+                        "node_name": "Door to EMMI Zone Tower East (Power)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone East Tower Access (doorclosedcharge)": {
+                        "Door to EMMI Zone East Tower Access (Bottom)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14900,6 +15076,32 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Simple IBJ"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -15050,7 +15252,7 @@
                                 ]
                             }
                         },
-                        "Door to EMMI Zone East Tower Access (doorpowerpower_000)": {
+                        "Door to EMMI Zone East Tower Access (Top)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -15137,7 +15339,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone East Tower Access (doorpowerpower_000)": {
+                "Door to EMMI Zone East Tower Access (Top)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -15176,7 +15378,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone East Tower Access (doorclosedcharge)": {
+                "Door to EMMI Zone East Tower Access (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -15239,7 +15441,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone Exit East",
-                        "node_name": "Door to EMMI Zone Tower East (doorclosedcharge_001)"
+                        "node_name": "Door to EMMI Zone Tower East (Charge)"
                     },
                     "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
@@ -15252,7 +15454,7 @@
                                 "items": []
                             }
                         },
-                        "Tunnel to EMMI Zone East Tower Access (2)": {
+                        "Tunnel to EMMI Zone East Tower Access (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -15323,7 +15525,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone East Tower Access (doorpowerpower_015)": {
+                        "Door to EMMI Zone East Tower Access (Middle)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -15334,7 +15536,7 @@
                             "type": "template",
                             "data": "Can Slide"
                         },
-                        "Tunnel to EMMI Zone East Tower Access (1)": {
+                        "Tunnel to EMMI Zone East Tower Access (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -15343,7 +15545,7 @@
                         }
                     }
                 },
-                "Tunnel to EMMI Zone East Tower Access (1)": {
+                "Tunnel to EMMI Zone East Tower Access (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -15360,7 +15562,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone East Tower Access",
-                        "node_name": "Tunnel to EMMI Zone Tower East (1)"
+                        "node_name": "Tunnel to EMMI Zone Tower East (Lower)"
                     },
                     "default_dock_weakness": "Morph Ball Tunnel",
                     "override_default_open_requirement": null,
@@ -15375,7 +15577,7 @@
                         }
                     }
                 },
-                "Tunnel to EMMI Zone East Tower Access (2)": {
+                "Tunnel to EMMI Zone East Tower Access (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -15392,7 +15594,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone East Tower Access",
-                        "node_name": "Tunnel to EMMI Zone Tower East (2)"
+                        "node_name": "Tunnel to EMMI Zone Tower East (Upper)"
                     },
                     "default_dock_weakness": "Cataris EMMI Tunnel",
                     "override_default_open_requirement": null,
@@ -15961,35 +16163,34 @@
                                 "items": []
                             }
                         },
-                        "Event - Central Unit Blob through wall": {
-                            "type": "or",
+                        "Door to Central Unit": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Wave",
+                                            "type": "events",
+                                            "name": "s020_magma:default:breakablemag008",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Diffusion",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Can Slide"
                                     }
                                 ]
                             }
+                        },
+                        "Event - Central Unit Bottom Blob through Wall": {
+                            "type": "template",
+                            "data": "Shoot Diffusion or Wave"
                         }
                     }
                 },
-                "Event - Top Blob (breakablemag007)": {
+                "Event - Central Unit Top Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -16016,7 +16217,7 @@
                         }
                     }
                 },
-                "Event - Central Unit Blob (breakablemag008)": {
+                "Event - Central Unit Bottom Blob, adjacent": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -16122,9 +16323,21 @@
                                 "items": []
                             }
                         },
-                        "Event - Top Blob (breakablemag007)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                        "Event - Central Unit Top Blob": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Door to Central Unit": {
                             "type": "or",
@@ -16215,35 +16428,25 @@
                                 ]
                             }
                         },
-                        "Event - Top Blob (breakablemag007)": {
+                        "Event - Central Unit Top Blob": {
+                            "type": "template",
+                            "data": "Shoot Diffusion or Wave"
+                        },
+                        "Event - Central Unit Bottom Blob, adjacent": {
                             "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Wave",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Shoot Beam"
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Diffusion",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Lay Bomb"
                                     }
                                 ]
                             }
-                        },
-                        "Event - Central Unit Blob (breakablemag008)": {
-                            "type": "template",
-                            "data": "Shoot Beam"
                         },
                         "Upper-right Corner": {
                             "type": "or",
@@ -16282,7 +16485,7 @@
                         }
                     }
                 },
-                "Event - Central Unit Blob through wall": {
+                "Event - Central Unit Bottom Blob through Wall": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -20103,13 +20306,13 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone Tower East",
-                        "node_name": "Door to EMMI Zone East Tower Access (doorpowerpower_015)"
+                        "node_name": "Door to EMMI Zone East Tower Access (Middle)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Green EMMI Introduction (doorchargecharge_005)": {
+                        "Door to Green EMMI Introduction (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -20123,7 +20326,7 @@
                                 "items": []
                             }
                         },
-                        "Tunnel to EMMI Zone Tower East (1)": {
+                        "Tunnel to EMMI Zone Tower East (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -20137,7 +20340,7 @@
                                 "items": []
                             }
                         },
-                        "Tunnel to EMMI Zone Tower East (2)": {
+                        "Tunnel to EMMI Zone Tower East (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -20190,7 +20393,7 @@
                         }
                     }
                 },
-                "Door to Green EMMI Introduction (doorchargecharge_005)": {
+                "Door to Green EMMI Introduction (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -20214,7 +20417,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Green EMMI Introduction",
-                        "node_name": "Door to EMMI Zone East Tower Access (doorchargecharge_005)"
+                        "node_name": "Door to EMMI Zone East Tower Access (Lower)"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -20253,13 +20456,13 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone Tower East",
-                        "node_name": "Door to EMMI Zone East Tower Access (doorpowerpower_000)"
+                        "node_name": "Door to EMMI Zone East Tower Access (Top)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Green EMMI Introduction (doorshutter_001)": {
+                        "Door to Green EMMI Introduction (Upper)": {
                             "type": "template",
                             "data": "Can Slide"
                         }
@@ -20289,7 +20492,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone Tower East",
-                        "node_name": "Door to EMMI Zone East Tower Access (doorclosedcharge)"
+                        "node_name": "Door to EMMI Zone East Tower Access (Bottom)"
                     },
                     "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
@@ -20304,7 +20507,7 @@
                         }
                     }
                 },
-                "Door to Green EMMI Introduction (doorshutter_001)": {
+                "Door to Green EMMI Introduction (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -20328,7 +20531,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Green EMMI Introduction",
-                        "node_name": "Door to EMMI Zone East Tower Access (doorshutter_001)"
+                        "node_name": "Door to EMMI Zone East Tower Access (Upper)"
                     },
                     "default_dock_weakness": "Phase Shift Door",
                     "override_default_open_requirement": null,
@@ -20345,7 +20548,7 @@
                                 "items": []
                             }
                         },
-                        "Tunnel to EMMI Zone Tower East (2)": {
+                        "Tunnel to EMMI Zone Tower East (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -20373,7 +20576,7 @@
                         }
                     }
                 },
-                "Tunnel to EMMI Zone Tower East (1)": {
+                "Tunnel to EMMI Zone Tower East (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -20390,7 +20593,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone Tower East",
-                        "node_name": "Tunnel to EMMI Zone East Tower Access (1)"
+                        "node_name": "Tunnel to EMMI Zone East Tower Access (Lower)"
                     },
                     "default_dock_weakness": "Morph Ball Tunnel",
                     "override_default_open_requirement": null,
@@ -20460,7 +20663,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Green EMMI Introduction (doorshutter_001)": {
+                        "Door to Green EMMI Introduction (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -20469,7 +20672,7 @@
                         }
                     }
                 },
-                "Tunnel to EMMI Zone Tower East (2)": {
+                "Tunnel to EMMI Zone Tower East (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -20486,7 +20689,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone Tower East",
-                        "node_name": "Tunnel to EMMI Zone East Tower Access (2)"
+                        "node_name": "Tunnel to EMMI Zone East Tower Access (Upper)"
                     },
                     "default_dock_weakness": "Cataris EMMI Tunnel",
                     "override_default_open_requirement": null,
@@ -20518,7 +20721,7 @@
                                 ]
                             }
                         },
-                        "Door to Green EMMI Introduction (doorshutter_001)": {
+                        "Door to Green EMMI Introduction (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -21950,7 +22153,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Suitless",
-                                                        "amount": 2,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
@@ -21991,134 +22194,40 @@
                     "major_location": false,
                     "connections": {
                         "Door to Above Z-57 Fight": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "or",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": "Get through the room",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Varia",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Heat",
-                                                                    "amount": 200,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "Varia",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
-                                            "comment": "Reach the door",
+                                            "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Flash",
-                                                        "amount": 1,
+                                                        "type": "damage",
+                                                        "name": "Heat",
+                                                        "amount": 200,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
                                                         "amount": 1,
                                                         "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Slide",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Slide",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Lava",
-                                                                    "amount": 200,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
                                                     }
                                                 }
                                             ]
@@ -24313,7 +24422,7 @@
                         }
                     }
                 },
-                "Event - Lava Grapple Block (grapplepulloff1x2_000)": {
+                "Event - Lava Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -24673,7 +24782,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Event - Lava Grapple Block (grapplepulloff1x2_000)": {
+                        "Event - Lava Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -24771,6 +24880,41 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Dock to Underlava Puzzle Room 1": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisUnderlavaSpeedBlocks",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -24904,7 +25048,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s020_magma:default:grapplepulloff1x2_000",
+                                            "name": "CatarisUnderlavaSpeedBlocks",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -24944,6 +25088,100 @@
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Below Lava": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisUnderlavaSpeedBlocks",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Underlava Puzzle Speed Blocks Destroyed": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s020_magma:default:grapplepulloff1x2_000",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Event - Underlava Puzzle Speed Blocks Destroyed": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -3650.0,
+                        "y": -6150.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "CatarisUnderlavaSpeedBlocks",
+                    "connections": {
+                        "Dock to Underlava Puzzle Room 1": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -25113,15 +25351,6 @@
                     "pickup_index": 47,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (WEIGHT)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
                         "Tile Group (MISSILE)": {
                             "type": "resource",
                             "data": {
@@ -25130,31 +25359,8 @@
                                 "amount": 1,
                                 "negate": false
                             }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT)": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 4600.0,
-                        "y": 2200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_013",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Tunnel to EMMI Zone Tower East": {
+                        },
+                        "Main Room": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -25270,6 +25476,10 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
                                     }
                                 ]
                             }
@@ -25566,7 +25776,7 @@
                         "area_name": "EMMI Zone Exits West",
                         "node_name": "Door to EMMI Zone West Exit Path"
                     },
-                    "default_dock_weakness": "Phase Shift Door",
+                    "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -147,7 +147,7 @@
                                 ]
                             }
                         },
-                        "Event - Artaria Transport Blob through Wall": {
+                        "Event - Blob through Wall": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -188,7 +188,7 @@
                         }
                     }
                 },
-                "Event - Artaria Transport Blob, adjacent": {
+                "Event - Blob, adjacent": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -388,7 +388,7 @@
                                 "items": []
                             }
                         },
-                        "Event - Artaria Transport Blob, adjacent": {
+                        "Event - Blob, adjacent": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -406,7 +406,7 @@
                         }
                     }
                 },
-                "Event - Artaria Transport Blob through Wall": {
+                "Event - Blob through Wall": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -1444,7 +1444,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - First Device Blob": {
+                        "Event - Blob": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -1459,7 +1459,7 @@
                         }
                     }
                 },
-                "Event - First Device Blob": {
+                "Event - Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -1577,7 +1577,7 @@
                                 "negate": false
                             }
                         },
-                        "Event - First Device Blob": {
+                        "Event - Blob": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -8649,7 +8649,7 @@
                                 "items": []
                             }
                         },
-                        "Event - Green EMMI Blob": {
+                        "Event - Blob": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -8915,7 +8915,7 @@
                         }
                     }
                 },
-                "Event - Green EMMI Blob": {
+                "Event - Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -9277,7 +9277,7 @@
                                 ]
                             }
                         },
-                        "Event - Green EMMI Blob": {
+                        "Event - Blob": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -9418,7 +9418,7 @@
                                 ]
                             }
                         },
-                        "Event - Open Passage Blob": {
+                        "Event - Blob": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -9551,7 +9551,7 @@
                         }
                     }
                 },
-                "Event - Open Passage Blob": {
+                "Event - Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -10011,7 +10011,7 @@
                                 ]
                             }
                         },
-                        "Event - Path to Kraid Blob": {
+                        "Event - Blob": {
                             "type": "template",
                             "data": "Shoot Beam"
                         },
@@ -10077,7 +10077,7 @@
                         }
                     }
                 },
-                "Event - Path to Kraid Blob": {
+                "Event - Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -10346,7 +10346,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Blob above Kraid, from below": {
+                        "Event - Blob above Kraid, below": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -10497,7 +10497,7 @@
                         }
                     }
                 },
-                "Event - Above Kraid Ceiling Blob": {
+                "Event - Ceiling Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -10524,12 +10524,12 @@
                         }
                     }
                 },
-                "Event - Blob above Kraid, from below": {
+                "Event - Blob above Kraid, below": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": -15434.62590912364,
-                        "y": -3771.3365689218112,
+                        "x": -15434.63,
+                        "y": -3771.34,
                         "z": 0.0
                     },
                     "description": "",
@@ -10662,7 +10662,7 @@
                         ]
                     },
                     "connections": {
-                        "Event - Above Kraid Ceiling Blob": {
+                        "Event - Ceiling Blob": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11474,13 +11474,13 @@
                                 ]
                             }
                         },
-                        "Event - Blob above Kraid, from left": {
+                        "Event - Blob above Kraid, above": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         }
                     }
                 },
-                "Event - Blob above Kraid, from left": {
+                "Event - Blob above Kraid, above": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -11795,7 +11795,7 @@
                                 ]
                             }
                         },
-                        "Event - Ghavoran Teleport Lower Blob": {
+                        "Event - Blob": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -11937,7 +11937,7 @@
                         }
                     }
                 },
-                "Event - Ghavoran Teleport Lower Blob": {
+                "Event - Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12231,7 +12231,7 @@
                         }
                     }
                 },
-                "Event - Ghavoran Teleport Lower Blob": {
+                "Event - Lower Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12258,7 +12258,7 @@
                         }
                     }
                 },
-                "Event - Ghavoran Teleport Upper Blob": {
+                "Event - Upper Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12285,7 +12285,7 @@
                         }
                     }
                 },
-                "Event - Ghavoran Teleport Grapple Block": {
+                "Event - Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -12339,7 +12339,7 @@
                     "keep_name_when_vanilla": true,
                     "editable": true,
                     "connections": {
-                        "Event - Ghavoran Teleport Grapple Block": {
+                        "Event - Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12775,7 +12775,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Event - Ghavoran Teleport Lower Blob": {
+                        "Event - Lower Blob": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -13131,7 +13131,7 @@
                                 ]
                             }
                         },
-                        "Event - Ghavoran Teleport Upper Blob": {
+                        "Event - Upper Blob": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -13520,7 +13520,7 @@
                                 "items": []
                             }
                         },
-                        "Event - Ghavoran Teleport Upper Blob": {
+                        "Event - Blob": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -13582,7 +13582,7 @@
                         }
                     }
                 },
-                "Event - Ghavoran Teleport Upper Blob": {
+                "Event - Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -16184,13 +16184,13 @@
                                 ]
                             }
                         },
-                        "Event - Central Unit Bottom Blob through Wall": {
+                        "Event - Bottom Blob through Wall": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         }
                     }
                 },
-                "Event - Central Unit Top Blob": {
+                "Event - Top Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -16217,7 +16217,7 @@
                         }
                     }
                 },
-                "Event - Central Unit Bottom Blob, adjacent": {
+                "Event - Bottom Blob, adjacent": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -16323,7 +16323,7 @@
                                 "items": []
                             }
                         },
-                        "Event - Central Unit Top Blob": {
+                        "Event - Top Blob": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -16428,11 +16428,11 @@
                                 ]
                             }
                         },
-                        "Event - Central Unit Top Blob": {
+                        "Event - Top Blob": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
-                        "Event - Central Unit Bottom Blob, adjacent": {
+                        "Event - Bottom Blob, adjacent": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -16485,7 +16485,7 @@
                         }
                     }
                 },
-                "Event - Central Unit Bottom Blob through Wall": {
+                "Event - Bottom Blob through Wall": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -18907,7 +18907,7 @@
                                 ]
                             }
                         },
-                        "Event - Diffusion Tutorial Blob": {
+                        "Event - Blob": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -19094,7 +19094,7 @@
                         }
                     }
                 },
-                "Event - Diffusion Tutorial Blob": {
+                "Event - Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -19121,7 +19121,7 @@
                         }
                     }
                 },
-                "Event - PB Tank Grapple Block": {
+                "Event - Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -19562,7 +19562,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Diffusion Tutorial Blob": {
+                        "Event - Blob": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -19864,7 +19864,7 @@
                                 ]
                             }
                         },
-                        "Event - PB Tank Grapple Block": {
+                        "Event - Grapple Block": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -22365,7 +22365,7 @@
                     "pickup_index": 39,
                     "major_location": false,
                     "connections": {
-                        "Event - Missile Tank Blob": {
+                        "Event - Lava Blob": {
                             "type": "template",
                             "data": "Lay Bomb"
                         },
@@ -22626,7 +22626,7 @@
                         }
                     }
                 },
-                "Event - Missile Tank Blob": {
+                "Event - Lava Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -22689,7 +22689,7 @@
                         }
                     }
                 },
-                "Event - Diffusion Tutorial Blob 2, below": {
+                "Event - Diffusion Blob, below": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -23226,7 +23226,7 @@
                                 ]
                             }
                         },
-                        "Event - Diffusion Tutorial Blob 2, below": {
+                        "Event - Diffusion Blob, below": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -23523,7 +23523,7 @@
                         }
                     }
                 },
-                "Event - Diffusion Tutorial Blob 2, above": {
+                "Event - Diffusion Blob, above": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -23655,7 +23655,7 @@
                                 ]
                             }
                         },
-                        "Event - Missile Tank Blob": {
+                        "Event - Lava Blob": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -23954,7 +23954,7 @@
                                 "negate": false
                             }
                         },
-                        "Event - Diffusion Tutorial Blob 2, above": {
+                        "Event - Diffusion Blob, above": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -24089,7 +24089,7 @@
                                 "items": []
                             }
                         },
-                        "Event - Green EMMI Access Blob": {
+                        "Event - Blob": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -24199,7 +24199,7 @@
                         }
                     }
                 },
-                "Event - Green EMMI Access Blob": {
+                "Event - Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -24422,7 +24422,7 @@
                         }
                     }
                 },
-                "Event - Lava Grapple Block": {
+                "Event - Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -24782,7 +24782,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Event - Lava Grapple Block": {
+                        "Event - Grapple Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -25125,7 +25125,7 @@
                                 ]
                             }
                         },
-                        "Event - Underlava Puzzle Speed Blocks Destroyed": {
+                        "Event - Speed Blocks Destroyed": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -25162,7 +25162,7 @@
                         }
                     }
                 },
-                "Event - Underlava Puzzle Speed Blocks Destroyed": {
+                "Event - Speed Blocks Destroyed": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -26238,7 +26238,7 @@
                         }
                     }
                 },
-                "Event - Kraid Eyedoor Blob": {
+                "Event - Wall Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -26265,7 +26265,7 @@
                         }
                     }
                 },
-                "Event - Kraid Eyedoor Ceiling Blob": {
+                "Event - Ceiling Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -26604,7 +26604,7 @@
                                 ]
                             }
                         },
-                        "Event - Kraid Eyedoor Blob": {
+                        "Event - Wall Blob": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -26919,7 +26919,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Event - Kraid Eyedoor Ceiling Blob": {
+                        "Event - Ceiling Blob": {
                             "type": "template",
                             "data": "Shoot Beam"
                         },

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -2516,13 +2516,8 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "IBJ",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Simple IBJ"
                                     }
                                 ]
                             }
@@ -7752,82 +7747,40 @@
                             }
                         },
                         "Top Ledge": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "or",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Magnet",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "Varia",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Varia",
-                                                        "amount": 1,
+                                                        "type": "damage",
+                                                        "name": "Heat",
+                                                        "amount": 50,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Heat",
-                                                                    "amount": 50,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
+                                                        "amount": 2,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -13484,41 +13437,8 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Dock to Ghavoran Teleport Access": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Slide"
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Can Slide"
                         },
                         "Dock to Long Mouth Statue Room (Upper)": {
                             "type": "resource",
@@ -16211,30 +16131,8 @@
                             }
                         },
                         "Event - Top Blob": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Wave",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Diffusion",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Shoot Diffusion or Wave"
                         },
                         "Event - Bottom Blob, adjacent": {
                             "type": "template",
@@ -18699,7 +18597,7 @@
                                 ]
                             }
                         },
-                        "Event - Diffusion Tutorial Blob": {
+                        "Event - Blob": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -18886,7 +18784,7 @@
                         }
                     }
                 },
-                "Event - Diffusion Tutorial Blob": {
+                "Event - Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -18913,7 +18811,7 @@
                         }
                     }
                 },
-                "Event - PB Tank Grapple Block": {
+                "Event - Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -19354,7 +19252,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Diffusion Tutorial Blob": {
+                        "Event - Blob": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -19656,7 +19554,7 @@
                                 ]
                             }
                         },
-                        "Event - PB Tank Grapple Block": {
+                        "Event - Grapple Block": {
                             "type": "resource",
                             "data": {
                                 "type": "items",

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -389,20 +389,8 @@
                             }
                         },
                         "Event - Blob, adjacent": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Shoot Beam"
                         }
                     }
                 },
@@ -1087,29 +1075,12 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Start Point": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s020_magma:default:deviceheat",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -1578,20 +1549,8 @@
                             }
                         },
                         "Event - Blob": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Shoot Beam"
                         },
                         "Total Recharge": {
                             "type": "and",
@@ -1601,8 +1560,11 @@
                             }
                         },
                         "Tile Group (POWERBEAM)": {
-                            "type": "template",
-                            "data": "Can Slide"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -1790,21 +1752,9 @@
                                 "items": []
                             }
                         },
-                        "Event - Z-57 Blob": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
-                                    }
-                                ]
-                            }
+                        "Event - Blob": {
+                            "type": "template",
+                            "data": "Shoot Beam"
                         },
                         "Tunnel to Dropdown Pit": {
                             "type": "and",
@@ -1849,17 +1799,15 @@
                     "major_location": false,
                     "connections": {
                         "Pickup Corner": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
                 },
-                "Event - Z-57 Blob": {
+                "Event - Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -2512,7 +2460,7 @@
                 "asset_id": "collision_camera_010"
             },
             "nodes": {
-                "Door to EMMI Zone Tower East (Power)": {
+                "Door to EMMI Zone Tower East (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2542,7 +2490,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (Charge)": {
+                        "Door to EMMI Zone Tower East (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2568,49 +2516,10 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
-                                    },
-                                    {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "GrappleMovement",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Flash",
+                                            "type": "tricks",
+                                            "name": "IBJ",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -2646,7 +2555,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (Charge)": {
+                        "Door to EMMI Zone Tower East (Upper)": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -2657,7 +2566,7 @@
                         }
                     }
                 },
-                "Door to EMMI Zone Tower East (Charge)": {
+                "Door to EMMI Zone Tower East (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2687,7 +2596,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (Power)": {
+                        "Door to EMMI Zone Tower East (Lower)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -2710,23 +2619,6 @@
                                         "data": {
                                             "type": "items",
                                             "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Cross Comb"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Movement",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -2768,7 +2660,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower East (Power)": {
+                        "Door to EMMI Zone Tower East (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7610,12 +7502,12 @@
                         }
                     }
                 },
-                "Event - First Tunnel Blob, in tunnel": {
+                "Event - First Tunnel Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
                         "x": -2300.0,
-                        "y": -2300.0,
+                        "y": -2200.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -7628,7 +7520,7 @@
                     },
                     "event_name": "s020_magma:default:breakablemag004",
                     "connections": {
-                        "Tiny Alcove": {
+                        "Right Platform": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7860,40 +7752,82 @@
                             }
                         },
                         "Top Ledge": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Varia",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "damage",
-                                                        "name": "Heat",
-                                                        "amount": 50,
+                                                        "type": "items",
+                                                        "name": "Magnet",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Suitless",
-                                                        "amount": 2,
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 50,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -8056,20 +7990,8 @@
                     "extra": {},
                     "connections": {
                         "Event - Second Tunnel Blob": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Shoot Beam"
                         },
                         "Tunnel to Z-57 Heat Room West (Right)": {
                             "type": "and",
@@ -8297,20 +8219,8 @@
                             }
                         },
                         "Event - Green EMMI Access Blob": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Shoot Beam"
                         }
                     }
                 },
@@ -8328,30 +8238,42 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Event - First Tunnel Blob, in tunnel": {
-                            "type": "and",
+                        "Event - First Tunnel Blob": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Lay Bomb"
+                                        "data": "Shoot Diffusion or Wave"
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Simple IBJ"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Use Spin Boost"
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
                                                     "type": "template",
-                                                    "data": "Simple IBJ"
+                                                    "data": "Lay Bomb"
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "or",
                                                     "data": {
                                                         "comment": null,
                                                         "items": [
@@ -8359,82 +8281,35 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
-                                                                    "name": "Slide",
+                                                                    "name": "Varia",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Slide",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Shoot Ice Missile"
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "FrozenEnemy",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Varia",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Heat",
-                                                                    "amount": 100,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Heat",
+                                                                                "amount": 100,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -8551,34 +8426,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        },
-                        "Event - First Tunnel Blob, below": {
-                            "type": "template",
-                            "data": "Shoot Diffusion or Wave"
-                        }
-                    }
-                },
-                "Event - First Tunnel Blob, below": {
-                    "node_type": "event",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -2300.0,
-                        "y": -2500.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "event_name": "s020_magma:default:breakablemag004",
-                    "connections": {
-                        "Right Platform": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }
@@ -8787,78 +8634,35 @@
                             }
                         },
                         "Tunnel to EMMI Zone Item Tunnel": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "events",
-                                            "name": "CatarisCU",
+                                            "type": "items",
+                                            "name": "Magnet",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Magnet",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Grapple",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "GrappleMovement",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spin Boost"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
                                     }
                                 ]
                             }
@@ -9001,12 +8805,18 @@
                     },
                     "connections": {
                         "Tile Group (POWERBEAM) 1": {
-                            "type": "template",
-                            "data": "Can Slide"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         },
                         "Tile Group (POWERBEAM) 3": {
-                            "type": "template",
-                            "data": "Can Slide"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -9278,20 +9088,8 @@
                             }
                         },
                         "Event - Blob": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Shoot Beam"
                         }
                     }
                 }
@@ -9419,20 +9217,8 @@
                             }
                         },
                         "Event - Blob": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Shoot Beam"
                         }
                     }
                 },
@@ -9760,15 +9546,6 @@
                                                     }
                                                 }
                                             ]
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
                                         }
                                     }
                                 ]
@@ -11474,13 +11251,13 @@
                                 ]
                             }
                         },
-                        "Event - Blob above Kraid, above": {
+                        "Event - Blob above Kraid, left": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         }
                     }
                 },
-                "Event - Blob above Kraid, above": {
+                "Event - Blob above Kraid, left": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -13707,8 +13484,41 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Dock to Ghavoran Teleport Access": {
-                            "type": "template",
-                            "data": "Can Slide"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Dock to Long Mouth Statue Room (Upper)": {
                             "type": "resource",
@@ -14192,8 +14002,13 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Slide"
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     },
                                     {
                                         "type": "resource",
@@ -14230,6 +14045,62 @@
                         ]
                     },
                     "connections": {
+                        "Tile Group (POWERBOMB)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Tile Group (WEIGHT)": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -6300.0,
+                        "y": 1400.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "actor_name": "breakabletilegroup_017",
+                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
+                        "actor_layer": "breakables",
+                        "tile_types": [
+                            "WEIGHT"
+                        ]
+                    },
+                    "connections": {}
+                },
+                "Tile Group (POWERBOMB)": {
+                    "node_type": "configurable_node",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -6500.0,
+                        "y": 1500.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "actor_name": "breakabletilegroup_076",
+                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
+                        "actor_layer": "breakables",
+                        "tile_types": [
+                            "POWERBOMB"
+                        ]
+                    },
+                    "connections": {
+                        "Pickup (Power Bomb Tank)": {
+                            "type": "template",
+                            "data": "Ballspark"
+                        },
                         "Center of Tunnel": {
                             "type": "resource",
                             "data": {
@@ -14323,45 +14194,6 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Pickup (Power Bomb Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Power Bomb"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "CatarisCU",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLocks",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    }
-                                ]
-                            }
-                        },
                         "Door to EMMI Zone Exit to Map Station": {
                             "type": "and",
                             "data": {
@@ -14386,6 +14218,15 @@
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Tile Group (POWERBOMB)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Tunnel to Green EMMI Introduction": {
@@ -15037,7 +14878,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone Exit East",
-                        "node_name": "Door to EMMI Zone Tower East (Power)"
+                        "node_name": "Door to EMMI Zone Tower East (Lower)"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "override_default_open_requirement": null,
@@ -15076,32 +14917,6 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Simple IBJ"
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Speed",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "misc",
-                                                                    "name": "DoorLocks",
-                                                                    "amount": 1,
-                                                                    "negate": true
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
                                                 }
                                             ]
                                         }
@@ -15441,7 +15256,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone Exit East",
-                        "node_name": "Door to EMMI Zone Tower East (Charge)"
+                        "node_name": "Door to EMMI Zone Tower East (Upper)"
                     },
                     "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
@@ -16163,28 +15978,7 @@
                                 "items": []
                             }
                         },
-                        "Door to Central Unit": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s020_magma:default:breakablemag008",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Can Slide"
-                                    }
-                                ]
-                            }
-                        },
-                        "Event - Bottom Blob through Wall": {
+                        "Event - Bottom Blob through wall": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         }
@@ -16324,20 +16118,8 @@
                             }
                         },
                         "Event - Top Blob": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Shoot Beam"
                         },
                         "Door to Central Unit": {
                             "type": "or",
@@ -16429,24 +16211,34 @@
                             }
                         },
                         "Event - Top Blob": {
-                            "type": "template",
-                            "data": "Shoot Diffusion or Wave"
-                        },
-                        "Event - Bottom Blob, adjacent": {
                             "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Wave",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Diffusion",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
+                        },
+                        "Event - Bottom Blob, adjacent": {
+                            "type": "template",
+                            "data": "Shoot Beam"
                         },
                         "Upper-right Corner": {
                             "type": "or",
@@ -16485,7 +16277,7 @@
                         }
                     }
                 },
-                "Event - Bottom Blob through Wall": {
+                "Event - Bottom Blob through wall": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -18907,7 +18699,7 @@
                                 ]
                             }
                         },
-                        "Event - Blob": {
+                        "Event - Diffusion Tutorial Blob": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
@@ -19094,7 +18886,7 @@
                         }
                     }
                 },
-                "Event - Blob": {
+                "Event - Diffusion Tutorial Blob": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -19121,7 +18913,7 @@
                         }
                     }
                 },
-                "Event - Grapple Block": {
+                "Event - PB Tank Grapple Block": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -19562,7 +19354,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Blob": {
+                        "Event - Diffusion Tutorial Blob": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -19864,7 +19656,7 @@
                                 ]
                             }
                         },
-                        "Event - Grapple Block": {
+                        "Event - PB Tank Grapple Block": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -20533,7 +20325,7 @@
                         "area_name": "Green EMMI Introduction",
                         "node_name": "Door to EMMI Zone East Tower Access (Upper)"
                     },
-                    "default_dock_weakness": "Phase Shift Door",
+                    "default_dock_weakness": "Access Open",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -24884,41 +24676,6 @@
                                     }
                                 ]
                             }
-                        },
-                        "Dock to Underlava Puzzle Room 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "CatarisUnderlavaSpeedBlocks",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
                         }
                     }
                 },
@@ -25048,7 +24805,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "CatarisUnderlavaSpeedBlocks",
+                                            "name": "s020_magma:default:grapplepulloff1x2_000",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -25088,100 +24845,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        },
-                        "Below Lava": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "CatarisUnderlavaSpeedBlocks",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Event - Speed Blocks Destroyed": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s020_magma:default:grapplepulloff1x2_000",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "Event - Speed Blocks Destroyed": {
-                    "node_type": "event",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3650.0,
-                        "y": -6150.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "event_name": "CatarisUnderlavaSpeedBlocks",
-                    "connections": {
-                        "Dock to Underlava Puzzle Room 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }
@@ -25476,10 +25139,6 @@
                                                 }
                                             ]
                                         }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
                                     }
                                 ]
                             }

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -572,7 +572,7 @@ Extra - asset_id: collision_camera_010
   > Door to EMMI Zone Tower East (Upper)
       Trivial
   > Tunnel to EMMI Zone Tower East
-      Spider Magnet or Infinite Bomb Jump (Beginner) or Use Spin Boost
+      Spider Magnet or Simple IBJ or Use Spin Boost
 
 > Dock to Tall Magnet Walls Access; Heals? False
   * Layers: default
@@ -1474,11 +1474,9 @@ Extra - asset_id: collision_camera_019
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
   > Top Ledge
-      All of the following:
-          Grapple Beam or Spider Magnet or Simple IBJ or Use Spin Boost
-          Any of the following:
-              Varia Suit
-              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
+      Any of the following:
+          Varia Suit
+          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
   > Right Platform
       Any of the following:
           Varia Suit
@@ -2435,9 +2433,7 @@ Extra - asset_id: collision_camera_028
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Dock to Ghavoran Teleport Access
-      All of the following:
-          Can Slide
-          Speed Booster or Simple IBJ or Use Spin Boost
+      Can Slide
   > Dock to Long Mouth Statue Room (Upper)
       Morph Ball
   > Tunnel to Central Unit Access
@@ -3015,7 +3011,7 @@ Extra - asset_id: collision_camera_036
           Morph Ball
           After Cataris - Central Unit Bottom Blob and Can Slide
   > Event - Top Blob
-      Diffusion Beam or Wave Beam
+      Shoot Diffusion or Wave
   > Event - Bottom Blob, adjacent
       Shoot Beam
   > Upper-right Corner
@@ -3482,7 +3478,7 @@ Extra - asset_id: collision_camera_044
       Any of the following:
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
-  > Event - Diffusion Tutorial Blob
+  > Event - Blob
       Shoot Diffusion or Wave
   > Tunnel to Teleport to Dairon
       All of the following:
@@ -3510,7 +3506,7 @@ Extra - asset_id: collision_camera_044
   > Alcove
       Morph Ball and After Cataris - PB Tank Grapple Block
 
-> Event - Diffusion Tutorial Blob; Heals? False
+> Event - Blob; Heals? False
   * Layers: default
   * Event Cataris - Diffusion Tutorial Blob
   * Extra - actor_name: db_dif_mg_002
@@ -3518,7 +3514,7 @@ Extra - asset_id: collision_camera_044
   > Door from Teleport to Dairon
       Trivial
 
-> Event - PB Tank Grapple Block; Heals? False
+> Event - Grapple Block; Heals? False
   * Layers: default
   * Event Cataris - PB Tank Grapple Block
   * Extra - actor_name: grapplepulloff1x2
@@ -3640,7 +3636,7 @@ Extra - asset_id: collision_camera_044
 > Tunnel to Kraid Arena (top); Heals? False
   * Layers: default
   * Morph Ball Tunnel to Kraid Arena/Tunnel to Diffusion Beam Room (Top)
-  > Event - Diffusion Tutorial Blob
+  > Event - Blob
       Morph Ball and Shoot Diffusion or Wave
   > Tunnel to Teleport to Dairon
       All of the following:
@@ -3675,7 +3671,7 @@ Extra - asset_id: collision_camera_044
   * Layers: default
   > Pickup (Power Bomb Tank)
       Morph Ball and After Cataris - PB Tank Grapple Block
-  > Event - PB Tank Grapple Block
+  > Event - Grapple Block
       Grapple Beam
   > Tile Group (WEIGHT) 4
       Trivial

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -94,7 +94,7 @@ Extra - asset_id: collision_camera_000
   > Pickup (Missile Tank)
       Trivial
   > Event - Blob, adjacent
-      Lay Bomb or Shoot Beam
+      Shoot Beam
 
 > Event - Blob through Wall; Heals? False
   * Layers: default
@@ -259,7 +259,7 @@ Extra - asset_id: collision_camera_004
   * Layers: default
   * Morph Ball Launcher to Above Z-57 Fight/Dock from Thermal Device Room South
   > Start Point
-      Morph Ball and After Cataris - First Thermal Device
+      Morph Ball
 
 > Front of Thermal Door; Heals? False
   * Layers: default
@@ -389,11 +389,11 @@ Extra - asset_id: collision_camera_007
   > Door to Thermal Device Room South (Top)
       After Cataris - First Device Blob
   > Event - Blob
-      Lay Bomb or Shoot Beam
+      Shoot Beam
   > Total Recharge
       Trivial
   > Tile Group (POWERBEAM)
-      Can Slide
+      Trivial
 
 > Next to Thermal Door; Heals? False
   * Layers: default
@@ -434,8 +434,8 @@ Extra - asset_id: collision_camera_009
   * Extra - right_shield_def: None
   > Door to Z-57 Heat Room East
       Trivial
-  > Event - Z-57 Blob
-      Lay Bomb or Shoot Beam
+  > Event - Blob
+      Shoot Beam
   > Tunnel to Dropdown Pit
       After Cataris - Z-57 Blob and Can Slide
 
@@ -445,9 +445,9 @@ Extra - asset_id: collision_camera_009
   * Extra - actor_name: item_missiletank_008
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Pickup Corner
-      Morph Ball
+      Trivial
 
-> Event - Z-57 Blob; Heals? False
+> Event - Blob; Heals? False
   * Layers: default
   * Event Cataris - Z-57 Blob
   * Extra - actor_name: breakablemag003
@@ -560,7 +560,7 @@ EMMI Zone Exit East
 Extra - total_boundings: {'x1': 4400.0, 'x2': 8500.0, 'y1': -1300.0, 'y2': 1800.0}
 Extra - polygon: [[8500.0, 1800.0], [4400.0, 1800.0], [4400.0, -1300.0], [8500.0, -1300.0]]
 Extra - asset_id: collision_camera_010
-> Door to EMMI Zone Tower East (Power); Heals? False
+> Door to EMMI Zone Tower East (Lower); Heals? False
   * Layers: default
   * Power Beam Door to EMMI Zone Tower East/Door to EMMI Zone Exit East (Power)
   * Extra - actor_name: doorpowerpower_016
@@ -569,22 +569,20 @@ Extra - asset_id: collision_camera_010
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Tower East (Charge)
+  > Door to EMMI Zone Tower East (Upper)
       Trivial
   > Tunnel to EMMI Zone Tower East
-      Any of the following:
-          Flash Shift or Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
-          Grapple Beam and Grapple Movement (Beginner)
+      Spider Magnet or Infinite Bomb Jump (Beginner) or Use Spin Boost
 
 > Dock to Tall Magnet Walls Access; Heals? False
   * Layers: default
   * EMMI Door to Tall Magnet Walls Access/Dock to EMMI Zone Exit East
   * Extra - actor_name: dooremmy
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Door to EMMI Zone Tower East (Charge)
+  > Door to EMMI Zone Tower East (Upper)
       After Cataris - Hallway Thermal Device
 
-> Door to EMMI Zone Tower East (Charge); Heals? False
+> Door to EMMI Zone Tower East (Upper); Heals? False
   * Layers: default
   * Charge Beam Door to EMMI Zone Tower East/Door to EMMI Zone Exit East (Charge)
   * Extra - actor_name: doorclosedcharge_001
@@ -593,15 +591,15 @@ Extra - asset_id: collision_camera_010
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Tower East (Power)
-      Flash Shift or Speed Booster or Movement (Beginner) or Can Slide or Lay Cross Comb or Use Spin Boost
+  > Door to EMMI Zone Tower East (Lower)
+      Flash Shift or Speed Booster or Can Slide
   > Dock to Tall Magnet Walls Access
       After Cataris - Hallway Thermal Device
 
 > Tunnel to EMMI Zone Tower East; Heals? False
   * Layers: default
   * Morph Ball Tunnel to EMMI Zone Tower East/Tunnel to EMMI Zone Exit East
-  > Door to EMMI Zone Tower East (Power)
+  > Door to EMMI Zone Tower East (Lower)
       Trivial
 
 ----------------
@@ -1433,12 +1431,12 @@ Extra - asset_id: collision_camera_019
   > Top Ledge
       After Cataris - Green EMMI Access Blob
 
-> Event - First Tunnel Blob, in tunnel; Heals? False
+> Event - First Tunnel Blob; Heals? False
   * Layers: default
   * Event Cataris - Z-57 First Tunnel Blob
   * Extra - actor_name: breakablemag004
   * Extra - actor_def: actordef:actors/props/breakablemag004/charclasses/breakablemag004.bmsad
-  > Tiny Alcove
+  > Right Platform
       Trivial
 
 > Event - Second Tunnel Blob; Heals? False
@@ -1476,9 +1474,11 @@ Extra - asset_id: collision_camera_019
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
   > Top Ledge
-      Any of the following:
-          Varia Suit
-          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
+      All of the following:
+          Grapple Beam or Spider Magnet or Simple IBJ or Use Spin Boost
+          Any of the following:
+              Varia Suit
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
   > Right Platform
       Any of the following:
           Varia Suit
@@ -1497,7 +1497,7 @@ Extra - asset_id: collision_camera_019
 > Tiny Alcove; Heals? False
   * Layers: default
   > Event - Second Tunnel Blob
-      Lay Bomb or Shoot Beam
+      Shoot Beam
   > Tunnel to Z-57 Heat Room West (Right)
       All of the following:
           Morph Ball and After Cataris - Z-57 Second Tunnel Blob
@@ -1526,20 +1526,19 @@ Extra - asset_id: collision_camera_019
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 10
   > Event - Green EMMI Access Blob
-      Lay Bomb or Shoot Beam
+      Shoot Beam
 
 > Right Platform; Heals? False
   * Layers: default
-  > Event - First Tunnel Blob, in tunnel
-      All of the following:
-          Lay Bomb
-          Any of the following:
+  > Event - First Tunnel Blob
+      Any of the following:
+          Shoot Diffusion or Wave
+          All of the following:
+              Lay Bomb
               Simple IBJ or Use Spin Boost
-              Slide and Slide Jump (Intermediate)
-              Stand on Frozen Enemy (Beginner) and Shoot Ice Missile
-          Any of the following:
-              Varia Suit
-              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
+              Any of the following:
+                  Varia Suit
+                  Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
   > Event - Open Passage Blob
       Shoot Beam
   > Dock to Z-57 Heat Room West (Right)
@@ -1552,14 +1551,6 @@ Extra - asset_id: collision_camera_019
       Any of the following:
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
-  > Event - First Tunnel Blob, below
-      Shoot Diffusion or Wave
-
-> Event - First Tunnel Blob, below; Heals? False
-  * Layers: default
-  * Event Cataris - Z-57 First Tunnel Blob
-  > Right Platform
-      Trivial
 
 ----------------
 Green EMMI Introduction
@@ -1606,11 +1597,7 @@ Extra - asset_id: collision_camera_020
   > Tile Group (POWERBEAM) 1
       Trivial
   > Tunnel to EMMI Zone Item Tunnel
-      All of the following:
-          After Cataris - Central Unit
-          Any of the following:
-              Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
-              Grapple Beam and Grapple Movement (Beginner)
+      Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
   > Tunnel to EMMI Zone East Tower Access (Upper)
       Trivial
   > Center Alcove
@@ -1656,9 +1643,9 @@ Extra - asset_id: collision_camera_020
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
   > Tile Group (POWERBEAM) 1
-      Can Slide
+      Trivial
   > Tile Group (POWERBEAM) 3
-      Can Slide
+      Trivial
 
 > Tile Group (POWERBEAM) 3; Heals? False
   * Layers: default
@@ -1703,7 +1690,7 @@ Extra - asset_id: collision_camera_020
               Flash Shift or Spider Magnet or Lay Cross Comb or Use Spin Boost
               Infinite Bomb Jump (Intermediate) and Lay Bomb
   > Event - Blob
-      Lay Bomb or Shoot Beam
+      Shoot Beam
 
 ----------------
 Z-57 Heat Room West (Right)
@@ -1726,7 +1713,7 @@ Extra - asset_id: collision_camera_021
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
   > Event - Blob
-      Lay Bomb or Shoot Beam
+      Shoot Beam
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -1784,7 +1771,7 @@ Extra - asset_id: collision_camera_022
       Trivial
   > Tunnel to EMMI Zone Tower West
       Any of the following:
-          Space Jump or Speed Booster or Simple IBJ
+          Space Jump or Simple IBJ
           Flash Shift and Walljump (Intermediate) and Use Spin Boost
 
 > Tunnel to EMMI Zone Tower West; Heals? False
@@ -2061,10 +2048,10 @@ Extra - asset_id: collision_camera_024
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
-  > Event - Blob above Kraid, above
+  > Event - Blob above Kraid, left
       Shoot Diffusion or Wave
 
-> Event - Blob above Kraid, above; Heals? False
+> Event - Blob above Kraid, left; Heals? False
   * Layers: default
   * Event Cataris - Blob above Kraid
   > Center Room
@@ -2448,7 +2435,9 @@ Extra - asset_id: collision_camera_028
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Dock to Ghavoran Teleport Access
-      Can Slide
+      All of the following:
+          Can Slide
+          Speed Booster or Simple IBJ or Use Spin Boost
   > Dock to Long Mouth Statue Room (Upper)
       Morph Ball
   > Tunnel to Central Unit Access
@@ -2566,7 +2555,7 @@ Extra - asset_id: collision_camera_029
   > Door to EMMI Zone Exits West
       Can Slide
   > Center of Tunnel
-      After Cataris - Central Unit and Can Slide
+      Morph Ball and After Cataris - Central Unit
 
 > Tile Group (POWERBEAM); Heals? False
   * Layers: default
@@ -2575,6 +2564,25 @@ Extra - asset_id: collision_camera_029
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
+  > Tile Group (POWERBOMB)
+      Trivial
+
+> Tile Group (WEIGHT); Heals? False
+  * Layers: default
+  * Extra - actor_name: breakabletilegroup_017
+  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
+  * Extra - actor_layer: breakables
+  * Extra - tile_types: ('WEIGHT',)
+
+> Tile Group (POWERBOMB); Heals? False
+  * Layers: default
+  * Configurable Node
+  * Extra - actor_name: breakabletilegroup_076
+  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
+  * Extra - actor_layer: breakables
+  * Extra - tile_types: ('POWERBOMB',)
+  > Pickup (Power Bomb Tank)
+      Ballspark
   > Center of Tunnel
       Morph Ball
 
@@ -2592,10 +2600,10 @@ Extra - asset_id: collision_camera_029
 
 > Center of Tunnel; Heals? False
   * Layers: default
-  > Pickup (Power Bomb Tank)
-      Speed Booster and After Cataris - Central Unit and Disabled Door Lock Randomizer and Lay Power Bomb
   > Door to EMMI Zone Exit to Map Station
       Morph Ball and After Cataris - Central Unit
+  > Tile Group (POWERBOMB)
+      Morph Ball
   > Tunnel to Green EMMI Introduction
       Morph Ball
   > Tunnel to EMMI Zone Exits West
@@ -2702,7 +2710,7 @@ Extra - asset_id: collision_camera_032
 
 > Door to EMMI Zone Exit East (Power); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone Exit East/Door to EMMI Zone Tower East (Power)
+  * Power Beam Door to EMMI Zone Exit East/Door to EMMI Zone Tower East (Lower)
   * Extra - actor_name: doorpowerpower_016
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2714,9 +2722,7 @@ Extra - asset_id: collision_camera_032
   > Tunnel to EMMI Zone Exit East
       All of the following:
           Morph Ball
-          Any of the following:
-              Simple IBJ or Use Spin Boost
-              Speed Booster and Disabled Door Lock Randomizer
+          Simple IBJ or Use Spin Boost
 
 > Dock to Moving Magnet Walls (Small); Heals? False
   * Layers: default
@@ -2776,7 +2782,7 @@ Extra - asset_id: collision_camera_032
 
 > Door to EMMI Zone Exit East (Charge); Heals? False
   * Layers: default
-  * Access Locked to EMMI Zone Exit East/Door to EMMI Zone Tower East (Charge)
+  * Access Locked to EMMI Zone Exit East/Door to EMMI Zone Tower East (Upper)
   * Extra - actor_name: doorclosedcharge_001
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2960,9 +2966,7 @@ Extra - asset_id: collision_camera_036
       Trivial
   > Upper-right Corner
       Trivial
-  > Door to Central Unit
-      After Cataris - Central Unit Bottom Blob and Can Slide
-  > Event - Bottom Blob through Wall
+  > Event - Bottom Blob through wall
       Shoot Diffusion or Wave
 
 > Event - Top Blob; Heals? False
@@ -2999,7 +3003,7 @@ Extra - asset_id: collision_camera_036
   > Door from EMMI Zone Tower West
       Trivial
   > Event - Top Blob
-      Lay Bomb or Shoot Beam
+      Shoot Beam
   > Door to Central Unit
       Morph Ball or After Cataris - Central Unit Top Blob
 
@@ -3011,15 +3015,15 @@ Extra - asset_id: collision_camera_036
           Morph Ball
           After Cataris - Central Unit Bottom Blob and Can Slide
   > Event - Top Blob
-      Shoot Diffusion or Wave
+      Diffusion Beam or Wave Beam
   > Event - Bottom Blob, adjacent
-      Lay Bomb or Shoot Beam
+      Shoot Beam
   > Upper-right Corner
       Morph Ball or After Cataris - Central Unit Top Blob
   > Pickup (Morph Ball)
       After Cataris - Central Unit
 
-> Event - Bottom Blob through Wall; Heals? False
+> Event - Bottom Blob through wall; Heals? False
   * Layers: default
   * Event Cataris - Central Unit Bottom Blob
   > Door from EMMI Zone Tower West
@@ -3478,7 +3482,7 @@ Extra - asset_id: collision_camera_044
       Any of the following:
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
-  > Event - Blob
+  > Event - Diffusion Tutorial Blob
       Shoot Diffusion or Wave
   > Tunnel to Teleport to Dairon
       All of the following:
@@ -3506,7 +3510,7 @@ Extra - asset_id: collision_camera_044
   > Alcove
       Morph Ball and After Cataris - PB Tank Grapple Block
 
-> Event - Blob; Heals? False
+> Event - Diffusion Tutorial Blob; Heals? False
   * Layers: default
   * Event Cataris - Diffusion Tutorial Blob
   * Extra - actor_name: db_dif_mg_002
@@ -3514,7 +3518,7 @@ Extra - asset_id: collision_camera_044
   > Door from Teleport to Dairon
       Trivial
 
-> Event - Grapple Block; Heals? False
+> Event - PB Tank Grapple Block; Heals? False
   * Layers: default
   * Event Cataris - PB Tank Grapple Block
   * Extra - actor_name: grapplepulloff1x2
@@ -3636,7 +3640,7 @@ Extra - asset_id: collision_camera_044
 > Tunnel to Kraid Arena (top); Heals? False
   * Layers: default
   * Morph Ball Tunnel to Kraid Arena/Tunnel to Diffusion Beam Room (Top)
-  > Event - Blob
+  > Event - Diffusion Tutorial Blob
       Morph Ball and Shoot Diffusion or Wave
   > Tunnel to Teleport to Dairon
       All of the following:
@@ -3671,7 +3675,7 @@ Extra - asset_id: collision_camera_044
   * Layers: default
   > Pickup (Power Bomb Tank)
       Morph Ball and After Cataris - PB Tank Grapple Block
-  > Event - Grapple Block
+  > Event - PB Tank Grapple Block
       Grapple Beam
   > Tile Group (WEIGHT) 4
       Trivial
@@ -3841,7 +3845,7 @@ Extra - asset_id: collision_camera_046
 
 > Door to Green EMMI Introduction (Upper); Heals? False
   * Layers: default
-  * Phase Shift Door to Green EMMI Introduction/Door to EMMI Zone East Tower Access (Upper)
+  * Access Open to Green EMMI Introduction/Door to EMMI Zone East Tower Access (Upper)
   * Extra - actor_name: doorshutter_001
   * Extra - actor_def: actordef:actors/props/doorshutter/charclasses/doorshutter.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -4529,8 +4533,6 @@ Extra - asset_id: collision_camera_053
       Any of the following:
           Gravity Suit
           Heat/Cold Runs (Intermediate) and Lava Damage ≥ 500
-  > Dock to Underlava Puzzle Room 1
-      Gravity Suit and Morph Ball and After Cataris - Underlava Puzzle Speed Blocks Destroyed
 
 > Tunnel to Dropdown Pit; Heals? False
   * Layers: default
@@ -4553,18 +4555,8 @@ Extra - asset_id: collision_camera_053
   * Open Passage to Underlava Puzzle Room 1/Dock to Underlava Puzzle Room 2
   > Pickup (Energy Part)
       All of the following:
-          Gravity Suit and After Cataris - Underlava Puzzle Speed Blocks Destroyed and Ballspark
+          Gravity Suit and After Cataris - Lava Grapple Block and Ballspark
           Flash Shift or Speedbooster Conservation (Beginner) or Simple IBJ or Use Spin Boost
-  > Below Lava
-      Gravity Suit and Morph Ball and After Cataris - Underlava Puzzle Speed Blocks Destroyed
-  > Event - Speed Blocks Destroyed
-      Gravity Suit and Speed Booster and After Cataris - Lava Grapple Block
-
-> Event - Speed Blocks Destroyed; Heals? False
-  * Layers: default
-  * Event Cataris - Underlava Puzzle Speed Blocks Destroyed
-  > Dock to Underlava Puzzle Room 1
-      Trivial
 
 ----------------
 Underlava Puzzle Room 1
@@ -4614,7 +4606,7 @@ Extra - asset_id: collision_camera_055
   * Layers: default
   > Tile Group (MISSILE)
       Any of the following:
-          Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
+          Spider Magnet or Speed Booster or Use Spin Boost
           Grapple Beam and Grapple Movement (Beginner)
   > Tunnel to EMMI Zone Tower East
       Morph Ball

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -26,8 +26,8 @@ Extra - asset_id: collision_camera_000
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Tunnel to Total Recharge Station South
-      Morph Ball and After Cataris - breakablemag002
-  > Event - Missile Tank Blob through wall (breakablemag002)
+      Morph Ball and After Cataris - Artaria Transport Blob
+  > Event - Artaria Transport Blob through Wall
       Shoot Diffusion or Wave
   > Mid-Level
       Trivial
@@ -40,9 +40,9 @@ Extra - asset_id: collision_camera_000
   > Tunnel to Total Recharge Station South
       Trivial
 
-> Event - Missile Tank Blob (breakablemag002); Heals? False
+> Event - Artaria Transport Blob, adjacent; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag002
+  * Event Cataris - Artaria Transport Blob
   * Extra - actor_name: breakablemag002
   * Extra - actor_def: actordef:actors/props/breakablemag002/charclasses/breakablemag002.bmsad
   > Tunnel to Total Recharge Station South
@@ -90,15 +90,15 @@ Extra - asset_id: collision_camera_000
   * Layers: default
   * Morph Ball Tunnel to Total Recharge Station South/Tunnel to Transport to Artaria
   > Door to Navigation Station Southeast
-      Morph Ball and After Cataris - breakablemag002
+      Morph Ball and After Cataris - Artaria Transport Blob
   > Pickup (Missile Tank)
       Trivial
-  > Event - Missile Tank Blob (breakablemag002)
-      Shoot Beam
+  > Event - Artaria Transport Blob, adjacent
+      Lay Bomb or Shoot Beam
 
-> Event - Missile Tank Blob through wall (breakablemag002); Heals? False
+> Event - Artaria Transport Blob through Wall; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag002
+  * Event Cataris - Artaria Transport Blob
   > Door to Navigation Station Southeast
       Trivial
 
@@ -259,7 +259,7 @@ Extra - asset_id: collision_camera_004
   * Layers: default
   * Morph Ball Launcher to Above Z-57 Fight/Dock from Thermal Device Room South
   > Start Point
-      Morph Ball
+      Morph Ball and After Cataris - First Thermal Device
 
 > Front of Thermal Door; Heals? False
   * Layers: default
@@ -349,14 +349,14 @@ Extra - asset_id: collision_camera_007
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Event - Breakable (breakablemag001)
-      Wave Beam
+  > Event - First Device Blob
+      Shoot Diffusion or Wave
   > Tunnel to Transport to Artaria
-      After Cataris - breakablemag001
+      After Cataris - First Device Blob
 
-> Event - Breakable (breakablemag001); Heals? False
+> Event - First Device Blob; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag001
+  * Event Cataris - First Device Blob
   * Extra - actor_name: breakablemag001
   * Extra - actor_def: actordef:actors/props/breakablemag001/charclasses/breakablemag001.bmsad
   > Tunnel to Transport to Artaria
@@ -387,13 +387,13 @@ Extra - asset_id: collision_camera_007
   * Layers: default
   * Morph Ball Tunnel to Transport to Artaria/Tunnel to Total Recharge Station South
   > Door to Thermal Device Room South (Top)
-      After Cataris - breakablemag001
-  > Event - Breakable (breakablemag001)
-      Shoot Beam
+      After Cataris - First Device Blob
+  > Event - First Device Blob
+      Lay Bomb or Shoot Beam
   > Total Recharge
       Trivial
   > Tile Group (POWERBEAM)
-      Trivial
+      Can Slide
 
 > Next to Thermal Door; Heals? False
   * Layers: default
@@ -434,10 +434,10 @@ Extra - asset_id: collision_camera_009
   * Extra - right_shield_def: None
   > Door to Z-57 Heat Room East
       Trivial
-  > Event - Blob (breakablemag003)
-      Shoot Beam
+  > Event - Z-57 Blob
+      Lay Bomb or Shoot Beam
   > Tunnel to Dropdown Pit
-      After Cataris - breakablemag003 and Can Slide
+      After Cataris - Z-57 Blob and Can Slide
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -445,11 +445,11 @@ Extra - asset_id: collision_camera_009
   * Extra - actor_name: item_missiletank_008
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Pickup Corner
-      Trivial
+      Morph Ball
 
-> Event - Blob (breakablemag003); Heals? False
+> Event - Z-57 Blob; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag003
+  * Event Cataris - Z-57 Blob
   * Extra - actor_name: breakablemag003
   * Extra - actor_def: actordef:actors/props/breakablemag003/charclasses/breakablemag003.bmsad
   > Door to Z-57 Heat Room West (Right)
@@ -497,13 +497,13 @@ Extra - asset_id: collision_camera_009
   > Tile Group (SCREWATTACK) 2
       Trivial
   > Between Thermal Gates
-      Trivial
+      After Cataris - First Thermal Device
 
 > Tunnel to Dropdown Pit; Heals? False
   * Layers: default
   * Slide Tunnel to Dropdown Pit/Tunnel to Above Z-57 Fight
   > Door to Z-57 Heat Room West (Right)
-      Morph Ball and After Cataris - breakablemag003
+      Morph Ball and After Cataris - Z-57 Blob
 
 > Dock to Thermal Device Room South; Heals? False
   * Layers: default
@@ -542,7 +542,7 @@ Extra - asset_id: collision_camera_009
   > Tile Group (SCREWATTACK) 1
       Trivial
   > Center Hall
-      Trivial
+      After Cataris - First Thermal Device
   > Z-57 Room
       After Cataris - First Thermal Device
 
@@ -560,7 +560,7 @@ EMMI Zone Exit East
 Extra - total_boundings: {'x1': 4400.0, 'x2': 8500.0, 'y1': -1300.0, 'y2': 1800.0}
 Extra - polygon: [[8500.0, 1800.0], [4400.0, 1800.0], [4400.0, -1300.0], [8500.0, -1300.0]]
 Extra - asset_id: collision_camera_010
-> Door to EMMI Zone Tower East (doorpowerpower_016); Heals? False
+> Door to EMMI Zone Tower East (Power); Heals? False
   * Layers: default
   * Power Beam Door to EMMI Zone Tower East/Door to EMMI Zone Exit East (Power)
   * Extra - actor_name: doorpowerpower_016
@@ -569,20 +569,22 @@ Extra - asset_id: collision_camera_010
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Tower East (doorclosedcharge_001)
+  > Door to EMMI Zone Tower East (Charge)
       Trivial
   > Tunnel to EMMI Zone Tower East
-      Spider Magnet or Infinite Bomb Jump (Beginner) or Use Spin Boost
+      Any of the following:
+          Flash Shift or Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
+          Grapple Beam and Grapple Movement (Beginner)
 
 > Dock to Tall Magnet Walls Access; Heals? False
   * Layers: default
   * EMMI Door to Tall Magnet Walls Access/Dock to EMMI Zone Exit East
   * Extra - actor_name: dooremmy
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Door to EMMI Zone Tower East (doorclosedcharge_001)
+  > Door to EMMI Zone Tower East (Charge)
       After Cataris - Hallway Thermal Device
 
-> Door to EMMI Zone Tower East (doorclosedcharge_001); Heals? False
+> Door to EMMI Zone Tower East (Charge); Heals? False
   * Layers: default
   * Charge Beam Door to EMMI Zone Tower East/Door to EMMI Zone Exit East (Charge)
   * Extra - actor_name: doorclosedcharge_001
@@ -591,15 +593,15 @@ Extra - asset_id: collision_camera_010
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone Tower East (doorpowerpower_016)
-      Flash Shift or Speed Booster or Can Slide
+  > Door to EMMI Zone Tower East (Power)
+      Flash Shift or Speed Booster or Movement (Beginner) or Can Slide or Lay Cross Comb or Use Spin Boost
   > Dock to Tall Magnet Walls Access
       After Cataris - Hallway Thermal Device
 
 > Tunnel to EMMI Zone Tower East; Heals? False
   * Layers: default
   * Morph Ball Tunnel to EMMI Zone Tower East/Tunnel to EMMI Zone Exit East
-  > Door to EMMI Zone Tower East (doorpowerpower_016)
+  > Door to EMMI Zone Tower East (Power)
       Trivial
 
 ----------------
@@ -1431,25 +1433,25 @@ Extra - asset_id: collision_camera_019
   > Top Ledge
       After Cataris - Green EMMI Access Blob
 
-> Event - First Tunnel Blob (breakablemag004); Heals? False
+> Event - First Tunnel Blob, in tunnel; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag004
+  * Event Cataris - Z-57 First Tunnel Blob
   * Extra - actor_name: breakablemag004
   * Extra - actor_def: actordef:actors/props/breakablemag004/charclasses/breakablemag004.bmsad
-  > Right Platform
+  > Tiny Alcove
       Trivial
 
-> Event - Second Tunnel Blob (breakablemag014); Heals? False
+> Event - Second Tunnel Blob; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag014
+  * Event Cataris - Z-57 Second Tunnel Blob
   * Extra - actor_name: breakablemag014
   * Extra - actor_def: actordef:actors/props/breakablemag014/charclasses/breakablemag014.bmsad
   > Tiny Alcove
       Trivial
 
-> Event - Open Passage Blob (breakablemag013); Heals? False
+> Event - Open Passage Blob; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag013
+  * Event Cataris - Z-57 Open Passage Blob
   * Extra - actor_name: breakablemag013
   * Extra - actor_def: actordef:actors/props/breakablemag013/charclasses/breakablemag013.bmsad
   > Right Platform
@@ -1460,7 +1462,7 @@ Extra - asset_id: collision_camera_019
   * Open Passage to Z-57 Heat Room West (Right)/Dock to Z-57 Heat Room West (Left)
   > Right Platform
       All of the following:
-          After Cataris - breakablemag013
+          After Cataris - Z-57 Open Passage Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
@@ -1469,16 +1471,14 @@ Extra - asset_id: collision_camera_019
   * Layers: default
   > Tiny Alcove
       All of the following:
-          Morph Ball and After Cataris - breakablemag004
+          Morph Ball and After Cataris - Z-57 First Tunnel Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
   > Top Ledge
-      All of the following:
-          Grapple Beam or Spider Magnet or Simple IBJ or Use Spin Boost
-          Any of the following:
-              Varia Suit
-              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
+      Any of the following:
+          Varia Suit
+          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
   > Right Platform
       Any of the following:
           Varia Suit
@@ -1489,29 +1489,29 @@ Extra - asset_id: collision_camera_019
   * Morph Ball Tunnel to Z-57 Heat Room West (Right)/Tunnel to Z-57 Heat Room West (Left)
   > Tiny Alcove
       All of the following:
-          Morph Ball and After Cataris - breakablemag014
+          Morph Ball and After Cataris - Z-57 Second Tunnel Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 10
 
 > Tiny Alcove; Heals? False
   * Layers: default
-  > Event - Second Tunnel Blob (breakablemag014)
-      Shoot Beam
+  > Event - Second Tunnel Blob
+      Lay Bomb or Shoot Beam
   > Tunnel to Z-57 Heat Room West (Right)
       All of the following:
-          Morph Ball and After Cataris - breakablemag014
+          Morph Ball and After Cataris - Z-57 Second Tunnel Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 10
   > Right Platform
       All of the following:
-          After Cataris - breakablemag004 and Can Slide
+          After Cataris - Z-57 First Tunnel Blob and Can Slide
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
 
-> Event - Door Blob (db_hdoor_mg_002); Heals? False
+> Event - Green EMMI Access Blob; Heals? False
   * Layers: default
   * Event Cataris - Green EMMI Access Blob
   > Top Ledge
@@ -1525,25 +1525,26 @@ Extra - asset_id: collision_camera_019
       Any of the following:
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 10
-  > Event - Door Blob (db_hdoor_mg_002)
-      Shoot Beam
+  > Event - Green EMMI Access Blob
+      Lay Bomb or Shoot Beam
 
 > Right Platform; Heals? False
   * Layers: default
-  > Event - First Tunnel Blob (breakablemag004)
-      Any of the following:
-          Shoot Diffusion or Wave
-          All of the following:
-              Lay Bomb
+  > Event - First Tunnel Blob, in tunnel
+      All of the following:
+          Lay Bomb
+          Any of the following:
               Simple IBJ or Use Spin Boost
-              Any of the following:
-                  Varia Suit
-                  Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
-  > Event - Open Passage Blob (breakablemag013)
+              Slide and Slide Jump (Intermediate)
+              Stand on Frozen Enemy (Beginner) and Shoot Ice Missile
+          Any of the following:
+              Varia Suit
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
+  > Event - Open Passage Blob
       Shoot Beam
   > Dock to Z-57 Heat Room West (Right)
       All of the following:
-          After Cataris - breakablemag013
+          After Cataris - Z-57 Open Passage Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
@@ -1551,6 +1552,14 @@ Extra - asset_id: collision_camera_019
       Any of the following:
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
+  > Event - First Tunnel Blob, below
+      Shoot Diffusion or Wave
+
+> Event - First Tunnel Blob, below; Heals? False
+  * Layers: default
+  * Event Cataris - Z-57 First Tunnel Blob
+  > Right Platform
+      Trivial
 
 ----------------
 Green EMMI Introduction
@@ -1562,20 +1571,20 @@ Extra - asset_id: collision_camera_020
   * EMMI Door to Green EMMI Introduction Access/Dock to Green EMMI Introduction
   * Extra - actor_name: dooremmy_003
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
-  > Door to EMMI Zone East Tower Access (doorchargecharge_005)
+  > Door to EMMI Zone East Tower Access (Lower)
       Trivial
-  > Event - Lower-left Blob (breakablemag005)
+  > Event - Green EMMI Blob
       Wave Beam
   > Tunnel to EMMI Zone East Tower Access (Bottom)
       Trivial
   > Center Alcove
       Any of the following:
-          After Cataris - breakablemag005
+          After Cataris - Green EMMI Blob
           Morph Ball and After Cataris - Central Unit
 
-> Door to EMMI Zone East Tower Access (doorchargecharge_005); Heals? False
+> Door to EMMI Zone East Tower Access (Lower); Heals? False
   * Layers: default
-  * Charge Beam Door to EMMI Zone East Tower Access/Door to Green EMMI Introduction (doorchargecharge_005)
+  * Charge Beam Door to EMMI Zone East Tower Access/Door to Green EMMI Introduction (Lower)
   * Extra - actor_name: doorchargecharge_005
   * Extra - actor_def: actordef:actors/props/doorchargecharge/charclasses/doorchargecharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1599,15 +1608,17 @@ Extra - asset_id: collision_camera_020
   > Tunnel to EMMI Zone Item Tunnel
       All of the following:
           After Cataris - Central Unit
-          Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
+          Any of the following:
+              Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
+              Grapple Beam and Grapple Movement (Beginner)
   > Tunnel to EMMI Zone East Tower Access (Upper)
       Trivial
   > Center Alcove
       Can Slide
 
-> Door to EMMI Zone East Tower Access (doorshutter_001); Heals? False
+> Door to EMMI Zone East Tower Access (Upper); Heals? False
   * Layers: default
-  * Phase Shift Door to EMMI Zone East Tower Access/Door to Green EMMI Introduction (doorshutter_001)
+  * Phase Shift Door to EMMI Zone East Tower Access/Door to Green EMMI Introduction (Upper)
   * Extra - actor_name: doorshutter_001
   * Extra - actor_def: actordef:actors/props/doorshutter/charclasses/doorshutter.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1617,9 +1628,9 @@ Extra - asset_id: collision_camera_020
   > Tile Group (POWERBEAM) 3
       Trivial
 
-> Event - Lower-left Blob (breakablemag005); Heals? False
+> Event - Green EMMI Blob; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag005
+  * Event Cataris - Green EMMI Blob
   * Extra - actor_name: breakablemag005
   * Extra - actor_def: actordef:actors/props/breakablemag005/charclasses/breakablemag005.bmsad
   > Center Alcove
@@ -1645,9 +1656,9 @@ Extra - asset_id: collision_camera_020
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
   > Tile Group (POWERBEAM) 1
-      Trivial
+      Can Slide
   > Tile Group (POWERBEAM) 3
-      Trivial
+      Can Slide
 
 > Tile Group (POWERBEAM) 3; Heals? False
   * Layers: default
@@ -1656,7 +1667,7 @@ Extra - asset_id: collision_camera_020
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
-  > Door to EMMI Zone East Tower Access (doorshutter_001)
+  > Door to EMMI Zone East Tower Access (Upper)
       Trivial
   > Tile Group (POWERBEAM) 2
       Trivial
@@ -1683,7 +1694,7 @@ Extra - asset_id: collision_camera_020
   * Layers: default
   > Dock to Green EMMI Introduction Access
       Any of the following:
-          After Cataris - breakablemag005
+          After Cataris - Green EMMI Blob
           Morph Ball and After Cataris - Central Unit
   > Door to EMMI Zone West Exit Path
       All of the following:
@@ -1691,8 +1702,8 @@ Extra - asset_id: collision_camera_020
           Any of the following:
               Flash Shift or Spider Magnet or Lay Cross Comb or Use Spin Boost
               Infinite Bomb Jump (Intermediate) and Lay Bomb
-  > Event - Lower-left Blob (breakablemag005)
-      Shoot Beam
+  > Event - Green EMMI Blob
+      Lay Bomb or Shoot Beam
 
 ----------------
 Z-57 Heat Room West (Right)
@@ -1710,12 +1721,12 @@ Extra - asset_id: collision_camera_021
   * Extra - right_shield_def: None
   > Dock to Z-57 Heat Room West (Left)
       All of the following:
-          After Cataris - breakablemag013
+          After Cataris - Z-57 Open Passage Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
-  > Event - Open Passage Blob (breakablemag013)
-      Shoot Beam
+  > Event - Open Passage Blob
+      Lay Bomb or Shoot Beam
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -1730,14 +1741,14 @@ Extra - asset_id: collision_camera_021
   * Open Passage to Z-57 Heat Room West (Left)/Dock to Z-57 Heat Room West (Right)
   > Door to Above Z-57 Fight
       All of the following:
-          After Cataris - breakablemag013
+          After Cataris - Z-57 Open Passage Blob
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
-> Event - Open Passage Blob (breakablemag013); Heals? False
+> Event - Open Passage Blob; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag013
+  * Event Cataris - Z-57 Open Passage Blob
   > Door to Above Z-57 Fight
       Trivial
 
@@ -1773,7 +1784,7 @@ Extra - asset_id: collision_camera_022
       Trivial
   > Tunnel to EMMI Zone Tower West
       Any of the following:
-          Space Jump or Simple IBJ
+          Space Jump or Speed Booster or Simple IBJ
           Flash Shift and Walljump (Intermediate) and Use Spin Boost
 
 > Tunnel to EMMI Zone Tower West; Heals? False
@@ -1789,7 +1800,7 @@ Extra - polygon: [[-10400.0, 3100.0], [-12500.0, 3100.0], [-12500.0, 1100.0], [-
 Extra - asset_id: collision_camera_023
 > Dock to EMMI Zone Exits West (Upper); Heals? False
   * Layers: default
-  * EMMI Door to EMMI Zone Exits West/Dock to Long Mouth Statue Room (dooremmy_008)
+  * EMMI Door to EMMI Zone Exits West/Dock to Long Mouth Statue Room (Upper)
   * Extra - actor_name: dooremmy_008
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Dock to EMMI Zone Exits West (Lower)
@@ -1797,7 +1808,7 @@ Extra - asset_id: collision_camera_023
 
 > Dock to EMMI Zone Exits West (Lower); Heals? False
   * Layers: default
-  * EMMI Door to EMMI Zone Exits West/Dock to Long Mouth Statue Room (dooremmy_009)
+  * EMMI Door to EMMI Zone Exits West/Dock to Long Mouth Statue Room (Lower)
   * Extra - actor_name: dooremmy_009
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to Path to Kraid Entryway
@@ -2437,10 +2448,8 @@ Extra - asset_id: collision_camera_028
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Dock to Ghavoran Teleport Access
-      All of the following:
-          Can Slide
-          Speed Booster or Simple IBJ or Use Spin Boost
-  > Dock to Long Mouth Statue Room (dooremmy_008)
+      Can Slide
+  > Dock to Long Mouth Statue Room (Upper)
       Morph Ball
   > Tunnel to Central Unit Access
       Trivial
@@ -2453,7 +2462,7 @@ Extra - asset_id: collision_camera_028
   > Door to EMMI Zone Item Tunnel
       Can Slide
 
-> Dock to Long Mouth Statue Room (dooremmy_008); Heals? False
+> Dock to Long Mouth Statue Room (Upper); Heals? False
   * Layers: default
   * EMMI Door to Long Mouth Statue Room/Dock to EMMI Zone Exits West (Upper)
   * Extra - actor_name: dooremmy_008
@@ -2463,7 +2472,7 @@ Extra - asset_id: collision_camera_028
   > Pickup (Missile Tank)
       Trivial
 
-> Dock to Long Mouth Statue Room (dooremmy_009); Heals? False
+> Dock to Long Mouth Statue Room (Lower); Heals? False
   * Layers: default
   * EMMI Door to Long Mouth Statue Room/Dock to EMMI Zone Exits West (Lower)
   * Extra - actor_name: dooremmy_009
@@ -2488,7 +2497,7 @@ Extra - asset_id: collision_camera_028
   * Pickup 40; Major Location? False
   * Extra - actor_name: item_missiletank_004
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Dock to Long Mouth Statue Room (dooremmy_008)
+  > Dock to Long Mouth Statue Room (Upper)
       Trivial
 
 > Tunnel to EMMI Zone West Exit Path; Heals? False
@@ -2511,7 +2520,7 @@ Extra - asset_id: collision_camera_028
 
 > Upper Ledge; Heals? False
   * Layers: default
-  > Dock to Long Mouth Statue Room (dooremmy_009)
+  > Dock to Long Mouth Statue Room (Lower)
       Trivial
   > Door to EMMI Zone West Exit Path
       Trivial
@@ -2557,7 +2566,7 @@ Extra - asset_id: collision_camera_029
   > Door to EMMI Zone Exits West
       Can Slide
   > Center of Tunnel
-      Morph Ball and After Cataris - Central Unit
+      After Cataris - Central Unit and Can Slide
 
 > Tile Group (POWERBEAM); Heals? False
   * Layers: default
@@ -2566,25 +2575,6 @@ Extra - asset_id: collision_camera_029
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
-  > Tile Group (POWERBOMB)
-      Trivial
-
-> Tile Group (WEIGHT); Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_017
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-
-> Tile Group (POWERBOMB); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_076
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBOMB',)
-  > Pickup (Power Bomb Tank)
-      Ballspark
   > Center of Tunnel
       Morph Ball
 
@@ -2602,10 +2592,10 @@ Extra - asset_id: collision_camera_029
 
 > Center of Tunnel; Heals? False
   * Layers: default
+  > Pickup (Power Bomb Tank)
+      Speed Booster and After Cataris - Central Unit and Disabled Door Lock Randomizer and Lay Power Bomb
   > Door to EMMI Zone Exit to Map Station
       Morph Ball and After Cataris - Central Unit
-  > Tile Group (POWERBOMB)
-      Morph Ball
   > Tunnel to Green EMMI Introduction
       Morph Ball
   > Tunnel to EMMI Zone Exits West
@@ -2663,12 +2653,13 @@ Extra - asset_id: collision_camera_031
   * Extra - right_shield_def: None
   > Dock to EMMI Zone Tower East
       Any of the following:
-          Grapple Beam or Space Jump or Speed Booster or Simple IBJ
+          Space Jump or Speed Booster or Simple IBJ
+          All of the following:
+              Grapple Beam
+              Spider Magnet or Grapple Movement (Beginner)
           Spider Magnet and After Cataris - Lower Lava Button
   > Dock to EMMI Zone Tower West
-      Any of the following:
-          Flash Shift or Grapple Beam or Spider Magnet or Use Spin Boost
-          Speed Booster and Knowledge (Beginner)
+      Flash Shift or Grapple Beam or Spider Magnet or Speed Booster or Use Spin Boost
 
 > Dock to EMMI Zone Tower East; Heals? False
   * Layers: default
@@ -2677,9 +2668,12 @@ Extra - asset_id: collision_camera_031
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to Map Station
       Any of the following:
-          Grapple Beam or Space Jump or Simple IBJ
-          Spider Magnet and After Cataris - Lower Lava Button
+          Space Jump or Simple IBJ
+          All of the following:
+              Grapple Beam
+              Spider Magnet or Grapple Movement (Beginner)
           Speed Booster and Disabled Door Lock Randomizer
+          Spider Magnet and After Cataris - Lower Lava Button
 
 > Dock to EMMI Zone Tower West; Heals? False
   * Layers: default
@@ -2694,7 +2688,7 @@ EMMI Zone Tower East
 Extra - total_boundings: {'x1': 2400.0, 'x2': 4500.0, 'y1': -1300.0, 'y2': 4150.0}
 Extra - polygon: [[4500.0, 4150.0], [2400.0, 4150.0], [2400.0, -1300.0], [4500.0, -1300.0]]
 Extra - asset_id: collision_camera_032
-> Door to EMMI Zone East Tower Access (doorpowerpower_015); Heals? False
+> Door to EMMI Zone East Tower Access (Middle); Heals? False
   * Layers: default
   * Power Beam Door to EMMI Zone East Tower Access/Door to EMMI Zone Tower East (Middle)
   * Extra - actor_name: doorpowerpower_015
@@ -2708,19 +2702,21 @@ Extra - asset_id: collision_camera_032
 
 > Door to EMMI Zone Exit East (Power); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone Exit East/Door to EMMI Zone Tower East (doorpowerpower_016)
+  * Power Beam Door to EMMI Zone Exit East/Door to EMMI Zone Tower East (Power)
   * Extra - actor_name: doorpowerpower_016
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to EMMI Zone East Tower Access (doorclosedcharge)
+  > Door to EMMI Zone East Tower Access (Bottom)
       Trivial
   > Tunnel to EMMI Zone Exit East
       All of the following:
           Morph Ball
-          Simple IBJ or Use Spin Boost
+          Any of the following:
+              Simple IBJ or Use Spin Boost
+              Speed Booster and Disabled Door Lock Randomizer
 
 > Dock to Moving Magnet Walls (Small); Heals? False
   * Layers: default
@@ -2739,7 +2735,7 @@ Extra - asset_id: collision_camera_032
                       Any of the following:
                           Space Jump
                           Speed Booster and Disabled Door Lock Randomizer
-  > Door to EMMI Zone East Tower Access (doorpowerpower_000)
+  > Door to EMMI Zone East Tower Access (Top)
       Trivial
 
 > Dock to Hall Thermal Device Room; Heals? False
@@ -2754,7 +2750,7 @@ Extra - asset_id: collision_camera_032
   > Tunnel to EMMI Zone Hidden Missile Room
       Trivial
 
-> Door to EMMI Zone East Tower Access (doorpowerpower_000); Heals? False
+> Door to EMMI Zone East Tower Access (Top); Heals? False
   * Layers: default
   * Power Beam Door to EMMI Zone East Tower Access/Door to EMMI Zone Tower East (Top)
   * Extra - actor_name: doorpowerpower_000
@@ -2766,7 +2762,7 @@ Extra - asset_id: collision_camera_032
   > Dock to Moving Magnet Walls (Small)
       Trivial
 
-> Door to EMMI Zone East Tower Access (doorclosedcharge); Heals? False
+> Door to EMMI Zone East Tower Access (Bottom); Heals? False
   * Layers: default
   * Charge Beam Door to EMMI Zone East Tower Access/Door to EMMI Zone Tower East (Bottom)
   * Extra - actor_name: doorclosedcharge
@@ -2780,7 +2776,7 @@ Extra - asset_id: collision_camera_032
 
 > Door to EMMI Zone Exit East (Charge); Heals? False
   * Layers: default
-  * Access Locked to EMMI Zone Exit East/Door to EMMI Zone Tower East (doorclosedcharge_001)
+  * Access Locked to EMMI Zone Exit East/Door to EMMI Zone Tower East (Charge)
   * Extra - actor_name: doorclosedcharge_001
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2789,7 +2785,7 @@ Extra - asset_id: collision_camera_032
   * Extra - right_shield_def: None
   > Tunnel to EMMI Zone Hidden Missile Room
       Trivial
-  > Tunnel to EMMI Zone East Tower Access (2)
+  > Tunnel to EMMI Zone East Tower Access (Upper)
       Trivial
 
 > Tunnel to EMMI Zone Hidden Missile Room; Heals? False
@@ -2803,22 +2799,22 @@ Extra - asset_id: collision_camera_032
 > Tunnel to EMMI Zone Exit East; Heals? False
   * Layers: default
   * Morph Ball Tunnel to EMMI Zone Exit East/Tunnel to EMMI Zone Tower East
-  > Door to EMMI Zone East Tower Access (doorpowerpower_015)
+  > Door to EMMI Zone East Tower Access (Middle)
       Trivial
   > Door to EMMI Zone Exit East (Power)
       Can Slide
-  > Tunnel to EMMI Zone East Tower Access (1)
+  > Tunnel to EMMI Zone East Tower Access (Lower)
       Trivial
 
-> Tunnel to EMMI Zone East Tower Access (1); Heals? False
+> Tunnel to EMMI Zone East Tower Access (Lower); Heals? False
   * Layers: default
-  * Morph Ball Tunnel to EMMI Zone East Tower Access/Tunnel to EMMI Zone Tower East (1)
+  * Morph Ball Tunnel to EMMI Zone East Tower Access/Tunnel to EMMI Zone Tower East (Lower)
   > Tunnel to EMMI Zone Exit East
       Trivial
 
-> Tunnel to EMMI Zone East Tower Access (2); Heals? False
+> Tunnel to EMMI Zone East Tower Access (Upper); Heals? False
   * Layers: default
-  * Cataris EMMI Tunnel to EMMI Zone East Tower Access/Tunnel to EMMI Zone Tower East (2)
+  * Cataris EMMI Tunnel to EMMI Zone East Tower Access/Tunnel to EMMI Zone Tower East (Upper)
   > Door to EMMI Zone Exit East (Charge)
       Trivial
 
@@ -2964,20 +2960,22 @@ Extra - asset_id: collision_camera_036
       Trivial
   > Upper-right Corner
       Trivial
-  > Event - Central Unit Blob through wall
-      Diffusion Beam or Wave Beam
+  > Door to Central Unit
+      After Cataris - Central Unit Bottom Blob and Can Slide
+  > Event - Central Unit Bottom Blob through Wall
+      Shoot Diffusion or Wave
 
-> Event - Top Blob (breakablemag007); Heals? False
+> Event - Central Unit Top Blob; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag007
+  * Event Cataris - Central Unit Top Blob
   * Extra - actor_name: breakablemag007
   * Extra - actor_def: actordef:actors/props/breakablemag007/charclasses/breakablemag007.bmsad
   > Upper-right Corner
       Trivial
 
-> Event - Central Unit Blob (breakablemag008); Heals? False
+> Event - Central Unit Bottom Blob, adjacent; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag008
+  * Event Cataris - Central Unit Bottom Blob
   * Extra - actor_name: breakablemag008
   * Extra - actor_def: actordef:actors/props/breakablemag008/charclasses/breakablemag008.bmsad
   > Door to Central Unit
@@ -3000,10 +2998,10 @@ Extra - asset_id: collision_camera_036
   * Layers: default
   > Door from EMMI Zone Tower West
       Trivial
-  > Event - Top Blob (breakablemag007)
-      Shoot Beam
+  > Event - Central Unit Top Blob
+      Lay Bomb or Shoot Beam
   > Door to Central Unit
-      Morph Ball or After Cataris - breakablemag007
+      Morph Ball or After Cataris - Central Unit Top Blob
 
 > Door to Central Unit; Heals? False
   * Layers: default
@@ -3011,19 +3009,19 @@ Extra - asset_id: collision_camera_036
   > Door from EMMI Zone Tower West
       Any of the following:
           Morph Ball
-          After Cataris - breakablemag008 and Can Slide
-  > Event - Top Blob (breakablemag007)
-      Diffusion Beam or Wave Beam
-  > Event - Central Unit Blob (breakablemag008)
-      Shoot Beam
+          After Cataris - Central Unit Bottom Blob and Can Slide
+  > Event - Central Unit Top Blob
+      Shoot Diffusion or Wave
+  > Event - Central Unit Bottom Blob, adjacent
+      Lay Bomb or Shoot Beam
   > Upper-right Corner
-      Morph Ball or After Cataris - breakablemag007
+      Morph Ball or After Cataris - Central Unit Top Blob
   > Pickup (Morph Ball)
       After Cataris - Central Unit
 
-> Event - Central Unit Blob through wall; Heals? False
+> Event - Central Unit Bottom Blob through Wall; Heals? False
   * Layers: default
-  * Event Cataris - breakablemag008
+  * Event Cataris - Central Unit Bottom Blob
   > Door from EMMI Zone Tower West
       Trivial
 
@@ -3785,29 +3783,29 @@ Extra - polygon: [[2500.0, 2000.0], [-700.0, 2000.0], [-700.0, -1300.0], [2500.0
 Extra - asset_id: collision_camera_046
 > Door to EMMI Zone Tower East (Middle); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone Tower East/Door to EMMI Zone East Tower Access (doorpowerpower_015)
+  * Power Beam Door to EMMI Zone Tower East/Door to EMMI Zone East Tower Access (Middle)
   * Extra - actor_name: doorpowerpower_015
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Green EMMI Introduction (doorchargecharge_005)
+  > Door to Green EMMI Introduction (Lower)
       Trivial
   > Door to EMMI Zone Tower East (Bottom)
       Trivial
-  > Tunnel to EMMI Zone Tower East (1)
+  > Tunnel to EMMI Zone Tower East (Lower)
       Trivial
   > Tunnel to Green EMMI Introduction (Bottom)
       Trivial
-  > Tunnel to EMMI Zone Tower East (2)
+  > Tunnel to EMMI Zone Tower East (Upper)
       All of the following:
           Morph Ball and After Cataris - Central Unit
           Speed Booster or Simple IBJ or Use Spin Boost
 
-> Door to Green EMMI Introduction (doorchargecharge_005); Heals? False
+> Door to Green EMMI Introduction (Lower); Heals? False
   * Layers: default
-  * Charge Beam Door to Green EMMI Introduction/Door to EMMI Zone East Tower Access (doorchargecharge_005)
+  * Charge Beam Door to Green EMMI Introduction/Door to EMMI Zone East Tower Access (Lower)
   * Extra - actor_name: doorchargecharge_005
   * Extra - actor_def: actordef:actors/props/doorchargecharge/charclasses/doorchargecharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -3819,19 +3817,19 @@ Extra - asset_id: collision_camera_046
 
 > Door to EMMI Zone Tower East (Top); Heals? False
   * Layers: default
-  * Power Beam Door to EMMI Zone Tower East/Door to EMMI Zone East Tower Access (doorpowerpower_000)
+  * Power Beam Door to EMMI Zone Tower East/Door to EMMI Zone East Tower Access (Top)
   * Extra - actor_name: doorpowerpower_000
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Green EMMI Introduction (doorshutter_001)
+  > Door to Green EMMI Introduction (Upper)
       Can Slide
 
 > Door to EMMI Zone Tower East (Bottom); Heals? False
   * Layers: default
-  * Access Locked to EMMI Zone Tower East/Door to EMMI Zone East Tower Access (doorclosedcharge)
+  * Access Locked to EMMI Zone Tower East/Door to EMMI Zone East Tower Access (Bottom)
   * Extra - actor_name: doorclosedcharge
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -3841,9 +3839,9 @@ Extra - asset_id: collision_camera_046
   > Door to EMMI Zone Tower East (Middle)
       Trivial
 
-> Door to Green EMMI Introduction (doorshutter_001); Heals? False
+> Door to Green EMMI Introduction (Upper); Heals? False
   * Layers: default
-  * Phase Shift Door to Green EMMI Introduction/Door to EMMI Zone East Tower Access (doorshutter_001)
+  * Phase Shift Door to Green EMMI Introduction/Door to EMMI Zone East Tower Access (Upper)
   * Extra - actor_name: doorshutter_001
   * Extra - actor_def: actordef:actors/props/doorshutter/charclasses/doorshutter.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -3854,12 +3852,12 @@ Extra - asset_id: collision_camera_046
       Can Slide
   > Tunnel to Green EMMI Introduction (Upper)
       Trivial
-  > Tunnel to EMMI Zone Tower East (2)
+  > Tunnel to EMMI Zone Tower East (Upper)
       Morph Ball and After Cataris - Central Unit
 
-> Tunnel to EMMI Zone Tower East (1); Heals? False
+> Tunnel to EMMI Zone Tower East (Lower); Heals? False
   * Layers: default
-  * Morph Ball Tunnel to EMMI Zone Tower East/Tunnel to EMMI Zone East Tower Access (1)
+  * Morph Ball Tunnel to EMMI Zone Tower East/Tunnel to EMMI Zone East Tower Access (Lower)
   > Door to EMMI Zone Tower East (Middle)
       Trivial
 
@@ -3872,15 +3870,15 @@ Extra - asset_id: collision_camera_046
 > Tunnel to Green EMMI Introduction (Upper); Heals? False
   * Layers: default
   * Cataris EMMI Tunnel to Green EMMI Introduction/Tunnel to EMMI Zone East Tower Access (Upper)
-  > Door to Green EMMI Introduction (doorshutter_001)
+  > Door to Green EMMI Introduction (Upper)
       Trivial
 
-> Tunnel to EMMI Zone Tower East (2); Heals? False
+> Tunnel to EMMI Zone Tower East (Upper); Heals? False
   * Layers: default
-  * Cataris EMMI Tunnel to EMMI Zone Tower East/Tunnel to EMMI Zone East Tower Access (2)
+  * Cataris EMMI Tunnel to EMMI Zone Tower East/Tunnel to EMMI Zone East Tower Access (Upper)
   > Door to EMMI Zone Tower East (Middle)
       Morph Ball and After Cataris - Central Unit
-  > Door to Green EMMI Introduction (doorshutter_001)
+  > Door to Green EMMI Introduction (Upper)
       Morph Ball and After Cataris - Central Unit
 
 ----------------
@@ -4102,7 +4100,7 @@ Extra - asset_id: collision_camera_049
   > Pickup (Missile Tank)
       Any of the following:
           Varia Suit
-          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 200
+          Heat/Cold Runs (Beginner) and Heat Damage ≥ 200
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -4110,16 +4108,9 @@ Extra - asset_id: collision_camera_049
   * Extra - actor_name: item_missiletank_002
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Door to Above Z-57 Fight
-      All of the following:
-          Any of the following:
-              # Get through the room
-              Varia Suit
-              Heat/Cold Runs (Beginner) and Heat Damage ≥ 200
-          Any of the following:
-              # Reach the door
-              Flash Shift or Gravity Suit or Simple IBJ or Use Spin Boost
-              Slide and Slide Jump (Intermediate)
-              Heat/Cold Runs (Beginner) and Lava Damage ≥ 200
+      Any of the following:
+          Varia Suit
+          Heat/Cold Runs (Beginner) and Heat Damage ≥ 200
 
 ----------------
 Teleport to Dairon
@@ -4463,9 +4454,9 @@ Extra - asset_id: collision_camera_053
   > Dock to Underlava Puzzle Room 1
       Morph Ball
 
-> Event - Lava Grapple Block (grapplepulloff1x2_000); Heals? False
+> Event - Lava Grapple Block; Heals? False
   * Layers: default
-  * Event Cataris - grapplepulloff1x2_000
+  * Event Cataris - Lava Grapple Block
   * Extra - actor_name: grapplepulloff1x2_000
   * Extra - actor_def: actordef:actors/props/grapplepulloff1x2/charclasses/grapplepulloff1x2.bmsad
   > Below Lava
@@ -4528,7 +4519,7 @@ Extra - asset_id: collision_camera_053
 
 > Below Lava; Heals? False
   * Layers: default
-  > Event - Lava Grapple Block (grapplepulloff1x2_000)
+  > Event - Lava Grapple Block
       All of the following:
           Grapple Beam
           Any of the following:
@@ -4538,6 +4529,8 @@ Extra - asset_id: collision_camera_053
       Any of the following:
           Gravity Suit
           Heat/Cold Runs (Intermediate) and Lava Damage ≥ 500
+  > Dock to Underlava Puzzle Room 1
+      Gravity Suit and Morph Ball and After Cataris - Underlava Puzzle Speed Blocks Destroyed
 
 > Tunnel to Dropdown Pit; Heals? False
   * Layers: default
@@ -4560,8 +4553,18 @@ Extra - asset_id: collision_camera_053
   * Open Passage to Underlava Puzzle Room 1/Dock to Underlava Puzzle Room 2
   > Pickup (Energy Part)
       All of the following:
-          Gravity Suit and After Cataris - grapplepulloff1x2_000 and Ballspark
+          Gravity Suit and After Cataris - Underlava Puzzle Speed Blocks Destroyed and Ballspark
           Flash Shift or Speedbooster Conservation (Beginner) or Simple IBJ or Use Spin Boost
+  > Below Lava
+      Gravity Suit and Morph Ball and After Cataris - Underlava Puzzle Speed Blocks Destroyed
+  > Event - Underlava Puzzle Speed Blocks Destroyed
+      Gravity Suit and Speed Booster and After Cataris - Lava Grapple Block
+
+> Event - Underlava Puzzle Speed Blocks Destroyed; Heals? False
+  * Layers: default
+  * Event Cataris - Underlava Puzzle Speed Blocks Destroyed
+  > Dock to Underlava Puzzle Room 1
+      Trivial
 
 ----------------
 Underlava Puzzle Room 1
@@ -4590,18 +4593,9 @@ Extra - asset_id: collision_camera_055
   * Pickup 47; Major Location? False
   * Extra - actor_name: item_missiletank_011
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Tile Group (WEIGHT)
-      Morph Ball
   > Tile Group (MISSILE)
       Morph Ball
-
-> Tile Group (WEIGHT); Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_013
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Tunnel to EMMI Zone Tower East
+  > Main Room
       Morph Ball
 
 > Tile Group (MISSILE); Heals? False
@@ -4620,7 +4614,7 @@ Extra - asset_id: collision_camera_055
   * Layers: default
   > Tile Group (MISSILE)
       Any of the following:
-          Spider Magnet or Speed Booster or Use Spin Boost
+          Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
           Grapple Beam and Grapple Movement (Beginner)
   > Tunnel to EMMI Zone Tower East
       Morph Ball
@@ -4692,7 +4686,7 @@ Extra - asset_id: collision_camera_059
 
 > Door to EMMI Zone Exits West; Heals? False
   * Layers: default
-  * Phase Shift Door to EMMI Zone Exits West/Door to EMMI Zone West Exit Path
+  * Access Open to EMMI Zone Exits West/Door to EMMI Zone West Exit Path
   * Extra - actor_name: doorshutter_002
   * Extra - actor_def: actordef:actors/props/doorshutter/charclasses/doorshutter.bmsad
   * Extra - left_shield_entity: {EMPTY}

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -27,7 +27,7 @@ Extra - asset_id: collision_camera_000
   * Extra - right_shield_def: None
   > Tunnel to Total Recharge Station South
       Morph Ball and After Cataris - Artaria Transport Blob
-  > Event - Artaria Transport Blob through Wall
+  > Event - Blob through Wall
       Shoot Diffusion or Wave
   > Mid-Level
       Trivial
@@ -40,7 +40,7 @@ Extra - asset_id: collision_camera_000
   > Tunnel to Total Recharge Station South
       Trivial
 
-> Event - Artaria Transport Blob, adjacent; Heals? False
+> Event - Blob, adjacent; Heals? False
   * Layers: default
   * Event Cataris - Artaria Transport Blob
   * Extra - actor_name: breakablemag002
@@ -93,10 +93,10 @@ Extra - asset_id: collision_camera_000
       Morph Ball and After Cataris - Artaria Transport Blob
   > Pickup (Missile Tank)
       Trivial
-  > Event - Artaria Transport Blob, adjacent
+  > Event - Blob, adjacent
       Lay Bomb or Shoot Beam
 
-> Event - Artaria Transport Blob through Wall; Heals? False
+> Event - Blob through Wall; Heals? False
   * Layers: default
   * Event Cataris - Artaria Transport Blob
   > Door to Navigation Station Southeast
@@ -349,12 +349,12 @@ Extra - asset_id: collision_camera_007
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Event - First Device Blob
+  > Event - Blob
       Shoot Diffusion or Wave
   > Tunnel to Transport to Artaria
       After Cataris - First Device Blob
 
-> Event - First Device Blob; Heals? False
+> Event - Blob; Heals? False
   * Layers: default
   * Event Cataris - First Device Blob
   * Extra - actor_name: breakablemag001
@@ -388,7 +388,7 @@ Extra - asset_id: collision_camera_007
   * Morph Ball Tunnel to Transport to Artaria/Tunnel to Total Recharge Station South
   > Door to Thermal Device Room South (Top)
       After Cataris - First Device Blob
-  > Event - First Device Blob
+  > Event - Blob
       Lay Bomb or Shoot Beam
   > Total Recharge
       Trivial
@@ -1573,7 +1573,7 @@ Extra - asset_id: collision_camera_020
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to EMMI Zone East Tower Access (Lower)
       Trivial
-  > Event - Green EMMI Blob
+  > Event - Blob
       Wave Beam
   > Tunnel to EMMI Zone East Tower Access (Bottom)
       Trivial
@@ -1628,7 +1628,7 @@ Extra - asset_id: collision_camera_020
   > Tile Group (POWERBEAM) 3
       Trivial
 
-> Event - Green EMMI Blob; Heals? False
+> Event - Blob; Heals? False
   * Layers: default
   * Event Cataris - Green EMMI Blob
   * Extra - actor_name: breakablemag005
@@ -1702,7 +1702,7 @@ Extra - asset_id: collision_camera_020
           Any of the following:
               Flash Shift or Spider Magnet or Lay Cross Comb or Use Spin Boost
               Infinite Bomb Jump (Intermediate) and Lay Bomb
-  > Event - Green EMMI Blob
+  > Event - Blob
       Lay Bomb or Shoot Beam
 
 ----------------
@@ -1725,7 +1725,7 @@ Extra - asset_id: collision_camera_021
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
-  > Event - Open Passage Blob
+  > Event - Blob
       Lay Bomb or Shoot Beam
 
 > Pickup (Missile Tank); Heals? False
@@ -1746,7 +1746,7 @@ Extra - asset_id: collision_camera_021
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
-> Event - Open Passage Blob; Heals? False
+> Event - Blob; Heals? False
   * Layers: default
   * Event Cataris - Z-57 Open Passage Blob
   > Door to Above Z-57 Fight
@@ -1829,7 +1829,7 @@ Extra - asset_id: collision_camera_023
       All of the following:
           Morph Ball
           Flash Shift or After Cataris - Path to Kraid Blob or Simple IBJ or Use Spin Boost
-  > Event - Path to Kraid Blob
+  > Event - Blob
       Shoot Beam
   > Ammo Recharge
       Trivial
@@ -1850,7 +1850,7 @@ Extra - asset_id: collision_camera_023
   > Dock to EMMI Zone Exits West (Lower)
       Trivial
 
-> Event - Path to Kraid Blob; Heals? False
+> Event - Blob; Heals? False
   * Layers: default
   * Event Cataris - Path to Kraid Blob
   * Extra - actor_name: db_reg_mg_017
@@ -1915,7 +1915,7 @@ Extra - asset_id: collision_camera_024
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Event - Blob above Kraid, from below
+  > Event - Blob above Kraid, below
       Lay Bomb or Shoot Beam
   > Dock to Kraid Arena
       All of the following:
@@ -1930,7 +1930,7 @@ Extra - asset_id: collision_camera_024
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
-> Event - Above Kraid Ceiling Blob; Heals? False
+> Event - Ceiling Blob; Heals? False
   * Layers: default
   * Event Cataris - Above Kraid Ceiling Blob
   * Extra - actor_name: breakablemag010
@@ -1938,7 +1938,7 @@ Extra - asset_id: collision_camera_024
   > Right Tile Barrier
       Trivial
 
-> Event - Blob above Kraid, from below; Heals? False
+> Event - Blob above Kraid, below; Heals? False
   * Layers: default
   * Event Cataris - Blob above Kraid
   * Extra - actor_name: db_reg_mg_019
@@ -1969,7 +1969,7 @@ Extra - asset_id: collision_camera_024
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBEAM',)
-  > Event - Above Kraid Ceiling Blob
+  > Event - Ceiling Blob
       Morph Ball and Shoot Beam
   > Left Tile Barrier
       All of the following:
@@ -2061,10 +2061,10 @@ Extra - asset_id: collision_camera_024
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
-  > Event - Blob above Kraid, from left
+  > Event - Blob above Kraid, above
       Shoot Diffusion or Wave
 
-> Event - Blob above Kraid, from left; Heals? False
+> Event - Blob above Kraid, above; Heals? False
   * Layers: default
   * Event Cataris - Blob above Kraid
   > Center Room
@@ -2111,7 +2111,7 @@ Extra - asset_id: collision_camera_025
                   Walljump (Beginner) and Use Spin Boost
           Bomb and Morph Ball and Infinite Bomb Jump (Advanced)
           Speed Booster and Speedbooster Conservation (Beginner) and Disabled Door Lock Randomizer
-  > Event - Ghavoran Teleport Lower Blob
+  > Event - Blob
       Lay Bomb or Shoot Beam
   > Tile Group (BOMB)
       Trivial
@@ -2150,7 +2150,7 @@ Extra - asset_id: collision_camera_025
   > Door to Path to Kraid Entryway
       Morph Ball
 
-> Event - Ghavoran Teleport Lower Blob; Heals? False
+> Event - Blob; Heals? False
   * Layers: default
   * Event Cataris - Ghavoran Teleport Lower Blob
   * Extra - actor_name: db_dside_mg_002b_000
@@ -2220,7 +2220,7 @@ Extra - asset_id: collision_camera_026
   > Lower Center
       Trivial
 
-> Event - Ghavoran Teleport Lower Blob; Heals? False
+> Event - Lower Blob; Heals? False
   * Layers: default
   * Event Cataris - Ghavoran Teleport Lower Blob
   * Extra - actor_name: db_dside_mg_003
@@ -2228,7 +2228,7 @@ Extra - asset_id: collision_camera_026
   > Lower Center
       Trivial
 
-> Event - Ghavoran Teleport Upper Blob; Heals? False
+> Event - Upper Blob; Heals? False
   * Layers: default
   * Event Cataris - Ghavoran Teleport Upper Blob
   * Extra - actor_name: db_dside_mg_001b_000
@@ -2236,7 +2236,7 @@ Extra - asset_id: collision_camera_026
   > Top room
       Trivial
 
-> Event - Ghavoran Teleport Grapple Block; Heals? False
+> Event - Grapple Block; Heals? False
   * Layers: default
   * Event Cataris - Ghavoran Teleport Grapple Block
   * Extra - actor_name: grapplepulloff1x2_001
@@ -2253,7 +2253,7 @@ Extra - asset_id: collision_camera_026
   * Extra - target_spawn_point: teleporter_magma_000_platform
   * Extra - start_point_actor_name: teleporter_forest_000_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad
-  > Event - Ghavoran Teleport Grapple Block
+  > Event - Grapple Block
       All of the following:
           Grapple Beam
           Any of the following:
@@ -2318,7 +2318,7 @@ Extra - asset_id: collision_camera_026
 
 > Lower Center; Heals? False
   * Layers: default
-  > Event - Ghavoran Teleport Lower Blob
+  > Event - Lower Blob
       Lay Bomb or Shoot Beam
   > Tile Group (POWERBEAM) 2
       Gravity Suit
@@ -2353,7 +2353,7 @@ Extra - asset_id: collision_camera_026
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
-  > Event - Ghavoran Teleport Upper Blob
+  > Event - Upper Blob
       Lay Bomb or Shoot Beam
   > Teleporter to Ghavoran - Teleport to Cataris
       All of the following:
@@ -2406,7 +2406,7 @@ Extra - asset_id: collision_camera_027
   * Extra - right_shield_def: None
   > Dock to EMMI Zone Exits West
       Trivial
-  > Event - Ghavoran Teleport Upper Blob
+  > Event - Blob
       Lay Bomb or Shoot Beam
   > Tunnel to Teleport to Ghavoran
       After Cataris - Ghavoran Teleport Upper Blob
@@ -2419,7 +2419,7 @@ Extra - asset_id: collision_camera_027
   > Door to Navigation Station Northwest
       Trivial
 
-> Event - Ghavoran Teleport Upper Blob; Heals? False
+> Event - Blob; Heals? False
   * Layers: default
   * Event Cataris - Ghavoran Teleport Upper Blob
   * Extra - actor_name: db_dside_mg_002
@@ -2962,10 +2962,10 @@ Extra - asset_id: collision_camera_036
       Trivial
   > Door to Central Unit
       After Cataris - Central Unit Bottom Blob and Can Slide
-  > Event - Central Unit Bottom Blob through Wall
+  > Event - Bottom Blob through Wall
       Shoot Diffusion or Wave
 
-> Event - Central Unit Top Blob; Heals? False
+> Event - Top Blob; Heals? False
   * Layers: default
   * Event Cataris - Central Unit Top Blob
   * Extra - actor_name: breakablemag007
@@ -2973,7 +2973,7 @@ Extra - asset_id: collision_camera_036
   > Upper-right Corner
       Trivial
 
-> Event - Central Unit Bottom Blob, adjacent; Heals? False
+> Event - Bottom Blob, adjacent; Heals? False
   * Layers: default
   * Event Cataris - Central Unit Bottom Blob
   * Extra - actor_name: breakablemag008
@@ -2998,7 +2998,7 @@ Extra - asset_id: collision_camera_036
   * Layers: default
   > Door from EMMI Zone Tower West
       Trivial
-  > Event - Central Unit Top Blob
+  > Event - Top Blob
       Lay Bomb or Shoot Beam
   > Door to Central Unit
       Morph Ball or After Cataris - Central Unit Top Blob
@@ -3010,16 +3010,16 @@ Extra - asset_id: collision_camera_036
       Any of the following:
           Morph Ball
           After Cataris - Central Unit Bottom Blob and Can Slide
-  > Event - Central Unit Top Blob
+  > Event - Top Blob
       Shoot Diffusion or Wave
-  > Event - Central Unit Bottom Blob, adjacent
+  > Event - Bottom Blob, adjacent
       Lay Bomb or Shoot Beam
   > Upper-right Corner
       Morph Ball or After Cataris - Central Unit Top Blob
   > Pickup (Morph Ball)
       After Cataris - Central Unit
 
-> Event - Central Unit Bottom Blob through Wall; Heals? False
+> Event - Bottom Blob through Wall; Heals? False
   * Layers: default
   * Event Cataris - Central Unit Bottom Blob
   > Door from EMMI Zone Tower West
@@ -3478,7 +3478,7 @@ Extra - asset_id: collision_camera_044
       Any of the following:
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
-  > Event - Diffusion Tutorial Blob
+  > Event - Blob
       Shoot Diffusion or Wave
   > Tunnel to Teleport to Dairon
       All of the following:
@@ -3506,7 +3506,7 @@ Extra - asset_id: collision_camera_044
   > Alcove
       Morph Ball and After Cataris - PB Tank Grapple Block
 
-> Event - Diffusion Tutorial Blob; Heals? False
+> Event - Blob; Heals? False
   * Layers: default
   * Event Cataris - Diffusion Tutorial Blob
   * Extra - actor_name: db_dif_mg_002
@@ -3514,7 +3514,7 @@ Extra - asset_id: collision_camera_044
   > Door from Teleport to Dairon
       Trivial
 
-> Event - PB Tank Grapple Block; Heals? False
+> Event - Grapple Block; Heals? False
   * Layers: default
   * Event Cataris - PB Tank Grapple Block
   * Extra - actor_name: grapplepulloff1x2
@@ -3636,7 +3636,7 @@ Extra - asset_id: collision_camera_044
 > Tunnel to Kraid Arena (top); Heals? False
   * Layers: default
   * Morph Ball Tunnel to Kraid Arena/Tunnel to Diffusion Beam Room (Top)
-  > Event - Diffusion Tutorial Blob
+  > Event - Blob
       Morph Ball and Shoot Diffusion or Wave
   > Tunnel to Teleport to Dairon
       All of the following:
@@ -3671,7 +3671,7 @@ Extra - asset_id: collision_camera_044
   * Layers: default
   > Pickup (Power Bomb Tank)
       Morph Ball and After Cataris - PB Tank Grapple Block
-  > Event - PB Tank Grapple Block
+  > Event - Grapple Block
       Grapple Beam
   > Tile Group (WEIGHT) 4
       Trivial
@@ -4137,7 +4137,7 @@ Extra - asset_id: collision_camera_051
   * Pickup 39; Major Location? False
   * Extra - actor_name: item_missiletank_003
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Event - Missile Tank Blob
+  > Event - Lava Blob
       Lay Bomb
   > Ledge above Teleport
       All of the following:
@@ -4172,7 +4172,7 @@ Extra - asset_id: collision_camera_051
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
-> Event - Missile Tank Blob; Heals? False
+> Event - Lava Blob; Heals? False
   * Layers: default
   * Event Cataris - Missile Tank Blob
   * Extra - actor_name: breakablemag009
@@ -4182,7 +4182,7 @@ Extra - asset_id: collision_camera_051
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
 
-> Event - Diffusion Tutorial Blob 2, below; Heals? False
+> Event - Diffusion Blob, below; Heals? False
   * Layers: default
   * Event Cataris - Diffusion Tutorial Blob 2
   * Extra - actor_name: db_dif_mg_001
@@ -4261,7 +4261,7 @@ Extra - asset_id: collision_camera_051
       Any of the following:
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
-  > Event - Diffusion Tutorial Blob 2, below
+  > Event - Diffusion Blob, below
       Shoot Diffusion or Wave
   > Above Tutorial Blob
       All of the following:
@@ -4296,7 +4296,7 @@ Extra - asset_id: collision_camera_051
   > Above Tutorial Blob
       Trivial
 
-> Event - Diffusion Tutorial Blob 2, above; Heals? False
+> Event - Diffusion Blob, above; Heals? False
   * Layers: default
   * Event Cataris - Diffusion Tutorial Blob 2
   > Above Tutorial Blob
@@ -4314,7 +4314,7 @@ Extra - asset_id: collision_camera_051
                   Any of the following:
                       Varia Suit
                       Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
-  > Event - Missile Tank Blob
+  > Event - Lava Blob
       All of the following:
           Shoot Diffusion or Wave
           Any of the following:
@@ -4345,7 +4345,7 @@ Extra - asset_id: collision_camera_051
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
   > Event - Kraid Eyedoor Blob
       Wave Beam
-  > Event - Diffusion Tutorial Blob 2, above
+  > Event - Diffusion Blob, above
       Wave Beam
 
 ----------------
@@ -4375,7 +4375,7 @@ Extra - asset_id: collision_camera_052
       After Cataris - Green EMMI Access Blob
   > Door to Teleport to Dairon
       Trivial
-  > Event - Green EMMI Access Blob
+  > Event - Blob
       Lay Bomb or Shoot Beam
 
 > Door from Underlava Puzzle Room 2; Heals? False
@@ -4406,7 +4406,7 @@ Extra - asset_id: collision_camera_052
   > Tunnel to Underlava Puzzle Room 2
       Trivial
 
-> Event - Green EMMI Access Blob; Heals? False
+> Event - Blob; Heals? False
   * Layers: default
   * Event Cataris - Green EMMI Access Blob
   * Extra - actor_name: db_hdoor_mg_002
@@ -4454,7 +4454,7 @@ Extra - asset_id: collision_camera_053
   > Dock to Underlava Puzzle Room 1
       Morph Ball
 
-> Event - Lava Grapple Block; Heals? False
+> Event - Grapple Block; Heals? False
   * Layers: default
   * Event Cataris - Lava Grapple Block
   * Extra - actor_name: grapplepulloff1x2_000
@@ -4519,7 +4519,7 @@ Extra - asset_id: collision_camera_053
 
 > Below Lava; Heals? False
   * Layers: default
-  > Event - Lava Grapple Block
+  > Event - Grapple Block
       All of the following:
           Grapple Beam
           Any of the following:
@@ -4557,10 +4557,10 @@ Extra - asset_id: collision_camera_053
           Flash Shift or Speedbooster Conservation (Beginner) or Simple IBJ or Use Spin Boost
   > Below Lava
       Gravity Suit and Morph Ball and After Cataris - Underlava Puzzle Speed Blocks Destroyed
-  > Event - Underlava Puzzle Speed Blocks Destroyed
+  > Event - Speed Blocks Destroyed
       Gravity Suit and Speed Booster and After Cataris - Lava Grapple Block
 
-> Event - Underlava Puzzle Speed Blocks Destroyed; Heals? False
+> Event - Speed Blocks Destroyed; Heals? False
   * Layers: default
   * Event Cataris - Underlava Puzzle Speed Blocks Destroyed
   > Dock to Underlava Puzzle Room 1
@@ -4759,7 +4759,7 @@ Extra - asset_id: collision_camera_061
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
-> Event - Kraid Eyedoor Blob; Heals? False
+> Event - Wall Blob; Heals? False
   * Layers: default
   * Event Cataris - Kraid Eyedoor Blob
   * Extra - actor_name: db_reg_mg_021
@@ -4767,7 +4767,7 @@ Extra - asset_id: collision_camera_061
   > Safe Ledge
       Trivial
 
-> Event - Kraid Eyedoor Ceiling Blob; Heals? False
+> Event - Ceiling Blob; Heals? False
   * Layers: default
   * Event Cataris - Kraid Eyedoor Ceiling Blob
   * Extra - actor_name: db_reg_mg_020
@@ -4814,7 +4814,7 @@ Extra - asset_id: collision_camera_061
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
-  > Event - Kraid Eyedoor Blob
+  > Event - Wall Blob
       Shoot Diffusion or Wave
   > Tile Group (BOMB)
       All of the following:
@@ -4848,7 +4848,7 @@ Extra - asset_id: collision_camera_061
 
 > Ledge below blob; Heals? False
   * Layers: default
-  > Event - Kraid Eyedoor Ceiling Blob
+  > Event - Ceiling Blob
       Shoot Beam
   > Tunnel to Above Kraid
       Any of the following:

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1022,10 +1022,6 @@
                 "long_name": "Dairon - Freezer Speed Blocks Destroyed",
                 "extra": {}
             },
-            "CatarisUnderlavaSpeedBlocks": {
-                "long_name": "Cataris - Underlava Puzzle Speed Blocks Destroyed",
-                "extra": {}
-            },
             "GoldChozoFight": {
                 "long_name": "Hanubia - Gold Chozo Fight",
                 "extra": {}

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -419,31 +419,31 @@
                 "extra": {}
             },
             "s020_magma:default:breakablemag001": {
-                "long_name": "Cataris - breakablemag001",
+                "long_name": "Cataris - First Device Blob",
                 "extra": {}
             },
             "s020_magma:default:breakablemag002": {
-                "long_name": "Cataris - breakablemag002",
+                "long_name": "Cataris - Artaria Transport Blob",
                 "extra": {}
             },
             "s020_magma:default:breakablemag003": {
-                "long_name": "Cataris - breakablemag003",
+                "long_name": "Cataris - Z-57 Blob",
                 "extra": {}
             },
             "s020_magma:default:breakablemag004": {
-                "long_name": "Cataris - breakablemag004",
+                "long_name": "Cataris - Z-57 First Tunnel Blob",
                 "extra": {}
             },
             "s020_magma:default:breakablemag005": {
-                "long_name": "Cataris - breakablemag005",
+                "long_name": "Cataris - Green EMMI Blob",
                 "extra": {}
             },
             "s020_magma:default:breakablemag007": {
-                "long_name": "Cataris - breakablemag007",
+                "long_name": "Cataris - Central Unit Top Blob",
                 "extra": {}
             },
             "s020_magma:default:breakablemag008": {
-                "long_name": "Cataris - breakablemag008",
+                "long_name": "Cataris - Central Unit Bottom Blob",
                 "extra": {}
             },
             "s020_magma:default:breakablemag009": {
@@ -475,11 +475,11 @@
                 "extra": {}
             },
             "s020_magma:default:breakablemag014": {
-                "long_name": "Cataris - breakablemag014",
+                "long_name": "Cataris - Z-57 Second Tunnel Blob",
                 "extra": {}
             },
             "s020_magma:default:breakablemag013": {
-                "long_name": "Cataris - breakablemag013",
+                "long_name": "Cataris - Z-57 Open Passage Blob",
                 "extra": {}
             },
             "s020_magma:default:db_dif_mg_002": {
@@ -651,7 +651,7 @@
                 "extra": {}
             },
             "s020_magma:default:grapplepulloff1x2_000": {
-                "long_name": "Cataris - grapplepulloff1x2_000",
+                "long_name": "Cataris - Lava Grapple Block",
                 "extra": {}
             },
             "s020_magma:default:grapplepulloff1x2_001": {
@@ -1024,6 +1024,10 @@
             },
             "DaironFreezerSpeedBlocks": {
                 "long_name": "Dairon - Freezer Speed Blocks Destroyed",
+                "extra": {}
+            },
+            "CatarisUnderlavaSpeedBlocks": {
+                "long_name": "Cataris - Underlava Puzzle Speed Blocks Destroyed",
                 "extra": {}
             }
         },


### PR DESCRIPTION
This revision goes over the entire EMMI Zone and up to the Artaria Transport, renaming events and other nodes, and adding other methods to trickless connection and some tricks. Pretty much every room is affected within the EMMI Zone and between Green EMMI Introduction Access and Transport to Artaria.