### PR TITLE
Dread: Final Trickless Cataris Revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
-- Added FAQ entry about Speed Booster/Phantom Cloak/Storm Missile not working.
+- Added: FAQ entry about Speed Booster/Phantom Cloak/Storm Missile not working.
+- Added: FAQ entry about Golzuna and Experiment Z-57 spawn conditions
  
 #### Logic Database
 
-- Nothing yet.
+- Changed: Various logic changes in Cataris, Ghavoran, and Artaria
 
 ### Metroid Prime
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  
 #### Logic Database
 
-- Changed: Various logic changes in Cataris, Ghavoran, and Artaria
+- Added: Event in Underlava Puzzle Room 2 for breaking the speed blocks so that going between the two parts can be accounted for
+- Added: Event for the trigger that reopens the door to Central Unit Access, allowing it logical to go back through
+- Added: Other various methods of going through rooms
+- Changed: Separated the First Tunnel Blob event into two to account for Diffusion/Wave not needing to be in the tunnel
+- Changed: Deleted some unnecessary tile nodes
+- Changed: Various instances of Walljump (Beginner) to trivial
+- Changed: Some Grapple options to include Grapple Movement
+- Changed: Some Movement tricks to Climb Sloped Tunnels
+- Changed: Some Movement tricks to Skip Cross Bomb
+- Fixed: Accounted for whether the player could have Varia or not when trudging through lava
+- Fixed: Accounted for the upper parts of Thermal Device Room North being heated without pressing the lava button
+- Fixed: Ghavoran Orange backdoor properly connects to Above Pulse Radar
 
 ### Metroid Prime
 

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -389,8 +389,20 @@
                             }
                         },
                         "Event - Blob, adjacent": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -1075,12 +1087,29 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Start Point": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s020_magma:default:deviceheat",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -1753,8 +1782,20 @@
                             }
                         },
                         "Event - Blob": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Tunnel to Dropdown Pit": {
                             "type": "and",
@@ -2186,7 +2227,7 @@
                                                             },
                                                             {
                                                                 "type": "template",
-                                                                "data": "Shoot Wide Beam"
+                                                                "data": "Shoot Plasma Beam"
                                                             }
                                                         ]
                                                     }
@@ -2269,6 +2310,24 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Storm",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MissileAmmo",
+                                            "amount": 12,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -2518,6 +2577,41 @@
                                     {
                                         "type": "template",
                                         "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "GrappleMovement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -2614,6 +2708,23 @@
                                         "data": {
                                             "type": "items",
                                             "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spin Boost"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Cross Bomb"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Movement",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -2769,7 +2880,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Suitless",
-                                                        "amount": 2,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -2853,7 +2964,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Suitless",
-                                                        "amount": 2,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -2917,19 +3028,45 @@
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "events",
-                                                        "name": "CatarisMoveMagnetWallsButton",
+                                                        "type": "items",
+                                                        "name": "Gravity",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Varia",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Varia",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Lava",
+                                                                    "amount": 80,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
@@ -2949,13 +3086,31 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Lava",
+                                                                    "amount": 80,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
                                                                     "type": "tricks",
                                                                     "name": "Suitless",
-                                                                    "amount": 2,
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             }
                                                         ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "CatarisMoveMagnetWallsButton",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
@@ -3036,7 +3191,12 @@
                         "start_point_actor_name": "SP_Checkpoint_PistonRight",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "connections": {}
+                    "connections": {
+                        "Door to Lava Button East Access (Cloak)": {
+                            "type": "template",
+                            "data": "Can Slide"
+                        }
+                    }
                 },
                 "Event - Activate Magnet Walls Button": {
                     "node_type": "event",
@@ -3105,7 +3265,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Varia",
+                                                        "name": "Gravity",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -3118,9 +3278,18 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
+                                                                    "type": "items",
+                                                                    "name": "Varia",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
                                                                     "type": "damage",
-                                                                    "name": "Heat",
-                                                                    "amount": 200,
+                                                                    "name": "Lava",
+                                                                    "amount": 80,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -3129,7 +3298,42 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "Suitless",
-                                                                    "amount": 2,
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 100,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Lava",
+                                                                    "amount": 80,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -3209,7 +3413,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Suitless",
-                                                        "amount": 2,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -3261,7 +3465,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Suitless",
-                                                        "amount": 2,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -3322,7 +3526,7 @@
                                                                 "data": {
                                                                     "type": "damage",
                                                                     "name": "Heat",
-                                                                    "amount": 200,
+                                                                    "amount": 30,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -3726,6 +3930,15 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Tile Group (POWERBEAM)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
+                            }
                         }
                     }
                 },
@@ -3788,41 +4001,12 @@
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Magnet",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Grapple",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Use Spin Boost"
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "Magnet",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -4117,12 +4301,63 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "or",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Varia",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Suitless",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "damage",
+                                                                                            "name": "Heat",
+                                                                                            "amount": 500,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Suitless",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -4348,6 +4583,23 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -4409,12 +4661,29 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Grapple",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "GrappleMovement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
@@ -4607,12 +4876,63 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Suitless",
-                                                        "amount": 2,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Varia",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Heat",
+                                                                                "amount": 50,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -4755,58 +5075,6 @@
                             }
                         }
                     }
-                },
-                "Tile Group (WEIGHT) 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 18400.0,
-                        "y": 2300.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_029",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Right Room": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT) 2": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 17000.0,
-                        "y": 2900.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_030",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {}
                 },
                 "Tile Group (BOMB) 1": {
                     "node_type": "configurable_node",
@@ -5153,13 +5421,8 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "IBJ",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
                                                 }
                                             ]
                                         }
@@ -5242,7 +5505,16 @@
                         ]
                     },
                     "connections": {
-                        "Tile Group (WEIGHT) 1": {
+                        "Tile Group (BOMB) 3": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Right Room": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5300,15 +5572,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        },
-                        "Tile Group (BOMB) 3": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
                             }
                         }
                     }
@@ -6182,13 +6445,8 @@
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Spin",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
+                                                                            "type": "template",
+                                                                            "data": "Use Spin Boost"
                                                                         },
                                                                         {
                                                                             "type": "resource",
@@ -6334,12 +6592,63 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "or",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Varia",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Suitless",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "damage",
+                                                                                            "name": "Heat",
+                                                                                            "amount": 500,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Suitless",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -6524,8 +6833,20 @@
                     "extra": {},
                     "connections": {
                         "Event - West Blob": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Tile Group (POWERBEAM) 1": {
                             "type": "or",
@@ -7195,10 +7516,6 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
-                                    },
-                                    {
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
@@ -7206,6 +7523,10 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spin Boost"
                                     },
                                     {
                                         "type": "template",
@@ -7238,12 +7559,29 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Grapple",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "GrappleMovement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -7461,7 +7799,7 @@
                         }
                     }
                 },
-                "Event - First Tunnel Blob": {
+                "Event - First Tunnel Blob, in Tunnel": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -7479,7 +7817,7 @@
                     },
                     "event_name": "s020_magma:default:breakablemag004",
                     "connections": {
-                        "Right Platform": {
+                        "Tiny Alcove": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7907,8 +8245,20 @@
                     "extra": {},
                     "connections": {
                         "Event - Second Tunnel Blob": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Tunnel to Z-57 Heat Room West (Right)": {
                             "type": "and",
@@ -8136,8 +8486,20 @@
                             }
                         },
                         "Event - Green EMMI Access Blob": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -8155,42 +8517,30 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Event - First Tunnel Blob": {
-                            "type": "or",
+                        "Event - First Tunnel Blob, in Tunnel": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Shoot Diffusion or Wave"
+                                        "data": "Lay Bomb"
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Simple IBJ"
-                                                            },
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Use Spin Boost"
-                                                            }
-                                                        ]
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
                                                 },
                                                 {
                                                     "type": "template",
-                                                    "data": "Lay Bomb"
+                                                    "data": "Simple IBJ"
                                                 },
                                                 {
-                                                    "type": "or",
+                                                    "type": "and",
                                                     "data": {
                                                         "comment": null,
                                                         "items": [
@@ -8198,35 +8548,82 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
-                                                                    "name": "Varia",
+                                                                    "name": "Slide",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
-                                                                "type": "and",
+                                                                "type": "resource",
                                                                 "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Heat",
-                                                                                "amount": 100,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Suitless",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
+                                                                    "type": "tricks",
+                                                                    "name": "Slide",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Ice Missile"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "FrozenEnemy",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 100,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]
@@ -8343,6 +8740,34 @@
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Event - First Tunnel Blob, below": {
+                            "type": "template",
+                            "data": "Shoot Diffusion or Wave"
+                        }
+                    }
+                },
+                "Event - First Tunnel Blob, below": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -2300.0,
+                        "y": -2500.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "s020_magma:default:breakablemag004",
+                    "connections": {
+                        "Right Platform": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -8580,6 +9005,32 @@
                                     {
                                         "type": "template",
                                         "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "GrappleMovement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -9005,8 +9456,20 @@
                             }
                         },
                         "Event - Blob": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 }
@@ -9134,8 +9597,20 @@
                             }
                         },
                         "Event - Blob": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -9463,6 +9938,15 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -13414,10 +13898,38 @@
                             }
                         },
                         "Tunnel to Central Unit Access": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "CatarisPostEmmiTrigger",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Event - Door Trigger": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisCU",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -13697,10 +14209,38 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to EMMI Zone Item Tunnel": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "CatarisPostEmmiTrigger",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Event - Door Trigger": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisCU",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -13741,6 +14281,30 @@
                             }
                         },
                         "Tunnel to EMMI Zone Item Tunnel": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Door Trigger": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -8900.0,
+                        "y": 3020.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "CatarisPostEmmiTrigger",
+                    "connections": {
+                        "Tunnel to Central Unit Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13982,8 +14546,25 @@
                     },
                     "connections": {
                         "Pickup (Power Bomb Tank)": {
-                            "type": "template",
-                            "data": "Ballspark"
+                            "type": "and",
+                            "data": {
+                                "comment": "Item logically unattainable with door rando",
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "DoorLocks",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Center of Tunnel": {
                             "type": "resource",
@@ -14474,12 +15055,29 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Grapple",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "GrappleMovement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -14801,6 +15399,15 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Simple IBJ"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -15731,7 +16338,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Central Unit Access",
-                        "node_name": "Door from EMMI Zone Tower West"
+                        "node_name": "Door to EMMI Zone Tower West"
                     },
                     "default_dock_weakness": "Wide Beam Door",
                     "override_default_open_requirement": null,
@@ -15818,7 +16425,7 @@
                 "asset_id": "collision_camera_036"
             },
             "nodes": {
-                "Door from EMMI Zone Tower West": {
+                "Door to EMMI Zone Tower West": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -15826,7 +16433,7 @@
                         "y": 3600.0,
                         "z": 0.0
                     },
-                    "description": "Door opens up after Green EMMI is defeated\n\n",
+                    "description": "Door opens up after Green EMMI is defeated and rolling through a trigger in\nEMMI Zone Exits West\n\n",
                     "layers": [
                         "default"
                     ],
@@ -15844,7 +16451,7 @@
                         "area_name": "EMMI Zone Tower West",
                         "node_name": "Door to Central Unit Access"
                     },
-                    "default_dock_weakness": "Access Closed",
+                    "default_dock_weakness": "Wide Beam Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -15971,11 +16578,30 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from EMMI Zone Tower West": {
-                            "type": "and",
+                        "Door to EMMI Zone Tower West": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisCU",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisPostEmmiTrigger",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -15994,16 +16620,47 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Door from EMMI Zone Tower West": {
-                            "type": "and",
+                        "Door to EMMI Zone Tower West": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisCU",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisPostEmmiTrigger",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Event - Top Blob": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Door to Central Unit": {
                             "type": "or",
@@ -16056,22 +16713,13 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door from EMMI Zone Tower West": {
-                            "type": "or",
+                        "Door to EMMI Zone Tower West": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
@@ -16079,14 +16727,57 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "events",
-                                                        "name": "s020_magma:default:breakablemag008",
+                                                        "name": "CatarisCU",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "CatarisPostEmmiTrigger",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Slide"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "s020_magma:default:breakablemag008",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Slide"
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -16099,8 +16790,20 @@
                             "data": "Shoot Diffusion or Wave"
                         },
                         "Event - Bottom Blob, adjacent": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Upper-right Corner": {
                             "type": "or",
@@ -16154,11 +16857,30 @@
                     "extra": {},
                     "event_name": "s020_magma:default:breakablemag008",
                     "connections": {
-                        "Door from EMMI Zone Tower West": {
-                            "type": "and",
+                        "Door to EMMI Zone Tower West": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisCU",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisPostEmmiTrigger",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -16417,12 +17139,80 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "damage",
-                                            "name": "Lava",
-                                            "amount": 400,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Lava",
+                                                        "amount": 400,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Varia",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Heat",
+                                                                                "amount": 500,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -16553,38 +17343,21 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "and",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 3,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Lava",
-                                                                    "amount": 500,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "damage",
+                                                        "name": "Lava",
+                                                        "amount": 500,
+                                                        "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "or",
                                                     "data": {
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "or",
+                                                                "type": "and",
                                                                 "data": {
                                                                     "comment": null,
                                                                     "items": [
@@ -16600,9 +17373,35 @@
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
                                                                                 "type": "damage",
                                                                                 "name": "Heat",
                                                                                 "amount": 500,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 3,
                                                                                 "negate": false
                                                                             }
                                                                         }
@@ -16771,13 +17570,6 @@
                                 "comment": null,
                                 "items": []
                             }
-                        },
-                        "Tile Group (POWERBEAM)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
                         }
                     }
                 },
@@ -16936,36 +17728,6 @@
                         }
                     }
                 },
-                "Tile Group (POWERBEAM)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 700.0,
-                        "y": 7600.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_002",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Transport to Dairon": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Dock to Thermal Device Room North": {
                     "node_type": "dock",
                     "heal": false,
@@ -17010,7 +17772,7 @@
                     "extra": {},
                     "event_name": "CatarisTransportDaironWideBeamBlock",
                     "connections": {
-                        "Door to Thermal Device Room North": {
+                        "Dock to EMMI Zone Tower West": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -17191,8 +17953,68 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Dairon Transport Access": {
-                            "type": "template",
-                            "data": "Can Slide"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "CatarisThermalLowerLava",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 200,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Past Magnet Floor": {
                             "type": "resource",
@@ -17300,6 +18122,41 @@
                                                         "amount": 200,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Varia",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 100,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -17340,8 +18197,68 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Total Recharge Station North": {
-                            "type": "template",
-                            "data": "Can Slide"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "CatarisThermalLowerLava",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 200,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Event - Thermal Device 2": {
                             "type": "and",
@@ -17372,10 +18289,46 @@
                     "major_location": true,
                     "connections": {
                         "Tunnel to Lava Button West": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Varia",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Heat",
+                                                        "amount": 60,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -17490,10 +18443,46 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Pickup (Energy Part)": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Varia",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Heat",
+                                                        "amount": 60,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -17545,12 +18534,80 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "damage",
-                                            "name": "Lava",
-                                            "amount": 500,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Lava",
+                                                        "amount": 500,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Varia",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Heat",
+                                                                                "amount": 200,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -17807,6 +18864,41 @@
                                                         "amount": 200,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Suitless",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Varia",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 100,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -17838,12 +18930,80 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "damage",
-                                            "name": "Lava",
-                                            "amount": 500,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Lava",
+                                                        "amount": 500,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Varia",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Heat",
+                                                                                "amount": 200,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -17884,6 +19044,79 @@
                                                         "name": "Gravity",
                                                         "amount": 1,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Lava",
+                                                                    "amount": 30,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Grapple",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Use Spin Boost"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Varia",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Heat",
+                                                                                "amount": 50,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -19701,8 +20934,20 @@
                             }
                         },
                         "Event - Blob, adjacent": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         },
                         "Tunnel to Teleport to Artaria (Blue)": {
                             "type": "resource",
@@ -20556,7 +21801,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Suitless",
-                                                        "amount": 2,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -20613,7 +21858,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "Suitless",
-                                                                    "amount": 2,
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -20691,7 +21936,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Suitless",
-                                                        "amount": 2,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -20699,36 +21944,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        }
-                    }
-                },
-                "Tile Group (BOMB) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 11300.0,
-                        "y": 7700.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_048",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "BOMB"
-                        ]
-                    },
-                    "connections": {
-                        "Left Floor": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }
@@ -20763,7 +21978,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "Spin",
+                                            "name": "Varia",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -20835,7 +22050,127 @@
                                                                 "data": {
                                                                     "type": "damage",
                                                                     "name": "Heat",
-                                                                    "amount": 20,
+                                                                    "amount": 40,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tile Group (MISSILE) 3": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tunnel to Teleport to Artaria (Blue)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 100,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -21042,7 +22377,67 @@
                                                                 "data": {
                                                                     "type": "damage",
                                                                     "name": "Heat",
-                                                                    "amount": 20,
+                                                                    "amount": 40,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tunnel to Teleport to Artaria (Blue)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Cold",
+                                                                    "amount": 80,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -21125,7 +22520,7 @@
                                                                 "data": {
                                                                     "type": "damage",
                                                                     "name": "Heat",
-                                                                    "amount": 20,
+                                                                    "amount": 40,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -21316,6 +22711,66 @@
                         ]
                     },
                     "connections": {
+                        "Tile Group (POWERBEAM) 2": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 60,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Tile Group (MISSILE) 1": {
                             "type": "and",
                             "data": {
@@ -21349,7 +22804,7 @@
                                                                 "data": {
                                                                     "type": "damage",
                                                                     "name": "Heat",
-                                                                    "amount": 20,
+                                                                    "amount": 40,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -21482,6 +22937,186 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Tile Group (POWERBEAM) 2": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 100,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tile Group (MISSILE) 1": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 80,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tile Group (MISSILE) 2": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Varia",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Heat",
+                                                                    "amount": 60,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Suitless",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Tile Group (MISSILE) 3": {
                             "type": "or",
                             "data": {
@@ -21506,7 +23141,7 @@
                                                     "data": {
                                                         "type": "damage",
                                                         "name": "Heat",
-                                                        "amount": 20,
+                                                        "amount": 40,
                                                         "negate": false
                                                     }
                                                 },
@@ -21621,7 +23256,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "Suitless",
-                                                                    "amount": 2,
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -21632,15 +23267,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        },
-                        "Tile Group (BOMB) 2": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
                             }
                         },
                         "Tile Group (POWERBEAM) 2": {
@@ -21691,8 +23317,20 @@
                             "data": "Push Wide Beam Block"
                         },
                         "Event - Blob": {
-                            "type": "template",
-                            "data": "Shoot Beam"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -24066,12 +25704,29 @@
                     "major_location": true,
                     "connections": {
                         "Dock to Underlava Puzzle Room 1": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisUnderlavaSpeedBlocks",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -24406,12 +26061,63 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Suitless",
-                                                        "amount": 2,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Varia",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Heat",
+                                                                                "amount": 200,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -24525,15 +26231,92 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Suitless",
-                                                        "amount": 2,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Varia",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Heat",
+                                                                                "amount": 200,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Suitless",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Dock to Underlava Puzzle Room 1": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisUnderlavaSpeedBlocks",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -24660,14 +26443,19 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Ballspark"
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s020_magma:default:grapplepulloff1x2_000",
+                                            "name": "CatarisUnderlavaSpeedBlocks",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -24707,6 +26495,91 @@
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Below Lava": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisUnderlavaSpeedBlocks",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Speed Blocks Destroyed": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s020_magma:default:grapplepulloff1x2_000",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Event - Speed Blocks Destroyed": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -3650.0,
+                        "y": -6150.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "CatarisUnderlavaSpeedBlocks",
+                    "connections": {
+                        "Dock to Underlava Puzzle Room 1": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -25001,6 +26874,10 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
                                     }
                                 ]
                             }

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -16455,23 +16455,12 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tunnel to EMMI Zone Exits West": {
+                        "Room Center": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
-                        },
-                        "Upper-right Corner": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Event - Bottom Blob through wall": {
-                            "type": "template",
-                            "data": "Shoot Diffusion or Wave"
                         }
                     }
                 },
@@ -16578,30 +16567,11 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower West": {
-                            "type": "or",
+                        "Room Center": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "CatarisCU",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "CatarisPostEmmiTrigger",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }
@@ -16620,32 +16590,6 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Door to EMMI Zone Tower West": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "CatarisCU",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "CatarisPostEmmiTrigger",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
                         "Event - Top Blob": {
                             "type": "or",
                             "data": {
@@ -16687,6 +16631,13 @@
                                     }
                                 ]
                             }
+                        },
+                        "Room Center": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -16713,78 +16664,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to EMMI Zone Tower West": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "CatarisCU",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "CatarisPostEmmiTrigger",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Morph",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "events",
-                                                                    "name": "s020_magma:default:breakablemag008",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Can Slide"
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
                         "Event - Top Blob": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
@@ -16839,6 +16718,27 @@
                                 "amount": 1,
                                 "negate": false
                             }
+                        },
+                        "Room Center": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s020_magma:default:breakablemag008",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -16846,8 +16746,8 @@
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": -5729.91,
-                        "y": 5300.16,
+                        "x": -5730.0,
+                        "y": 5300.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -16857,30 +16757,11 @@
                     "extra": {},
                     "event_name": "s020_magma:default:breakablemag008",
                     "connections": {
-                        "Door to EMMI Zone Tower West": {
-                            "type": "or",
+                        "Room Center": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "CatarisCU",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "CatarisPostEmmiTrigger",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }
@@ -16913,6 +16794,87 @@
                                 "comment": null,
                                 "items": []
                             }
+                        }
+                    }
+                },
+                "Room Center": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -5030.0,
+                        "y": 4700.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "connections": {
+                        "Door to EMMI Zone Tower West": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisCU",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "CatarisPostEmmiTrigger",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Tunnel to EMMI Zone Exits West": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Upper-right Corner": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Door to Central Unit": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s020_magma:default:breakablemag008",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Can Slide"
+                                    }
+                                ]
+                            }
+                        },
+                        "Event - Bottom Blob through wall": {
+                            "type": "template",
+                            "data": "Shoot Diffusion or Wave"
                         }
                     }
                 }

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -3932,12 +3932,24 @@
                             }
                         },
                         "Tile Group (POWERBEAM)": {
-                            "type": "resource",
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "Speed",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
+                                    }
+                                ]
                             }
                         }
                     }
@@ -8523,8 +8535,37 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "The blob can be shot while holding the ledge to the tunnel",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Bomb"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Beam"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "or",

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -800,7 +800,7 @@ Extra - asset_id: collision_camera_014
   > Door to Tall Magnet Walls Access
       Trivial
   > Tile Group (POWERBEAM)
-      Speed Booster
+      Speed Booster or Simple IBJ
 
 > Door to Energy Recharge Station (Charge); Heals? False
   * Layers: default
@@ -1525,7 +1525,10 @@ Extra - asset_id: collision_camera_019
   * Layers: default
   > Event - First Tunnel Blob, in Tunnel
       All of the following:
-          Lay Bomb
+          Any of the following:
+              # The blob can be shot while holding the ledge to the tunnel
+              Lay Bomb
+              Movement (Beginner) and Shoot Beam
           Any of the following:
               Simple IBJ or Use Spin Boost
               Slide and Slide Jump (Intermediate)

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -2979,12 +2979,8 @@ EMMI Zone Exits West
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorwidebeam_000
   * Extra - right_shield_def: actordef:actors/props/doorwidebeam/charclasses/doorwidebeam.bmsad
-  > Tunnel to EMMI Zone Exits West
+  > Room Center
       Trivial
-  > Upper-right Corner
-      Trivial
-  > Event - Bottom Blob through wall
-      Shoot Diffusion or Wave
 
 > Event - Top Blob; Heals? False
   * Layers: default
@@ -3012,27 +3008,21 @@ EMMI Zone Exits West
 > Tunnel to EMMI Zone Exits West; Heals? False
   * Layers: default
   * Cataris EMMI Tunnel to EMMI Zone Exits West/Tunnel to Central Unit Access
-  > Door to EMMI Zone Tower West
-      Before Cataris - Central Unit or After Cataris - Post-EMMI Door Trigger
+  > Room Center
+      Trivial
 
 > Upper-right Corner; Heals? False
   * Layers: default
-  > Door to EMMI Zone Tower West
-      Before Cataris - Central Unit or After Cataris - Post-EMMI Door Trigger
   > Event - Top Blob
       Lay Bomb or Shoot Beam
   > Door to Central Unit
       Morph Ball or After Cataris - Central Unit Top Blob
+  > Room Center
+      Trivial
 
 > Door to Central Unit; Heals? False
   * Layers: default
   * Access Open to Central Unit/Door to Central Unit Access
-  > Door to EMMI Zone Tower West
-      All of the following:
-          Before Cataris - Central Unit or After Cataris - Post-EMMI Door Trigger
-          Any of the following:
-              Morph Ball
-              After Cataris - Central Unit Bottom Blob and Can Slide
   > Event - Top Blob
       Shoot Diffusion or Wave
   > Event - Bottom Blob, adjacent
@@ -3041,12 +3031,14 @@ EMMI Zone Exits West
       Morph Ball or After Cataris - Central Unit Top Blob
   > Pickup (Morph Ball)
       After Cataris - Central Unit
+  > Room Center
+      After Cataris - Central Unit Bottom Blob and Can Slide
 
 > Event - Bottom Blob through wall; Heals? False
   * Layers: default
   * Event Cataris - Central Unit Bottom Blob
-  > Door to EMMI Zone Tower West
-      Before Cataris - Central Unit or After Cataris - Post-EMMI Door Trigger
+  > Room Center
+      Trivial
 
 > Pickup (Morph Ball); Heals? False
   * Layers: default
@@ -3058,6 +3050,19 @@ EMMI Zone Exits West
   * Extra - boss_hint_name: E.M.M.I.-03MB
   > Door to Central Unit
       Trivial
+
+> Room Center; Heals? False
+  * Layers: default
+  > Door to EMMI Zone Tower West
+      Before Cataris - Central Unit or After Cataris - Post-EMMI Door Trigger
+  > Tunnel to EMMI Zone Exits West
+      Trivial
+  > Upper-right Corner
+      Trivial
+  > Door to Central Unit
+      After Cataris - Central Unit Bottom Blob and Can Slide
+  > Event - Bottom Blob through wall
+      Shoot Diffusion or Wave
 
 ----------------
 Central Unit

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -94,7 +94,7 @@ Extra - asset_id: collision_camera_000
   > Pickup (Missile Tank)
       Trivial
   > Event - Blob, adjacent
-      Shoot Beam
+      Lay Bomb or Shoot Beam
 
 > Event - Blob through Wall; Heals? False
   * Layers: default
@@ -259,7 +259,7 @@ Extra - asset_id: collision_camera_004
   * Layers: default
   * Morph Ball Launcher to Above Z-57 Fight/Dock from Thermal Device Room South
   > Start Point
-      Morph Ball
+      Morph Ball and After Cataris - First Thermal Device
 
 > Front of Thermal Door; Heals? False
   * Layers: default
@@ -435,7 +435,7 @@ Extra - asset_id: collision_camera_009
   > Door to Z-57 Heat Room East
       Trivial
   > Event - Blob
-      Shoot Beam
+      Lay Bomb or Shoot Beam
   > Tunnel to Dropdown Pit
       After Cataris - Z-57 Blob and Can Slide
 
@@ -519,9 +519,9 @@ Extra - asset_id: collision_camera_009
   > Pickup (Z-57)
       All of the following:
           # TODO: proper fight requirements
-          After Elun - Release X Parasites and Use Spin Boost
+          Missiles ≥ 12 and Storm Missile and After Elun - Release X Parasites and Use Spin Boost
           Any of the following:
-              Shoot Charge Beam and Shoot Wide Beam
+              Shoot Charge Beam and Shoot Plasma Beam
               Missiles ≥ 30 and Shoot Super Missile
           Any of the following:
               # Energy Requirements
@@ -572,7 +572,9 @@ Extra - asset_id: collision_camera_010
   > Door to EMMI Zone Tower East (Upper)
       Trivial
   > Tunnel to EMMI Zone Tower East
-      Spider Magnet or Simple IBJ or Use Spin Boost
+      Any of the following:
+          Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
+          Grapple Beam and Grapple Movement (Beginner)
 
 > Dock to Tall Magnet Walls Access; Heals? False
   * Layers: default
@@ -592,7 +594,7 @@ Extra - asset_id: collision_camera_010
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to EMMI Zone Tower East (Lower)
-      Flash Shift or Speed Booster or Can Slide
+      Flash Shift or Speed Booster or Movement (Beginner) or Can Slide or Lay Cross Bomb or Use Spin Boost
   > Dock to Tall Magnet Walls Access
       After Cataris - Hallway Thermal Device
 
@@ -620,7 +622,7 @@ Extra - asset_id: collision_camera_012
   > Above Thermal Door
       Any of the following:
           Varia Suit or After Cataris - Move Magnet Walls Button
-          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
+          Heat/Cold Runs (Beginner) and Heat Damage ≥ 100
 
 > Door to Lava Button East Access (Charge); Heals? False
   * Layers: default
@@ -634,7 +636,7 @@ Extra - asset_id: collision_camera_012
   > Above Thermal Door
       Any of the following:
           Varia Suit or After Cataris - Move Magnet Walls Button
-          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
+          Heat/Cold Runs (Beginner) and Heat Damage ≥ 100
 
 > Door to Artaria Transport Access; Heals? False
   * Layers: default
@@ -649,8 +651,10 @@ Extra - asset_id: collision_camera_012
       All of the following:
           Morph Ball
           Any of the following:
-              Varia Suit or After Cataris - Move Magnet Walls Button
-              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
+              Gravity Suit or After Cataris - Move Magnet Walls Button
+              All of the following:
+                  Heat/Cold Runs (Beginner) and Lava Damage ≥ 80
+                  Varia Suit or Heat Damage ≥ 100
 
 > Door to Lava Button East Access (Cloak); Heals? False
   * Layers: default
@@ -673,6 +677,8 @@ Extra - asset_id: collision_camera_012
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_PistonRight
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
+  > Door to Lava Button East Access (Cloak)
+      Can Slide
 
 > Event - Activate Magnet Walls Button; Heals? False
   * Layers: default
@@ -686,8 +692,10 @@ Extra - asset_id: collision_camera_012
       All of the following:
           Morph Ball
           Any of the following:
-              Varia Suit or After Cataris - Move Magnet Walls Button
-              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 200
+              Gravity Suit or After Cataris - Move Magnet Walls Button
+              All of the following:
+                  Heat/Cold Runs (Beginner) and Lava Damage ≥ 80
+                  Varia Suit or Heat Damage ≥ 100
   > Above Thermal Door
       After Cataris - Hallway Thermal Device
 
@@ -696,11 +704,11 @@ Extra - asset_id: collision_camera_012
   > Door to Tall Magnet Walls Access
       Any of the following:
           Varia Suit or After Cataris - Move Magnet Walls Button
-          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
+          Heat/Cold Runs (Beginner) and Heat Damage ≥ 100
   > Door to Lava Button East Access (Charge)
       Any of the following:
           Varia Suit or After Cataris - Move Magnet Walls Button
-          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
+          Heat/Cold Runs (Beginner) and Heat Damage ≥ 100
   > Below Thermal Door
       After Cataris - Hallway Thermal Device
   > Event - Activate Magnet Walls Button (Below)
@@ -708,7 +716,7 @@ Extra - asset_id: collision_camera_012
           Shoot Diffusion or Wave
           Any of the following:
               Varia Suit
-              Heat/Cold Runs (Beginner) and Heat Damage ≥ 200
+              Heat/Cold Runs (Beginner) and Heat Damage ≥ 30
 
 > Event - Activate Magnet Walls Button (Below); Heals? False
   * Layers: default
@@ -791,6 +799,8 @@ Extra - asset_id: collision_camera_014
   * Extra - right_shield_def: None
   > Door to Tall Magnet Walls Access
       Trivial
+  > Tile Group (POWERBEAM)
+      Speed Booster
 
 > Door to Energy Recharge Station (Charge); Heals? False
   * Layers: default
@@ -806,11 +816,7 @@ Extra - asset_id: collision_camera_014
   > Door to Energy Recharge Station (Cloak)
       Trivial
   > Tile Group (POWERBEAM)
-      Any of the following:
-          Space Jump
-          All of the following:
-              Spider Magnet
-              Grapple Beam or Use Spin Boost
+      Spider Magnet or Space Jump
 
 > Door to Energy Recharge Station (Cloak); Heals? False
   * Layers: default
@@ -876,7 +882,11 @@ Extra - asset_id: collision_camera_015
           Morph Ball
           Any of the following:
               Gravity Suit
-              Heat/Cold Runs (Intermediate) and Lava Damage ≥ 1000
+              All of the following:
+                  Lava Damage ≥ 1000
+                  Any of the following:
+                      Varia Suit and Heat/Cold Runs (Intermediate)
+                      Heat/Cold Runs (Advanced) and Heat Damage ≥ 500
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -911,14 +921,16 @@ Extra - asset_id: collision_camera_015
       All of the following:
           Morph Ball and After Cataris - Lower Power Bomb Tank Ceiling
           Any of the following:
-              Varia Suit
+              Varia Suit or Walljump (Beginner) or Simple IBJ or Use Spin Boost
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
   > Tile Group (POWERBEAM) 4
       All of the following:
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
-          Grapple Beam or Simple IBJ or Use Spin Boost
+          Any of the following:
+              Simple IBJ or Use Spin Boost
+              Grapple Beam and Grapple Movement (Beginner)
 
 > Event - East Blob, below; Heals? False
   * Layers: default
@@ -956,7 +968,11 @@ Extra - asset_id: collision_camera_015
   > Lava Room
       Any of the following:
           Gravity Suit
-          Heat/Cold Runs (Intermediate) and Lava Damage ≥ 200
+          All of the following:
+              Lava Damage ≥ 200
+              Any of the following:
+                  Varia Suit and Heat/Cold Runs (Intermediate)
+                  Heat/Cold Runs (Advanced) and Heat Damage ≥ 50
 
 > Tile Group (POWERBEAM) 1; Heals? False
   * Layers: default
@@ -977,22 +993,6 @@ Extra - asset_id: collision_camera_015
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
-
-> Tile Group (WEIGHT) 1; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_029
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Right Room
-      Trivial
-
-> Tile Group (WEIGHT) 2; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_030
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
 
 > Tile Group (BOMB) 1; Heals? False
   * Layers: default
@@ -1046,7 +1046,7 @@ Extra - asset_id: collision_camera_015
   > Tile Group (BOMB) 2
       All of the following:
           Morph Ball
-          Space Jump or Infinite Bomb Jump (Beginner)
+          Space Jump or Simple IBJ
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 200
@@ -1060,14 +1060,14 @@ Extra - asset_id: collision_camera_015
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('BOMB',)
-  > Tile Group (WEIGHT) 1
+  > Tile Group (BOMB) 3
+      Morph Ball
+  > Right Room
       All of the following:
           Morph Ball
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 10
-  > Tile Group (BOMB) 3
-      Morph Ball
 
 > Tile Group (POWERBOMB); Heals? False
   * Layers: default
@@ -1198,7 +1198,7 @@ Extra - asset_id: collision_camera_015
                   Heat/Cold Runs (Intermediate) and Heat Damage ≥ 200
               Any of the following:
                   Spider Magnet or Space Jump
-                  Spin Boost and Walljump (Beginner)
+                  Walljump (Beginner) and Use Spin Boost
           All of the following:
               Simple IBJ
               Any of the following:
@@ -1212,7 +1212,11 @@ Extra - asset_id: collision_camera_015
           Morph Ball
           Any of the following:
               Gravity Suit
-              Heat/Cold Runs (Intermediate) and Lava Damage ≥ 1000
+              All of the following:
+                  Lava Damage ≥ 1000
+                  Any of the following:
+                      Varia Suit and Heat/Cold Runs (Intermediate)
+                      Heat/Cold Runs (Advanced) and Heat Damage ≥ 500
   > Teleporter to Artaria - Screw Attack Room
       All of the following:
           Gravity Suit
@@ -1234,7 +1238,7 @@ Extra - asset_id: collision_camera_015
 > Center Room; Heals? False
   * Layers: default
   > Event - West Blob
-      Shoot Beam
+      Lay Bomb or Shoot Beam
   > Tile Group (POWERBEAM) 1
       Any of the following:
           Varia Suit
@@ -1362,8 +1366,9 @@ Extra - asset_id: collision_camera_018
       Trivial
   > Tile Group (POWERBEAM)
       Any of the following:
-          Grapple Beam or Spider Magnet or Simple IBJ or Use Spin Boost
+          Spider Magnet or Simple IBJ or Use Spin Boost
           Speed Booster and Disabled Door Lock Randomizer
+          Grapple Beam and Grapple Movement (Beginner)
 
 > Door to Moving Magnet Walls (Tall) (Cloak); Heals? False
   * Layers: default
@@ -1421,12 +1426,12 @@ Extra - asset_id: collision_camera_019
   > Top Ledge
       After Cataris - Green EMMI Access Blob
 
-> Event - First Tunnel Blob; Heals? False
+> Event - First Tunnel Blob, in Tunnel; Heals? False
   * Layers: default
   * Event Cataris - Z-57 First Tunnel Blob
   * Extra - actor_name: breakablemag004
   * Extra - actor_def: actordef:actors/props/breakablemag004/charclasses/breakablemag004.bmsad
-  > Right Platform
+  > Tiny Alcove
       Trivial
 
 > Event - Second Tunnel Blob; Heals? False
@@ -1485,7 +1490,7 @@ Extra - asset_id: collision_camera_019
 > Tiny Alcove; Heals? False
   * Layers: default
   > Event - Second Tunnel Blob
-      Shoot Beam
+      Lay Bomb or Shoot Beam
   > Tunnel to Z-57 Heat Room West (Right)
       All of the following:
           Morph Ball and After Cataris - Z-57 Second Tunnel Blob
@@ -1514,19 +1519,20 @@ Extra - asset_id: collision_camera_019
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 10
   > Event - Green EMMI Access Blob
-      Shoot Beam
+      Lay Bomb or Shoot Beam
 
 > Right Platform; Heals? False
   * Layers: default
-  > Event - First Tunnel Blob
-      Any of the following:
-          Shoot Diffusion or Wave
-          All of the following:
-              Lay Bomb
+  > Event - First Tunnel Blob, in Tunnel
+      All of the following:
+          Lay Bomb
+          Any of the following:
               Simple IBJ or Use Spin Boost
-              Any of the following:
-                  Varia Suit
-                  Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
+              Slide and Slide Jump (Intermediate)
+              Stand on Frozen Enemy (Beginner) and Shoot Ice Missile
+          Any of the following:
+              Varia Suit
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
   > Event - Open Passage Blob
       Shoot Beam
   > Dock to Z-57 Heat Room West (Right)
@@ -1539,6 +1545,14 @@ Extra - asset_id: collision_camera_019
       Any of the following:
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
+  > Event - First Tunnel Blob, below
+      Shoot Diffusion or Wave
+
+> Event - First Tunnel Blob, below; Heals? False
+  * Layers: default
+  * Event Cataris - Z-57 First Tunnel Blob
+  > Right Platform
+      Trivial
 
 ----------------
 Green EMMI Introduction
@@ -1585,7 +1599,9 @@ Extra - asset_id: collision_camera_020
   > Tile Group (POWERBEAM) 1
       Trivial
   > Tunnel to EMMI Zone Item Tunnel
-      Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
+      Any of the following:
+          Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
+          Grapple Beam and Grapple Movement (Beginner)
   > Tunnel to EMMI Zone East Tower Access (Upper)
       Trivial
   > Center Alcove
@@ -1678,7 +1694,7 @@ Extra - asset_id: collision_camera_020
               Flash Shift or Spider Magnet or Lay Cross Bomb or Use Spin Boost
               Infinite Bomb Jump (Intermediate) and Lay Bomb
   > Event - Blob
-      Shoot Beam
+      Lay Bomb or Shoot Beam
 
 ----------------
 Z-57 Heat Room West (Right)
@@ -1701,7 +1717,7 @@ Extra - asset_id: collision_camera_021
               Varia Suit
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
   > Event - Blob
-      Shoot Beam
+      Lay Bomb or Shoot Beam
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -1759,7 +1775,7 @@ Extra - asset_id: collision_camera_022
       Trivial
   > Tunnel to EMMI Zone Tower West
       Any of the following:
-          Space Jump or Simple IBJ
+          Space Jump or Speed Booster or Simple IBJ
           Flash Shift and Walljump (Intermediate) and Use Spin Boost
 
 > Tunnel to EMMI Zone Tower West; Heals? False
@@ -2427,7 +2443,9 @@ Extra - asset_id: collision_camera_028
   > Dock to Long Mouth Statue Room (Upper)
       Morph Ball
   > Tunnel to Central Unit Access
-      Trivial
+      After Cataris - Post-EMMI Door Trigger
+  > Event - Door Trigger
+      Morph Ball and After Cataris - Central Unit
 
 > Dock to Ghavoran Teleport Access; Heals? False
   * Layers: default
@@ -2491,7 +2509,9 @@ Extra - asset_id: collision_camera_028
   * Layers: default
   * Cataris EMMI Tunnel to Central Unit Access/Tunnel to EMMI Zone Exits West
   > Door to EMMI Zone Item Tunnel
-      Trivial
+      After Cataris - Post-EMMI Door Trigger
+  > Event - Door Trigger
+      Morph Ball and After Cataris - Central Unit
 
 > Upper Ledge; Heals? False
   * Layers: default
@@ -2502,6 +2522,12 @@ Extra - asset_id: collision_camera_028
   > Tunnel to EMMI Zone West Exit Path
       Trivial
   > Tunnel to EMMI Zone Item Tunnel
+      Trivial
+
+> Event - Door Trigger; Heals? False
+  * Layers: default
+  * Event Cataris - Post-EMMI Door Trigger
+  > Tunnel to Central Unit Access
       Trivial
 
 ----------------
@@ -2568,7 +2594,9 @@ Extra - asset_id: collision_camera_029
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('POWERBOMB',)
   > Pickup (Power Bomb Tank)
-      Ballspark
+      All of the following:
+          # Item logically unattainable with door rando
+          Disabled Door Lock Randomizer and Ballspark
   > Center of Tunnel
       Morph Ball
 
@@ -2653,7 +2681,9 @@ Extra - asset_id: collision_camera_031
               Spider Magnet or Grapple Movement (Beginner)
           Spider Magnet and After Cataris - Lower Lava Button
   > Dock to EMMI Zone Tower West
-      Flash Shift or Grapple Beam or Spider Magnet or Speed Booster or Use Spin Boost
+      Any of the following:
+          Flash Shift or Spider Magnet or Speed Booster or Use Spin Boost
+          Grapple Beam and Grapple Movement (Beginner)
 
 > Dock to EMMI Zone Tower East; Heals? False
   * Layers: default
@@ -2708,7 +2738,7 @@ Extra - asset_id: collision_camera_032
   > Tunnel to EMMI Zone Exit East
       All of the following:
           Morph Ball
-          Simple IBJ or Use Spin Boost
+          Speed Booster or Simple IBJ or Use Spin Boost
 
 > Dock to Moving Magnet Walls (Small); Heals? False
   * Layers: default
@@ -2912,7 +2942,7 @@ Extra - asset_id: collision_camera_035
 
 > Door to Central Unit Access; Heals? False
   * Layers: default
-  * Wide Beam Door to Central Unit Access/Door from EMMI Zone Tower West
+  * Wide Beam Door to Central Unit Access/Door to EMMI Zone Tower West
   * Extra - actor_name: doorpowerpower_030
   * Extra - actor_def: actordef:actors/props/doorpowerpower/charclasses/doorpowerpower.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2936,10 +2966,11 @@ Central Unit Access
 Extra - total_boundings: {'x1': -7650.0, 'x2': -2600.0, 'y1': 3000.0, 'y2': 6500.0}
 Extra - polygon: [[-2600.0, 6500.0], [-7650.0, 6500.0], [-7650.0, 3000.0], [-2600.0, 3000.0]]
 Extra - asset_id: collision_camera_036
-> Door from EMMI Zone Tower West; Heals? False
+> Door to EMMI Zone Tower West; Heals? False
   * Layers: default
-  * Access Closed to EMMI Zone Tower West/Door to Central Unit Access
-  * Door opens up after Green EMMI is defeated
+  * Wide Beam Door to EMMI Zone Tower West/Door to Central Unit Access
+  * Door opens up after Green EMMI is defeated and rolling through a trigger in
+EMMI Zone Exits West
 
 
   * Extra - actor_name: doorpowerpower_030
@@ -2981,29 +3012,31 @@ Extra - asset_id: collision_camera_036
 > Tunnel to EMMI Zone Exits West; Heals? False
   * Layers: default
   * Cataris EMMI Tunnel to EMMI Zone Exits West/Tunnel to Central Unit Access
-  > Door from EMMI Zone Tower West
-      Trivial
+  > Door to EMMI Zone Tower West
+      Before Cataris - Central Unit or After Cataris - Post-EMMI Door Trigger
 
 > Upper-right Corner; Heals? False
   * Layers: default
-  > Door from EMMI Zone Tower West
-      Trivial
+  > Door to EMMI Zone Tower West
+      Before Cataris - Central Unit or After Cataris - Post-EMMI Door Trigger
   > Event - Top Blob
-      Shoot Beam
+      Lay Bomb or Shoot Beam
   > Door to Central Unit
       Morph Ball or After Cataris - Central Unit Top Blob
 
 > Door to Central Unit; Heals? False
   * Layers: default
   * Access Open to Central Unit/Door to Central Unit Access
-  > Door from EMMI Zone Tower West
-      Any of the following:
-          Morph Ball
-          After Cataris - Central Unit Bottom Blob and Can Slide
+  > Door to EMMI Zone Tower West
+      All of the following:
+          Before Cataris - Central Unit or After Cataris - Post-EMMI Door Trigger
+          Any of the following:
+              Morph Ball
+              After Cataris - Central Unit Bottom Blob and Can Slide
   > Event - Top Blob
       Shoot Diffusion or Wave
   > Event - Bottom Blob, adjacent
-      Shoot Beam
+      Lay Bomb or Shoot Beam
   > Upper-right Corner
       Morph Ball or After Cataris - Central Unit Top Blob
   > Pickup (Morph Ball)
@@ -3012,8 +3045,8 @@ Extra - asset_id: collision_camera_036
 > Event - Bottom Blob through wall; Heals? False
   * Layers: default
   * Event Cataris - Central Unit Bottom Blob
-  > Door from EMMI Zone Tower West
-      Trivial
+  > Door to EMMI Zone Tower West
+      Before Cataris - Central Unit or After Cataris - Post-EMMI Door Trigger
 
 > Pickup (Morph Ball); Heals? False
   * Layers: default
@@ -3068,7 +3101,13 @@ Extra - asset_id: collision_camera_038
   * Layers: default
   * Slide Tunnel to Thermal Device Room North/Tunnel to Lava Button West
   > Dock to Thermal Device Room North (Bottom)
-      Gravity Suit or After Cataris - Lower Lava Button or Lava Damage ≥ 400
+      Any of the following:
+          Gravity Suit or After Cataris - Lower Lava Button
+          All of the following:
+              Lava Damage ≥ 400
+              Any of the following:
+                  Varia Suit and Heat/Cold Runs (Intermediate)
+                  Heat/Cold Runs (Advanced) and Heat Damage ≥ 500
   > Event - Lower Lava Button (Above)
       All of the following:
           Shoot Diffusion or Wave
@@ -3083,8 +3122,10 @@ Extra - asset_id: collision_camera_038
       Any of the following:
           Gravity Suit or After Cataris - Lower Lava Button
           All of the following:
-              Heat/Cold Runs (Advanced) and Lava Damage ≥ 500
-              Varia Suit or Heat Damage ≥ 500
+              Lava Damage ≥ 500
+              Any of the following:
+                  Varia Suit and Heat/Cold Runs (Intermediate)
+                  Heat/Cold Runs (Advanced) and Heat Damage ≥ 500
 
 > Dock to Thermal Device Room North (Mid); Heals? False
   * Layers: default
@@ -3119,8 +3160,6 @@ Extra - asset_id: collision_camera_040
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to Thermal Device Room North
-      Trivial
-  > Tile Group (POWERBEAM)
       Trivial
 
 > Dock to EMMI Zone Tower West; Heals? False
@@ -3161,16 +3200,6 @@ Extra - asset_id: collision_camera_040
   > Door to Thermal Device Room North
       Trivial
 
-> Tile Group (POWERBEAM); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_002
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-  > Door to Transport to Dairon
-      Trivial
-
 > Dock to Thermal Device Room North; Heals? False
   * Layers: default
   * Open Passage to Thermal Device Room North/Dock to Dairon Transport Access
@@ -3180,7 +3209,7 @@ Extra - asset_id: collision_camera_040
 > Event - Push Wide Beam Block; Heals? False
   * Layers: default
   * Event Cataris - Dairon Transport Wide Beam Block
-  > Door to Thermal Device Room North
+  > Dock to EMMI Zone Tower West
       Trivial
 
 ----------------
@@ -3228,7 +3257,11 @@ Extra - asset_id: collision_camera_042
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to Dairon Transport Access
-      Can Slide
+      All of the following:
+          Can Slide
+          Any of the following:
+              Varia Suit or After Cataris - Lower Lava Button
+              Heat/Cold Runs (Beginner) and Heat Damage ≥ 200
   > Past Magnet Floor
       Before Cataris - Final Thermal Device
 
@@ -3246,7 +3279,9 @@ Extra - asset_id: collision_camera_042
           All of the following:
               Can Slide
               Gravity Suit or After Cataris - Lower Lava Button
-          Morph Ball and Lava Damage ≥ 200
+          All of the following:
+              Morph Ball and Heat/Cold Runs (Beginner) and Lava Damage ≥ 200
+              Varia Suit or Heat Damage ≥ 100
 
 > Door to Dairon Transport Access; Heals? False
   * Layers: default
@@ -3258,7 +3293,11 @@ Extra - asset_id: collision_camera_042
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to Total Recharge Station North
-      Can Slide
+      All of the following:
+          Can Slide
+          Any of the following:
+              Varia Suit or After Cataris - Lower Lava Button
+              Heat/Cold Runs (Beginner) and Heat Damage ≥ 200
   > Event - Thermal Device 2
       Trivial
 
@@ -3268,7 +3307,9 @@ Extra - asset_id: collision_camera_042
   * Extra - actor_name: item_energyfragment_001
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Tunnel to Lava Button West
-      Trivial
+      Any of the following:
+          Varia Suit
+          Heat/Cold Runs (Beginner) and Heat Damage ≥ 60
 
 > Pickup (Energy Tank); Heals? False
   * Layers: default
@@ -3302,13 +3343,21 @@ Extra - asset_id: collision_camera_042
   * Layers: default
   * Slide Tunnel to Lava Button West/Tunnel to Thermal Device Room North
   > Pickup (Energy Part)
-      Trivial
+      Any of the following:
+          Varia Suit
+          Heat/Cold Runs (Beginner) and Heat Damage ≥ 60
 
 > Dock to Lava Button West (Bottom); Heals? False
   * Layers: default
   * Open Passage to Lava Button West/Dock to Thermal Device Room North (Bottom)
   > Below Spider Magnet Wall
-      Gravity Suit or After Cataris - Lower Lava Button or Lava Damage ≥ 500
+      Any of the following:
+          Gravity Suit or After Cataris - Lower Lava Button
+          All of the following:
+              Lava Damage ≥ 500
+              Any of the following:
+                  Varia Suit and Heat/Cold Runs (Intermediate)
+                  Heat/Cold Runs (Advanced) and Heat Damage ≥ 200
 
 > Dock to Lava Button West (Mid); Heals? False
   * Layers: default
@@ -3352,13 +3401,26 @@ Extra - asset_id: collision_camera_042
           All of the following:
               Can Slide
               Gravity Suit or After Cataris - Lower Lava Button
-          Morph Ball and Lava Damage ≥ 200
+          All of the following:
+              Morph Ball and Heat/Cold Runs (Beginner) and Lava Damage ≥ 200
+              Varia Suit or Heat Damage ≥ 100
   > Dock to Lava Button West (Bottom)
-      Gravity Suit or After Cataris - Lower Lava Button or Lava Damage ≥ 500
+      Any of the following:
+          Gravity Suit or After Cataris - Lower Lava Button
+          All of the following:
+              Lava Damage ≥ 500
+              Any of the following:
+                  Varia Suit and Heat/Cold Runs (Intermediate)
+                  Heat/Cold Runs (Advanced) and Heat Damage ≥ 200
   > Event - Lower Spider Magnet Floor
       All of the following:
           Spider Magnet
-          Gravity Suit or After Cataris - Lower Lava Button
+          Any of the following:
+              Gravity Suit or After Cataris - Lower Lava Button
+              All of the following:
+                  Heat/Cold Runs (Beginner) and Lava Damage ≥ 30
+                  Grapple Beam or Use Spin Boost
+                  Varia Suit or Heat Damage ≥ 50
 
 ----------------
 Path to Kraid Entryway
@@ -3711,7 +3773,7 @@ Extra - asset_id: collision_camera_045
   > Door to Moving Magnet Walls (Tall)
       Trivial
   > Event - Blob, adjacent
-      Shoot Beam
+      Lay Bomb or Shoot Beam
   > Tunnel to Teleport to Artaria (Blue)
       After Cataris - Lava Button East Blob
 
@@ -3906,13 +3968,13 @@ Extra - asset_id: collision_camera_048
   > Tile Group (POWERBEAM) 1
       Any of the following:
           Varia Suit
-          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
+          Heat/Cold Runs (Beginner) and Heat Damage ≥ 50
   > Left Floor
       All of the following:
           After Cataris - Heated Wide Beam Block
           Any of the following:
               Varia Suit
-              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
+              Heat/Cold Runs (Beginner) and Heat Damage ≥ 50
 
 > Tile Group (POWERBEAM) 1; Heals? False
   * Layers: default
@@ -3926,17 +3988,7 @@ Extra - asset_id: collision_camera_048
   > Tile Group (BOMB) 1
       Any of the following:
           Varia Suit
-          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
-
-> Tile Group (BOMB) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_048
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('BOMB',)
-  > Left Floor
-      Trivial
+          Heat/Cold Runs (Beginner) and Heat Damage ≥ 50
 
 > Tile Group (POWERBEAM) 2; Heals? False
   * Layers: default
@@ -3947,14 +3999,26 @@ Extra - asset_id: collision_camera_048
   * Extra - tile_types: ('POWERBEAM',)
   > Tile Group (MISSILE) 1
       Any of the following:
-          Spin Boost
+          Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
   > Tile Group (MISSILE) 2
       All of the following:
           Morph Ball
           Any of the following:
               Varia Suit
-              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 40
+  > Tile Group (MISSILE) 3
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Varia Suit
+              Heat/Cold Runs (Intermediate) and Heat Damage
+  > Tunnel to Teleport to Artaria (Blue)
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Varia Suit
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
   > Left Floor
       Any of the following:
           Varia Suit
@@ -3980,7 +4044,13 @@ Extra - asset_id: collision_camera_048
           Can Slide
           Any of the following:
               Varia Suit
-              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 40
+  > Tunnel to Teleport to Artaria (Blue)
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Varia Suit
+              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 80
 
 > Tile Group (MISSILE) 2; Heals? False
   * Layers: default
@@ -3994,7 +4064,7 @@ Extra - asset_id: collision_camera_048
           Morph Ball
           Any of the following:
               Varia Suit
-              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 40
   > Tile Group (MISSILE) 1
       Any of the following:
           Varia Suit
@@ -4017,12 +4087,18 @@ Extra - asset_id: collision_camera_048
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
   * Extra - tile_types: ('MISSILE',)
+  > Tile Group (POWERBEAM) 2
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Varia Suit
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 60
   > Tile Group (MISSILE) 1
       All of the following:
           Can Slide
           Any of the following:
               Varia Suit
-              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 40
   > Tile Group (MISSILE) 2
       Any of the following:
           Varia Suit
@@ -4035,10 +4111,28 @@ Extra - asset_id: collision_camera_048
 > Tunnel to Teleport to Artaria (Blue); Heals? False
   * Layers: default
   * Morph Ball Tunnel to Teleport to Artaria (Blue)/Tunnel to Double Obsydomithon Room
+  > Tile Group (POWERBEAM) 2
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Varia Suit
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
+  > Tile Group (MISSILE) 1
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Varia Suit
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 80
+  > Tile Group (MISSILE) 2
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Varia Suit
+              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 60
   > Tile Group (MISSILE) 3
       Any of the following:
           Varia Suit
-          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 20
+          Heat/Cold Runs (Intermediate) and Heat Damage ≥ 40
 
 > Event - Wide Beam Block; Heals? False
   * Layers: default
@@ -4055,9 +4149,7 @@ Extra - asset_id: collision_camera_048
           After Cataris - Heated Wide Beam Block
           Any of the following:
               Varia Suit
-              Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
-  > Tile Group (BOMB) 2
-      Morph Ball
+              Heat/Cold Runs (Beginner) and Heat Damage ≥ 50
   > Tile Group (POWERBEAM) 2
       Any of the following:
           Varia Suit
@@ -4065,7 +4157,7 @@ Extra - asset_id: collision_camera_048
   > Event - Wide Beam Block
       Push Wide Beam Block
   > Event - Blob
-      Shoot Beam
+      Lay Bomb or Shoot Beam
 
 > Event - Blob; Heals? False
   * Layers: default
@@ -4442,7 +4534,7 @@ Extra - asset_id: collision_camera_053
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Dock to Underlava Puzzle Room 1
-      Morph Ball
+      Morph Ball and After Cataris - Underlava Speed Blocks Destroyed
 
 > Event - Grapple Block; Heals? False
   * Layers: default
@@ -4505,7 +4597,11 @@ Extra - asset_id: collision_camera_053
   > Below Lava
       Any of the following:
           Gravity Suit
-          Heat/Cold Runs (Intermediate) and Lava Damage ≥ 400
+          All of the following:
+              Lava Damage ≥ 400
+              Any of the following:
+                  Varia Suit and Heat/Cold Runs (Intermediate)
+                  Heat/Cold Runs (Advanced) and Heat Damage ≥ 200
 
 > Below Lava; Heals? False
   * Layers: default
@@ -4518,7 +4614,13 @@ Extra - asset_id: collision_camera_053
   > Above Lava
       Any of the following:
           Gravity Suit
-          Heat/Cold Runs (Intermediate) and Lava Damage ≥ 500
+          All of the following:
+              Lava Damage ≥ 500
+              Any of the following:
+                  Varia Suit and Heat/Cold Runs (Intermediate)
+                  Heat/Cold Runs (Advanced) and Heat Damage ≥ 200
+  > Dock to Underlava Puzzle Room 1
+      Morph Ball and After Cataris - Underlava Speed Blocks Destroyed
 
 > Tunnel to Dropdown Pit; Heals? False
   * Layers: default
@@ -4541,8 +4643,18 @@ Extra - asset_id: collision_camera_053
   * Open Passage to Underlava Puzzle Room 1/Dock to Underlava Puzzle Room 2
   > Pickup (Energy Part)
       All of the following:
-          Gravity Suit and After Cataris - Lava Grapple Block and Ballspark
+          Gravity Suit and Morph Ball and After Cataris - Underlava Speed Blocks Destroyed
           Flash Shift or Speedbooster Conservation (Beginner) or Simple IBJ or Use Spin Boost
+  > Below Lava
+      Morph Ball and After Cataris - Underlava Speed Blocks Destroyed
+  > Event - Speed Blocks Destroyed
+      Gravity Suit and Speed Booster and After Cataris - Lava Grapple Block
+
+> Event - Speed Blocks Destroyed; Heals? False
+  * Layers: default
+  * Event Cataris - Underlava Speed Blocks Destroyed
+  > Dock to Underlava Puzzle Room 1
+      Trivial
 
 ----------------
 Underlava Puzzle Room 1
@@ -4592,7 +4704,7 @@ Extra - asset_id: collision_camera_055
   * Layers: default
   > Tile Group (MISSILE)
       Any of the following:
-          Spider Magnet or Speed Booster or Use Spin Boost
+          Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
           Grapple Beam and Grapple Movement (Beginner)
   > Tunnel to EMMI Zone Tower East
       Morph Ball

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1033,6 +1033,14 @@
             "GhavoranChozoX": {
                 "long_name": "Ghavoran - Chozo-X",
                 "extra": {}
+            },
+            "CatarisUnderlavaSpeedBlocks": {
+                "long_name": "Cataris - Underlava Speed Blocks Destroyed",
+                "extra": {}
+            },
+            "CatarisPostEmmiTrigger": {
+                "long_name": "Cataris - Post-EMMI Door Trigger",
+                "extra": {}
             }
         },
         "tricks": {


### PR DESCRIPTION
Finishes the primarily trickless-focused revision for Cataris. A few rooms in the EMMI Zone were affected, and most rooms ranging from Underlava Puzzle Room 2 all the way to Teleport to Artaria (Blue), and all the way to the upper edge of the EMMI Zone from there.

- Added event in Underlava Puzzle Room 2 for breaking the speed blocks so that going between the two parts can be accounted for
- Added event for the trigger that reopens the door to Central Unit Access, allowing it logical to go back through
- Separated the First Tunnel Blob event into two to account for Diffusion/Wave not needing to be in the tunnel
- Deleted some unnecessary tile nodes
- Accounted for whether the player could have Varia or not when trudging through lava
- Accounted for the upper parts of Thermal Device Room North being heated without pressing the lava button
- Added other various methods of going through rooms