### PR TITLE
fixed tab order in ui for enemy attribute rando

### DIFF
--- a/randovania/gui/ui_files/preset_prime_enemy_stat_randomizer.ui
+++ b/randovania/gui/ui_files/preset_prime_enemy_stat_randomizer.ui
@@ -43,8 +43,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>670</width>
-         <height>423</height>
+         <width>653</width>
+         <height>554</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -708,6 +708,21 @@
   </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <tabstops>
+  <tabstop>scroll_area</tabstop>
+  <tabstop>activate_randomizer</tabstop>
+  <tabstop>range_scale_low</tabstop>
+  <tabstop>range_scale_high</tabstop>
+  <tabstop>diff_xyz</tabstop>
+  <tabstop>range_health_low</tabstop>
+  <tabstop>range_health_high</tabstop>
+  <tabstop>range_speed_low</tabstop>
+  <tabstop>range_speed_high</tabstop>
+  <tabstop>range_damage_low</tabstop>
+  <tabstop>range_damage_high</tabstop>
+  <tabstop>range_knockback_low</tabstop>
+  <tabstop>range_knockback_high</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
when pressing tab in the 'enemy attribute randomizer' tab, it would be completely out of order, so now that's fixed.