### PR TITLE
Add trick for Short Boost

### DIFF
--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -4539,6 +4539,32 @@
                         }
                     ]
                 }
+            },
+            "Can Short Boost": {
+                "type": "and",
+                "data": {
+                    "comment": null,
+                    "items": [
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Flash",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        }
+                    ]
+                }
             }
         },
         "damage_reductions": [

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1140,6 +1140,11 @@
                 "long_name": "Climb Sloped Tunnels",
                 "description": "There are various tunnels that contain slopes in the game, many of which can also be ascended with bombs or good movement.",
                 "extra": {}
+            },
+            "ShortBoost": {
+                "long_name": "Short Boost",
+                "description": "Flash Shift can be manipulated to allow you to charge Speed Booster in a smaller area than intended.",
+                "extra": {}
             }
         },
         "damage": {

--- a/randovania/games/dread/json_data/header.txt
+++ b/randovania/games/dread/json_data/header.txt
@@ -362,6 +362,9 @@ Templates
               Combat (Advanced) and Shoot Beam
               Combat (Beginner) and Shoot Plasma Beam
 
+* Can Short Boost:
+      Flash Shift and Speed Booster
+
 ====================
 Dock Weaknesses
 


### PR DESCRIPTION
This adds Short Boost to the list of tricks. No implementation included, only adds it to the header. Trick description is as follows:
> Flash Shift can be manipulated to allow you to charge Speed Booster in a smaller area than intended.

Also adds template for Short Boost, requiring Flash Shift and Speed Booster.