### PR TITLE
Dread: Add Diffusion Abuse trick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Event in Underlava Puzzle Room 2 for breaking the speed blocks so that going between the two parts can be accounted for
 - Added: Event for the trigger that reopens the door to Central Unit Access, allowing it logical to go back through
 - Added: Other various methods of going through rooms
+- Added: New Diffusion Abuse trick for pushing Wide Beam blocks and activating the lava buttons in Cataris.
 - Changed: Separated the First Tunnel Blob event into two to account for Diffusion/Wave not needing to be in the tunnel
 - Changed: Deleted some unnecessary tile nodes
 - Changed: Various instances of Walljump (Beginner) to trivial

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -21620,7 +21620,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "https://youtu.be/ubyYAvEgBck",
                                             "items": [
                                                 {
                                                     "type": "template",
@@ -21630,7 +21630,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "DiffusionAbuse",
+                                                        "name": "TunnelSlope",
                                                         "amount": 5,
                                                         "negate": false
                                                     }

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -21597,8 +21597,49 @@
                             }
                         },
                         "Event - EMMI Wide Beam Block": {
-                            "type": "template",
-                            "data": "Push Wide Beam Block"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Charge Beam"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Wide Beam"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Diffusion Beam"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DiffusionAbuse",
+                                                        "amount": 5,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Tunnel to EMMI Zone Hub": {
                             "type": "and",
@@ -21664,7 +21705,11 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Push Wide Beam Block"
+                                        "data": "Shoot Charge Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Wide Beam"
                                     },
                                     {
                                         "type": "resource",

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -21602,20 +21602,8 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Shoot Charge Beam"
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Shoot Wide Beam"
-                                                }
-                                            ]
-                                        }
+                                        "type": "template",
+                                        "data": "Push Wide Beam Block"
                                     },
                                     {
                                         "type": "and",
@@ -21705,11 +21693,7 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Shoot Charge Beam"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Wide Beam"
+                                        "data": "Push Wide Beam Block"
                                     },
                                     {
                                         "type": "resource",

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -21630,7 +21630,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "TunnelSlope",
+                                                        "name": "DiffusionAbuse",
                                                         "amount": 5,
                                                         "negate": false
                                                     }

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -4403,7 +4403,7 @@ Extra - asset_id: collision_camera_069
           Shoot Charge Beam and Shoot Wide Beam
           All of the following:
               # https://youtu.be/ubyYAvEgBck
-              Climb Sloped Tunnels (Hypermode) and Shoot Diffusion Beam
+              Diffusion Abuse (Hypermode) and Shoot Diffusion Beam
   > Tunnel to EMMI Zone Hub
       Trivial
 

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -4400,7 +4400,7 @@ Extra - asset_id: collision_camera_069
       After Artaria - EMMI Wide Beam Block
   > Event - EMMI Wide Beam Block
       Any of the following:
-          Shoot Charge Beam and Shoot Wide Beam
+          Push Wide Beam Block
           All of the following:
               # https://youtu.be/ubyYAvEgBck
               Diffusion Abuse (Hypermode) and Shoot Diffusion Beam
@@ -4421,7 +4421,7 @@ Extra - asset_id: collision_camera_069
   > Door to EMMI Zone Spinner
       After Artaria - EMMI Wide Beam Block
   > Event - EMMI Wide Beam Block
-      Wave Beam and Shoot Charge Beam and Shoot Wide Beam
+      Wave Beam and Push Wide Beam Block
 
 > Door to EMMI Zone Spinner; Heals? False
   * Layers: default

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -4401,7 +4401,9 @@ Extra - asset_id: collision_camera_069
   > Event - EMMI Wide Beam Block
       Any of the following:
           Shoot Charge Beam and Shoot Wide Beam
-          Diffusion Abuse (Hypermode) and Shoot Diffusion Beam
+          All of the following:
+              # https://youtu.be/ubyYAvEgBck
+              Climb Sloped Tunnels (Hypermode) and Shoot Diffusion Beam
   > Tunnel to EMMI Zone Hub
       Trivial
 

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -4399,7 +4399,9 @@ Extra - asset_id: collision_camera_069
   > Door to EMMI Zone Hub (Upper)
       After Artaria - EMMI Wide Beam Block
   > Event - EMMI Wide Beam Block
-      Push Wide Beam Block
+      Any of the following:
+          Shoot Charge Beam and Shoot Wide Beam
+          Diffusion Abuse (Hypermode) and Shoot Diffusion Beam
   > Tunnel to EMMI Zone Hub
       Trivial
 
@@ -4417,7 +4419,7 @@ Extra - asset_id: collision_camera_069
   > Door to EMMI Zone Spinner
       After Artaria - EMMI Wide Beam Block
   > Event - EMMI Wide Beam Block
-      Wave Beam and Push Wide Beam Block
+      Wave Beam and Shoot Charge Beam and Shoot Wide Beam
 
 > Door to EMMI Zone Spinner; Heals? False
   * Layers: default

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -17786,8 +17786,37 @@
                             }
                         },
                         "Event - Push Wide Beam Block": {
-                            "type": "template",
-                            "data": "Push Wide Beam Block"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Push Wide Beam Block"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Diffusion Beam"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DiffusionAbuse",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -23404,8 +23433,37 @@
                             }
                         },
                         "Event - Wide Beam Block": {
-                            "type": "template",
-                            "data": "Push Wide Beam Block"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Push Wide Beam Block"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Diffusion Beam"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DiffusionAbuse",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Event - Blob": {
                             "type": "or",

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -3891,7 +3891,7 @@
                                 ]
                             }
                         },
-                        "Event - Activate Magnet Walls with Wave": {
+                        "Event - Activate Magnet Walls": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3899,28 +3899,48 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Wave",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "CatarisMoveMagnetWallsButton",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
                                             "type": "tricks",
                                             "name": "Knowledge",
                                             "amount": 3,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Wave",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Diffusion Beam"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "DiffusionAbuse",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -4201,7 +4221,7 @@
                         }
                     }
                 },
-                "Event - Activate Magnet Walls with Wave": {
+                "Event - Activate Magnet Walls": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -4209,7 +4229,7 @@
                         "y": 2126.03,
                         "z": 0.0
                     },
-                    "description": "",
+                    "description": "Activating the switch from this room will darken the room and require the\nplayer to reload the room to see.\n\n",
                     "layers": [
                         "default"
                     ],

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -3490,8 +3490,42 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Shoot Diffusion or Wave"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Wave",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Diffusion Beam"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "DiffusionAbuse",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "or",
@@ -17227,8 +17261,42 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Shoot Diffusion or Wave"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Wave",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Diffusion Beam"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "DiffusionAbuse",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "or",

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -3210,7 +3210,9 @@ Extra - asset_id: collision_camera_040
   > Pickup (Missile Tank)
       Speed Booster
   > Event - Push Wide Beam Block
-      Push Wide Beam Block
+      Any of the following:
+          Push Wide Beam Block
+          Diffusion Abuse (Intermediate) and Shoot Diffusion Beam
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -4175,7 +4177,9 @@ Extra - asset_id: collision_camera_048
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 50
   > Event - Wide Beam Block
-      Push Wide Beam Block
+      Any of the following:
+          Push Wide Beam Block
+          Diffusion Abuse (Intermediate) and Shoot Diffusion Beam
   > Event - Blob
       Lay Bomb or Shoot Beam
 

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -713,7 +713,9 @@ Extra - asset_id: collision_camera_012
       After Cataris - Hallway Thermal Device
   > Event - Activate Magnet Walls Button (Below)
       All of the following:
-          Shoot Diffusion or Wave
+          Any of the following:
+              Wave Beam
+              Diffusion Abuse (Beginner) and Shoot Diffusion Beam
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Beginner) and Heat Damage ≥ 30
@@ -3118,7 +3120,9 @@ Extra - asset_id: collision_camera_038
                   Heat/Cold Runs (Advanced) and Heat Damage ≥ 500
   > Event - Lower Lava Button (Above)
       All of the following:
-          Shoot Diffusion or Wave
+          Any of the following:
+              Wave Beam
+              Diffusion Abuse (Beginner) and Shoot Diffusion Beam
           Any of the following:
               Varia Suit
               Heat/Cold Runs (Beginner) and Heat Damage ≥ 100

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -787,8 +787,12 @@ Extra - asset_id: collision_camera_014
           All of the following:
               Spider Magnet
               Grapple Beam or After Cataris - Move Magnet Walls Button
-  > Event - Activate Magnet Walls with Wave
-      Wave Beam and Before Cataris - Move Magnet Walls Button and Knowledge (Advanced)
+  > Event - Activate Magnet Walls
+      All of the following:
+          Knowledge (Advanced)
+          Any of the following:
+              Wave Beam
+              Diffusion Abuse (Beginner) and Shoot Diffusion Beam
 
 > Door to Lava Button East Access; Heals? False
   * Layers: default
@@ -858,9 +862,13 @@ Extra - asset_id: collision_camera_014
   > Door to Teleport to Artaria (Blue)
       Trivial
 
-> Event - Activate Magnet Walls with Wave; Heals? False
+> Event - Activate Magnet Walls; Heals? False
   * Layers: default
   * Event Cataris - Move Magnet Walls Button
+  * Activating the switch from this room will darken the room and require the
+player to reload the room to see.
+
+
   > Door to Tall Magnet Walls Access
       Trivial
 

--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -754,8 +754,37 @@
                             }
                         },
                         "Event - Push Wide Beam Block": {
-                            "type": "template",
-                            "data": "Push Wide Beam Block"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Push Wide Beam Block"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Diffusion Beam"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DiffusionAbuse",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -1127,8 +1156,37 @@
                             }
                         },
                         "Event - Push Wide Beam Block": {
-                            "type": "template",
-                            "data": "Push Wide Beam Block"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Push Wide Beam Block"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Diffusion Beam"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DiffusionAbuse",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -9314,8 +9372,37 @@
                             }
                         },
                         "Event - Ferenia Transport Wide Beam Block": {
-                            "type": "template",
-                            "data": "Push Wide Beam Block"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Push Wide Beam Block"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Diffusion Beam"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DiffusionAbuse",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -145,7 +145,9 @@ Extra - asset_id: collision_camera_001
           Space Jump or Simple IBJ
           Walljump (Beginner) and Use Spin Boost
   > Event - Push Wide Beam Block
-      Push Wide Beam Block
+      Any of the following:
+          Push Wide Beam Block
+          Diffusion Abuse (Intermediate) and Shoot Diffusion Beam
 
 > Wide Beam Block - Above; Heals? False
   * Layers: default
@@ -210,7 +212,9 @@ Extra - asset_id: collision_camera_002
   > Door to Save Station East
       After Dairon - Wide Beam Block by Save Room
   > Event - Push Wide Beam Block
-      Push Wide Beam Block
+      Any of the following:
+          Push Wide Beam Block
+          Diffusion Abuse (Intermediate) and Shoot Diffusion Beam
 
 > Tile Group (WEIGHT); Heals? False
   * Layers: default
@@ -1686,7 +1690,9 @@ Extra - asset_id: collision_camera_019
   > Dock to EMMI Zone Exit North
       After Dairon - Wide Beam Block Ferenia Elevator
   > Event - Ferenia Transport Wide Beam Block
-      Push Wide Beam Block
+      Any of the following:
+          Push Wide Beam Block
+          Diffusion Abuse (Intermediate) and Shoot Diffusion Beam
 
 > Door to Navigation Station North (Upper); Heals? False
   * Layers: default

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1148,7 +1148,7 @@
             },
             "DiffusionAbuse": {
                 "long_name": "Diffusion Abuse",
-                "description": "Using Diffusion Beam in certain situations can bypass the usual requirements for some objects.",
+                "description": "Using Diffusion Beam in certain situations can bypass the usual requirements for some objects. https://youtu.be/p9XJHW10QC8",
                 "extra": {}
             }
         },

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1411,46 +1411,17 @@
                 }
             },
             "Push Wide Beam Block": {
-                "type": "or",
+                "type": "and",
                 "data": {
                     "comment": null,
                     "items": [
                         {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Charge Beam"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Wide Beam"
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Shoot Charge Beam"
                         },
                         {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Diffusion Beam"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "DiffusionAbuse",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                            "type": "template",
+                            "data": "Shoot Wide Beam"
                         }
                     ]
                 }

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1148,7 +1148,7 @@
             },
             "DiffusionAbuse": {
                 "long_name": "Diffusion Abuse",
-                "description": "Using Diffusion Beam in certain situations can bypass the usual requirements for some objects",
+                "description": "Using Diffusion Beam in certain situations can bypass the usual requirements for some objects.",
                 "extra": {}
             }
         },

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1145,6 +1145,11 @@
                 "long_name": "Short Boost",
                 "description": "Flash Shift can be manipulated to allow you to charge Speed Booster in a smaller area than intended.",
                 "extra": {}
+            },
+            "DiffusionAbuse": {
+                "long_name": "Diffusion Abuse",
+                "description": "Using Diffusion Beam in certain situations can bypass the usual requirements for some objects",
+                "extra": {}
             }
         },
         "damage": {
@@ -1406,17 +1411,46 @@
                 }
             },
             "Push Wide Beam Block": {
-                "type": "and",
+                "type": "or",
                 "data": {
                     "comment": null,
                     "items": [
                         {
-                            "type": "template",
-                            "data": "Shoot Charge Beam"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Charge Beam"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Wide Beam"
+                                    }
+                                ]
+                            }
                         },
                         {
-                            "type": "template",
-                            "data": "Shoot Wide Beam"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Diffusion Beam"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "DiffusionAbuse",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     ]
                 }

--- a/randovania/games/dread/json_data/header.txt
+++ b/randovania/games/dread/json_data/header.txt
@@ -31,7 +31,9 @@ Templates
       Ice Missile and Shoot Missile
 
 * Push Wide Beam Block:
-      Shoot Charge Beam and Shoot Wide Beam
+      Any of the following:
+          Shoot Charge Beam and Shoot Wide Beam
+          Diffusion Abuse (Intermediate) and Shoot Diffusion Beam
 
 * Activate Storm Missile Locks:
       Missiles ≥ 15 and Storm Missile

--- a/randovania/games/dread/json_data/header.txt
+++ b/randovania/games/dread/json_data/header.txt
@@ -31,9 +31,7 @@ Templates
       Ice Missile and Shoot Missile
 
 * Push Wide Beam Block:
-      Any of the following:
-          Shoot Charge Beam and Shoot Wide Beam
-          Diffusion Abuse (Intermediate) and Shoot Diffusion Beam
+      Shoot Charge Beam and Shoot Wide Beam
 
 * Activate Storm Missile Locks:
       Missiles ≥ 15 and Storm Missile


### PR DESCRIPTION
- Add the new Diffusion Abuse trick
- Apply it to pushing Wide Beam Blocks while next to them as intermediate
- Added the trick to activating the Cataris lava buttons from outside as beginner
- Added hypermode trick for the Artaria Wide Beam Block