### PR TITLE
Add trick for ADC and adjust SSC trick description

### DIFF
--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1145,6 +1145,11 @@
                 "long_name": "Short Boost",
                 "description": "Flash Shift can be manipulated to allow you to charge Speed Booster in a smaller area than intended.",
                 "extra": {}
+            },
+            "ADC": {
+                "long_name": "Aim Down Clip",
+                "description": "A type of shine sink clip that allows you to clip through 2 tile thick floors.",
+                "extra": {}
             }
         },
         "damage": {

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1101,7 +1101,7 @@
             },
             "SSC": {
                 "long_name": "Shinesink Clip",
-                "description": "Shinesparking and firing the grapple beam in certain locations allows you to clip through 1 tile thick floors.",
+                "description": "Shinesparking and firing the grapple beam in certain locations allows you to clip through 1-tile thick floors.",
                 "extra": {}
             },
             "Suitless": {
@@ -1148,7 +1148,7 @@
             },
             "ADC": {
                 "long_name": "Aim Down Clip",
-                "description": "A type of shine sink clip that allows you to clip through 2 tile thick floors.",
+                "description": "A type of shine sink clip that allows you to clip through 2-tile thick floors.",
                 "extra": {}
             }
         },

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1101,7 +1101,7 @@
             },
             "SSC": {
                 "long_name": "Shinesink Clip",
-                "description": "Shinesparking and firing the grapple beam in certain locations allows you to clip through floors.",
+                "description": "Shinesparking and firing the grapple beam in certain locations allows you to clip through 1 tile thick floors.",
                 "extra": {}
             },
             "Suitless": {


### PR DESCRIPTION
Adds a trick for Aim Down Clip. Description is as follows:
> A type of shine sink clip that allows you to clip through 2 tile thick floors.

Also adjusts the description for Shinesink Clip. It is now as follows:
> Shinesparking and firing the grapple beam in certain locations allows you to clip through 1 tile thick floors.

Includes no implementation of the new trick. This will be handled in future PRs.