### PR TITLE
Ghovran: Add entrance grapple block requirement to the spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Some Grapple options to include Grapple Movement
 - Changed: Some Movement tricks to Climb Sloped Tunnels
 - Changed: Some Movement tricks to Skip Cross Bomb
+- Changed: Rotating the spinner in Ghavoran - Flipper Room now requires either pulling the grapple block in Right Entrance, or activating the Freezer in Dairon.
 - Changed: Allow pickup in Ghavoran Elun Transport Access by charging speed via navigation room
 - Changed: Help solver by adding Morph Ball requirment on connections to event to flip the spinner in Ghavoran Flipper Room
 - Changed: Shooting occluded objects requires at least Intermediate Knowledge

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -2780,6 +2780,32 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "TODO: If the elevator to Dairon is shuffled is also an alternative",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "GhavoranBureniaTransportGrappleBox",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s030_baselab:default:powergenerator_002",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -539,7 +539,11 @@ Extra - asset_id: collision_camera_007
   > Dock to Spin Boost Tower
       After Ghavoran - Super Missile Rotatable Enky
   > Event - Super Missile Rotatable
-      Morph Ball and Before Ghavoran - Super Missile Rotatable
+      All of the following:
+          Morph Ball and Before Ghavoran - Super Missile Rotatable
+          Any of the following:
+              # TODO: If the elevator to Dairon is shuffled is also an alternative
+              After Ghavoran - Burenia Transport Grapple Box or After Dairon - Power Switch 2
   > Event - Super Missile Rotatable Enky
       Destroy Enky
 


### PR DESCRIPTION
This prevents the generator from getting stuck by rotating it before either enabling the freezer or pulling the grapple block.