### PR TITLE
Dread: Add the remaining Wide Block Diffusion Abuse tricks

### DIFF
--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -2171,8 +2171,37 @@
                             }
                         },
                         "Event - Push Wide Beam Block": {
-                            "type": "template",
-                            "data": "Push Wide Beam Block"
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Push Wide Beam Block"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Diffusion Beam"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "DiffusionAbuse",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -414,7 +414,9 @@ Extra - asset_id: collision_camera_004
   > Tile Group (BOMB)
       Morph Ball and After Dairon - Big Hub Grapple Block
   > Event - Push Wide Beam Block
-      Push Wide Beam Block
+      Any of the following:
+          Push Wide Beam Block
+          Diffusion Abuse (Intermediate) and Shoot Diffusion Beam
 
 > Tunnel to Hub Access; Heals? False
   * Layers: default

--- a/randovania/games/dread/json_data/Ferenia.json
+++ b/randovania/games/dread/json_data/Ferenia.json
@@ -13950,8 +13950,37 @@
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
-                                                                            "type": "template",
-                                                                            "data": "Push Wide Beam Block"
+                                                                            "type": "or",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Push Wide Beam Block"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "and",
+                                                                                        "data": {
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "template",
+                                                                                                    "data": "Shoot Diffusion Beam"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "tricks",
+                                                                                                        "name": "DiffusionAbuse",
+                                                                                                        "amount": 2,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
                                                                         },
                                                                         {
                                                                             "type": "or",

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -2759,7 +2759,9 @@ Extra - asset_id: collision_camera_034
               Any of the following:
                   Combat (Advanced)
                   All of the following:
-                      Push Wide Beam Block
+                      Any of the following:
+                          Push Wide Beam Block
+                          Diffusion Abuse (Intermediate) and Shoot Diffusion Beam
                       Any of the following:
                           Shoot Diffusion or Wave
                           Slide and Pseudo-Wave Beam (Beginner)


### PR DESCRIPTION
- Added the two remaining implementations of Diffusion Abuse for Wide Beam Blocks in Big Hub and Purple EMMI Arena