### PR TITLE
Dread: Add new setting for Highly Dangerous Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.0] - 2022-11-01
+
+- Nothing.
+
+### Cave Story
+
+- Nothing.
+
+### Metroid Dread
+ 
+- Added: New Highly Dangerous Logic setting for enabling situations that may be unrecoverable upon saving.
+
+### Metroid Prime
+
+- Nothing.
+
+### Metroid Prime 2: Echoes
+
+- Nothing.
+
 ## [5.1.0] - 2022-10-01
 
 - Added: You can now view past versions of the presets and revert your preset to it.

--- a/randovania/games/blank/presets/starter_preset.rdvpreset
+++ b/randovania/games/blank/presets/starter_preset.rdvpreset
@@ -1,9 +1,9 @@
 {
-    "schema_version": 36,
+    "schema_version": 40,
+    "base_preset_uuid": null,
     "name": "Starter Preset",
     "uuid": "98fd4d7d-7d17-4a81-bb17-0838311c7be1",
     "description": "Basic preset.",
-    "base_preset_uuid": null,
     "game": "blank",
     "configuration": {
         "trick_level": {

--- a/randovania/games/cave_story/presets/classic.rdvpreset
+++ b/randovania/games/cave_story/presets/classic.rdvpreset
@@ -1,9 +1,9 @@
 {
-    "schema_version": 36,
+    "schema_version": 40,
+    "base_preset_uuid": null,
     "name": "CSR Classic",
     "uuid": "a66ea8a6-cf92-4cd9-992b-977911279a86",
     "description": "For Cave Story Randomizer veterans.<br />Settings are as close as possible to the experience of playing the original randomizer.",
-    "base_preset_uuid": null,
     "game": "cave_story",
     "configuration": {
         "trick_level": {

--- a/randovania/games/cave_story/presets/starter_preset.rdvpreset
+++ b/randovania/games/cave_story/presets/starter_preset.rdvpreset
@@ -1,9 +1,9 @@
 {
-    "schema_version": 36,
+    "schema_version": 40,
+    "base_preset_uuid": null,
     "name": "Starter Preset",
     "uuid": "955aaac1-7ab4-4414-83db-45cfc35e68d7",
     "description": "Default preset.",
-    "base_preset_uuid": null,
     "game": "cave_story",
     "configuration": {
         "trick_level": {

--- a/randovania/games/dread/generator/bootstrap.py
+++ b/randovania/games/dread/generator/bootstrap.py
@@ -6,6 +6,19 @@ from randovania.resolver.bootstrap import MetroidBootstrap
 
 
 class DreadBootstrap(MetroidBootstrap):
+    def _get_enabled_misc_resources(self, configuration: BaseConfiguration,
+                                    resource_database: ResourceDatabase) -> set[str]:
+        enabled_resources = set()
+
+        logical_patches = {
+            "allow_highly_dangerous_logic": "HighDanger",
+        }
+        for name, index in logical_patches.items():
+            if getattr(configuration, name):
+                enabled_resources.add(index)
+
+        return enabled_resources
+
     def event_resources_for_configuration(self, configuration: BaseConfiguration,
                                           resource_database: ResourceDatabase,
                                           ) -> ResourceGain:

--- a/randovania/games/dread/gui/preset_settings/__init__.py
+++ b/randovania/games/dread/gui/preset_settings/__init__.py
@@ -7,8 +7,8 @@ from randovania.interface_common.preset_editor import PresetEditor
 def dread_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
     from randovania.gui.preset_settings.trick_level_tab import PresetTrickLevel
     from randovania.gui.preset_settings.starting_area_tab import PresetMetroidStartingArea
-    from randovania.gui.preset_settings.generation_tab import PresetGeneration
     from randovania.gui.preset_settings.location_pool_tab import PresetLocationPool
+    from randovania.games.dread.gui.preset_settings.dread_generation_tab import PresetDreadGeneration
     from randovania.games.dread.gui.preset_settings.dread_patches_tab import PresetDreadPatches
     from randovania.games.dread.gui.preset_settings.dread_item_pool_tab import DreadPresetItemPool
     from randovania.games.dread.gui.preset_settings.dread_energy_tab import PresetDreadEnergy
@@ -19,7 +19,7 @@ def dread_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
         *([
               PresetMetroidStartingArea,
           ] if window_manager.is_preview_mode else []),
-        PresetGeneration,
+        PresetDreadGeneration,
         PresetLocationPool,
         PresetDreadGoal,
         DreadPresetItemPool,

--- a/randovania/games/dread/gui/preset_settings/dread_generation_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_generation_tab.py
@@ -1,13 +1,12 @@
 from typing import Iterable
 
 from PySide6 import QtWidgets, QtCore
-from PySide6.QtWidgets import *
 
 from randovania.game_description.game_description import GameDescription
 from randovania.game_description.resources.resource_type import ResourceType
-from randovania.game_description.resources.trick_resource_info import TrickResourceInfo
-from randovania.gui.dialog.trick_details_popup import TrickDetailsPopup, ResourceDetailsPopup
-from randovania.gui.lib import common_qt_lib, signal_handling
+from randovania.games.dread.layout.dread_configuration import DreadConfiguration
+from randovania.gui.dialog.trick_details_popup import ResourceDetailsPopup
+from randovania.gui.lib import signal_handling
 from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.preset_settings.generation_tab import PresetGeneration
 from randovania.interface_common.preset_editor import PresetEditor
@@ -15,32 +14,35 @@ from randovania.layout.preset import Preset
 
 
 class PresetDreadGeneration(PresetGeneration):
-    highdanger_logic_check: QCheckBox
-    highdanger_logic_label: QLabel
+    highdanger_logic_check: QtWidgets.QCheckBox
+    highdanger_logic_label: QtWidgets.QLabel
 
     def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
         super().__init__(editor, game_description, window_manager)
 
         signal_handling.on_checked(self.highdanger_logic_check, self._on_highdanger_logic_check)
         self.highdanger_logic_label.linkActivated.connect(self._on_click_link_highdanger_logic_details)
-        
 
     def setupUi(self, obj):
         super().setupUi(obj)
 
-        self.highdanger_logic_check = QCheckBox(
-            "Allow Highly Dangerous Logic")
-        self.highdanger_logic_label = QLabel(
-            """<html><head/><body><p>Highly Dangerous Logic is a setting which enables dangerous actions that are not as obvious.</p><p>Using these dangerous actions could render
-            a seed unbeatable if the player were to save afterwards.</p><p><a href=\"resource-details://misc/highdanger\"><span style=\" text-decoration: underline;
-            color:#0000ff;\">Click here</span></a> to see which rooms are affected.</p></body></html>""")
+        self.highdanger_logic_check = QtWidgets.QCheckBox("Allow Highly Dangerous Logic", obj)
+        self.highdanger_logic_label = QtWidgets.QLabel(obj)
+        self.highdanger_logic_label.setText(
+            """<html><head/><body>
+            <p>Highly Dangerous Logic is a setting which enables dangerous actions that are not as obvious.</p>
+            <p>Using these dangerous actions could render a seed unbeatable if the player were to save afterwards.</p>
+            <p><a href=\"resource-details://misc/highdanger\"><span style=\" text-decoration: underline;
+            color:#0000ff;\">Click here</span></a> to see which rooms are affected.</p></body></html>""",
+        )
 
     @property
-    def game_specific_widgets(self) -> Iterable[QWidget] | None:
+    def game_specific_widgets(self) -> Iterable[QtWidgets.QWidget] | None:
         yield self.highdanger_logic_check
         yield self.highdanger_logic_label
 
     def on_preset_changed(self, preset: Preset):
+        assert isinstance(preset.configuration, DreadConfiguration)
         super().on_preset_changed(preset)
         self.highdanger_logic_check.setChecked(preset.configuration.allow_highly_dangerous_logic)
 
@@ -59,8 +61,7 @@ class PresetDreadGeneration(PresetGeneration):
             self.game_description.resource_database.get_by_type_and_index(ResourceType.MISC, "HighDanger"),
         ))
 
-    def _exec_trick_details(self, popup: TrickDetailsPopup):
+    def _exec_trick_details(self, popup: ResourceDetailsPopup):
         self._trick_details_popup = popup
         self._trick_details_popup.setWindowModality(QtCore.Qt.WindowModal)
         self._trick_details_popup.open()
-

--- a/randovania/games/dread/gui/preset_settings/dread_generation_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_generation_tab.py
@@ -31,7 +31,9 @@ class PresetDreadGeneration(PresetGeneration):
         self.highdanger_logic_check = QCheckBox(
             "Allow Highly Dangerous Logic")
         self.highdanger_logic_label = QLabel(
-            "<html><head/><body><p>Highly Dangerous Logic is a setting which enables dangerous actions that are not as obvious.</p><p>Using these dangerous actions could render a seed unbeatable if the player were to save afterwards.</p><p><a href=\"resource-details://misc/highdanger\"><span style=\" text-decoration: underline; color:#0000ff;\">Click here</span></a> to see which rooms are affected.</p></body></html>")
+            """<html><head/><body><p>Highly Dangerous Logic is a setting which enables dangerous actions that are not as obvious.</p><p>Using these dangerous actions could render
+            a seed unbeatable if the player were to save afterwards.</p><p><a href=\"resource-details://misc/highdanger\"><span style=\" text-decoration: underline;
+            color:#0000ff;\">Click here</span></a> to see which rooms are affected.</p></body></html>""")
 
     @property
     def game_specific_widgets(self) -> Iterable[QWidget] | None:
@@ -62,11 +64,3 @@ class PresetDreadGeneration(PresetGeneration):
         self._trick_details_popup.setWindowModality(QtCore.Qt.WindowModal)
         self._trick_details_popup.open()
 
-    def _open_trick_details_popup(self, trick: TrickResourceInfo):
-        self._exec_trick_details(TrickDetailsPopup(
-            self,
-            self._window_manager,
-            self.game_description,
-            trick,
-            self._editor.configuration.trick_level.level_for_trick(trick),
-        ))

--- a/randovania/games/dread/gui/preset_settings/dread_generation_tab.py
+++ b/randovania/games/dread/gui/preset_settings/dread_generation_tab.py
@@ -1,0 +1,72 @@
+from typing import Iterable
+
+from PySide6 import QtWidgets, QtCore
+from PySide6.QtWidgets import *
+
+from randovania.game_description.game_description import GameDescription
+from randovania.game_description.resources.resource_type import ResourceType
+from randovania.game_description.resources.trick_resource_info import TrickResourceInfo
+from randovania.gui.dialog.trick_details_popup import TrickDetailsPopup, ResourceDetailsPopup
+from randovania.gui.lib import common_qt_lib, signal_handling
+from randovania.gui.lib.window_manager import WindowManager
+from randovania.gui.preset_settings.generation_tab import PresetGeneration
+from randovania.interface_common.preset_editor import PresetEditor
+from randovania.layout.preset import Preset
+
+
+class PresetDreadGeneration(PresetGeneration):
+    highdanger_logic_check: QCheckBox
+    highdanger_logic_label: QLabel
+
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
+
+        signal_handling.on_checked(self.highdanger_logic_check, self._on_highdanger_logic_check)
+        self.highdanger_logic_label.linkActivated.connect(self._on_click_link_highdanger_logic_details)
+        
+
+    def setupUi(self, obj):
+        super().setupUi(obj)
+
+        self.highdanger_logic_check = QCheckBox(
+            "Allow Highly Dangerous Logic")
+        self.highdanger_logic_label = QLabel(
+            "<html><head/><body><p>Highly Dangerous Logic is a setting which enables dangerous actions that are not as obvious.</p><p>Using these dangerous actions could render a seed unbeatable if the player were to save afterwards.</p><p><a href=\"resource-details://misc/highdanger\"><span style=\" text-decoration: underline; color:#0000ff;\">Click here</span></a> to see which rooms are affected.</p></body></html>")
+
+    @property
+    def game_specific_widgets(self) -> Iterable[QWidget] | None:
+        yield self.highdanger_logic_check
+        yield self.highdanger_logic_label
+
+    def on_preset_changed(self, preset: Preset):
+        super().on_preset_changed(preset)
+        self.highdanger_logic_check.setChecked(preset.configuration.allow_highly_dangerous_logic)
+
+    def _on_highdanger_logic_check(self, state: bool):
+        with self._editor as options:
+            options.set_configuration_field(
+                "allow_highly_dangerous_logic",
+                state,
+            )
+
+    def _on_click_link_highdanger_logic_details(self, link: str):
+        self._exec_trick_details(ResourceDetailsPopup(
+            self,
+            self._window_manager,
+            self.game_description,
+            self.game_description.resource_database.get_by_type_and_index(ResourceType.MISC, "HighDanger"),
+        ))
+
+    def _exec_trick_details(self, popup: TrickDetailsPopup):
+        self._trick_details_popup = popup
+        self._trick_details_popup.setWindowModality(QtCore.Qt.WindowModal)
+        self._trick_details_popup.open()
+
+    def _open_trick_details_popup(self, trick: TrickResourceInfo):
+        self._exec_trick_details(TrickDetailsPopup(
+            self,
+            self._window_manager,
+            self.game_description,
+            trick,
+            self._editor.configuration.trick_level.level_for_trick(trick),
+        ))

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1199,7 +1199,7 @@
                 "extra": {}
             },
             "HighDanger": {
-                "long_name": "Allow Highly Dangerous Logic",
+                "long_name": "Highly Dangerous Logic",
                 "extra": {}
             }
         },

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1199,7 +1199,7 @@
                 "extra": {}
             },
             "HighDanger": {
-                "long_name": "Highly Dangerous Logic",
+                "long_name": "Allow Highly Dangerous Logic",
                 "extra": {}
             }
         },

--- a/randovania/games/dread/layout/dread_configuration.py
+++ b/randovania/games/dread/layout/dread_configuration.py
@@ -22,6 +22,7 @@ class DreadConfiguration(BaseConfiguration):
     hanubia_shortcut_no_grapple: bool
     hanubia_easier_path_to_itorash: bool
     x_starts_released: bool
+    allow_highly_dangerous_logic: bool
     artifacts: DreadArtifactConfig
     constant_heat_damage: int | None = dataclasses.field(metadata={"min": 0, "max": 1000, "precision": 1})
     constant_cold_damage: int | None = dataclasses.field(metadata={"min": 0, "max": 1000, "precision": 1})

--- a/randovania/games/dread/layout/preset_describer.py
+++ b/randovania/games/dread/layout/preset_describer.py
@@ -53,6 +53,12 @@ class DreadPresetDescriber(GamePresetDescriber):
         template_strings = super().format_params(configuration)
 
         extra_message_tree = {
+            "Logic Settings": [
+                {
+                    "Highly Dangerous Logic":
+                        configuration.allow_highly_dangerous_logic,
+                }
+            ],
             "Difficulty": [
                 {
                     "Immediate Energy Part": configuration.immediate_energy_parts,

--- a/randovania/games/dread/presets/starter_preset.rdvpreset
+++ b/randovania/games/dread/presets/starter_preset.rdvpreset
@@ -1,9 +1,9 @@
 {
-    "schema_version": 36,
+    "schema_version": 40,
+    "base_preset_uuid": null,
     "name": "Starter Preset",
     "uuid": "407e97ed-decb-4889-8ab7-943f86ae48a4",
     "description": "Basic preset.",
-    "base_preset_uuid": null,
     "game": "dread",
     "configuration": {
         "trick_level": {
@@ -167,13 +167,14 @@
         "hanubia_shortcut_no_grapple": true,
         "hanubia_easier_path_to_itorash": true,
         "x_starts_released": false,
-		"allow_highly_dangerous_logic": false,
+        "allow_highly_dangerous_logic": false,
         "artifacts": {
             "prefer_emmi": true,
             "prefer_major_bosses": true,
             "required_artifacts": 3
         },
-        "linear_damage_runs": true,
-        "linear_dps": 20
+        "constant_heat_damage": 20,
+        "constant_cold_damage": 20,
+        "constant_lava_damage": 20
     }
 }

--- a/randovania/games/dread/presets/starter_preset.rdvpreset
+++ b/randovania/games/dread/presets/starter_preset.rdvpreset
@@ -167,6 +167,7 @@
         "hanubia_shortcut_no_grapple": true,
         "hanubia_easier_path_to_itorash": true,
         "x_starts_released": false,
+		"allow_highly_dangerous_logic": false,
         "artifacts": {
             "prefer_emmi": true,
             "prefer_major_bosses": true,

--- a/randovania/games/prime1/presets/april_fools_2022.rdvpreset
+++ b/randovania/games/prime1/presets/april_fools_2022.rdvpreset
@@ -1,9 +1,9 @@
 {
-    "schema_version": 36,
+    "schema_version": 40,
+    "base_preset_uuid": null,
     "name": "April Fools 2022",
     "uuid": "798dd544-d607-4304-981d-388468192159",
     "description": "Having debuted with the reveal of 'Chaos Options' on April 1st 2022, this preset features logicless room rando with random superheated rooms, random submerged rooms and random boss sizes. Because of the logicless nature of Chaos Options, this preset may generate seeds which are not able to be completed.<br><br>To help compensate for the lack of logic, hypermode difficulty is enabled and many duplicate items have been placed into the pool.",
-    "base_preset_uuid": null,
     "game": "prime1",
     "configuration": {
         "trick_level": {
@@ -251,6 +251,7 @@
         "phazon_elite_without_dynamo": true,
         "qol_game_breaking": true,
         "qol_pickup_scans": true,
-        "qol_cutscenes": "competitive"
+        "qol_cutscenes": "competitive",
+        "enemy_attributes": null
     }
 }

--- a/randovania/games/prime1/presets/moderate_challenge.rdvpreset
+++ b/randovania/games/prime1/presets/moderate_challenge.rdvpreset
@@ -1,9 +1,9 @@
 {
-    "schema_version": 36,
+    "schema_version": 40,
+    "base_preset_uuid": null,
     "name": "Moderate Challenge",
     "uuid": "7c57ecf6-ff1c-4ab9-bc84-802ac70e980a",
     "description": "Generates seeds which can require some tricks to complete. A moderate amount of practice, knowledge and wit is required to overcome the typical seed.<br/><br/>Elevator connections are randomized and the game can start in almost any Save Station.",
-    "base_preset_uuid": null,
     "game": "prime1",
     "configuration": {
         "trick_level": {
@@ -286,6 +286,7 @@
         "phazon_elite_without_dynamo": true,
         "qol_game_breaking": true,
         "qol_pickup_scans": true,
-        "qol_cutscenes": "competitive"
+        "qol_cutscenes": "competitive",
+        "enemy_attributes": null
     }
 }

--- a/randovania/games/prime1/presets/starter_preset.rdvpreset
+++ b/randovania/games/prime1/presets/starter_preset.rdvpreset
@@ -1,9 +1,9 @@
 {
-    "schema_version": 36,
+    "schema_version": 40,
+    "base_preset_uuid": null,
     "name": "Starter Preset",
     "uuid": "e36f52b3-ccd9-4dd7-a18f-b57b25f6b079",
     "description": "This preset is ideal for those new to playing Metroid Prime or it's Randomizer. Every seed can be completed without utilizing any tricks or glitches, and the world will be familiar to the base game.<br/><br/>In addition to shuffling items, this preset includes some minor improvements over the base game such as crash and soft-lock fixes.",
-    "base_preset_uuid": null,
     "game": "prime1",
     "configuration": {
         "trick_level": {
@@ -226,6 +226,7 @@
         "phazon_elite_without_dynamo": true,
         "qol_game_breaking": true,
         "qol_pickup_scans": true,
-        "qol_cutscenes": "competitive"
+        "qol_cutscenes": "competitive",
+        "enemy_attributes": null
     }
 }

--- a/randovania/games/prime2/presets/darkszero_deluxe.rdvpreset
+++ b/randovania/games/prime2/presets/darkszero_deluxe.rdvpreset
@@ -1,9 +1,9 @@
 {
-    "schema_version": 36,
+    "schema_version": 40,
+    "base_preset_uuid": null,
     "name": "Darkszero's Deluxe",
     "uuid": "ea1eced4-53b8-4bb3-a08f-27ac1afe6aab",
     "description": "This preset focus on having every single upgrade you find being valuable, as well as having diverse seeds.<br />Softlocks and crashes are fixed and other changes are made to improve seed variety.",
-    "base_preset_uuid": null,
     "game": "prime2",
     "configuration": {
         "trick_level": {

--- a/randovania/games/prime2/presets/fewest_changes.rdvpreset
+++ b/randovania/games/prime2/presets/fewest_changes.rdvpreset
@@ -1,9 +1,9 @@
 {
-    "schema_version": 36,
+    "schema_version": 40,
+    "base_preset_uuid": null,
     "name": "Fewest Changes",
     "uuid": "bba48268-0710-4ac5-baae-dcd5fcd31d80",
     "description": "This preset keeps the game as close as possible to how the original game operates. Only crashes are fixed.",
-    "base_preset_uuid": null,
     "game": "prime2",
     "configuration": {
         "trick_level": {

--- a/randovania/games/prime2/presets/starter_preset.rdvpreset
+++ b/randovania/games/prime2/presets/starter_preset.rdvpreset
@@ -1,9 +1,9 @@
 {
-    "schema_version": 36,
+    "schema_version": 40,
+    "base_preset_uuid": null,
     "name": "Starter Preset",
     "uuid": "fcbe4e3f-b1fa-41cc-83cb-c86d84c10f0f",
     "description": "This preset balances the item pool with additional beam ammo expansions and progressive suits, while minimizing softlocks as much as possible.<br />Crashes are fixed and unexpected behaviours of the game are changed to what would be expected from a casual view.",
-    "base_preset_uuid": null,
     "game": "prime2",
     "configuration": {
         "trick_level": {

--- a/randovania/games/prime3/presets/starter_preset.rdvpreset
+++ b/randovania/games/prime3/presets/starter_preset.rdvpreset
@@ -1,9 +1,9 @@
 {
-    "schema_version": 36,
+    "schema_version": 40,
+    "base_preset_uuid": null,
     "name": "Starter Preset",
     "uuid": "5682c9ef-d447-4327-b473-ba1216d83439",
     "description": "In these settings, the game starts after the two trips to G.F.S. Olympus and the pirate attack to Norion, but with no items you'd have at that moment.",
-    "base_preset_uuid": null,
     "game": "prime3",
     "configuration": {
         "trick_level": {

--- a/randovania/games/super_metroid/presets/starter_preset.rdvpreset
+++ b/randovania/games/super_metroid/presets/starter_preset.rdvpreset
@@ -1,9 +1,9 @@
 {
-    "schema_version": 36,
+    "schema_version": 40,
+    "base_preset_uuid": null,
     "name": "Starter Preset",
     "uuid": "d3ece985-f0aa-46aa-ae30-a0c794b6560c",
     "description": "Basic preset.",
-    "base_preset_uuid": null,
     "game": "super_metroid",
     "configuration": {
         "trick_level": {

--- a/randovania/gui/preset_settings/generation_tab.py
+++ b/randovania/gui/preset_settings/generation_tab.py
@@ -1,14 +1,10 @@
 import dataclasses
 from typing import Iterable
 
-from PySide6 import QtWidgets, QtCore
 from PySide6.QtWidgets import *
 
 from randovania.game_description.game_description import GameDescription
-from randovania.game_description.resources.resource_type import ResourceType
-from randovania.game_description.resources.trick_resource_info import TrickResourceInfo
 from randovania.games.game import RandovaniaGame
-from randovania.gui.dialog.trick_details_popup import TrickDetailsPopup, ResourceDetailsPopup
 from randovania.gui.generated.preset_generation_ui import Ui_PresetGeneration
 from randovania.gui.lib import common_qt_lib, signal_handling
 from randovania.gui.lib.window_manager import WindowManager
@@ -43,14 +39,6 @@ class PresetGeneration(PresetTab, Ui_PresetGeneration):
         signal_handling.on_combo(self.dangerous_combo, self._on_dangerous_changed)
 
         signal_handling.on_checked(self.trick_level_minimal_logic_check, self._on_trick_level_minimal_logic_check)
-        signal_handling.on_checked(self.highdanger_logic_check, self._on_highdanger_logic_check)
-        self.highdanger_logic_label.linkActivated.connect(self._on_click_link_highdanger_logic_details)
-        
-        self.highdanger_logic_label.setText(self.highdanger_logic_label.text().replace("color:#0000ff;", ""))
-
-        if self.game_enum != RandovaniaGame.METROID_DREAD:
-            for w in [self.highdanger_logic_check, self.highdanger_logic_label, self.highdanger_logic_line]:
-                w.setVisible(False)
 
         #Minimal Logic
         for w in [
@@ -83,9 +71,6 @@ class PresetGeneration(PresetTab, Ui_PresetGeneration):
         common_qt_lib.set_combo_with_value(self.dangerous_combo, layout.logical_resource_action)
 
         common_qt_lib.set_combo_with_value(self.damage_strictness_combo, preset.configuration.damage_strictness)
-
-        if self.game_enum == RandovaniaGame.METROID_DREAD:
-            self.highdanger_logic_check.setChecked(preset.configuration.allow_highly_dangerous_logic)
 
     @classmethod
     def tab_title(cls) -> str:
@@ -123,35 +108,6 @@ class PresetGeneration(PresetTab, Ui_PresetGeneration):
                 dataclasses.replace(options.configuration.trick_level,
                                     minimal_logic=state)
             )
-
-    def _on_highdanger_logic_check(self, state: bool):
-        with self._editor as options:
-            options.set_configuration_field(
-                "allow_highly_dangerous_logic",
-                state,
-            )
-
-    def _on_click_link_highdanger_logic_details(self, link: str):
-        self._exec_trick_details(ResourceDetailsPopup(
-            self,
-            self._window_manager,
-            self.game_description,
-            self.game_description.resource_database.get_by_type_and_index(ResourceType.MISC, "HighDanger"),
-        ))
-
-    def _exec_trick_details(self, popup: TrickDetailsPopup):
-        self._trick_details_popup = popup
-        self._trick_details_popup.setWindowModality(QtCore.Qt.WindowModal)
-        self._trick_details_popup.open()
-
-    def _open_trick_details_popup(self, trick: TrickResourceInfo):
-        self._exec_trick_details(TrickDetailsPopup(
-            self,
-            self._window_manager,
-            self.game_description,
-            trick,
-            self._editor.configuration.trick_level.level_for_trick(trick),
-        ))
 
     def _on_update_damage_strictness(self, new_index: int):
         with self._editor as editor:

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -689,6 +689,13 @@ def _migrate_v38(preset: dict) -> dict:
     return preset
 
 
+def _migrate_v39(preset: dict) -> dict:
+    if preset["game"] == "dread":
+        preset["configuration"]["allow_highly_dangerous_logic"] = False
+
+    return preset
+
+
 _MIGRATIONS = [
     _migrate_v1,  # v1.1.1-247-gaf9e4a69
     _migrate_v2,  # v1.2.2-71-g0fbabe91
@@ -728,6 +735,7 @@ _MIGRATIONS = [
     _migrate_v36,
     _migrate_v37,
     _migrate_v38,
+    _migrate_v39,
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/test/games/dread/gui/preset_settings/test_dread_generation_tab.py
+++ b/test/games/dread/gui/preset_settings/test_dread_generation_tab.py
@@ -1,0 +1,31 @@
+import dataclasses
+import uuid
+from unittest.mock import MagicMock
+
+from PySide6 import QtCore
+
+from randovania.game_description import default_database
+from randovania.games.dread.gui.preset_settings.dread_generation_tab import PresetDreadGeneration
+from randovania.games.dread.layout.dread_configuration import DreadConfiguration
+from randovania.games.game import RandovaniaGame
+from randovania.interface_common.preset_editor import PresetEditor
+
+
+def test_on_preset_changed(skip_qtbot, preset_manager):
+    # Setup
+    game = RandovaniaGame.METROID_DREAD
+
+    base = preset_manager.default_preset_for_game(game).get_preset()
+    preset = dataclasses.replace(base, uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'))
+    editor = PresetEditor(preset)
+    window = PresetDreadGeneration(editor, default_database.game_description_for(game), MagicMock())
+    skip_qtbot.addWidget(window)
+
+    # Run
+    window.on_preset_changed(editor.create_custom_preset_with())
+    skip_qtbot.mouseClick(window.highdanger_logic_check, QtCore.Qt.LeftButton)
+
+    # Assert
+    final_preset = editor.create_custom_preset_with()
+    assert isinstance(final_preset.configuration, DreadConfiguration)
+    assert final_preset.configuration.allow_highly_dangerous_logic

--- a/test/gui/preset_settings/test_generation_tab.py
+++ b/test/gui/preset_settings/test_generation_tab.py
@@ -8,6 +8,7 @@ from PySide6.QtWidgets import *
 
 from randovania.game_description import default_database
 from randovania.games.cave_story.gui.preset_settings.cs_generation_tab import PresetCSGeneration
+from randovania.games.dread.gui.preset_settings.dread_generation_tab import PresetDreadGeneration
 from randovania.games.game import RandovaniaGame
 from randovania.games.prime1.gui.preset_settings.prime_generation_tab import PresetPrimeGeneration
 from randovania.gui.preset_settings.generation_tab import PresetGeneration
@@ -15,13 +16,14 @@ from randovania.interface_common.preset_editor import PresetEditor
 
 
 @pytest.mark.parametrize("game_data", [
+    (RandovaniaGame.METROID_DREAD, True, True, PresetDreadGeneration),
     (RandovaniaGame.METROID_PRIME, True, True, PresetPrimeGeneration),
     (RandovaniaGame.METROID_PRIME_ECHOES, False, True, PresetGeneration),
     (RandovaniaGame.CAVE_STORY, True, False, PresetCSGeneration)
 ])
 def test_on_preset_changed(skip_qtbot, preset_manager, game_data):
     # Setup
-    game, has_specific_settings, has_min_logic, tab = game_data
+    game, has_specific_settings, has_min_logic, has_highdanger_logic, tab = game_data
 
     base = preset_manager.default_preset_for_game(game).get_preset()
     preset = dataclasses.replace(base, uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'))
@@ -35,6 +37,7 @@ def test_on_preset_changed(skip_qtbot, preset_manager, game_data):
 
     # Assert
     assert window.trick_level_minimal_logic_check.isVisibleTo(parent) == has_min_logic
+    assert window.highdanger_logic_check.isVisibleTo(parent) == has_highdanger_logic
     assert window.game_specific_group.isVisibleTo(parent) == has_specific_settings
 
 

--- a/test/gui/preset_settings/test_generation_tab.py
+++ b/test/gui/preset_settings/test_generation_tab.py
@@ -3,8 +3,7 @@ import uuid
 from unittest.mock import MagicMock
 
 import pytest
-from PySide6 import QtCore
-from PySide6.QtWidgets import *
+from PySide6 import QtCore, QtWidgets
 
 from randovania.game_description import default_database
 from randovania.games.cave_story.gui.preset_settings.cs_generation_tab import PresetCSGeneration
@@ -16,38 +15,37 @@ from randovania.interface_common.preset_editor import PresetEditor
 
 
 @pytest.mark.parametrize("game_data", [
-    (RandovaniaGame.METROID_DREAD, True, True, PresetDreadGeneration),
+    (RandovaniaGame.METROID_DREAD, True, False, PresetDreadGeneration),
     (RandovaniaGame.METROID_PRIME, True, True, PresetPrimeGeneration),
     (RandovaniaGame.METROID_PRIME_ECHOES, False, True, PresetGeneration),
     (RandovaniaGame.CAVE_STORY, True, False, PresetCSGeneration)
 ])
 def test_on_preset_changed(skip_qtbot, preset_manager, game_data):
     # Setup
-    game, has_specific_settings, has_min_logic, has_highdanger_logic, tab = game_data
+    game, has_specific_settings, has_min_logic, tab = game_data
 
     base = preset_manager.default_preset_for_game(game).get_preset()
     preset = dataclasses.replace(base, uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'))
     editor = PresetEditor(preset)
     window: PresetGeneration = tab(editor, default_database.game_description_for(game), MagicMock())
-    parent = QGroupBox()
+    parent = QtWidgets.QWidget()
     window.setParent(parent)
+    skip_qtbot.addWidget(window)
 
     # Run
     window.on_preset_changed(editor.create_custom_preset_with())
 
     # Assert
     assert window.trick_level_minimal_logic_check.isVisibleTo(parent) == has_min_logic
-    assert window.highdanger_logic_check.isVisibleTo(parent) == has_highdanger_logic
     assert window.game_specific_group.isVisibleTo(parent) == has_specific_settings
 
 
 def test_persist_local_first_progression(skip_qtbot, preset_manager):
-    parent = QGroupBox()
     game = RandovaniaGame.BLANK
 
     editor = MagicMock()
     window = PresetGeneration(editor, default_database.game_description_for(game), MagicMock())
-    window.setParent(parent)
+    skip_qtbot.addWidget(window)
 
     # Run
     skip_qtbot.mouseClick(window.local_first_progression_check, QtCore.Qt.LeftButton)


### PR DESCRIPTION
- Adds a setting in the Generation tab for the Highly Dangerous Logic misc resource
- Updates the presets with the new setting defaulted to off
- Setting appears under Logic Settings on the preset summary
- Supplied a link to view the rooms affected by the setting