### PR TITLE
[Echoes Logic] Fixed every logical instance of a Screw Attack with no morph ball.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Logic Database
 
-- Added: Movement(Beginner) trick for crossing HoCM from the Portal Side, after the tunnel is destroyed, with NSJ Screw Attack. 
+- Added: Movement(Beginner) trick for crossing HoCM from the Portal Side, after the tunnel is destroyed, with NSJ Screw Attack.
+- Fixed up miscellaneous cases where Screw Attack could be logically used without Morph Ball.
 
 ## [5.1.0] - 2022-10-01
 

--- a/randovania/games/prime2/json_data/Agon Wastes.json
+++ b/randovania/games/prime2/json_data/Agon Wastes.json
@@ -5948,13 +5948,8 @@
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "ScrewAttack",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
+                                                                "type": "template",
+                                                                "data": "Use Screw Attack (No Space Jump)"
                                                             },
                                                             {
                                                                 "type": "resource",
@@ -7944,13 +7939,8 @@
                                                                                 "comment": null,
                                                                                 "items": [
                                                                                     {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "items",
-                                                                                            "name": "ScrewAttack",
-                                                                                            "amount": 1,
-                                                                                            "negate": false
-                                                                                        }
+                                                                                        "type": "template",
+                                                                                        "data": "Use Screw Attack (No Space Jump)"
                                                                                     },
                                                                                     {
                                                                                         "type": "resource",
@@ -11297,13 +11287,8 @@
                                                                                 "comment": null,
                                                                                 "items": [
                                                                                     {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "items",
-                                                                                            "name": "ScrewAttack",
-                                                                                            "amount": 1,
-                                                                                            "negate": false
-                                                                                        }
+                                                                                        "type": "template",
+                                                                                        "data": "Use Screw Attack (No Space Jump)"
                                                                                     },
                                                                                     {
                                                                                         "type": "resource",
@@ -24622,13 +24607,8 @@
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "ScrewAttack",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
+                                                                            "type": "template",
+                                                                            "data": "Use Screw Attack (No Space Jump)"
                                                                         },
                                                                         {
                                                                             "type": "resource",
@@ -27016,13 +26996,8 @@
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "ScrewAttack",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
+                                                                "type": "template",
+                                                                "data": "Use Screw Attack (No Space Jump)"
                                                             },
                                                             {
                                                                 "type": "resource",

--- a/randovania/games/prime2/json_data/Agon Wastes.txt
+++ b/randovania/games/prime2/json_data/Agon Wastes.txt
@@ -860,7 +860,7 @@ Extra - in_dark_aether: True
               Dark World Damage ≥ 10 and Activate Safe Zone
           Any of the following:
               Space Jump Boots or Movement (Advanced)
-              Screw Attack and Movement (Beginner)
+              Movement (Beginner) and Use Screw Attack (No Space Jump)
               Scan Visor and Combat/Scan Dash (Advanced)
   > Portal to Mining Station B
       Any of the following:
@@ -1140,7 +1140,7 @@ Extra - in_dark_aether: True
                   Dark World Damage ≥ 20 or Activate Safe Zone
                   Any of the following:
                       Space Jump Boots
-                      Screw Attack and Movement (Beginner)
+                      Movement (Beginner) and Use Screw Attack (No Space Jump)
               All of the following:
                   Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner)
                   Any of the following:
@@ -1487,7 +1487,7 @@ Extra - in_dark_aether: True
                   Dark World Damage ≥ 10 or Activate Safe Zone
                   Any of the following:
                       Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner)
-                      Screw Attack and Standable Terrain (Beginner)
+                      Standable Terrain (Beginner) and Use Screw Attack (No Space Jump)
   > Event - Portal Site Gate
       All of the following:
           After Portal Site Cutscene
@@ -3203,7 +3203,7 @@ Extra - in_dark_aether: True
               Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner)
               All of the following:
                   Standable Terrain (Beginner)
-                  Screw Attack or Movement (Expert)
+                  Movement (Expert) or Use Screw Attack (No Space Jump)
   > Pickup (Power Bomb)
       Light Suit
 
@@ -3528,7 +3528,7 @@ Extra - in_dark_aether: True
                       Dark World Damage ≥ 80
                       Dark World Damage ≥ 15 and Activate Safe Zone
               All of the following:
-                  Screw Attack and Movement (Intermediate)
+                  Movement (Intermediate) and Use Screw Attack (No Space Jump)
                   Any of the following:
                       Dark World Damage ≥ 99
                       Dark World Damage ≥ 10 and Activate Safe Zone

--- a/randovania/games/prime2/json_data/Sanctuary Fortress.json
+++ b/randovania/games/prime2/json_data/Sanctuary Fortress.json
@@ -7696,13 +7696,8 @@
                                                                             }
                                                                         },
                                                                         {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "ScrewAttack",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
+                                                                            "type": "template",
+                                                                            "data": "Use Screw Attack (No Space Jump)"
                                                                         },
                                                                         {
                                                                             "type": "or",
@@ -7938,13 +7933,8 @@
                                                                             }
                                                                         },
                                                                         {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "ScrewAttack",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
+                                                                            "type": "template",
+                                                                            "data": "Use Screw Attack (No Space Jump)"
                                                                         },
                                                                         {
                                                                             "type": "or",
@@ -23493,13 +23483,8 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ScrewAttack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Use Screw Attack (No Space Jump)"
                                                 },
                                                 {
                                                     "type": "resource",
@@ -23619,13 +23604,8 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ScrewAttack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Use Screw Attack (No Space Jump)"
                                                 },
                                                 {
                                                     "type": "resource",
@@ -25663,13 +25643,8 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "ScrewAttack",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Use Screw Attack (No Space Jump)"
                                     },
                                     {
                                         "type": "resource",
@@ -25790,13 +25765,8 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "ScrewAttack",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Use Screw Attack (No Space Jump)"
                                     },
                                     {
                                         "type": "resource",
@@ -28410,13 +28380,8 @@
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "ScrewAttack",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
+                                                                "type": "template",
+                                                                "data": "Use Screw Attack (No Space Jump)"
                                                             },
                                                             {
                                                                 "type": "resource",
@@ -28553,13 +28518,8 @@
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "ScrewAttack",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
+                                                                "type": "template",
+                                                                "data": "Use Screw Attack (No Space Jump)"
                                                             },
                                                             {
                                                                 "type": "resource",

--- a/randovania/games/prime2/json_data/Sanctuary Fortress.txt
+++ b/randovania/games/prime2/json_data/Sanctuary Fortress.txt
@@ -1131,7 +1131,7 @@ Extra - in_dark_aether: True
                           Dark World Damage ≥ 99
                           Dark World Damage ≥ 30 and Activate Safe Zone
                   All of the following:
-                      Screw Attack and Movement (Intermediate)
+                      Movement (Intermediate) and Use Screw Attack (No Space Jump)
                       Any of the following:
                           Dark World Damage ≥ 150
                           Dark World Damage ≥ 40 and Activate Safe Zone
@@ -1156,7 +1156,7 @@ Extra - in_dark_aether: True
                           Dark World Damage ≥ 99
                           Dark World Damage ≥ 35 and Activate Safe Zone
                   All of the following:
-                      Screw Attack and Movement (Intermediate)
+                      Movement (Intermediate) and Use Screw Attack (No Space Jump)
                       Any of the following:
                           Dark World Damage ≥ 115
                           Dark World Damage ≥ 35 and Activate Safe Zone
@@ -2813,7 +2813,7 @@ Extra - in_dark_aether: False
       Any of the following:
           Morph Ball Bomb and Morph Ball
           Bomb Slot without Bombs (Advanced) and Activate Bomb Slot without Bombs (Space Jump)
-          Screw Attack and Bomb Slot without Bombs (Expert) and Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Activate Bomb Slot without Bombs (No Space Jump)
+          Bomb Slot without Bombs (Expert) and Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Activate Bomb Slot without Bombs (No Space Jump) and Use Screw Attack (No Space Jump)
 
 > Door to Sanctuary Energy Controller; Heals? False
   * Layers: default
@@ -2823,7 +2823,7 @@ Extra - in_dark_aether: False
       Any of the following:
           Morph Ball Bomb and Morph Ball
           Bomb Slot without Bombs (Advanced) and Activate Bomb Slot without Bombs (Space Jump)
-          Screw Attack and Bomb Slot without Bombs (Expert) and Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Activate Bomb Slot without Bombs (No Space Jump)
+          Bomb Slot without Bombs (Expert) and Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Activate Bomb Slot without Bombs (No Space Jump) and Use Screw Attack (No Space Jump)
 
 ----------------
 Hive Gyro Chamber
@@ -3008,7 +3008,7 @@ Extra - in_dark_aether: True
   * Extra - dock_index: 3
   > Post-Fight Pillar
       All of the following:
-          Screw Attack and After Quadraxis and Dark World Damage ≥ 40
+          After Quadraxis and Dark World Damage ≥ 40 and Use Screw Attack (No Space Jump)
           Any of the following:
               Space Jump Boots
               Screw Attack at Z-Axis (Beginner) and Disabled Room Randomizer
@@ -3023,7 +3023,7 @@ Extra - in_dark_aether: True
   * Extra - dock_index: 0
   > Post-Fight Pillar
       All of the following:
-          Screw Attack and After Quadraxis and Dark World Damage ≥ 40
+          After Quadraxis and Dark World Damage ≥ 40 and Use Screw Attack (No Space Jump)
           Space Jump Boots or Screw Attack at Z-Axis (Beginner)
   > Before Quadraxis
       Dark World Damage ≥ 30
@@ -3368,7 +3368,7 @@ Extra - in_dark_aether: True
           Any of the following:
               Morph Ball Bomb and Morph Ball
               Bomb Slot without Bombs (Advanced) and Activate Bomb Slot without Bombs (Space Jump)
-              Screw Attack and Bomb Slot without Bombs (Expert) and Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Activate Bomb Slot without Bombs (No Space Jump)
+              Bomb Slot without Bombs (Expert) and Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Activate Bomb Slot without Bombs (No Space Jump) and Use Screw Attack (No Space Jump)
 
 > Door to Hive Energy Controller; Heals? True
   * Layers: default
@@ -3380,7 +3380,7 @@ Extra - in_dark_aether: True
           Any of the following:
               Morph Ball Bomb and Morph Ball
               Bomb Slot without Bombs (Advanced) and Activate Bomb Slot without Bombs (Space Jump)
-              Screw Attack and Bomb Slot without Bombs (Expert) and Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Activate Bomb Slot without Bombs (No Space Jump)
+              Bomb Slot without Bombs (Expert) and Screw Attack at Z-Axis (Advanced) and Disabled Room Randomizer and Activate Bomb Slot without Bombs (No Space Jump) and Use Screw Attack (No Space Jump)
 
 ----------------
 Aerie Access

--- a/randovania/games/prime2/json_data/Temple Grounds.json
+++ b/randovania/games/prime2/json_data/Temple Grounds.json
@@ -3596,13 +3596,8 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ScrewAttack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Use Screw Attack (No Space Jump)"
                                                 },
                                                 {
                                                     "type": "resource",
@@ -13236,13 +13231,8 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ScrewAttack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Use Screw Attack (No Space Jump)"
                                                 },
                                                 {
                                                     "type": "resource",

--- a/randovania/games/prime2/json_data/Temple Grounds.txt
+++ b/randovania/games/prime2/json_data/Temple Grounds.txt
@@ -559,7 +559,7 @@ Extra - in_dark_aether: False
       Any of the following:
           Scan Visor or Space Jump Boots or Slope Jump (Intermediate)
           Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner)
-          Screw Attack and Standable Terrain (Beginner)
+          Standable Terrain (Beginner) and Use Screw Attack (No Space Jump)
 
 > Front of Translator Gate; Heals? False
   * Layers: default
@@ -1977,7 +1977,7 @@ Extra - in_dark_aether: True
               Space Jump Boots and Dark World Damage ≥ 45
               Dark World Damage ≥ 40 or Activate Safe Zone
           All of the following:
-              Screw Attack and Movement (Intermediate) and Dark World Damage ≥ 45
+              Movement (Intermediate) and Dark World Damage ≥ 45 and Use Screw Attack (No Space Jump)
               Dark World Damage ≥ 40 or Activate Safe Zone
           All of the following:
               Combat/Scan Dash (Advanced) and Dark World Damage ≥ 55

--- a/randovania/games/prime2/json_data/Torvus Bog.json
+++ b/randovania/games/prime2/json_data/Torvus Bog.json
@@ -5675,13 +5675,8 @@
                                                                                 "comment": null,
                                                                                 "items": [
                                                                                     {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "items",
-                                                                                            "name": "ScrewAttack",
-                                                                                            "amount": 1,
-                                                                                            "negate": false
-                                                                                        }
+                                                                                        "type": "template",
+                                                                                        "data": "Use Screw Attack (No Space Jump)"
                                                                                     },
                                                                                     {
                                                                                         "type": "resource",
@@ -7625,13 +7620,8 @@
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "ScrewAttack",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
+                                                                "type": "template",
+                                                                "data": "Use Screw Attack (No Space Jump)"
                                                             },
                                                             {
                                                                 "type": "resource",
@@ -7862,13 +7852,8 @@
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "ScrewAttack",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
+                                                                            "type": "template",
+                                                                            "data": "Use Screw Attack (No Space Jump)"
                                                                         },
                                                                         {
                                                                             "type": "resource",
@@ -8252,13 +8237,8 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ScrewAttack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Use Screw Attack (No Space Jump)"
                                                 },
                                                 {
                                                     "type": "resource",
@@ -9372,13 +9352,8 @@
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "ScrewAttack",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
+                                                                            "type": "template",
+                                                                            "data": "Use Screw Attack (No Space Jump)"
                                                                         },
                                                                         {
                                                                             "type": "resource",
@@ -16566,13 +16541,8 @@
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "ScrewAttack",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
+                                                                "type": "template",
+                                                                "data": "Use Screw Attack (No Space Jump)"
                                                             },
                                                             {
                                                                 "type": "resource",
@@ -21029,13 +20999,8 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ScrewAttack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Use Screw Attack (No Space Jump)"
                                                 },
                                                 {
                                                     "type": "resource",
@@ -26396,13 +26361,8 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ScrewAttack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Use Screw Attack (No Space Jump)"
                                                 },
                                                 {
                                                     "type": "resource",
@@ -31217,13 +31177,8 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ScrewAttack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Use Screw Attack (No Space Jump)"
                                                 },
                                                 {
                                                     "type": "resource",

--- a/randovania/games/prime2/json_data/Torvus Bog.txt
+++ b/randovania/games/prime2/json_data/Torvus Bog.txt
@@ -776,7 +776,7 @@ Extra - in_dark_aether: True
                   Dark World Damage ≥ 40
                   Any of the following:
                       Before Dark Forgotten Bridge Rotated
-                      Screw Attack and Movement (Beginner)
+                      Movement (Beginner) and Use Screw Attack (No Space Jump)
               All of the following:
                   Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner)
                   Any of the following:
@@ -955,7 +955,7 @@ Extra - in_dark_aether: True
       All of the following:
           Dark World Damage ≥ 15 or Activate Safe Zone
           Any of the following:
-              Screw Attack and Movement (Beginner) and Dark World Damage ≥ 20
+              Movement (Beginner) and Dark World Damage ≥ 20 and Use Screw Attack (No Space Jump)
               All of the following:
                   Dark World Damage ≥ 25
                   Any of the following:
@@ -982,7 +982,7 @@ Extra - in_dark_aether: True
               Dark World Damage ≥ 35
               Any of the following:
                   Space Jump Boots
-                  Screw Attack and Movement (Intermediate)
+                  Movement (Intermediate) and Use Screw Attack (No Space Jump)
           All of the following:
               Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner)
               Any of the following:
@@ -1002,7 +1002,7 @@ Extra - in_dark_aether: True
               Any of the following:
                   No Light Suit and Bomb Jump (Beginner) and Dark World Damage ≥ 45 and Poison Water Damage ≥ 30 and Enabled Allow Jumping on Dark Water
                   Bomb Jump (Advanced) and Standable Terrain (Advanced) and Dark World Damage ≥ 60
-          Screw Attack and Slope Jump (Advanced) and Standable Terrain (Advanced) and Dark World Damage ≥ 50
+          Slope Jump (Advanced) and Standable Terrain (Advanced) and Dark World Damage ≥ 50 and Use Screw Attack (No Space Jump)
 
 > Under Poison Water; Heals? False
   * Layers: default
@@ -1110,7 +1110,7 @@ Extra - in_dark_aether: True
           All of the following:
               Scan Visor
               Any of the following:
-                  Screw Attack and Combat/Scan Dash (Intermediate) and Dark World Damage ≥ 30
+                  Combat/Scan Dash (Intermediate) and Dark World Damage ≥ 30 and Use Screw Attack (No Space Jump)
                   Combat/Scan Dash (Advanced) and Dark World Damage ≥ 45
           Boost Ball and Morph Ball and Boost Jump (Advanced) and Dark World Damage ≥ 50
   > Door to Dark Torvus Temple Access
@@ -1961,7 +1961,7 @@ Extra - in_dark_aether: True
               Grapple Beam and Dark World Damage ≥ 25
               Dark World Damage ≥ 10 and Use Screw Attack (Space Jump)
               Space Jump Boots and Dark World Damage ≥ 25 and Poison Water Damage ≥ 5
-              Screw Attack and Movement (Intermediate) and Dark World Damage ≥ 30 and Poison Water Damage ≥ 20
+              Movement (Intermediate) and Dark World Damage ≥ 30 and Poison Water Damage ≥ 20 and Use Screw Attack (No Space Jump)
               Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner) and Dark World Damage ≥ 50 and Poison Water Damage ≥ 35
               Gravity Boost and Dark World Damage ≥ 35 and Poison Water Damage ≥ 10
           Any of the following:
@@ -2555,7 +2555,7 @@ Extra - in_dark_aether: False
       Any of the following:
           Space Jump Boots
           Morph Ball Bomb and Morph Ball and Bomb Jump (Beginner)
-          Screw Attack and Slope Jump (Intermediate)
+          Slope Jump (Intermediate) and Use Screw Attack (No Space Jump)
 
 ----------------
 Save Station B
@@ -3128,7 +3128,7 @@ Extra - in_dark_aether: False
                   Morph Ball Bomb and Bomb Jump (Beginner)
                   Gravity Boost and Air Underwater (Advanced)
           Combat/Scan Dash (Advanced) and Standable Terrain (Advanced)
-          Screw Attack and Standable Terrain (Intermediate)
+          Standable Terrain (Intermediate) and Use Screw Attack (No Space Jump)
   > Portal to Dungeon
       Any of the following:
           Gravity Boost and Morph Ball and Air Underwater (Advanced)
@@ -3625,7 +3625,7 @@ Extra - in_dark_aether: False
   > Door to Transport to Sanctuary Fortress
       Any of the following:
           Gravity Boost or Space Jump Boots or Movement (Expert)
-          Screw Attack and Movement (Beginner)
+          Movement (Beginner) and Use Screw Attack (No Space Jump)
           Morph Ball Bomb and Morph Ball and Bomb Jump (Advanced)
 
 > Door to Transport to Sanctuary Fortress; Heals? False


### PR DESCRIPTION
If you attempt to screw attack without morph, you just awkwardly pause in place.