### PR TITLE
Prime3: Minor logic fixes for Elysia

### DIFF
--- a/randovania/games/prime3/json_data/SkyTown Elysia - Main.json
+++ b/randovania/games/prime3/json_data/SkyTown Elysia - Main.json
@@ -6827,6 +6827,15 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Event7",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -6940,13 +6949,8 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "PlasmaBeam",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Melt Objects (Plasma or Nova)"
                                     }
                                 ]
                             }

--- a/randovania/games/prime3/json_data/SkyTown Elysia - Main.json
+++ b/randovania/games/prime3/json_data/SkyTown Elysia - Main.json
@@ -6949,8 +6949,13 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Melt Objects (Plasma or Nova)"
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "PlasmaBeam",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/prime3/json_data/SkyTown Elysia - Main.json
+++ b/randovania/games/prime3/json_data/SkyTown Elysia - Main.json
@@ -5327,6 +5327,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Event94",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/prime3/json_data/SkyTown Elysia - Main.json
+++ b/randovania/games/prime3/json_data/SkyTown Elysia - Main.json
@@ -1329,12 +1329,29 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "items",
-                                            "name": "BoostBall",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": "You can use Spring Ball to rotate instead of Boost",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "BoostBall",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -5284,7 +5301,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Event6",
+                                            "name": "Event94",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -5326,15 +5343,6 @@
                                                     "data": "Bomb Jump/Spring Space Jump (Beginner)"
                                                 }
                                             ]
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "Event94",
-                                            "amount": 1,
-                                            "negate": false
                                         }
                                     }
                                 ]

--- a/randovania/games/prime3/json_data/SkyTown Elysia - Main.txt
+++ b/randovania/games/prime3/json_data/SkyTown Elysia - Main.txt
@@ -1169,7 +1169,7 @@ Extra - asset_id: 13389753286679728417
   * Normal Door to Barracks Access/Door to Transit Hub
   * Extra - dock_index: 1
   > Door to Hub Access
-      Boost Ball and Morph Ball
+      Boost Ball and Morph Ball and After Defense Drone
   > Bomb Part Platform
       Grapple Swing
 
@@ -1193,7 +1193,7 @@ Extra - asset_id: 13389753286679728417
   > Door to Barracks Access
       Grapple Swing
   > Door to Zipline Station Bravo
-      Morph Ball and Plasma Beam
+      Morph Ball and Melt Objects (Plasma or Nova)
   > Pickup (Missile Expansion)
       All of the following:
           Morph Ball

--- a/randovania/games/prime3/json_data/SkyTown Elysia - Main.txt
+++ b/randovania/games/prime3/json_data/SkyTown Elysia - Main.txt
@@ -239,7 +239,11 @@ Extra - asset_id: 3066396911819856814
   > Door to Maintenance Shaft AU
       Trivial
   > Inside Aurora Chamber
-      Boost Ball and Morph Ball
+      All of the following:
+          Morph Ball
+          Any of the following:
+              # You can use Spring Ball to rotate instead of Boost
+              Boost Ball or Knowledge (Beginner)
 
 > Inside Aurora Chamber; Heals? False
   * Layers: default
@@ -877,7 +881,7 @@ Extra - asset_id: 12622074872595627812
       After Steambot Barracks Gate
   > Door to Barracks Access
       All of the following:
-          Boost Ball and Morph Ball and After Steamlord (Steambot Barracks) and After Steambot Barracks Gate and After Steambot Barracks Lift Activated
+          Boost Ball and Morph Ball and After Steambot Barracks Gate and After Steambot Barracks Lift Activated
           Space Jump Boots or Bomb Jump/Spring Space Jump (Beginner)
   > Event - Steamlord
       Trivial

--- a/randovania/games/prime3/json_data/SkyTown Elysia - Main.txt
+++ b/randovania/games/prime3/json_data/SkyTown Elysia - Main.txt
@@ -877,7 +877,7 @@ Extra - asset_id: 12622074872595627812
       After Steambot Barracks Gate
   > Door to Barracks Access
       All of the following:
-          Boost Ball and Morph Ball and After Steamlord (Steambot Barracks) and After Steambot Barracks Lift Activated
+          Boost Ball and Morph Ball and After Steamlord (Steambot Barracks) and After Steambot Barracks Gate and After Steambot Barracks Lift Activated
           Space Jump Boots or Bomb Jump/Spring Space Jump (Beginner)
   > Event - Steamlord
       Trivial

--- a/randovania/games/prime3/json_data/SkyTown Elysia - Main.txt
+++ b/randovania/games/prime3/json_data/SkyTown Elysia - Main.txt
@@ -1193,7 +1193,7 @@ Extra - asset_id: 13389753286679728417
   > Door to Barracks Access
       Grapple Swing
   > Door to Zipline Station Bravo
-      Morph Ball and Melt Objects (Plasma or Nova)
+      Morph Ball and Plasma Beam
   > Pickup (Missile Expansion)
       All of the following:
           Morph Ball

--- a/randovania/games/prime3/json_data/SkyTown Elysia - Pod.json
+++ b/randovania/games/prime3/json_data/SkyTown Elysia - Pod.json
@@ -5358,7 +5358,7 @@
                                 "items": []
                             }
                         },
-                        "Event - Ship Grapple Acquired": {
+                        "Event - Ship Upgrade": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5387,7 +5387,7 @@
                         }
                     }
                 },
-                "Event - Ship Grapple Acquired": {
+                "Event - Ship Upgrade": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": null,

--- a/randovania/games/prime3/json_data/SkyTown Elysia - Pod.json
+++ b/randovania/games/prime3/json_data/SkyTown Elysia - Pod.json
@@ -4460,7 +4460,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Event97",
+                                            "name": "ShipGrappleAcquired",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -5358,7 +5358,7 @@
                                 "items": []
                             }
                         },
-                        "Pickup (Ship Grapple)": {
+                        "Event - Ship Grapple Acquired": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5379,6 +5379,26 @@
                     "event_name": "Event97",
                     "connections": {
                         "Door to Landing Access": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Ship Grapple Acquired": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": null,
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "ShipGrappleAcquired",
+                    "connections": {
+                        "Pickup (Ship Grapple)": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/prime3/json_data/SkyTown Elysia - Pod.txt
+++ b/randovania/games/prime3/json_data/SkyTown Elysia - Pod.txt
@@ -732,7 +732,7 @@ Extra - asset_id: 6708692299270885612
       Use Screw Attack (Space Jump)
   > Pickup (Missile Expansion)
       All of the following:
-          Space Jump Boots and Morph Ball and After SkyTown Federation Landing Site Unlocked
+          Space Jump Boots and Morph Ball and After SkyTown East - Ship Grapple Acquired
           Any of the following:
               Screw Attack
               Boost Ball and Bomb/Spring Space Jump (Intermediate)
@@ -889,13 +889,19 @@ Extra - asset_id: 18200553231954089224
   * Player Ship (Unlocked by After SkyTown Federation Landing Site Unlocked)
   > Door to Landing Access
       Trivial
-  > Pickup (Ship Grapple)
+  > Event - Ship Grapple Acquired
       Trivial
 
 > Event - Landing Site Unlocked; Heals? False
   * Layers: default
   * Event SkyTown Federation Landing Site Unlocked
   > Door to Landing Access
+      Trivial
+
+> Event - Ship Grapple Acquired; Heals? False
+  * Layers: default
+  * Event SkyTown East - Ship Grapple Acquired
+  > Pickup (Ship Grapple)
       Trivial
 
 ----------------

--- a/randovania/games/prime3/json_data/SkyTown Elysia - Pod.txt
+++ b/randovania/games/prime3/json_data/SkyTown Elysia - Pod.txt
@@ -732,7 +732,7 @@ Extra - asset_id: 6708692299270885612
       Use Screw Attack (Space Jump)
   > Pickup (Missile Expansion)
       All of the following:
-          Space Jump Boots and Morph Ball and After SkyTown East - Ship Grapple Acquired
+          Space Jump Boots and Morph Ball and After SkyTown East - Ship Upgrade
           Any of the following:
               Screw Attack
               Boost Ball and Bomb/Spring Space Jump (Intermediate)
@@ -889,7 +889,7 @@ Extra - asset_id: 18200553231954089224
   * Player Ship (Unlocked by After SkyTown Federation Landing Site Unlocked)
   > Door to Landing Access
       Trivial
-  > Event - Ship Grapple Acquired
+  > Event - Ship Upgrade
       Trivial
 
 > Event - Landing Site Unlocked; Heals? False
@@ -898,9 +898,9 @@ Extra - asset_id: 18200553231954089224
   > Door to Landing Access
       Trivial
 
-> Event - Ship Grapple Acquired; Heals? False
+> Event - Ship Upgrade; Heals? False
   * Layers: default
-  * Event SkyTown East - Ship Grapple Acquired
+  * Event SkyTown East - Ship Upgrade
   > Pickup (Ship Grapple)
       Trivial
 

--- a/randovania/games/prime3/json_data/header.json
+++ b/randovania/games/prime3/json_data/header.json
@@ -1117,7 +1117,7 @@
                 "extra": {}
             },
             "ShipGrappleAcquired": {
-                "long_name": "SkyTown East - Ship Grapple Acquired",
+                "long_name": "SkyTown East - Ship Upgrade",
                 "extra": {}
             }
         },

--- a/randovania/games/prime3/json_data/header.json
+++ b/randovania/games/prime3/json_data/header.json
@@ -1115,6 +1115,10 @@
             "Event155": {
                 "long_name": "Imperial Hall Grapple Lasso Walls",
                 "extra": {}
+            },
+            "ShipGrappleAcquired": {
+                "long_name": "SkyTown East - Ship Grapple Acquired",
+                "extra": {}
             }
         },
         "tricks": {


### PR DESCRIPTION
- Fixes Gearworks by adding an event for collecting Ship Grapple
- Fixes Steambot Barracks by requiring the Gate event so you can reload the room to go back up
- Fixes Transit Hub by requiring Defense Drone to be defeated before using the kinetic orb cannon
- Adds the possibility of beginner Knowledge to enter the AU Chamber