### PR TITLE
Lower difficulty of Central Mining Station Standable Terrain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: Intermediate Slope Jump and Intermediate Wall Boost to get next to the pickup in Communication Area.
 - Added: Beginner Movement for crossing Hall of Combat Mastery from the Portal Side with NSJ Screw Attack after the tunnel is destroyed. 
+- Changed: Standable Terrain to reach the upper Command Center Access door in Central Mining Station with Space Jump and Screw Attack has had its difficulty decreased from Intermediate to Beginner.
 
 ## [5.1.0] - 2022-10-01
 

--- a/randovania/games/prime2/json_data/Agon Wastes.json
+++ b/randovania/games/prime2/json_data/Agon Wastes.json
@@ -11749,7 +11749,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "https://www.youtube.com/watch?v=mprL_DAECUI",
                                                         "items": [
                                                             {
                                                                 "type": "template",
@@ -11760,7 +11760,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "StandableTerrain",
-                                                                    "amount": 2,
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             }

--- a/randovania/games/prime2/json_data/Agon Wastes.txt
+++ b/randovania/games/prime2/json_data/Agon Wastes.txt
@@ -1535,7 +1535,9 @@ Extra - in_dark_aether: False
                   Any of the following:
                       Spider Ball
                       Morph Ball Bomb and Space Jump Boots and Bomb Space Jump (Intermediate)
-              Standable Terrain (Intermediate) and Use Screw Attack (Space Jump)
+              All of the following:
+                  # https://www.youtube.com/watch?v=mprL_DAECUI
+                  Standable Terrain (Beginner) and Use Screw Attack (Space Jump)
               All of the following:
                   Space Jump Boots
                   Any of the following:


### PR DESCRIPTION
The standable terrain is massive. There is little to no risk of breaking the standable terrain. There is little to no risk of taking damage or softlocking from using the standable terrain. The Screw Attack itself is very lenient and is not difficult to perform. The majority of players should be able to perform the trick successfully 90%+ of the time. This all suggests the trick belongs in Beginner and not Intermediate.

I did not run the tests to see if they broke.