### PR TITLE
Dread: Add door exclusions to Door Lock Rando

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -3441,12 +3441,29 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "DoorLocks",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -3691,7 +3708,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Grapple Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -11674,7 +11694,7 @@
                                 "negate": false
                             }
                         },
-                        "Door to Invisible Corpius Room": {
+                        "Dock to Invisible Corpius Room": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -11727,7 +11747,7 @@
                         }
                     }
                 },
-                "Door to Invisible Corpius Room": {
+                "Dock to Invisible Corpius Room": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -11747,13 +11767,13 @@
                         "right_shield_entity": "{EMPTY}",
                         "right_shield_def": null
                     },
-                    "dock_type": "door",
+                    "dock_type": "other",
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Invisible Corpius Room",
                         "node_name": "Door to Thermal Door Tutorial"
                     },
-                    "default_dock_weakness": "Access Open",
+                    "default_dock_weakness": "Open Passage",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -11829,7 +11849,7 @@
                     },
                     "event_name": "s010_cave:default:db_reg_cv_021",
                     "connections": {
-                        "Door to Invisible Corpius Room": {
+                        "Dock to Invisible Corpius Room": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12662,7 +12682,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Lower Path to Cataris",
-                        "node_name": "Door to Hot Room Hub"
+                        "node_name": "Dock to Hot Room Hub"
                     },
                     "default_dock_weakness": "Sensor Lock Door",
                     "override_default_open_requirement": null,
@@ -12943,7 +12963,8 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "exclude_from_dock_rando": true
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -13711,7 +13732,8 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "exclude_from_dock_rando": true
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -16735,7 +16757,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Thermal Door Tutorial",
-                        "node_name": "Door to Invisible Corpius Room"
+                        "node_name": "Dock to Invisible Corpius Room"
                     },
                     "default_dock_weakness": "Sensor Lock Door",
                     "override_default_open_requirement": null,
@@ -17313,7 +17335,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Grapple Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -18277,7 +18302,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Grapple Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -19379,7 +19407,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Grapple Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -22825,7 +22856,7 @@
                 "asset_id": "collision_camera_072"
             },
             "nodes": {
-                "Door to Phantom Cloak Tutorial": {
+                "Dock to Phantom Cloak Tutorial": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -22845,13 +22876,13 @@
                         "right_shield_entity": "{EMPTY}",
                         "right_shield_def": null
                     },
-                    "dock_type": "door",
+                    "dock_type": "other",
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Phantom Cloak Tutorial",
                         "node_name": "Door to Path to Corpius"
                     },
-                    "default_dock_weakness": "Access Open",
+                    "default_dock_weakness": "Open Passage",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -22922,7 +22953,7 @@
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
                     "connections": {
-                        "Door to Phantom Cloak Tutorial": {
+                        "Dock to Phantom Cloak Tutorial": {
                             "type": "template",
                             "data": "Can Slide"
                         },
@@ -23031,7 +23062,7 @@
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Path to Corpius",
-                        "node_name": "Door to Phantom Cloak Tutorial"
+                        "node_name": "Dock to Phantom Cloak Tutorial"
                     },
                     "default_dock_weakness": "Sensor Lock Door",
                     "override_default_open_requirement": null,
@@ -24403,7 +24434,7 @@
                 "asset_id": "collision_camera_079"
             },
             "nodes": {
-                "Door to Hot Room Hub": {
+                "Dock to Hot Room Hub": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -24423,13 +24454,13 @@
                         "right_shield_entity": "{EMPTY}",
                         "right_shield_def": null
                     },
-                    "dock_type": "door",
+                    "dock_type": "other",
                     "default_connection": {
                         "world_name": "Artaria",
                         "area_name": "Hot Room Hub",
                         "node_name": "Door to Lower Path to Cataris"
                     },
-                    "default_dock_weakness": "Access Open",
+                    "default_dock_weakness": "Open Passage",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -24649,7 +24680,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Hot Room Hub": {
+                        "Dock to Hot Room Hub": {
                             "type": "or",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -699,7 +699,8 @@ Extra - asset_id: collision_camera_006
   > Door to Teleport to Dairon (Thermal)
       Any of the following:
           # Spider ceiling wall here. Probably don't need an event for it.
-          Spider Magnet or Speed Booster or Simple IBJ or Use Spin Boost
+          Spider Magnet or Simple IBJ or Use Spin Boost
+          Speed Booster and Disabled Door Lock Randomizer
   > Door to EMMI Zone Ballspark Hallway
       Any of the following:
           Flash Shift or Simple IBJ or Use Spin Boost
@@ -736,6 +737,7 @@ Extra - asset_id: collision_camera_006
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
   > Door to Teleport to Dairon (Lower)
       Trivial
 
@@ -2335,16 +2337,16 @@ Extra - asset_id: collision_camera_022
   * Extra - right_shield_def: None
   > Door to David Jaffe Room
       After Artaria - Thermal Device East Blob
-  > Door to Invisible Corpius Room
+  > Dock to Invisible Corpius Room
       After Artaria - Thermal Device West Blob
   > Event - Thermal Device East Blob
       Lay Bomb or Shoot Beam
   > Event - Thermal Device West Blob
       Wave Beam or Pseudo-Wave Beam (Intermediate)
 
-> Door to Invisible Corpius Room; Heals? False
+> Dock to Invisible Corpius Room; Heals? False
   * Layers: default
-  * Access Open to Invisible Corpius Room/Door to Thermal Door Tutorial
+  * Open Passage to Invisible Corpius Room/Door to Thermal Door Tutorial
   * Extra - actor_name: doorpresenceframe_000
   * Extra - actor_def: actordef:actors/props/doorpresenceframe/charclasses/doorpresenceframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2369,7 +2371,7 @@ Extra - asset_id: collision_camera_022
   * Event Artaria - Thermal Device West Blob
   * Extra - actor_name: db_reg_cv_021
   * Extra - actor_def: actordef:actors/props/db_reg_cv_020/charclasses/db_reg_cv_020.bmsad
-  > Door to Invisible Corpius Room
+  > Dock to Invisible Corpius Room
       Trivial
 
 > Door to Magma Flow Vista; Heals? False
@@ -2522,7 +2524,7 @@ Extra - asset_id: collision_camera_024
 
 > Door to Lower Path to Cataris; Heals? False
   * Layers: default
-  * Sensor Lock Door to Lower Path to Cataris/Door to Hot Room Hub
+  * Sensor Lock Door to Lower Path to Cataris/Dock to Hot Room Hub
   * Extra - actor_name: doorpresenceframe_001
   * Extra - actor_def: actordef:actors/props/doorpresenceframe/charclasses/doorpresenceframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2606,6 +2608,7 @@ Extra - asset_id: collision_camera_026
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - exclude_from_dock_rando: True
   > Start Point
       All of the following:
           # TODO: Find heat values after constand damage numbers are decided on
@@ -2737,6 +2740,7 @@ Extra - asset_id: collision_camera_029
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - exclude_from_dock_rando: True
   > Ledge above lava
       Any of the following:
           Varia Suit
@@ -3340,7 +3344,7 @@ Extra - asset_id: collision_camera_050
 
 > Door to Thermal Door Tutorial; Heals? False
   * Layers: default
-  * Sensor Lock Door to Thermal Door Tutorial/Door to Invisible Corpius Room
+  * Sensor Lock Door to Thermal Door Tutorial/Dock to Invisible Corpius Room
   * Extra - actor_name: doorpresenceframe_000
   * Extra - actor_def: actordef:actors/props/doorpresenceframe/charclasses/doorpresenceframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -3459,6 +3463,7 @@ Extra - asset_id: collision_camera_053
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
   > Door to EMMI Zone Hub
       Trivial
 
@@ -3669,6 +3674,7 @@ Extra - asset_id: collision_camera_056
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
   > Pickup (Missile Tank)
       Trivial
   > Tower Middle
@@ -3878,6 +3884,7 @@ Extra - asset_id: collision_camera_059
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
   > Door to Water Reservoir
       Trivial
 
@@ -4640,9 +4647,9 @@ Path to Corpius
 Extra - total_boundings: {'x1': 10800.0, 'x2': 15900.0, 'y1': -900.0, 'y2': 200.0}
 Extra - polygon: [[15900.0, 200.0], [10800.0, 200.0], [10800.0, -900.0], [15900.0, -900.0]]
 Extra - asset_id: collision_camera_072
-> Door to Phantom Cloak Tutorial; Heals? False
+> Dock to Phantom Cloak Tutorial; Heals? False
   * Layers: default
-  * Access Open to Phantom Cloak Tutorial/Door to Path to Corpius
+  * Open Passage to Phantom Cloak Tutorial/Door to Path to Corpius
   * Extra - actor_name: Door052
   * Extra - actor_def: actordef:actors/props/doorframepresence/charclasses/doorframepresence.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -4668,7 +4675,7 @@ Extra - asset_id: collision_camera_072
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Scorpius
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Phantom Cloak Tutorial
+  > Dock to Phantom Cloak Tutorial
       Can Slide
   > Door to Early Cloak Room
       Trivial
@@ -4692,7 +4699,7 @@ Extra - asset_id: collision_camera_073
 
 > Door to Path to Corpius; Heals? False
   * Layers: default
-  * Sensor Lock Door to Path to Corpius/Door to Phantom Cloak Tutorial
+  * Sensor Lock Door to Path to Corpius/Dock to Phantom Cloak Tutorial
   * Extra - actor_name: Door052
   * Extra - actor_def: actordef:actors/props/doorframepresence/charclasses/doorframepresence.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -4960,9 +4967,9 @@ Lower Path to Cataris
 Extra - total_boundings: {'x1': 26800.0, 'x2': 31800.0, 'y1': 1400.0, 'y2': 3000.0}
 Extra - polygon: [[31800.0, 3000.0], [26800.0, 3000.0], [26800.0, 1400.0], [31800.0, 1400.0]]
 Extra - asset_id: collision_camera_079
-> Door to Hot Room Hub; Heals? False
+> Dock to Hot Room Hub; Heals? False
   * Layers: default
-  * Access Open to Hot Room Hub/Door to Lower Path to Cataris
+  * Open Passage to Hot Room Hub/Door to Lower Path to Cataris
   * Extra - actor_name: doorpresenceframe_001
   * Extra - actor_def: actordef:actors/props/doorpresenceframe/charclasses/doorpresenceframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -4994,7 +5001,7 @@ Extra - asset_id: collision_camera_079
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Hot Room Hub
+  > Dock to Hot Room Hub
       Any of the following:
           Flash Shift or Speed Booster or Can Slide or Use Spin Boost
           Stand on Frozen Enemy (Beginner) and Shoot Ice Missile

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -6408,7 +6408,10 @@
                         "left_shield_entity": "Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:door_shield_plasma_003",
                         "left_shield_def": "actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad",
                         "right_shield_entity": "Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:door_shield_plasma_002",
-                        "right_shield_def": "actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad"
+                        "right_shield_def": "actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad",
+                        "excluded_dock_weaknesses": [
+                            "Grapple Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -9484,7 +9487,10 @@
                         "left_shield_entity": "Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:door_shield_plasma_003",
                         "left_shield_def": "actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad",
                         "right_shield_entity": "Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:door_shield_plasma_002",
-                        "right_shield_def": "actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad"
+                        "right_shield_def": "actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad",
+                        "excluded_dock_weaknesses": [
+                            "Grapple Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -10014,7 +10020,7 @@
                         "Event - Ghavoran Teleport Speed Blocks Destroyed": {
                             "type": "and",
                             "data": {
-                                "comment": "Proceeding down from here will be logically impossible with door rando enabled",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
@@ -10028,10 +10034,10 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "misc",
-                                            "name": "DoorLocks",
+                                            "type": "events",
+                                            "name": "BureniaEPart",
                                             "amount": 1,
-                                            "negate": true
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -10057,7 +10063,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Grapple Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -11151,6 +11160,13 @@
                                 "comment": null,
                                 "items": []
                             }
+                        },
+                        "Event - Early Gravity Pickup 1": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -11172,7 +11188,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Grapple Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -11571,6 +11590,30 @@
                                 "name": "Morph",
                                 "amount": 1,
                                 "negate": false
+                            }
+                        }
+                    }
+                },
+                "Event - Early Gravity Pickup 1": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 3200.0,
+                        "y": -4700.0,
+                        "z": 0.0
+                    },
+                    "description": "Event readded so that the door does not need excluded for door rando\n\n",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "event_name": "BureniaEPart",
+                    "connections": {
+                        "Door to Teleport to Ghavoran (Upper)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -12013,7 +12056,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Ammo Recharge South (Lower)": {
+                        "Dock to Ammo Recharge South (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12325,7 +12368,7 @@
                         }
                     }
                 },
-                "Door to Ammo Recharge South (Lower)": {
+                "Dock to Ammo Recharge South (Lower)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -12345,13 +12388,13 @@
                         "right_shield_entity": "{EMPTY}",
                         "right_shield_def": null
                     },
-                    "dock_type": "door",
+                    "dock_type": "other",
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Ammo Recharge South",
                         "node_name": "Door to Gravity Suit Tower (Lower)"
                     },
-                    "default_dock_weakness": "Access Open",
+                    "default_dock_weakness": "Open Passage",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -12364,7 +12407,7 @@
                                 "negate": true
                             }
                         },
-                        "Dock to Ammo Recharge South": {
+                        "Dock to Ammo Recharge South (Middle)": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -12461,7 +12504,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Ammo Recharge South (Lower)": {
+                        "Dock to Ammo Recharge South (Lower)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12583,7 +12626,7 @@
                         }
                     }
                 },
-                "Door to Ammo Recharge South (Upper)": {
+                "Dock to Ammo Recharge South (Upper)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -12603,13 +12646,13 @@
                         "right_shield_entity": "{EMPTY}",
                         "right_shield_def": null
                     },
-                    "dock_type": "door",
+                    "dock_type": "other",
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Ammo Recharge South",
                         "node_name": "Door to Gravity Suit Tower (Upper)"
                     },
-                    "default_dock_weakness": "Access Open",
+                    "default_dock_weakness": "Open Passage",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -12798,7 +12841,7 @@
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
                     "connections": {
-                        "Door to Ammo Recharge South (Upper)": {
+                        "Dock to Ammo Recharge South (Upper)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -13412,7 +13455,7 @@
                                 ]
                             }
                         },
-                        "Dock to Ammo Recharge South": {
+                        "Dock to Ammo Recharge South (Middle)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -13566,7 +13609,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Ammo Recharge South (Upper)": {
+                        "Dock to Ammo Recharge South (Upper)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -13577,7 +13620,7 @@
                         }
                     }
                 },
-                "Dock to Ammo Recharge South": {
+                "Dock to Ammo Recharge South (Middle)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -13609,7 +13652,7 @@
                                 "negate": false
                             }
                         },
-                        "Door to Ammo Recharge South (Lower)": {
+                        "Dock to Ammo Recharge South (Lower)": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -14109,7 +14152,7 @@
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Gravity Suit Tower",
-                        "node_name": "Door to Ammo Recharge South (Lower)"
+                        "node_name": "Dock to Ammo Recharge South (Lower)"
                     },
                     "default_dock_weakness": "Sensor Lock Door",
                     "override_default_open_requirement": null,
@@ -14155,7 +14198,7 @@
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Gravity Suit Tower",
-                        "node_name": "Door to Ammo Recharge South (Upper)"
+                        "node_name": "Dock to Ammo Recharge South (Upper)"
                     },
                     "default_dock_weakness": "Sensor Lock Door",
                     "override_default_open_requirement": null,
@@ -14249,7 +14292,7 @@
                     "default_connection": {
                         "world_name": "Burenia",
                         "area_name": "Gravity Suit Tower",
-                        "node_name": "Dock to Ammo Recharge South"
+                        "node_name": "Dock to Ammo Recharge South (Middle)"
                     },
                     "default_dock_weakness": "Open Passage",
                     "override_default_open_requirement": null,

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -1168,6 +1168,7 @@ Extra - asset_id: collision_camera_010
   * Extra - left_shield_def: actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:door_shield_plasma_002
   * Extra - right_shield_def: actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad
+  * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
   > Door to Teleport to Ghavoran (Charge)
       After Burenia - Hub Magnet Wall and Horizontal Water Movement
   > Missile Tank Plus Platform
@@ -1653,6 +1654,7 @@ Extra - asset_id: collision_camera_013
   * Extra - left_shield_def: actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:door_shield_plasma_002
   * Extra - right_shield_def: actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad
+  * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
   > Door to Main Hub Tower Bottom
       Trivial
   > Life Recharge
@@ -1788,9 +1790,7 @@ Extra - asset_id: collision_camera_015
   > Event - Destroy all Enkys
       Destroy Enky
   > Event - Ghavoran Teleport Speed Blocks Destroyed
-      All of the following:
-          # Proceeding down from here will be logically impossible with door rando enabled
-          Speed Booster and Disabled Door Lock Randomizer
+      Speed Booster and After Burenia - Early Gravity Pickup 1
 
 > Door to Early Gravity Speedboost Room 1 (Lower); Heals? False
   * Layers: default
@@ -1801,6 +1801,7 @@ Extra - asset_id: collision_camera_015
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
   > Door to Early Gravity Speedboost Room 1 (Upper)
       After Burenia - Ghavoran Teleoport Speed Blocks Destroyed
 
@@ -2058,6 +2059,8 @@ Extra - asset_id: collision_camera_018
   * Extra - right_shield_def: None
   > Pickup (Energy Part)
       Trivial
+  > Event - Early Gravity Pickup 1
+      Trivial
 
 > Door to Teleport to Ghavoran (Lower); Heals? False
   * Layers: default
@@ -2068,6 +2071,7 @@ Extra - asset_id: collision_camera_018
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
   > Tile Group (POWERBEAM) 2
       Can Slide
 
@@ -2148,6 +2152,15 @@ Extra - asset_id: collision_camera_018
   > Tile Group (POWERBEAM) 1
       Morph Ball
 
+> Event - Early Gravity Pickup 1; Heals? False
+  * Layers: default
+  * Event Burenia - Early Gravity Pickup 1
+  * Event readded so that the door does not need excluded for door rando
+
+
+  > Door to Teleport to Ghavoran (Upper)
+      Trivial
+
 ----------------
 Early Gravity Speedboost Room 2
 Extra - total_boundings: {'x1': -700.0, 'x2': 2100.0, 'y1': -8300.0, 'y2': -6000.0}
@@ -2217,7 +2230,7 @@ Extra - asset_id: collision_camera_021
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorshieldmissile_001
   * Extra - right_shield_def: actordef:actors/props/doorshieldmissile/charclasses/doorshieldmissile.bmsad
-  > Door to Ammo Recharge South (Lower)
+  > Dock to Ammo Recharge South (Lower)
       All of the following:
           After Burenia - Destroy Gravity Suit Floor
           Any of the following:
@@ -2257,9 +2270,9 @@ Extra - asset_id: collision_camera_021
   > Breakable Floor
       After Burenia - Destroy Gravity Suit Floor
 
-> Door to Ammo Recharge South (Lower); Heals? False
+> Dock to Ammo Recharge South (Lower); Heals? False
   * Layers: default
-  * Access Open to Ammo Recharge South/Door to Gravity Suit Tower (Lower)
+  * Open Passage to Ammo Recharge South/Door to Gravity Suit Tower (Lower)
   * Extra - actor_name: doorframepresence
   * Extra - actor_def: actordef:actors/props/doorframepresence/charclasses/doorframepresence.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2268,7 +2281,7 @@ Extra - asset_id: collision_camera_021
   * Extra - right_shield_def: None
   > Door to Gravity Suit Room (Lower)
       Before Burenia - Destroy Gravity Suit Floor
-  > Dock to Ammo Recharge South
+  > Dock to Ammo Recharge South (Middle)
       After Burenia - Destroy Gravity Suit Floor
 
 > Pickup (Missile+ Tank); Heals? False
@@ -2296,7 +2309,7 @@ Extra - asset_id: collision_camera_021
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Ammo Recharge South (Lower)
+  > Dock to Ammo Recharge South (Lower)
       All of the following:
           Before Burenia - Destroy Gravity Suit Floor
           Any of the following:
@@ -2321,9 +2334,9 @@ Extra - asset_id: collision_camera_021
   > Tile Group (MISSILE)
       Trivial
 
-> Door to Ammo Recharge South (Upper); Heals? False
+> Dock to Ammo Recharge South (Upper); Heals? False
   * Layers: default
-  * Access Open to Ammo Recharge South/Door to Gravity Suit Tower (Upper)
+  * Open Passage to Ammo Recharge South/Door to Gravity Suit Tower (Upper)
   * Extra - actor_name: doorframepresence_000
   * Extra - actor_def: actordef:actors/props/doorframepresence/charclasses/doorframepresence.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2375,7 +2388,7 @@ Extra - asset_id: collision_camera_021
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Demolition
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Ammo Recharge South (Upper)
+  > Dock to Ammo Recharge South (Upper)
       Trivial
 
 > Start Point 2; Heals? False
@@ -2514,7 +2527,7 @@ Extra - asset_id: collision_camera_021
           Any of the following:
               Space Jump or Simple IBJ
               Speed Booster and Disabled Door Lock Randomizer
-  > Dock to Ammo Recharge South
+  > Dock to Ammo Recharge South (Middle)
       Any of the following:
           Space Jump or Before Burenia - Destroy Gravity Suit Floor
           All of the following:
@@ -2530,15 +2543,15 @@ Extra - asset_id: collision_camera_021
 > Tunnel to Ammo Recharge South; Heals? False
   * Layers: default
   * Morph Ball Tunnel to Ammo Recharge South/Tunnel to Gravity Suit Tower
-  > Door to Ammo Recharge South (Upper)
+  > Dock to Ammo Recharge South (Upper)
       Morph Ball
 
-> Dock to Ammo Recharge South; Heals? False
+> Dock to Ammo Recharge South (Middle); Heals? False
   * Layers: default
   * Open Passage to Ammo Recharge South/Dock to Gravity Suit Tower
   > Door to Gravity Suit Room (Upper)
       After Burenia - Destroy Gravity Suit Floor
-  > Door to Ammo Recharge South (Lower)
+  > Dock to Ammo Recharge South (Lower)
       After Burenia - Destroy Gravity Suit Floor
   > Breakable Floor
       Before Burenia - Destroy Gravity Suit Floor or Horizontal Water Movement
@@ -2604,7 +2617,7 @@ Extra - polygon: [[11100.0, -8800.0], [9000.0, -8800.0], [9000.0, -10900.0], [11
 Extra - asset_id: collision_camera_022
 > Door to Gravity Suit Tower (Lower); Heals? False
   * Layers: default
-  * Sensor Lock Door to Gravity Suit Tower/Door to Ammo Recharge South (Lower)
+  * Sensor Lock Door to Gravity Suit Tower/Dock to Ammo Recharge South (Lower)
   * Extra - actor_name: doorframepresence
   * Extra - actor_def: actordef:actors/props/doorframepresence/charclasses/doorframepresence.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2618,7 +2631,7 @@ Extra - asset_id: collision_camera_022
 
 > Door to Gravity Suit Tower (Upper); Heals? False
   * Layers: default
-  * Sensor Lock Door to Gravity Suit Tower/Door to Ammo Recharge South (Upper)
+  * Sensor Lock Door to Gravity Suit Tower/Dock to Ammo Recharge South (Upper)
   * Extra - actor_name: doorframepresence_000
   * Extra - actor_def: actordef:actors/props/doorframepresence/charclasses/doorframepresence.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -2645,7 +2658,7 @@ Extra - asset_id: collision_camera_022
 
 > Dock to Gravity Suit Tower; Heals? False
   * Layers: default
-  * Open Passage to Gravity Suit Tower/Dock to Ammo Recharge South
+  * Open Passage to Gravity Suit Tower/Dock to Ammo Recharge South (Middle)
   > Tunnel to Gravity Suit Tower
       Morph Ball
 

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -2892,7 +2892,7 @@
                         }
                     }
                 },
-                "Door to Lava Button East Access (Charge)": {
+                "Door to Lava Button East Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3121,7 +3121,7 @@
                         }
                     }
                 },
-                "Door to Lava Button East Access (Cloak)": {
+                "Dock to Lava Button East Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3141,13 +3141,13 @@
                         "right_shield_entity": "{EMPTY}",
                         "right_shield_def": null
                     },
-                    "dock_type": "door",
+                    "dock_type": "other",
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Lava Button East Access",
                         "node_name": "Door to Lava Button East (Cloak)"
                     },
-                    "default_dock_weakness": "Access Open",
+                    "default_dock_weakness": "Open Passage",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -3192,7 +3192,7 @@
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
                     "connections": {
-                        "Door to Lava Button East Access (Cloak)": {
+                        "Dock to Lava Button East Access": {
                             "type": "template",
                             "data": "Can Slide"
                         }
@@ -3213,7 +3213,7 @@
                     "extra": {},
                     "event_name": "CatarisMoveMagnetWallsButton",
                     "connections": {
-                        "Door to Lava Button East Access (Cloak)": {
+                        "Dock to Lava Button East Access": {
                             "type": "template",
                             "data": "Can Slide"
                         }
@@ -3423,7 +3423,7 @@
                                 ]
                             }
                         },
-                        "Door to Lava Button East Access (Charge)": {
+                        "Door to Lava Button East Access": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -3822,7 +3822,7 @@
                                 "items": []
                             }
                         },
-                        "Door to Energy Recharge Station (Charge)": {
+                        "Door to Energy Recharge Station": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -4008,7 +4008,7 @@
                         }
                     }
                 },
-                "Door to Energy Recharge Station (Charge)": {
+                "Door to Energy Recharge Station": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4045,7 +4045,7 @@
                                 "items": []
                             }
                         },
-                        "Door to Energy Recharge Station (Cloak)": {
+                        "Dock to Energy Recharge Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4080,7 +4080,7 @@
                         }
                     }
                 },
-                "Door to Energy Recharge Station (Cloak)": {
+                "Dock to Energy Recharge Station": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4100,17 +4100,17 @@
                         "right_shield_entity": "{EMPTY}",
                         "right_shield_def": null
                     },
-                    "dock_type": "door",
+                    "dock_type": "other",
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Energy Recharge Station",
                         "node_name": "Door to Moving Magnet Walls (Tall) (Cloak)"
                     },
-                    "default_dock_weakness": "Access Open",
+                    "default_dock_weakness": "Open Passage",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Energy Recharge Station (Charge)": {
+                        "Door to Energy Recharge Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4186,7 +4186,7 @@
                                 "items": []
                             }
                         },
-                        "Door to Energy Recharge Station (Charge)": {
+                        "Door to Energy Recharge Station": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -7564,7 +7564,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Moving Magnet Walls (Tall)",
-                        "node_name": "Door to Energy Recharge Station (Charge)"
+                        "node_name": "Door to Energy Recharge Station"
                     },
                     "default_dock_weakness": "Access Locked",
                     "override_default_open_requirement": null,
@@ -7680,7 +7680,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Moving Magnet Walls (Tall)",
-                        "node_name": "Door to Energy Recharge Station (Cloak)"
+                        "node_name": "Dock to Energy Recharge Station"
                     },
                     "default_dock_weakness": "Sensor Lock Door",
                     "override_default_open_requirement": null,
@@ -9059,7 +9059,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "EMMI Zone West Exit Path",
-                        "node_name": "Door to Green EMMI Introduction"
+                        "node_name": "Dock to Green EMMI Introduction"
                     },
                     "default_dock_weakness": "Sensor Lock Door",
                     "override_default_open_requirement": null,
@@ -21072,7 +21072,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Lava Button East",
-                        "node_name": "Door to Lava Button East Access (Charge)"
+                        "node_name": "Door to Lava Button East Access"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "override_default_open_requirement": null,
@@ -21120,7 +21120,7 @@
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Lava Button East",
-                        "node_name": "Door to Lava Button East Access (Cloak)"
+                        "node_name": "Dock to Lava Button East Access"
                     },
                     "default_dock_weakness": "Sensor Lock Door",
                     "override_default_open_requirement": null,
@@ -26623,6 +26623,15 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "DoorLocks",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
                                     }
                                 ]
                             }
@@ -27340,7 +27349,7 @@
                 "asset_id": "collision_camera_059"
             },
             "nodes": {
-                "Door to Green EMMI Introduction": {
+                "Dock to Green EMMI Introduction": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -27360,13 +27369,13 @@
                         "right_shield_entity": "{EMPTY}",
                         "right_shield_def": null
                     },
-                    "dock_type": "door",
+                    "dock_type": "other",
                     "default_connection": {
                         "world_name": "Cataris",
                         "area_name": "Green EMMI Introduction",
                         "node_name": "Door to EMMI Zone West Exit Path"
                     },
-                    "default_dock_weakness": "Access Open",
+                    "default_dock_weakness": "Open Passage",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -27409,7 +27418,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Green EMMI Introduction": {
+                        "Dock to Green EMMI Introduction": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -624,7 +624,7 @@ Extra - asset_id: collision_camera_012
           Varia Suit or After Cataris - Move Magnet Walls Button
           Heat/Cold Runs (Beginner) and Heat Damage ≥ 100
 
-> Door to Lava Button East Access (Charge); Heals? False
+> Door to Lava Button East Access; Heals? False
   * Layers: default
   * Charge Beam Door to Lava Button East Access/Door to Lava Button East (Charge)
   * Extra - actor_name: doorchargecharge_002
@@ -656,9 +656,9 @@ Extra - asset_id: collision_camera_012
                   Heat/Cold Runs (Beginner) and Lava Damage ≥ 80
                   Varia Suit or Heat Damage ≥ 100
 
-> Door to Lava Button East Access (Cloak); Heals? False
+> Dock to Lava Button East Access; Heals? False
   * Layers: default
-  * Access Open to Lava Button East Access/Door to Lava Button East (Cloak)
+  * Open Passage to Lava Button East Access/Door to Lava Button East (Cloak)
   * Extra - actor_name: doorframepresence_001
   * Extra - actor_def: actordef:actors/props/doorframepresence/charclasses/doorframepresence.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -677,13 +677,13 @@ Extra - asset_id: collision_camera_012
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_PistonRight
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
-  > Door to Lava Button East Access (Cloak)
+  > Dock to Lava Button East Access
       Can Slide
 
 > Event - Activate Magnet Walls Button; Heals? False
   * Layers: default
   * Event Cataris - Move Magnet Walls Button
-  > Door to Lava Button East Access (Cloak)
+  > Dock to Lava Button East Access
       Can Slide
 
 > Below Thermal Door; Heals? False
@@ -705,7 +705,7 @@ Extra - asset_id: collision_camera_012
       Any of the following:
           Varia Suit or After Cataris - Move Magnet Walls Button
           Heat/Cold Runs (Beginner) and Heat Damage ≥ 100
-  > Door to Lava Button East Access (Charge)
+  > Door to Lava Button East Access
       Any of the following:
           Varia Suit or After Cataris - Move Magnet Walls Button
           Heat/Cold Runs (Beginner) and Heat Damage ≥ 100
@@ -781,7 +781,7 @@ Extra - asset_id: collision_camera_014
   * Extra - right_shield_def: None
   > Door to Lava Button East Access
       Trivial
-  > Door to Energy Recharge Station (Charge)
+  > Door to Energy Recharge Station
       Any of the following:
           Space Jump or Speed Booster
           All of the following:
@@ -808,7 +808,7 @@ Extra - asset_id: collision_camera_014
   > Tile Group (POWERBEAM)
       Speed Booster or Simple IBJ
 
-> Door to Energy Recharge Station (Charge); Heals? False
+> Door to Energy Recharge Station; Heals? False
   * Layers: default
   * Charge Beam Door to Energy Recharge Station/Door to Moving Magnet Walls (Tall) (Charge)
   * Extra - actor_name: doorclosedcharge_002
@@ -819,21 +819,21 @@ Extra - asset_id: collision_camera_014
   * Extra - right_shield_def: None
   > Door to Tall Magnet Walls Access
       Trivial
-  > Door to Energy Recharge Station (Cloak)
+  > Dock to Energy Recharge Station
       Trivial
   > Tile Group (POWERBEAM)
       Spider Magnet or Space Jump
 
-> Door to Energy Recharge Station (Cloak); Heals? False
+> Dock to Energy Recharge Station; Heals? False
   * Layers: default
-  * Access Open to Energy Recharge Station/Door to Moving Magnet Walls (Tall) (Cloak)
+  * Open Passage to Energy Recharge Station/Door to Moving Magnet Walls (Tall) (Cloak)
   * Extra - actor_name: doorpresenceframe_000
   * Extra - actor_def: actordef:actors/props/doorpresenceframe/charclasses/doorpresenceframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Energy Recharge Station (Charge)
+  > Door to Energy Recharge Station
       Trivial
 
 > Door to Teleport to Artaria (Blue); Heals? False
@@ -857,7 +857,7 @@ Extra - asset_id: collision_camera_014
   * Extra - tile_types: ('POWERBEAM',)
   > Door to Tall Magnet Walls Access
       Trivial
-  > Door to Energy Recharge Station (Charge)
+  > Door to Energy Recharge Station
       Spider Magnet or Space Jump
   > Door to Teleport to Artaria (Blue)
       Trivial
@@ -1366,7 +1366,7 @@ Extra - asset_id: collision_camera_018
 
 > Door to Moving Magnet Walls (Tall) (Charge); Heals? False
   * Layers: default
-  * Access Locked to Moving Magnet Walls (Tall)/Door to Energy Recharge Station (Charge)
+  * Access Locked to Moving Magnet Walls (Tall)/Door to Energy Recharge Station
   * Extra - actor_name: doorclosedcharge_002
   * Extra - actor_def: actordef:actors/props/doorclosedcharge/charclasses/doorclosedcharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1383,7 +1383,7 @@ Extra - asset_id: collision_camera_018
 
 > Door to Moving Magnet Walls (Tall) (Cloak); Heals? False
   * Layers: default
-  * Sensor Lock Door to Moving Magnet Walls (Tall)/Door to Energy Recharge Station (Cloak)
+  * Sensor Lock Door to Moving Magnet Walls (Tall)/Dock to Energy Recharge Station
   * Extra - actor_name: doorpresenceframe_000
   * Extra - actor_def: actordef:actors/props/doorpresenceframe/charclasses/doorpresenceframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -1604,7 +1604,7 @@ Extra - asset_id: collision_camera_020
 
 > Door to EMMI Zone West Exit Path; Heals? False
   * Layers: default
-  * Sensor Lock Door to EMMI Zone West Exit Path/Door to Green EMMI Introduction
+  * Sensor Lock Door to EMMI Zone West Exit Path/Dock to Green EMMI Introduction
   * Extra - actor_name: doorframepresence
   * Extra - actor_def: actordef:actors/props/doorframepresence/charclasses/doorframepresence.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -3768,7 +3768,7 @@ Extra - asset_id: collision_camera_045
 
 > Door to Lava Button East (Charge); Heals? False
   * Layers: default
-  * Charge Beam Door to Lava Button East/Door to Lava Button East Access (Charge)
+  * Charge Beam Door to Lava Button East/Door to Lava Button East Access
   * Extra - actor_name: doorchargecharge_002
   * Extra - actor_def: actordef:actors/props/doorchargecharge/charclasses/doorchargecharge.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -3782,7 +3782,7 @@ Extra - asset_id: collision_camera_045
 
 > Door to Lava Button East (Cloak); Heals? False
   * Layers: default
-  * Sensor Lock Door to Lava Button East/Door to Lava Button East Access (Cloak)
+  * Sensor Lock Door to Lava Button East/Dock to Lava Button East Access
   * Extra - actor_name: doorframepresence_001
   * Extra - actor_def: actordef:actors/props/doorframepresence/charclasses/doorframepresence.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -4657,7 +4657,7 @@ Extra - asset_id: collision_camera_053
   > Door to Green EMMI Introduction Access
       All of the following:
           # TODO: After proper blast shield logic is implemented, adjust this. This is a temporary connection.
-          Wave Beam
+          Wave Beam and Disabled Door Lock Randomizer
   > Tile Group (POWERBEAM) 2
       Trivial
 
@@ -4785,9 +4785,9 @@ EMMI Zone West Exit Path
 Extra - total_boundings: {'x1': -7650.0, 'x2': -4600.0, 'y1': -100.0, 'y2': 1042.0}
 Extra - polygon: [[-4600.0, 1042.0], [-7650.0, 1042.0], [-7650.0, -100.0], [-4600.0, -100.0]]
 Extra - asset_id: collision_camera_059
-> Door to Green EMMI Introduction; Heals? False
+> Dock to Green EMMI Introduction; Heals? False
   * Layers: default
-  * Access Open to Green EMMI Introduction/Door to EMMI Zone West Exit Path
+  * Open Passage to Green EMMI Introduction/Door to EMMI Zone West Exit Path
   * Extra - actor_name: doorframepresence
   * Extra - actor_def: actordef:actors/props/doorframepresence/charclasses/doorframepresence.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -4806,7 +4806,7 @@ Extra - asset_id: collision_camera_059
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Green EMMI Introduction
+  > Dock to Green EMMI Introduction
       Trivial
   > Tunnel to EMMI Zone Exits West
       Trivial

--- a/randovania/games/dread/json_data/Ferenia.json
+++ b/randovania/games/dread/json_data/Ferenia.json
@@ -7322,7 +7322,7 @@
                         "Tile Group (POWERBEAM)": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "If you can get in this part of the room, you can charge a speed",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -7375,19 +7375,6 @@
                                                 }
                                             ]
                                         }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLocks",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Open Charge Door"
                                     }
                                 ]
                             }
@@ -7459,92 +7446,6 @@
                                                         "name": "Suitless",
                                                         "amount": 2,
                                                         "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Tile Group (POWERBEAM)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Suitless",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Cold",
-                                                                    "amount": 50,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "misc",
-                                                        "name": "DoorLocks",
-                                                        "amount": 1,
-                                                        "negate": true
                                                     }
                                                 }
                                             ]

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -1490,7 +1490,8 @@ Extra - asset_id: collision_camera_018
           Simple IBJ or Use Spin Boost
   > Tile Group (POWERBEAM)
       All of the following:
-          Speed Booster and Disabled Door Lock Randomizer and Open Charge Door
+          # If you can get in this part of the room, you can charge a speed
+          Speed Booster
           Any of the following:
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
@@ -1508,12 +1509,6 @@ Extra - asset_id: collision_camera_018
       Any of the following:
           Gravity Suit
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 100
-  > Tile Group (POWERBEAM)
-      All of the following:
-          Grapple Beam and Speed Booster and Disabled Door Lock Randomizer
-          Any of the following:
-              Gravity Suit
-              Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
 
 > Event - Tunnel to Cold Room Grapple Block; Heals? False
   * Layers: default

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -2455,7 +2455,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Grapple Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -2579,7 +2582,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Grapple Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -11947,7 +11953,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Grapple Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -13152,7 +13161,7 @@
                         "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
-                                "comment": "Item logically unattainable if Door Lock Rando is enabled.",
+                                "comment": "Currently, this item does not care which direction you come from. if you can enter here, you can get the item. Will need looked at once Random Start/Transports is supported.",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -13161,53 +13170,6 @@
                                             "name": "Speed",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "DoorLocks",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": "Speed can be charged either to the right, requiring grapple beam, or to the left, after flipping the spinner.",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Shoot Super Missile"
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "events",
-                                                                    "name": "GhavoranSupersRotatable",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
                                         }
                                     }
                                 ]
@@ -14744,7 +14706,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Grapple Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -460,6 +460,7 @@ Extra - asset_id: collision_camera_005
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
   > Dock to Blue EMMI Introduction
       Trivial
 
@@ -491,6 +492,7 @@ Extra - asset_id: collision_camera_006
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
   > Door to Flipper Room
       Trivial
   > Navigation Room
@@ -2306,6 +2308,7 @@ Extra - asset_id: collision_camera_026
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
   > Before Golzuna
       After Elun - Release X Parasites
   > Start Point
@@ -2553,12 +2556,8 @@ blast shields
       Trivial
   > Pickup (Missile Tank)
       All of the following:
-          # Item logically unattainable if Door Lock Rando is enabled.
-          Speed Booster and Disabled Door Lock Randomizer
-          Any of the following:
-              # Speed can be charged either to the right, requiring grapple beam, or to the left, after flipping the spinner.
-              Grapple Beam
-              After Ghavoran - Super Missile Rotatable and Shoot Super Missile
+          # Currently, this item does not care which direction you come from. if you can enter here, you can get the item. Will need looked at once Random Start/Transports is supported.
+          Speed Booster
 
 ----------------
 Spin Boost Room
@@ -2884,6 +2883,7 @@ Extra - asset_id: collision_camera_033
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
   > Tile Group (BOMB) 1
       Morph Ball
 

--- a/randovania/games/dread/json_data/Hanubia.json
+++ b/randovania/games/dread/json_data/Hanubia.json
@@ -2341,7 +2341,7 @@
                         "Door to Navigation Station (Top)": {
                             "type": "and",
                             "data": {
-                                "comment": "Temporary. Will likely need removed with door rando",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
@@ -2350,6 +2350,15 @@
                                             "name": "Wave",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "DoorLocks",
+                                            "amount": 1,
+                                            "negate": true
                                         }
                                     }
                                 ]
@@ -2753,37 +2762,11 @@
                         "Pickup (Power Bomb Tank)": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "Door rando does not matter here until Random Start support. If you can get in here, you can get the item.",
                                 "items": [
                                     {
                                         "type": "template",
                                         "data": "Ballspark"
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": "Temporary until door rando. Wave likely removed at that point",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Wave",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "HanubiaTankSpeed",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
                                     }
                                 ]
                             }
@@ -3002,13 +2985,6 @@
                                 "comment": null,
                                 "items": []
                             }
-                        },
-                        "Event - Prepare Speedboost": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
                         }
                     }
                 },
@@ -3076,30 +3052,6 @@
                             }
                         },
                         "Tile Group (BOMB)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Event - Prepare Speedboost": {
-                    "node_type": "event",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 4800.0,
-                        "y": -100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "event_name": "HanubiaTankSpeed",
-                    "connections": {
-                        "Door to Speedboost Puzzle Room": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Hanubia.txt
+++ b/randovania/games/dread/json_data/Hanubia.txt
@@ -573,9 +573,7 @@ Extra - asset_id: collision_camera_009
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Door to Navigation Station (Top)
-      All of the following:
-          # Temporary. Will likely need removed with door rando
-          Wave Beam
+      Wave Beam and Disabled Door Lock Randomizer
   > Tile Group (BOMB) 1
       Trivial
 
@@ -680,10 +678,8 @@ Extra - asset_id: collision_camera_009
   * Extra - tile_types: ('BOMB',)
   > Pickup (Power Bomb Tank)
       All of the following:
+          # Door rando does not matter here until Random Start support. If you can get in here, you can get the item.
           Ballspark
-          Any of the following:
-              # Temporary until door rando. Wave likely removed at that point
-              Wave Beam or After Hanubia - Prepare Speedboost in Tank Room
   > Door from Tank Room
       Trivial
 
@@ -735,8 +731,6 @@ Extra - asset_id: collision_camera_010
   * Extra - right_shield_def: None
   > Dock to EMMI Zone Exit West (Top)
       Trivial
-  > Event - Prepare Speedboost
-      Trivial
 
 > Tile Group (BOMB); Heals? False
   * Layers: default
@@ -758,12 +752,6 @@ Extra - asset_id: collision_camera_010
   > Dock to EMMI Zone Exit West (Top)
       Trivial
   > Tile Group (BOMB)
-      Trivial
-
-> Event - Prepare Speedboost; Heals? False
-  * Layers: default
-  * Event Hanubia - Prepare Speedboost in Tank Room
-  > Door to Speedboost Puzzle Room
       Trivial
 
 ----------------

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -974,10 +974,6 @@
                 "long_name": "Ghavoran - Gold Robot Fight",
                 "extra": {}
             },
-            "HanubiaTankSpeed": {
-                "long_name": "Hanubia - Prepare Speedboost in Tank Room",
-                "extra": {}
-            },
             "DaironStormSpeedBlocks": {
                 "long_name": "Dairon - Storm Gate Speed Blocks Destroyed",
                 "extra": {}
@@ -1036,6 +1032,10 @@
             },
             "CatarisUnderlavaSpeedBlocks": {
                 "long_name": "Cataris - Underlava Speed Blocks Destroyed",
+                "extra": {}
+            },
+            "BureniaEPart": {
+                "long_name": "Burenia - Early Gravity Pickup 1",
                 "extra": {}
             }
         },


### PR DESCRIPTION
- Adds exclusions to all doors that need it
- Removes the Hanubia Tank Room event as it is unneeded
- Readds the Burenia Early Gravity Pickup 1 event to ensure the door next to it does not need excluded
- Adds and removes "Disabled Door Lock Randomizer" in a few places where necessary