### PR TITLE
Dread: Hide door lock rando for stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.0] - 2023-??-??
 
-## [5.2.0] - 2022-11-01
+- Nothing.
+
+### Metroid Dread
+
+- **Major** - Added: Door locks can now be randomized.
+
+## [5.2.0] - 2022-12-01
 
 - Added: Help -> Dependencies window, to see all dependencies included in Randovania, including their versions and licenses.
 - Added: A warning is now displayed when using presets with unsupported features enabled. These features are not present in the UI.
@@ -19,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
  
-- **Major** - Added: Door locks can now be randomized.
 - Added: The Power Beam tiles in the Artaria EMMI Zone Speed Boost puzzle have been changed to Speed Boost tiles to prevent softlocks.
 - Added: Entering Golzuna's arena without releasing the X displays a message explaining why the boss won't spawn.
 - Added: All doors locked while fighting an EMMI now unlock immediately upon defeating it.

--- a/randovania/games/dread/gui/preset_settings/__init__.py
+++ b/randovania/games/dread/gui/preset_settings/__init__.py
@@ -1,5 +1,4 @@
-from randovania.game_description import default_database
-
+import randovania
 from randovania.gui.lib.window_manager import WindowManager
 from randovania.interface_common.preset_editor import PresetEditor
 
@@ -20,11 +19,13 @@ def dread_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
         *([
               PresetMetroidStartingArea,
           ] if window_manager.is_preview_mode else []),
+        *([
+              PresetDockRando,
+          ] if randovania.is_dev_version() else []),
         PresetDreadGeneration,
         PresetLocationPool,
         PresetDreadGoal,
         DreadPresetItemPool,
         PresetDreadEnergy,
         PresetDreadPatches,
-        PresetDockRando,
     ]

--- a/randovania/games/dread/layout/dread_configuration.py
+++ b/randovania/games/dread/layout/dread_configuration.py
@@ -1,11 +1,13 @@
 import dataclasses
 
+import randovania
 from randovania.bitpacking.bitpacking import BitPackDataclass
 from randovania.bitpacking.json_dataclass import JsonDataclass
 from randovania.game_description import default_database
 from randovania.game_description.resources.resource_type import ResourceType
 from randovania.games.game import RandovaniaGame
 from randovania.layout.base.base_configuration import BaseConfiguration
+from randovania.layout.base.dock_rando_configuration import DockRandoMode
 from randovania.layout.base.trick_level import LayoutTrickLevel
 from randovania.layout.lib.teleporters import TeleporterConfiguration
 
@@ -54,5 +56,8 @@ class DreadConfiguration(BaseConfiguration):
 
         if not self.elevators.is_vanilla:
             result.append("Random Elevators")
+
+        if self.dock_rando.mode != DockRandoMode.VANILLA and not randovania.is_dev_version():
+            result.append("Random Door Lock")
 
         return result


### PR DESCRIPTION
Existing presets with it enabled will still work, but will have the unsupported feature warning.