### PR TITLE
Rersolver: Debug rollback also for results that had action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: A warning is now displayed when using presets with unsupported features enabled. These features are not present in the UI.
 - Added: When the generated game fails due to the solver, you're now offered to retry, cancel or keep the generated game.
 - Changed: Experimental games are no longer available on stable versions.
+- Fixed: Solver debug now contains previously missing rollback instances.
 
 ### Cave Story
 

--- a/randovania/resolver/resolver.py
+++ b/randovania/resolver/resolver.py
@@ -157,7 +157,7 @@ async def _inner_advance_depth(state: State,
                     max_attempts=max_attempts,
                 )
 
-                if not new_result[1]:
+                if new_result[0] is None:
                     debug.log_rollback(state, True, True)
 
                 # If a safe node was a dead end, we're certainly a dead end as well


### PR DESCRIPTION
This change makes the issue posted in https://discord.com/channels/914291389293027329/1045827510534930602 look less like looping and more like just not finding the correct path, because the rollbacks line up better.