### PR TITLE
Exclude Wide Beam for Eye-Doors

### DIFF
--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -10929,7 +10929,7 @@
                     "heal": false,
                     "coordinates": {
                         "x": 17850.0,
-                        "y": -500.0000305175781,
+                        "y": -500.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -10943,7 +10943,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Wide Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -23070,7 +23073,7 @@
                     "heal": false,
                     "coordinates": {
                         "x": 17850.0,
-                        "y": -500.0000305175781,
+                        "y": -500.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -23084,7 +23087,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Wide Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -2175,6 +2175,7 @@ Extra - asset_id: collision_camera_020
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Wide Beam Door',)
   > Start Point
       Trivial
 
@@ -4721,6 +4722,7 @@ Extra - asset_id: collision_camera_073
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Wide Beam Door',)
   > Door to Path to Corpius
       Trivial
 

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -2463,7 +2463,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Wide Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -15894,7 +15897,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Wide Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -460,6 +460,7 @@ Extra - asset_id: collision_camera_005
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Wide Beam Door',)
   > Center Platform
       Trivial
 
@@ -3001,6 +3002,7 @@ Extra - asset_id: collision_camera_029
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Wide Beam Door',)
   > Event - Drogyga Access Grapple Block
       Grapple Beam
   > Dock to Drogyga Arena

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -10617,7 +10617,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Wide Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -27750,7 +27753,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Wide Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -1923,6 +1923,7 @@ Extra - asset_id: collision_camera_024
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Wide Beam Door',)
   > Event - Blob above Kraid, below
       Lay Bomb or Shoot Beam
   > Dock to Kraid Arena
@@ -4868,6 +4869,7 @@ Extra - asset_id: collision_camera_061
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Wide Beam Door',)
   > Safe Ledge
       All of the following:
           Flash Shift or Gravity Suit or Spider Magnet or Movement (Beginner) or Lava Damage ≥ 10 or Lay Cross Bomb or Use Spin Boost

--- a/randovania/games/dread/json_data/Ferenia.json
+++ b/randovania/games/dread/json_data/Ferenia.json
@@ -10408,7 +10408,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Wide Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -10731,7 +10734,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Wide Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -2088,6 +2088,7 @@ Extra - asset_id: collision_camera_026
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Wide Beam Door',)
   > Tile Group (POWERBEAM) 4
       Trivial
 
@@ -2181,6 +2182,7 @@ Extra - asset_id: collision_camera_027
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Wide Beam Door',)
   > Event - Escue
       All of the following:
           Any of the following:

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -9551,7 +9551,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Wide Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {
@@ -15881,7 +15884,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Wide Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -1809,6 +1809,7 @@ Extra - asset_id: collision_camera_024
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Wide Beam Door',)
   > Door to Save Station East
       Trivial
   > Pickup (Energy Part)
@@ -3116,6 +3117,7 @@ Extra - asset_id: collision_camera_036
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Wide Beam Door',)
   > Door to Cross Bomb Tutorial
       Trivial
   > Tunnel to Golzuna Arena


### PR DESCRIPTION
I excluded Wide Beam Doors in door rando for Eye-doors because you can not pass them if they have wide beam cover.

Corpius, Kraid, Drogyga, Escue and Golzuna doors.

https://user-images.githubusercontent.com/117127188/206510843-7389e8c8-4994-4be9-88dc-8f6018e4bc05.mp4

