### PR TITLE
Missing exclude for eye door in elun

### DIFF
--- a/randovania/games/dread/json_data/Elun.json
+++ b/randovania/games/dread/json_data/Elun.json
@@ -2007,7 +2007,10 @@
                         "left_shield_entity": "{EMPTY}",
                         "left_shield_def": null,
                         "right_shield_entity": "{EMPTY}",
-                        "right_shield_def": null
+                        "right_shield_def": null,
+                        "excluded_dock_weaknesses": [
+                            "Wide Beam Door"
+                        ]
                     },
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/dread/json_data/Elun.txt
+++ b/randovania/games/dread/json_data/Elun.txt
@@ -501,6 +501,7 @@ Extra - asset_id: collision_camera_007
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  * Extra - excluded_dock_weaknesses: ('Wide Beam Door',)
   > Dock to Gyroscope Room
       Morph Ball
 


### PR DESCRIPTION
Missed the eye door in elun to exclude the wide beam in door lock rando.