### PR TITLE
Dread - Major/Minor Item Location Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Logic Database
 
 - Added: Climbing Z-57 Arena with Spin Boost and Ice Missiles (Beginner).
-- Changed: Energy Tanks are now Major Locations, Energy Parts are Minor Locations, Drogyga is a Major Location
+- Changed: Major/Minor Item Location Updates: Energy Tanks -> Major, Energy Parts -> Minor, Drogyga -> Major, Missile+ Tanks -> Major
 - Removed: Water Bomb Jump in Ghavoran - Map Station Access Secret.
 
 ## [5.2.1] - 2022-12-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Logic Database
 
 - Added: Climbing Z-57 Arena with Spin Boost and Ice Missiles (Beginner).
+- Changed: Energy Tanks are now Major Locations, Energy Parts are Minor Locations, Drogyga is a Major Location
 - Removed: Water Bomb Jump in Ghavoran - Map Station Access Secret.
 
 ## [5.2.1] - 2022-12-01

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -918,7 +918,7 @@
                         "actor_def": "actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad"
                     },
                     "pickup_index": 3,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Door to First Tutorial": {
                             "type": "template",
@@ -13885,7 +13885,7 @@
                         "actor_def": "actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad"
                     },
                     "pickup_index": 30,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Ledge above lava": {
                             "type": "and",
@@ -14278,7 +14278,7 @@
                         "actor_def": "actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad"
                     },
                     "pickup_index": 14,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Tile Group (BOMB)": {
                             "type": "resource",
@@ -18232,7 +18232,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 16,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Door to Save Station West": {
                             "type": "resource",
@@ -27581,7 +27581,7 @@
                         "actor_def": "actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad"
                     },
                     "pickup_index": 15,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Dock to Speed Booster Bonus Room": {
                             "type": "template",
@@ -27606,7 +27606,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 18,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Door to Red Chozo Arena": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -213,7 +213,7 @@ Extra - asset_id: collision_camera_001
 
 > Pickup (Energy Tank); Heals? False
   * Layers: default
-  * Pickup 3; Major Location? False
+  * Pickup 3; Major Location? True
   * Extra - actor_name: Item_EnergyTank001
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
   > Door to First Tutorial
@@ -2763,7 +2763,7 @@ Extra - asset_id: collision_camera_029
 
 > Pickup (Missile+ Tank); Heals? False
   * Layers: default
-  * Pickup 30; Major Location? False
+  * Pickup 30; Major Location? True
   * Extra - actor_name: item_missiletankplus_001
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
   > Ledge above lava
@@ -2814,7 +2814,7 @@ Extra - polygon: [[-12100.0, 10142.0], [-17100.0, 10142.0], [-17100.0, 9000.0], 
 Extra - asset_id: collision_camera_030
 > Pickup (Energy Tank); Heals? False
   * Layers: default
-  * Pickup 14; Major Location? False
+  * Pickup 14; Major Location? True
   * Extra - actor_name: item_energytank_000
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
   > Tile Group (BOMB)
@@ -3656,7 +3656,7 @@ Extra - asset_id: collision_camera_056
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 16; Major Location? True
+  * Pickup 16; Major Location? False
   * Extra - actor_name: item_energyfragment_001
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Door to Save Station West
@@ -5578,7 +5578,7 @@ Extra - polygon: [[-9100.0, -5700.0], [-14900.0, -5700.0], [-14900.0, -7800.0], 
 Extra - asset_id: collision_camera_086
 > Pickup (Missile+ Tank); Heals? False
   * Layers: default
-  * Pickup 15; Major Location? False
+  * Pickup 15; Major Location? True
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
   > Dock to Speed Booster Bonus Room
@@ -5586,7 +5586,7 @@ Extra - asset_id: collision_camera_086
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 18; Major Location? True
+  * Pickup 18; Major Location? False
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Door to Red Chozo Arena

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -1036,7 +1036,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 90,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Fan Platform - Above": {
                             "type": "and",
@@ -4599,7 +4599,7 @@
                         "actor_def": "actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad"
                     },
                     "pickup_index": 91,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Tile Group (WEIGHT) 1": {
                             "type": "resource",
@@ -5773,7 +5773,7 @@
                         "actor_def": "actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad"
                     },
                     "pickup_index": 82,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Tile Group (WEIGHT)": {
                             "type": "and",
@@ -6567,7 +6567,7 @@
                         "actor_def": "actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad"
                     },
                     "pickup_index": 89,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Missile Tank Plus Platform": {
                             "type": "and",
@@ -11248,7 +11248,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 86,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Door to Teleport to Ghavoran (Upper)": {
                             "type": "and",
@@ -11276,7 +11276,7 @@
                         "actor_def": "actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad"
                     },
                     "pickup_index": 87,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Tile Group (POWERBEAM) 1": {
                             "type": "and",
@@ -12457,7 +12457,7 @@
                         "actor_def": "actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad"
                     },
                     "pickup_index": 88,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Tile Group (SCREWATTACK) 2": {
                             "type": "and",
@@ -15167,7 +15167,7 @@
                         "actor_def": "actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad"
                     },
                     "pickup_index": 95,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Door to Main Hub Tower Bottom": {
                             "type": "resource",
@@ -15835,7 +15835,7 @@
                         "boss_hint_name": "Drogyga"
                     },
                     "pickup_index": 140,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Dock to Underneath Drogyga": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -204,7 +204,7 @@ Extra - asset_id: collision_camera_002
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 90; Major Location? True
+  * Pickup 90; Major Location? False
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Fan Platform - Above
@@ -811,7 +811,7 @@ Extra - asset_id: collision_camera_008
 
 > Pickup (Missile+ Tank); Heals? False
   * Layers: default
-  * Pickup 91; Major Location? False
+  * Pickup 91; Major Location? True
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
   > Tile Group (WEIGHT) 1
@@ -1079,7 +1079,7 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
 
 > Pickup (Energy Tank); Heals? False
   * Layers: default
-  * Pickup 82; Major Location? False
+  * Pickup 82; Major Location? True
   * Extra - actor_name: item_energytank_000
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
   > Tile Group (WEIGHT)
@@ -1198,7 +1198,7 @@ Extra - asset_id: collision_camera_010
 
 > Pickup (Missile+ Tank); Heals? False
   * Layers: default
-  * Pickup 89; Major Location? False
+  * Pickup 89; Major Location? True
   * Extra - actor_name: item_missiletankplus_001
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
   > Missile Tank Plus Platform
@@ -2085,7 +2085,7 @@ Extra - asset_id: collision_camera_018
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 86; Major Location? True
+  * Pickup 86; Major Location? False
   * Extra - actor_name: item_energyfragment_002
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Door to Teleport to Ghavoran (Upper)
@@ -2093,7 +2093,7 @@ Extra - asset_id: collision_camera_018
 
 > Pickup (Missile+ Tank); Heals? False
   * Layers: default
-  * Pickup 87; Major Location? False
+  * Pickup 87; Major Location? True
   * Extra - actor_name: item_missiletankplus_002
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
   > Tile Group (POWERBEAM) 1
@@ -2294,7 +2294,7 @@ Extra - asset_id: collision_camera_021
 
 > Pickup (Missile+ Tank); Heals? False
   * Layers: default
-  * Pickup 88; Major Location? False
+  * Pickup 88; Major Location? True
   * Extra - actor_name: item_missiletankplus
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
   > Tile Group (SCREWATTACK) 2
@@ -2834,7 +2834,7 @@ Extra - asset_id: collision_camera_025
 
 > Pickup (Energy Tank); Heals? False
   * Layers: default
-  * Pickup 95; Major Location? False
+  * Pickup 95; Major Location? True
   * Extra - actor_name: item_energytank
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
   > Door to Main Hub Tower Bottom
@@ -2981,7 +2981,7 @@ Extra - asset_id: collision_camera_028
 
 > Pickup (Drogyga); Heals? False
   * Layers: default
-  * Pickup 140; Major Location? False
+  * Pickup 140; Major Location? True
   * Extra - pickup_type: cutscene
   * Extra - callback_function: OnHydrogigaDead_CUSTOM
   * Extra - boss_hint_name: Drogyga

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -12269,7 +12269,7 @@
                         "actor_def": "actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad"
                     },
                     "pickup_index": 50,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Door to Path to Kraid Entryway": {
                             "type": "resource",
@@ -18465,7 +18465,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 42,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Tunnel to Lava Button West": {
                             "type": "or",
@@ -18529,7 +18529,7 @@
                         "actor_def": "actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad"
                     },
                     "pickup_index": 49,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Past Magnet Floor": {
                             "type": "and",
@@ -25986,7 +25986,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 44,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Dock to Underlava Puzzle Room 1": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -2159,7 +2159,7 @@ Extra - asset_id: collision_camera_025
 
 > Pickup (Missile+ Tank); Heals? False
   * Layers: default
-  * Pickup 50; Major Location? False
+  * Pickup 50; Major Location? True
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
   > Door to Path to Kraid Entryway
@@ -3326,7 +3326,7 @@ Extra - asset_id: collision_camera_042
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 42; Major Location? True
+  * Pickup 42; Major Location? False
   * Extra - actor_name: item_energyfragment_001
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Tunnel to Lava Button West
@@ -3336,7 +3336,7 @@ Extra - asset_id: collision_camera_042
 
 > Pickup (Energy Tank); Heals? False
   * Layers: default
-  * Pickup 49; Major Location? False
+  * Pickup 49; Major Location? True
   * Extra - actor_name: item_energytank_000
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
   > Past Magnet Floor
@@ -4561,7 +4561,7 @@ Extra - asset_id: collision_camera_053
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 44; Major Location? True
+  * Pickup 44; Major Location? False
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Dock to Underlava Puzzle Room 1

--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -3909,7 +3909,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 64,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Door to Heated Room West": {
                             "type": "and",
@@ -8203,7 +8203,7 @@
                         "actor_def": "actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad"
                     },
                     "pickup_index": 71,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Dock to Energy Recharge Station Middle": {
                             "type": "and",
@@ -9009,7 +9009,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 63,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Tile Group (WEIGHT)": {
                             "type": "resource",
@@ -15579,7 +15579,7 @@
                         "actor_def": "actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad"
                     },
                     "pickup_index": 68,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Room Center": {
                             "type": "and",
@@ -17422,7 +17422,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 72,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Door to EMMI Zone Exit South (Open)": {
                             "type": "resource",
@@ -17980,7 +17980,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 70,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Door to Freezer (Upper)": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -840,7 +840,7 @@ Extra - asset_id: collision_camera_010
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 64; Major Location? True
+  * Pickup 64; Major Location? False
   * Extra - actor_name: item_energyfragment_001
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Door to Heated Room West
@@ -1456,7 +1456,7 @@ Extra - asset_id: collision_camera_016
 
 > Pickup (Energy Tank); Heals? False
   * Layers: default
-  * Pickup 71; Major Location? False
+  * Pickup 71; Major Location? True
   * Extra - actor_name: item_energytank
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
   > Dock to Energy Recharge Station Middle
@@ -1611,7 +1611,7 @@ Extra - asset_id: collision_camera_018
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 63; Major Location? True
+  * Pickup 63; Major Location? False
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Tile Group (WEIGHT)
@@ -2827,7 +2827,7 @@ Extra - asset_id: collision_camera_033
 
 > Pickup (Missile+ Tank); Heals? False
   * Layers: default
-  * Pickup 68; Major Location? False
+  * Pickup 68; Major Location? True
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
   > Room Center
@@ -3175,7 +3175,7 @@ Extra - asset_id: collision_camera_040
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 72; Major Location? True
+  * Pickup 72; Major Location? False
   * Extra - actor_name: item_energyfragment_003
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Door to EMMI Zone Exit South (Open)
@@ -3307,7 +3307,7 @@ Extra - asset_id: collision_camera_042
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 70; Major Location? True
+  * Pickup 70; Major Location? False
   * Extra - actor_name: item_energyfragment_002
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Door to Freezer (Upper)

--- a/randovania/games/dread/json_data/Elun.json
+++ b/randovania/games/dread/json_data/Elun.json
@@ -734,7 +734,7 @@
                         "actor_def": "actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad"
                     },
                     "pickup_index": 114,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Tile Group (BOMB) 3": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Elun.txt
+++ b/randovania/games/dread/json_data/Elun.txt
@@ -173,7 +173,7 @@ Extra - asset_id: collision_camera_003
 
 > Pickup (Energy Tank); Heals? False
   * Layers: default
-  * Pickup 114; Major Location? False
+  * Pickup 114; Major Location? True
   * Extra - actor_name: item_energytank_000
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
   > Tile Group (BOMB) 3

--- a/randovania/games/dread/json_data/Ferenia.json
+++ b/randovania/games/dread/json_data/Ferenia.json
@@ -413,7 +413,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 123,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Tile Group (WEIGHT)": {
                             "type": "and",
@@ -1589,7 +1589,7 @@
                         "actor_def": "actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad"
                     },
                     "pickup_index": 128,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Tile Group (WEIGHT)": {
                             "type": "and",
@@ -2255,7 +2255,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 131,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Ledge above Slope": {
                             "type": "and",
@@ -4084,7 +4084,7 @@
                         "actor_def": "actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad"
                     },
                     "pickup_index": 130,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Tile Group (WEIGHT) 2": {
                             "type": "or",
@@ -8846,7 +8846,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 124,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Corner": {
                             "type": "and",
@@ -10221,7 +10221,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 133,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Tunnel to Escue Eyedoor Room": {
                             "type": "template",

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -78,7 +78,7 @@ Extra - asset_id: collision_camera_002
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 123; Major Location? True
+  * Pickup 123; Major Location? False
   * Extra - actor_name: item_energyfragment_002
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Tile Group (WEIGHT)
@@ -299,7 +299,7 @@ Extra - asset_id: collision_camera_006
 
 > Pickup (Missile+ Tank); Heals? False
   * Layers: default
-  * Pickup 128; Major Location? False
+  * Pickup 128; Major Location? True
   * Extra - actor_name: item_missiletankplus_001
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
   > Tile Group (WEIGHT)
@@ -460,7 +460,7 @@ Extra - asset_id: collision_camera_009
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 131; Major Location? True
+  * Pickup 131; Major Location? False
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Ledge above Slope
@@ -843,7 +843,7 @@ Extra - asset_id: collision_camera_012
 
 > Pickup (Missile+ Tank); Heals? False
   * Layers: default
-  * Pickup 130; Major Location? False
+  * Pickup 130; Major Location? True
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
   > Tile Group (WEIGHT) 2
@@ -1733,7 +1733,7 @@ Extra - polygon: [[-400.0, 2900.0], [-2500.0, 2900.0], [-2500.0, 1800.0], [-400.
 Extra - asset_id: collision_camera_020
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 124; Major Location? True
+  * Pickup 124; Major Location? False
   * Extra - actor_name: item_energyfragment_001
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Corner
@@ -2036,7 +2036,7 @@ Extra - asset_id: collision_camera_025
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 133; Major Location? True
+  * Pickup 133; Major Location? False
   * Extra - actor_name: item_energyfragment
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Tunnel to Escue Eyedoor Room

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -3659,7 +3659,7 @@
                         "actor_def": "actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad"
                     },
                     "pickup_index": 102,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "Tunnel to Super Missile Room": {
                             "type": "and",
@@ -8238,7 +8238,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 105,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Tile Group (MISSILE)": {
                             "type": "resource",
@@ -8268,7 +8268,7 @@
                         "actor_def": "actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad"
                     },
                     "pickup_index": 109,
-                    "major_location": false,
+                    "major_location": true,
                     "connections": {
                         "E-Tank Alcove": {
                             "type": "and",
@@ -9760,7 +9760,7 @@
                         "actor_def": "actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad"
                     },
                     "pickup_index": 112,
-                    "major_location": true,
+                    "major_location": false,
                     "connections": {
                         "Door to Energy Recharge Station": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -713,7 +713,7 @@ Extra - asset_id: collision_camera_009
 
 > Pickup (Missile+ Tank); Heals? False
   * Layers: default
-  * Pickup 102; Major Location? False
+  * Pickup 102; Major Location? True
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
   > Tunnel to Super Missile Room
@@ -1568,7 +1568,7 @@ Extra - asset_id: collision_camera_021
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 105; Major Location? True
+  * Pickup 105; Major Location? False
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Tile Group (MISSILE)
@@ -1576,7 +1576,7 @@ Extra - asset_id: collision_camera_021
 
 > Pickup (Energy Tank); Heals? False
   * Layers: default
-  * Pickup 109; Major Location? False
+  * Pickup 109; Major Location? True
   * Extra - actor_name: item_energytank_000
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
   > E-Tank Alcove
@@ -1859,7 +1859,7 @@ Extra - asset_id: collision_camera_024
 
 > Pickup (Energy Part); Heals? False
   * Layers: default
-  * Pickup 112; Major Location? True
+  * Pickup 112; Major Location? False
   * Extra - actor_name: item_energyfragment
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
   > Door to Energy Recharge Station


### PR DESCRIPTION
Adds 20 Major Item Locations to the pool

- Energy Tanks are now Major Locations
- Energy Parts are now Minor Locations
- Drogyga is now a Major Location
- Missile+ Tanks are now Major Locations
- Fixes #3867 