### PR TITLE
Dread: Add missing Main Power Bomb requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: You now retain Drogyga's and Corpius's item if you reload checkpoint after defeating them. This eliminates a way of rendering a seed impossible to complete.
 
 #### Logic Database
+
 - Fixed: Correctly require Morph Ball in all cases where Power Bombs are used.
 
 ## [5.3.0] - 2023-01-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Cutscene in Hanubia - Tank Room was removed because it teleports the player to the lower section, which can softlock the player
 - Fixed: You now retain Drogyga's and Corpius's item if you reload checkpoint after defeating them. This eliminates a way of rendering a seed impossible to complete.
 
+#### Logic Database
+- Fixed: Correctly require Morph Ball in all cases where Power Bombs are used.
+
 ## [5.3.0] - 2023-01-05
 
 - Added: You can now open a tracker for other player's inventories in a multiworld session.

--- a/randovania/games/dread/json_data/Ferenia.json
+++ b/randovania/games/dread/json_data/Ferenia.json
@@ -3983,13 +3983,8 @@
                                                     "data": "Lay Bomb"
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "PBAmmo",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Lay Power Bomb"
                                                 }
                                             ]
                                         }
@@ -4381,13 +4376,8 @@
                                                     "data": "Lay Bomb"
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "PBAmmo",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Lay Power Bomb"
                                                 }
                                             ]
                                         }

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -820,7 +820,7 @@ Extra - asset_id: collision_camera_012
   > Tile Group (WEIGHT) 2
       All of the following:
           Can Slide
-          Power Bombs or Speed Booster or Lay Bomb or Shoot Beam
+          Speed Booster or Lay Bomb or Lay Power Bomb or Shoot Beam
 
 > Pickup (Space Jump); Heals? False
   * Layers: default
@@ -909,7 +909,7 @@ Extra - asset_id: collision_camera_012
   > Pickup (Missile+ Tank)
       All of the following:
           Ballspark
-          Power Bombs or Lay Bomb
+          Lay Bomb or Lay Power Bomb
 
 > Tile Group (BOMB) 2; Heals? False
   * Layers: default


### PR DESCRIPTION
Use the "Lay Power Bomb" template when Power Bombs are used by logic. This includes both the Main Power Bomb and the Morph Ball as part of the template. The "Power Bombs" value is only referenced directly when the logic asks asks for more that one unit of ammo.