### PR TITLE
Fix typos where `it's` was used when it should have been `its`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.4.0] - 2023-??-??
 
 - Fixed: The minor/major split setting is obeyed much more accurately by the generator.
+- Fixed: Minor typos in the UI are fixed.
 
 ### Metroid Dread
 
@@ -293,7 +294,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Optimized the game validation. As example, Echoes' Starter Preset is 91% faster.
 - Changed: The algorithm for how locations lose value over generation has changed. This should have bigger impact in big multiworlds.
 - Changed: It's now possible to login again directly in the Game Session Window.
-- Removed: The server and discord bot are entirely removed from the distributed executables, reducing it's size.
+- Removed: The server and discord bot are entirely removed from the distributed executables, reducing its size.
 - Removed: Metroid Dread is no longer available in releases, as it was never intended to be considered stable.
 - Removed: All auto trackers based on pixel art style were removed by request of their artist.
 - Fixed: The "Spoiler: Pickups" tab no longer shows locations that aren't present in the given preset.
@@ -2798,7 +2799,7 @@ Her contributions to Randovania were invaluable and she'll be missed.
 
 ## [0.17.2] - 2018-12-27
 
--   Fixed: 'Clear loaded game' now properly does it's job.
+-   Fixed: 'Clear loaded game' now properly does its job.
 -   Changed: Add an error message to capture potential Randomizer failures.
 -   Changed: Improved README.
 

--- a/randovania/game_description/integrity_check.py
+++ b/randovania/game_description/integrity_check.py
@@ -193,7 +193,7 @@ def find_invalid_strongly_connected_components(game: GameDescription) -> Iterato
         if len(components) == 1:
             node = next(iter(components))
 
-            # If the component is a single node which is the default node of it's area, allow it
+            # If the component is a single node which is the default node of its area, allow it
             area = game.world_list.nodes_to_area(node)
             if area.default_node == node.name:
                 continue

--- a/randovania/games/prime1/presets/starter_preset.rdvpreset
+++ b/randovania/games/prime1/presets/starter_preset.rdvpreset
@@ -3,7 +3,7 @@
     "base_preset_uuid": null,
     "name": "Starter Preset",
     "uuid": "e36f52b3-ccd9-4dd7-a18f-b57b25f6b079",
-    "description": "This preset is ideal for those new to playing Metroid Prime or it's Randomizer. Every seed can be completed without utilizing any tricks or glitches, and the world will be familiar to the base game.<br/><br/>In addition to shuffling items, this preset includes some minor improvements over the base game such as crash and soft-lock fixes.",
+    "description": "This preset is ideal for those new to playing Metroid Prime or its Randomizer. Every seed can be completed without utilizing any tricks or glitches, and the world will be familiar to the base game.<br/><br/>In addition to shuffling items, this preset includes some minor improvements over the base game such as crash and soft-lock fixes.",
     "game": "prime1",
     "configuration": {
         "trick_level": {

--- a/randovania/lib/random_lib.py
+++ b/randovania/lib/random_lib.py
@@ -34,7 +34,7 @@ def iterate_with_weights(items: Iterator[T],
     while items and any(weight > 0 for weight in weights):
         pickup_node = rng.choices(items, weights)[0]
 
-        # Remove the pickup_node from the potential list, along with it's weight
+        # Remove the pickup_node from the potential list, along with its weight
         index = items.index(pickup_node)
         items.pop(index)
         weights.pop(index)


### PR DESCRIPTION
This PR fixes typos where `its` should have been used instead of `it's`. The first one I noticed was in the Prime Starter Preset description:

> This preset is ideal for those new to playing Metroid Prime or *it's* Randomizer.

Then I did a find-and-replace for all the other instances I could find where `it's` was used when it should have been `it's`.