### PR TITLE
Simplify requirements during generator to improve multi-pickup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.4.0] - 2023-??-??
 
 - Fixed: The minor/major split setting is obeyed much more accurately by the generator.
+- Fixed: Starting with ammo no longer causes all requirements for that ammo to be ignored. 
+- Fixed: The generator no longer attempts placing pickups based on alternatives to satisfied requirements, such as Missile Expansions for Quadraxis while already having Light Beam.
 - Fixed: Minor typos in the UI are fixed.
 
 ### Metroid Prime

--- a/randovania/game_description/requirements/resource_requirement.py
+++ b/randovania/game_description/requirements/resource_requirement.py
@@ -6,6 +6,7 @@ from math import ceil
 from randovania.game_description.requirements.base import Requirement
 from randovania.game_description.requirements.requirement_list import RequirementList
 from randovania.game_description.requirements.requirement_set import RequirementSet
+from randovania.game_description.resources.item_resource_info import ItemResourceInfo
 from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.game_description.resources.resource_info import ResourceInfo, ResourceCollection
 from randovania.game_description.resources.resource_type import ResourceType
@@ -91,8 +92,10 @@ class ResourceRequirement(Requirement):
         if static_resources.is_resource_set(self.resource):
             if self.satisfied(static_resources, 0, database):
                 return Requirement.trivial()
-            else:
+            elif not isinstance(self.resource, ItemResourceInfo) or self.resource.max_capacity <= 1:
                 return Requirement.impossible()
+            else:
+                return self
         else:
             return self.multiply_amount(damage_multiplier)
 

--- a/randovania/generator/filler/pickup_list.py
+++ b/randovania/generator/filler/pickup_list.py
@@ -93,11 +93,7 @@ def _requirement_lists_without_satisfied_resources(state: State,
                 continue
             seen_lists.add(alternative)
 
-            print("//////////////////////////")
-            print(alternative)
-
             for items in _unsatisfied_item_requirements_in_list(alternative, state, uncollected_resources):
-                print("=============", items)
                 _add_items(items)
 
     if debug.debug_level() > 2:

--- a/randovania/generator/old_generator_reach.py
+++ b/randovania/generator/old_generator_reach.py
@@ -111,7 +111,9 @@ class OldGeneratorReach(GeneratorReach):
             if extra_requirement is not None:
                 requirement = RequirementAnd([requirement, extra_requirement])
 
-            yield target_node, requirement.as_set(self._state.resource_database)
+            yield target_node, requirement.as_set(self._state.resource_database).patch_requirements(
+                self._state.resources, self._state.resource_database,
+            )
 
     def _expand_graph(self, paths_to_check: list[GraphPath]):
         # print("!! _expand_graph", len(paths_to_check))

--- a/test/generator/filler/test_pickup_list.py
+++ b/test/generator/filler/test_pickup_list.py
@@ -2,6 +2,8 @@ import dataclasses
 from random import Random
 from unittest.mock import MagicMock
 
+import pytest
+
 from randovania.game_description.requirements.requirement_list import RequirementList
 from randovania.game_description.requirements.requirement_set import RequirementSet
 from randovania.game_description.requirements.resource_requirement import ResourceRequirement
@@ -12,6 +14,7 @@ from randovania.generator import generator, reach_lib
 from randovania.generator.filler import pickup_list
 from randovania.generator.item_pool import pickup_creator
 from randovania.layout.base.base_configuration import StartingLocationList
+from randovania.layout.base.major_item_state import MajorItemState
 from randovania.resolver.state import State, StateGameData
 
 
@@ -159,8 +162,9 @@ def test_pickups_to_solve_list_multiple(echoes_game_description, echoes_item_dat
     assert result == [missile_expansion]
 
 
+@pytest.mark.parametrize("has_light_beam", [False, True])
 async def test_get_pickups_that_solves_unreachable_quad(small_echoes_game_description, echoes_item_database,
-                                                        default_echoes_preset, mocker):
+                                                        default_echoes_preset, mocker, has_light_beam):
     # Setup
     mocker.patch("randovania.game_description.default_database.game_description_for",
                  return_value=small_echoes_game_description)
@@ -171,23 +175,23 @@ async def test_get_pickups_that_solves_unreachable_quad(small_echoes_game_descri
         starting_location=StartingLocationList.with_elements([
             AreaIdentifier("Temple Grounds", "Fake Quad Arena")
         ], small_echoes_game_description.game),
-        # can't assign missile launcher here because of https://github.com/randovania/randovania/issues/4057
-        # major_items_configuration=config.major_items_configuration.replace_state_for_item(
-        #     config.major_items_configuration.get_item_with_name("Missile Launcher"),
-        #     MajorItemState(
-        #         num_included_in_starting_items=1,
-        #         included_ammo=(5,),
-        #     ),
-        # ),
+        major_items_configuration=config.major_items_configuration.replace_state_for_item(
+            config.major_items_configuration.get_item_with_name("Missile Launcher"),
+            MajorItemState(
+                num_included_in_starting_items=1,
+                included_ammo=(5,),
+            ),
+        ),
     )
     pool = await generator.create_player_pool(Random(0), config, 0, 1)
     new_game, state = pool.game_generator.bootstrap.logic_bootstrap(
         config, pool.game,
         pool.patches,
     )
-    launcher = next(p for p in pool.pickups if p.name == "Missile Launcher")
-    light_beam = next(p for p in pool.pickups if p.name == "Light Beam")
-    state = state.assign_pickups_resources([launcher, light_beam])
+    pickups_to_add = []
+    if has_light_beam:
+        pickups_to_add.append(next(p for p in pool.pickups if p.name == "Light Beam"))
+    state = state.assign_pickups_resources(pickups_to_add)
 
     reach = reach_lib.advance_reach_with_possible_unsafe_resources(
         reach_lib.reach_with_all_safe_resources(new_game, state))
@@ -198,13 +202,20 @@ async def test_get_pickups_that_solves_unreachable_quad(small_echoes_game_descri
         sorted(a.name for a in it)
         for it in result
     )
-    assert r2 == [
-        ['Boost Ball', 'Echo Visor', *['Energy Tank'] * 8, *['Missile Expansion'] * 12, 'Morph Ball Bomb',
-         'Progressive Suit', 'Progressive Suit', 'Spider Ball', 'Super Missile'],
-        ['Boost Ball', 'Echo Visor', *['Energy Tank'] * 8, *['Missile Expansion'] * 12, 'Morph Ball Bomb',
-         'Progressive Suit', 'Spider Ball', 'Super Missile'],
-        ['Boost Ball', 'Echo Visor', *['Energy Tank'] * 8, 'Morph Ball Bomb',
-         'Progressive Suit', 'Progressive Suit', 'Spider Ball'],
-        ['Boost Ball', 'Echo Visor', *['Energy Tank'] * 8, 'Morph Ball Bomb',
-         'Progressive Suit', 'Spider Ball'],
-    ]
+    base = ['Boost Ball', 'Echo Visor']
+    bomb = 'Morph Ball Bomb'
+    tanks = ['Energy Tank'] * 8
+    missiles = ['Missile Expansion'] * 12
+
+    if has_light_beam:
+        assert r2 == [
+            [*base, *tanks, bomb, 'Progressive Suit', 'Progressive Suit', 'Spider Ball'],
+            [*base, *tanks, bomb, 'Progressive Suit', 'Spider Ball'],
+        ]
+    else:
+        assert r2 == [
+            [*base, *tanks, 'Light Beam', bomb, 'Progressive Suit', 'Progressive Suit', 'Spider Ball'],
+            [*base, *tanks, 'Light Beam', bomb, 'Progressive Suit', 'Spider Ball'],
+            [*base, *tanks, *missiles, bomb, 'Progressive Suit', 'Progressive Suit', 'Spider Ball', 'Super Missile'],
+            [*base, *tanks, *missiles, bomb, 'Progressive Suit', 'Spider Ball', 'Super Missile'],
+        ]


### PR DESCRIPTION
Fixes #4057.
Fixes Echoes placing 13 missiles expansions for Quad, despite having Light Beam.