### PR TITLE
Dread - Burenia Updates (Tricks, Block Nodes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Damage Boost (Intermediate) for reaching the teleport in Cataris - Teleport to Ghavoran with Spider Magnet.
 - Added: "Adam Skip" added to logic as Wall Jump (Advanced) in Cataris - Moving Magnet Walls (Small).
 - Added: Space Jump method of Cross Bomb Skip (Hypermode) to skip needing Speed for the item in Cataris - EMMI Zone Item Tunnel.
+- Added: New trick "Flash Shift Skip" to account for skipping Flash Shift gates.
+- Added: Flash Shift Skip (Intermediate) with Bombs to skip the Flash Shift gate in Teleport to Ferenia.
+- Added: Shine Sink Clips (Intermediate/Advanced) to go to and from Storm Missile Gate Room without Morph Ball.
+- Added: Shine Sink Clip (Intermediate) and Speedbooster Conservation (Advanced) to reach the bottom of Teleport to Ghavoran from the top level.
+- Added: Shine Sink Clip (Advanced) to reach the blobs in Gravity Suit Tower from the top level.
+- Changed: Shine Sink Clip in Main Hub Tower Middle to Main Hub Tower Bottom is now Intermediate (from Expert).
 - Fixed: Correctly require Morph Ball in all cases where Power Bombs are used.
 - Added: Spin Boost Movement (Intermediate) and Speedbooster Conservation (Beginner) for getting up Hanubia - Central Unit without Space Jump or Infinite Bomb Jump.
 - Added: Spin Boost method to climb Hanubia - Escape Room 3.
 - Added: Morph Ball Single-Wall Walljumps to get to the Nav Station in Itorash - Transport to Hanubia.
 - Changed: Increased difficulty of Flash Shift Walljump to reach the Raven Beak elevator from Intermediate to Advanced.
 - Fixed: Replace some instances of Beginner Infinite Bomb Jump in Ferenia with the Simple Infinite Bomb Jump template. This ensures that the missing bomb or cross bomb item is required.
+- Fixed: Collecting the Power Bomb Tank in Gravity Suit Room now properly requires Speed Booster and Gravity Suit.
 
 ## [5.3.0] - 2023-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Morph Ball Single-Wall Walljumps to get to the Nav Station in Itorash - Transport to Hanubia.
 - Changed: Increased difficulty of Flash Shift Walljump to reach the Raven Beak elevator from Intermediate to Advanced.
 - Fixed: Replace some instances of Beginner Infinite Bomb Jump in Ferenia with the Simple Infinite Bomb Jump template. This ensures that the missing bomb or cross bomb item is required.
-- Fixed: Collecting the Power Bomb Tank in Gravity Suit Room now properly requires Speed Booster and Gravity Suit.
 
 ## [5.3.0] - 2023-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Space Jump method of Cross Bomb Skip (Hypermode) to skip needing Speed for the item in Cataris - EMMI Zone Item Tunnel.
 - Added: New trick "Flash Shift Skip" to account for skipping Flash Shift gates.
 - Added: Flash Shift Skip (Intermediate) with Bombs to skip the Flash Shift gate in Teleport to Ferenia.
-- Added: Shine Sink Clips (Intermediate/Advanced) to go to and from Storm Missile Gate Room without Morph Ball.
+- Added: Aim Down Clips (Intermediate/Advanced) to go to and from Storm Missile Gate Room without Morph Ball.
 - Added: Shine Sink Clip/Aim Down Clip (Intermediate) and Speedbooster Conservation (Advanced) to reach the bottom of Teleport to Ghavoran from the top level.
-- Added: Shine Sink Clip (Advanced) to reach the blobs in Gravity Suit Tower from the top level.
+- Added: Aim Down Clip (Expert) to reach the blobs in Gravity Suit Tower from the top level.
 - Added: Aim Down Clip (Intermediate) in Main Hub Tower Middle to Main Hub Tower Bottom.
 - Added: Shine Sink Clip/Aim Down Clip (Intermediate) in Gravity Suit room top door to bottom door.
 - Changed: Shine Sink Clip in Main Hub Tower Middle to Main Hub Tower Bottom is now Intermediate (from Expert).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Logic Database
 
+- Added: New trick "Flash Shift Skip" to account for skipping Flash Shift gates.
 - Added: Traverse to the bottom of Ferenia: Space Jump Room Access with some more options.
 - Added: Pseudo-Wave Beam (Beginner) for the two blobs in Cataris - Teleport to Dairon.
 - Added: Water Bomb Jump to reach the item in Cataris - Teleport to Dairon without Gravity Suit.
@@ -41,19 +42,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Damage Boost (Intermediate) for reaching the teleport in Cataris - Teleport to Ghavoran with Spider Magnet.
 - Added: "Adam Skip" added to logic as Wall Jump (Advanced) in Cataris - Moving Magnet Walls (Small).
 - Added: Space Jump method of Cross Bomb Skip (Hypermode) to skip needing Speed for the item in Cataris - EMMI Zone Item Tunnel.
-- Added: New trick "Flash Shift Skip" to account for skipping Flash Shift gates.
+- Added: Spin Boost Movement (Intermediate) and Speedbooster Conservation (Beginner) for getting up Hanubia - Central Unit without Space Jump or Infinite Bomb Jump.
+- Added: Spin Boost method to climb Hanubia - Escape Room 3.
+- Added: Morph Ball Single-Wall Walljumps to get to the Nav Station in Itorash - Transport to Hanubia.
 - Added: Flash Shift Skip (Intermediate) with Bombs to skip the Flash Shift gate in Teleport to Ferenia.
 - Added: Aim Down Clips (Intermediate/Advanced) to go to and from Storm Missile Gate Room without Morph Ball.
 - Added: Shine Sink Clip/Aim Down Clip (Intermediate) and Speedbooster Conservation (Advanced) to reach the bottom of Teleport to Ghavoran from the top level.
 - Added: Aim Down Clip (Expert) to reach the blobs in Gravity Suit Tower from the top level.
 - Added: Aim Down Clip (Intermediate) in Main Hub Tower Middle to Main Hub Tower Bottom.
 - Added: Shine Sink Clip/Aim Down Clip (Intermediate) in Gravity Suit room top door to bottom door.
+- Changed: Increased difficulty of Flash Shift Walljump to reach the Raven Beak elevator from Intermediate to Advanced.
 - Changed: Shine Sink Clip in Main Hub Tower Middle to Main Hub Tower Bottom is now Intermediate (from Expert).
 - Fixed: Correctly require Morph Ball in all cases where Power Bombs are used.
-- Added: Spin Boost Movement (Intermediate) and Speedbooster Conservation (Beginner) for getting up Hanubia - Central Unit without Space Jump or Infinite Bomb Jump.
-- Added: Spin Boost method to climb Hanubia - Escape Room 3.
-- Added: Morph Ball Single-Wall Walljumps to get to the Nav Station in Itorash - Transport to Hanubia.
-- Changed: Increased difficulty of Flash Shift Walljump to reach the Raven Beak elevator from Intermediate to Advanced.
 - Fixed: Replace some instances of Beginner Infinite Bomb Jump in Ferenia with the Simple Infinite Bomb Jump template. This ensures that the missing bomb or cross bomb item is required.
 
 ## [5.3.0] - 2023-01-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: New trick "Flash Shift Skip" to account for skipping Flash Shift gates.
 - Added: Flash Shift Skip (Intermediate) with Bombs to skip the Flash Shift gate in Teleport to Ferenia.
 - Added: Shine Sink Clips (Intermediate/Advanced) to go to and from Storm Missile Gate Room without Morph Ball.
-- Added: Shine Sink Clip (Intermediate) and Speedbooster Conservation (Advanced) to reach the bottom of Teleport to Ghavoran from the top level.
+- Added: Shine Sink Clip/Aim Down Clip (Intermediate) and Speedbooster Conservation (Advanced) to reach the bottom of Teleport to Ghavoran from the top level.
 - Added: Shine Sink Clip (Advanced) to reach the blobs in Gravity Suit Tower from the top level.
+- Added: Aim Down Clip (Intermediate) in Main Hub Tower Middle to Main Hub Tower Bottom.
+- Added: Shine Sink Clip/Aim Down Clip (Intermediate) in Gravity Suit room top door to bottom door.
 - Changed: Shine Sink Clip in Main Hub Tower Middle to Main Hub Tower Bottom is now Intermediate (from Expert).
 - Fixed: Correctly require Morph Ball in all cases where Power Bombs are used.
 - Added: Spin Boost Movement (Intermediate) and Speedbooster Conservation (Beginner) for getting up Hanubia - Central Unit without Space Jump or Infinite Bomb Jump.

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -390,7 +390,7 @@
                     "pickup_index": 92,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (MISSILE)": {
+                        "Tunnel to Transport to Ghavoran": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -423,45 +423,6 @@
                             "data": "Can Slide"
                         },
                         "Door to Navigation Station North": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (MISSILE)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -700.0,
-                        "y": 7200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_023",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "MISSILE"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Missile Tank)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Tunnel to Transport to Ghavoran": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -514,11 +475,25 @@
                                 ]
                             }
                         },
-                        "Tile Group (MISSILE)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Missile"
+                                    }
+                                ]
                             }
                         }
                     }
@@ -1047,7 +1022,7 @@
                         }
                     }
                 },
-                "Event - Water Blob Right, Adjacent": {
+                "Event - Water Blob Right": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -1065,12 +1040,9 @@
                     },
                     "event_name": "s040_aqua:default:db_reg_aq_001",
                     "connections": {
-                        "Tile Group (BOMB)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                        "Water Bottom": {
+                            "type": "template",
+                            "data": "Lay Bomb"
                         }
                     }
                 },
@@ -1146,108 +1118,6 @@
                     },
                     "event_name": "s040_aqua:default:grapplepulloff1x2_000",
                     "connections": {
-                        "Fan Platform - Below": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (BOMB)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 3800.0,
-                        "y": -2100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_025",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "BOMB"
-                        ]
-                    },
-                    "connections": {
-                        "Event - Water Blob Right, Adjacent": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Shoot Beam"
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Lay Bomb"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Water Bottom": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (POWERBEAM)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 4200.0,
-                        "y": 3900.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_033",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {
-                        "Fan Platform - Above": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Fan Platform - Below": {
                             "type": "and",
                             "data": {
@@ -1535,7 +1405,7 @@
                                 ]
                             }
                         },
-                        "Tile Group (POWERBEAM)": {
+                        "Fan Platform - Below": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1600,13 +1470,6 @@
                                 "name": "Grapple",
                                 "amount": 1,
                                 "negate": false
-                            }
-                        },
-                        "Tile Group (POWERBEAM)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         },
                         "Raft - Top Water Level": {
@@ -2030,13 +1893,25 @@
                                 ]
                             }
                         },
-                        "Tile Group (BOMB)": {
-                            "type": "resource",
+                        "Event - Water Blob Right": {
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Wave",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    }
+                                ]
                             }
                         },
                         "Bottom-left Corner": {
@@ -2046,15 +1921,6 @@
                         "Event - Water Blob Left, Through Wall": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
-                        },
-                        "Event - Water Blob Right, Through Wall": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Wave",
-                                "amount": 1,
-                                "negate": false
-                            }
                         },
                         "Event - Transport Blob from Below": {
                             "type": "or",
@@ -2114,30 +1980,6 @@
                     ],
                     "extra": {},
                     "event_name": "s040_aqua:default:db_reg_aq_002",
-                    "connections": {
-                        "Water Bottom": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Event - Water Blob Right, Through Wall": {
-                    "node_type": "event",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 3795.48,
-                        "y": -1527.22,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "event_name": "s040_aqua:default:db_reg_aq_001",
                     "connections": {
                         "Water Bottom": {
                             "type": "and",
@@ -4434,8 +4276,8 @@
                                 "items": []
                             }
                         },
-                        "Tile Group (MISSILE)": {
-                            "type": "or",
+                        "Pickup (Missile+ Tank)": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -4443,87 +4285,99 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "Flash",
+                                            "name": "Morph",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Space",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Shoot Missile"
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
-                                            "comment": "Carry it from the Map Station, or alternatively from the suction enemy below",
+                                            "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Speed",
+                                                        "name": "Flash",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "or",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
+                                                        "type": "items",
+                                                        "name": "Space",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Carry it from the Map Station, or alternatively from the suction enemy below",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "misc",
-                                                                    "name": "DoorLocks",
+                                                                    "type": "items",
+                                                                    "name": "Speed",
                                                                     "amount": 1,
-                                                                    "negate": true
+                                                                    "negate": false
                                                                 }
                                                             },
                                                             {
-                                                                "type": "and",
+                                                                "type": "or",
                                                                 "data": {
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
-                                                                                "type": "events",
-                                                                                "name": "s040_aqua:default:grapplepulloff1x2_001",
+                                                                                "type": "misc",
+                                                                                "name": "DoorLocks",
                                                                                 "amount": 1,
-                                                                                "negate": false
+                                                                                "negate": true
                                                                             }
                                                                         },
                                                                         {
-                                                                            "type": "resource",
+                                                                            "type": "and",
                                                                             "data": {
-                                                                                "type": "items",
-                                                                                "name": "Morph",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Speedbooster",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Knowledge",
-                                                                                "amount": 1,
-                                                                                "negate": false
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "events",
+                                                                                            "name": "s040_aqua:default:grapplepulloff1x2_001",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Speedbooster",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Knowledge",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         }
                                                                     ]
@@ -4531,44 +4385,90 @@
                                                             }
                                                         ]
                                                     }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": "You can stand on the edge of a flash gate without it closing",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Knowledge",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
                                                 },
                                                 {
-                                                    "type": "or",
+                                                    "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "You can stand on the edge of a flash gate without it closing",
                                                         "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Lay Cross Bomb"
-                                                            },
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Use Spin Boost"
-                                                            },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Movement",
+                                                                    "name": "Knowledge",
                                                                     "amount": 1,
                                                                     "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "FlashSkip",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "or",
+                                                                                        "data": {
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "tricks",
+                                                                                                        "name": "Movement",
+                                                                                                        "amount": 1,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "template",
+                                                                                                    "data": "Lay Cross Bomb"
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "template",
+                                                                                                    "data": "Use Spin Boost"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Lay Bomb"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "FlashSkip",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -4601,13 +4501,11 @@
                     "pickup_index": 91,
                     "major_location": true,
                     "connections": {
-                        "Tile Group (WEIGHT) 1": {
-                            "type": "resource",
+                        "Door to Drogyga Eyedoor": {
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -4720,183 +4618,6 @@
                     },
                     "keep_name_when_vanilla": true,
                     "editable": true,
-                    "connections": {
-                        "Tile Group (BOMB)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (WEIGHT) 4": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (BOMB)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -5900.0,
-                        "y": 3500.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_034",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "BOMB"
-                        ]
-                    },
-                    "connections": {
-                        "Teleporter to Ferenia - Teleport to Burenia (Cyan)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Lower Left Ledge": {
-                            "type": "resource",
-                            "data": {
-                                "type": "events",
-                                "name": "BureniaStormMissileGateTeleport",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT) 1": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -6700.0,
-                        "y": 8100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_027",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Drogyga Eyedoor": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT) 2": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -6900.0,
-                        "y": 8300.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_028",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Missile+ Tank)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (MISSILE)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -6600.0,
-                        "y": 8400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_029",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "MISSILE"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Drogyga Eyedoor": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (WEIGHT) 2": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT) 4": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -5200.0,
-                        "y": 3200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_037",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
                     "connections": {
                         "Door to Main Hub Tower Top": {
                             "type": "and",
@@ -5091,13 +4812,37 @@
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
-                        "Tile Group (BOMB)": {
-                            "type": "resource",
+                        "Teleporter to Ferenia - Teleport to Burenia (Cyan)": {
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "BureniaStormMissileGateTeleport",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "BureniaStormMissileGateTeleport",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Bomb"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Power Bomb"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Event - Storm Missile Gate": {
@@ -5522,7 +5267,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (POWERBEAM)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5545,7 +5290,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Magnet",
+                                                        "name": "Flash",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -5560,17 +5305,17 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Flash",
+                                                        "name": "Magnet",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
                                                 },
                                                 {
                                                     "type": "and",
@@ -5743,7 +5488,7 @@
                         "area_name": "Flash Shift Room",
                         "node_name": "Door from Main Hub Tower Top"
                     },
-                    "default_dock_weakness": "Power Beam Door",
+                    "default_dock_weakness": "Missile Door",
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -5775,13 +5520,6 @@
                     "pickup_index": 82,
                     "major_location": true,
                     "connections": {
-                        "Tile Group (WEIGHT)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Upper Left Magnet Wall": {
                             "type": "and",
                             "data": {
@@ -5841,7 +5579,7 @@
                     "pickup_index": 84,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (POWERBEAM)": {
+                        "Door to Teleport to Ferenia": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -5874,79 +5612,6 @@
                             "data": {
                                 "comment": null,
                                 "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT)": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -1800.0,
-                        "y": 0.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_018",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Upper Left Magnet Wall": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (POWERBEAM)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -2000.0,
-                        "y": 3500.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_007",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Teleport to Ferenia": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Pickup (Missile Tank)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
                             }
                         }
                     }
@@ -6360,13 +6025,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        },
-                        "Tile Group (WEIGHT)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }
@@ -7551,7 +7209,7 @@
                         "Dock to Main Hub Tower Bottom": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "https://youtu.be/xfpOoAN3HVI",
                                 "items": [
                                     {
                                         "type": "template",
@@ -7562,7 +7220,16 @@
                                         "data": {
                                             "type": "tricks",
                                             "name": "SSC",
-                                            "amount": 4,
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
                                             "negate": false
                                         }
                                     }
@@ -8024,7 +7691,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SCREWATTACK)": {
+                        "Above Screw Attack Blocks": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8205,6 +7872,45 @@
                                     }
                                 ]
                             }
+                        },
+                        "Inside Tunnel": {
+                            "type": "and",
+                            "data": {
+                                "comment": "https://youtu.be/yb_tJYnFFIw",
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can SSC"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "SSC",
+                                            "amount": 3,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "BureniaStormMissileGateEtank",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -8262,26 +7968,19 @@
                         }
                     }
                 },
-                "Tile Group (SCREWATTACK)": {
-                    "node_type": "configurable_node",
+                "Above Screw Attack Blocks": {
+                    "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": -4100.0,
-                        "y": -10300.0,
+                        "x": -3692.0087376514393,
+                        "y": -10108.925545526852,
                         "z": 0.0
                     },
                     "description": "",
                     "layers": [
                         "default"
                     ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_008",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SCREWATTACK"
-                        ]
-                    },
+                    "extra": {},
                     "connections": {
                         "Door to Save Station South Access (Lower)": {
                             "type": "and",
@@ -8326,17 +8025,10 @@
                             }
                         },
                         "Dock to Gravity Suit Room Access": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tunnel to Storm Missile Gate Room": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
-                                "name": "Morph",
+                                "name": "Screw",
                                 "amount": 1,
                                 "negate": false
                             }
@@ -8362,6 +8054,70 @@
                                             "name": "Gravity",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Inside Tunnel": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Screw",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "https://youtu.be/yb_tJYnFFIw",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can SSC"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SSC",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -8392,7 +8148,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SCREWATTACK)": {
+                        "Above Screw Attack Blocks": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8469,7 +8225,7 @@
                                 ]
                             }
                         },
-                        "Tunnel to Storm Missile Gate Room": {
+                        "Inside Tunnel": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8498,10 +8254,6 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                },
-                                                {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
@@ -8509,6 +8261,10 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
                                                 }
                                             ]
                                         }
@@ -8541,7 +8297,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (SCREWATTACK)": {
+                        "Inside Tunnel": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -9038,7 +8794,7 @@
                                 ]
                             }
                         },
-                        "Tile Group (SCREWATTACK)": {
+                        "Above Screw Attack Blocks": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9231,6 +8987,45 @@
                     "event_name": "BureniaPrepareSpeedSave",
                     "connections": {
                         "Door to Save Station South Access (Upper)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Inside Tunnel": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -1981.1350877799682,
+                        "y": -10411.400444951643,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "connections": {
+                        "Above Screw Attack Blocks": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Dock to Gravity Suit Room Access": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Tunnel to Storm Missile Gate Room": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9524,14 +9319,23 @@
                                 "items": []
                             }
                         },
-                        "Life Recharge": {
-                            "type": "and",
+                        "Pickup (Missile Tank)": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Power Bomb"
+                                    }
+                                ]
                             }
                         },
-                        "Tile Group (BOMB) 1": {
+                        "Life Recharge": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9599,22 +9403,6 @@
                                             "amount": 1,
                                             "negate": false
                                         }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                }
-                                            ]
-                                        }
                                     }
                                 ]
                             }
@@ -9643,15 +9431,6 @@
                         "Door to Main Hub Tower Bottom": {
                             "type": "template",
                             "data": "Can Slide Underwater"
-                        },
-                        "Tile Group (BOMB) 2": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
                         }
                     }
                 },
@@ -9679,98 +9458,6 @@
                             "data": {
                                 "comment": null,
                                 "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (BOMB) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -5448.496035001367,
-                        "y": -4700.3554826360405,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_005",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "BOMB"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Main Hub Tower Middle": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (BOMB) 2": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Tile Group (BOMB) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -5126.920973475526,
-                        "y": -5389.444900191414,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_006",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "BOMB"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Missile Tank)": {
-                            "type": "template",
-                            "data": "Can Slide Underwater"
-                        },
-                        "Tile Group (BOMB) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Gravity",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
                             }
                         }
                     }
@@ -10032,6 +9719,70 @@
                             "type": "template",
                             "data": "Destroy Enky"
                         },
+                        "Upper Water Platform": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can SSC"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "SSC",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "BureniaEPart",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "BureniaGhavoranTeleportEnky",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Speedbooster",
+                                            "amount": 3,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Cross Bomb - https://www.youtube.com/watch?v=1l7rJwAUSLE Power Bomb - https://www.youtube.com/watch?v=477-pmla1kU",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Cross Bomb"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Power Bomb"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Event - Ghavoran Teleport Speed Blocks Destroyed": {
                             "type": "and",
                             "data": {
@@ -10275,11 +10026,20 @@
                                 "items": []
                             }
                         },
-                        "Tile Group (BOMB)": {
-                            "type": "and",
+                        "Top of Enky Shaft": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Power Bomb"
+                                    }
+                                ]
                             }
                         }
                     }
@@ -10347,40 +10107,6 @@
                         }
                     }
                 },
-                "Tile Group (BOMB)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 1200.0,
-                        "y": -3200.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_003",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "BOMB"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Gravity Suit Tower": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Top of Enky Shaft": {
-                            "type": "template",
-                            "data": "Can Slide"
-                        }
-                    }
-                },
                 "Top of Enky Shaft": {
                     "node_type": "generic",
                     "heal": false,
@@ -10404,13 +10130,20 @@
                                 "negate": false
                             }
                         },
-                        "Tile Group (BOMB)": {
-                            "type": "resource",
+                        "Door to Gravity Suit Tower": {
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Power Bomb"
+                                    }
+                                ]
                             }
                         },
                         "Event - Destroy all Enkys": {
@@ -10959,14 +10692,16 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator to Artaria - Transport to Burenia": {
-                            "type": "and",
+                        "Pickup (Missile Tank)": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
-                        "Tile Group (SCREWATTACK) 1": {
+                        "Elevator to Artaria - Transport to Burenia": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -10994,11 +10729,13 @@
                     "pickup_index": 83,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (SCREWATTACK) 2": {
-                            "type": "and",
+                        "Door to Navigation Station South": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -11031,80 +10768,6 @@
                     "editable": true,
                     "connections": {
                         "Door to Navigation Station South": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SCREWATTACK) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 11200.0,
-                        "y": -7700.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_001",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SCREWATTACK"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Navigation Station South": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SCREWATTACK) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SCREWATTACK) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 11200.0,
-                        "y": -7500.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_040",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SCREWATTACK"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Missile Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SCREWATTACK) 1": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11225,7 +10888,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (POWERBEAM) 2": {
+                        "Above Water": {
                             "type": "template",
                             "data": "Can Slide"
                         }
@@ -11278,7 +10941,7 @@
                     "pickup_index": 87,
                     "major_location": true,
                     "connections": {
-                        "Tile Group (POWERBEAM) 1": {
+                        "Next to Exit Tunnel": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -11287,12 +10950,12 @@
                         }
                     }
                 },
-                "Tile Group (POWERBEAM) 1": {
-                    "node_type": "configurable_node",
+                "Next to Exit Tunnel": {
+                    "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 3800.0,
-                        "y": -8500.0,
+                        "x": 3368.1595692608907,
+                        "y": -8452.838962310328,
                         "z": 0.0
                     },
                     "description": "",
@@ -11335,26 +10998,19 @@
                         }
                     }
                 },
-                "Tile Group (POWERBEAM) 2": {
-                    "node_type": "configurable_node",
+                "Above Water": {
+                    "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 3100.0,
-                        "y": -6700.0,
+                        "x": 3472.1732745961817,
+                        "y": -6598.947626040137,
                         "z": 0.0
                     },
                     "description": "",
                     "layers": [
                         "default"
                     ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_016",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
+                    "extra": {},
                     "connections": {
                         "Door to Teleport to Ghavoran (Lower)": {
                             "type": "and",
@@ -11459,7 +11115,7 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Tile Group (POWERBEAM) 2": {
+                        "Above Water": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -11535,7 +11191,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (POWERBEAM) 2": {
+                        "Above Water": {
                             "type": "template",
                             "data": "Use Spin Boost"
                         },
@@ -11571,7 +11227,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (POWERBEAM) 1": {
+                        "Next to Exit Tunnel": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -11605,7 +11261,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (POWERBEAM) 1": {
+                        "Next to Exit Tunnel": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -12171,12 +11827,9 @@
                                 ]
                             }
                         },
-                        "Tile Group (POWERBOMB)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                        "Door to Gravity Suit Room (Lower)": {
+                            "type": "template",
+                            "data": "Lay Power Bomb"
                         },
                         "Breakable Floor": {
                             "type": "and",
@@ -12304,26 +11957,11 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Start Point 4": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SCREWATTACK) 2": {
+                        "Pickup (Missile+ Tank)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
-                                    },
                                     {
                                         "type": "resource",
                                         "data": {
@@ -12332,6 +11970,14 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spin Boost"
                                     },
                                     {
                                         "type": "and",
@@ -12355,8 +12001,8 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "misc",
-                                                                    "name": "DoorLocks",
+                                                                    "type": "events",
+                                                                    "name": "BureniaDestroyGravitySuitFloor",
                                                                     "amount": 1,
                                                                     "negate": true
                                                                 }
@@ -12364,8 +12010,8 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "events",
-                                                                    "name": "BureniaDestroyGravitySuitFloor",
+                                                                    "type": "misc",
+                                                                    "name": "DoorLocks",
                                                                     "amount": 1,
                                                                     "negate": true
                                                                 }
@@ -12379,13 +12025,58 @@
                                 ]
                             }
                         },
-                        "Breakable Floor": {
-                            "type": "resource",
+                        "Start Point 4": {
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "BureniaDestroyGravitySuitFloor",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Breakable Floor": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "BureniaDestroyGravitySuitFloor",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "https://youtu.be/-NZ2QPUxno0",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "BureniaDestroyGravitySuitFloor",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can SSC"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SSC",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -12459,11 +12150,22 @@
                     "pickup_index": 88,
                     "major_location": true,
                     "connections": {
-                        "Tile Group (SCREWATTACK) 2": {
-                            "type": "and",
+                        "Door to Navigation Station South": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Shaft Base": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -12487,7 +12189,7 @@
                     "pickup_index": 93,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (MISSILE)": {
+                        "Door to Teleport to Ghavoran": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12526,6 +12228,10 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Door to Gravity Suit Room (Upper)": {
+                            "type": "template",
+                            "data": "Lay Power Bomb"
+                        },
                         "Dock to Ammo Recharge South (Lower)": {
                             "type": "and",
                             "data": {
@@ -12592,13 +12298,6 @@
                                     }
                                 ]
                             }
-                        },
-                        "Tile Group (POWERBOMB)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
                         }
                     }
                 },
@@ -12632,14 +12331,11 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Start Point 3": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                        "Pickup (Missile Tank)": {
+                            "type": "template",
+                            "data": "Shoot Missile"
                         },
-                        "Tile Group (MISSILE)": {
+                        "Start Point 3": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12837,12 +12533,9 @@
                     },
                     "event_name": "s040_aqua:default:db_reg_aq_005",
                     "connections": {
-                        "Tile Group (WEIGHT)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
+                        "Breakable Floor": {
+                            "type": "template",
+                            "data": "Can Slide Underwater"
                         }
                     }
                 },
@@ -13041,314 +12734,6 @@
                         }
                     }
                 },
-                "Tile Group (POWERBOMB)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 4600.0,
-                        "y": -11300.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_011",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBOMB"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Gravity Suit Room (Upper)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Door to Gravity Suit Room (Lower)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (WEIGHT)": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 4100.0,
-                        "y": -8700.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_015",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "WEIGHT"
-                        ]
-                    },
-                    "connections": {
-                        "Event - Early Gravity Blob": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Beam"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Lay Bomb"
-                                    }
-                                ]
-                            }
-                        },
-                        "Breakable Floor": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s040_aqua:default:db_reg_aq_005",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SCREWATTACK) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 6100.0,
-                        "y": -7600.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_019",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SCREWATTACK"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Navigation Station South": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Pickup (Missile+ Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (POWERBEAM) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (POWERBEAM) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SCREWATTACK) 4": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (POWERBEAM) 1": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 6200.0,
-                        "y": -6400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_020",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (SCREWATTACK) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Shaft Base": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (MISSILE)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 2500.0,
-                        "y": -2900.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_022",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "MISSILE"
-                        ]
-                    },
-                    "connections": {
-                        "Pickup (Missile Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Door to Teleport to Ghavoran": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (POWERBEAM) 2": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 6800.0,
-                        "y": -6400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_041",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (SCREWATTACK) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Shaft Base": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Tile Group (SCREWATTACK) 4": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 6300.0,
-                        "y": -6400.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_042",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "SCREWATTACK"
-                        ]
-                    },
-                    "connections": {
-                        "Tile Group (SCREWATTACK) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Shaft Base": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Tunnel to Early Gravity Speedboost Room 1": {
                     "node_type": "dock",
                     "heal": false,
@@ -13372,11 +12757,20 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (WEIGHT)": {
-                            "type": "and",
+                        "Event - Early Gravity Blob": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Bomb"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Beam"
+                                    }
+                                ]
                             }
                         }
                     }
@@ -13926,6 +13320,15 @@
                     ],
                     "extra": {},
                     "connections": {
+                        "Pickup (Missile+ Tank)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
                         "Start Point 2": {
                             "type": "or",
                             "data": {
@@ -14044,27 +13447,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        },
-                        "Tile Group (POWERBEAM) 1": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (POWERBEAM) 2": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Tile Group (SCREWATTACK) 4": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }
@@ -14463,13 +13845,11 @@
                     "pickup_index": 85,
                     "major_location": false,
                     "connections": {
-                        "Tile Group (POWERBOMB)": {
-                            "type": "resource",
+                        "Tunnel to Gravity Suit Room Access (Lower)": {
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -14682,46 +14062,19 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (POWERBOMB)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Event - Gravity Suit Blob, Below": {
-                            "type": "template",
-                            "data": "Shoot Diffusion or Wave"
-                        }
-                    }
-                },
-                "Tile Group (POWERBOMB)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 3157.32,
-                        "y": -12212.64,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_036",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "tile_types": [
-                            "POWERBOMB"
-                        ]
-                    },
-                    "connections": {
                         "Pickup (Power Bomb Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Power Bomb"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Ballspark"
+                                    },
                                     {
                                         "type": "resource",
                                         "data": {
@@ -14730,30 +14083,13 @@
                                             "amount": 1,
                                             "negate": false
                                         }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Ballspark"
                                     }
                                 ]
                             }
                         },
-                        "Tunnel to Gravity Suit Room Access (Lower)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
+                        "Event - Gravity Suit Blob, Below": {
+                            "type": "template",
+                            "data": "Shoot Diffusion or Wave"
                         }
                     }
                 },
@@ -15135,7 +14471,7 @@
                                 ]
                             }
                         },
-                        "Tile Group (POWERBEAM)": {
+                        "Tunnel to Main Hub Tower Bottom": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -15180,47 +14516,6 @@
                         }
                     }
                 },
-                "Tile Group (POWERBEAM)": {
-                    "node_type": "configurable_node",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -700.0,
-                        "y": -10800.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_009",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
-                    "connections": {
-                        "Door to Main Hub Tower Bottom": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Tunnel to Main Hub Tower Bottom": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
                 "Tunnel to Main Hub Tower Bottom": {
                     "node_type": "dock",
                     "heal": false,
@@ -15244,14 +14539,9 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tile Group (POWERBEAM)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
+                        "Door to Main Hub Tower Bottom": {
+                            "type": "template",
+                            "data": "Can Slide Underwater"
                         }
                     }
                 },

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -7209,7 +7209,7 @@
                         "Dock to Main Hub Tower Bottom": {
                             "type": "and",
                             "data": {
-                                "comment": "https://youtu.be/xfpOoAN3HVI",
+                                "comment": "Aim Down Clip - https://youtu.be/xfpOoAN3HVI",
                                 "items": [
                                     {
                                         "type": "template",
@@ -7218,19 +7218,36 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "SSC",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
                                             "type": "items",
                                             "name": "Gravity",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "ADC",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SSC",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -7895,7 +7912,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "SSC",
+                                            "name": "ADC",
                                             "amount": 3,
                                             "negate": false
                                         }
@@ -8112,7 +8129,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "SSC",
+                                                        "name": "ADC",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -9731,15 +9748,6 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "SSC",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
                                             "type": "events",
                                             "name": "BureniaEPart",
                                             "amount": 1,
@@ -9776,6 +9784,32 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Lay Power Bomb"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "ADC",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SSC",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -12068,7 +12102,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "SSC",
+                                                        "name": "ADC",
                                                         "amount": 3,
                                                         "negate": false
                                                     }
@@ -13784,6 +13818,53 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Door to Gravity Suit Tower (Lower)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Can SSC"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "ADC",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SSC",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Event - Gravity Suit Blob, Above": {
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -569,7 +569,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Fan Platform - Above": {
+                        "Fan Platform": {
                             "type": "template",
                             "data": "Can Slide"
                         }
@@ -605,17 +605,8 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Fan Platform - Above": {
-                            "type": "resource",
-                            "data": {
-                                "type": "events",
-                                "name": "BureniaDaironSpeedBlocks",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Fan Platform - Below": {
-                            "type": "and",
+                        "Fan Platform": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -623,18 +614,35 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "s040_aqua:default:grapplepulloff1x2_000",
+                                            "name": "BureniaDaironSpeedBlocks",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s040_aqua:default:grapplepulloff1x2_000",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -1013,7 +1021,7 @@
                     "pickup_index": 90,
                     "major_location": false,
                     "connections": {
-                        "Fan Platform - Above": {
+                        "Fan Platform": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1041,8 +1049,11 @@
                     "event_name": "s040_aqua:default:db_reg_aq_001",
                     "connections": {
                         "Water Bottom": {
-                            "type": "template",
-                            "data": "Lay Bomb"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -1118,7 +1129,7 @@
                     },
                     "event_name": "s040_aqua:default:grapplepulloff1x2_000",
                     "connections": {
-                        "Fan Platform - Below": {
+                        "Fan Platform": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1215,7 +1226,7 @@
                         }
                     }
                 },
-                "Fan Platform - Above": {
+                "Fan Platform": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -1333,12 +1344,46 @@
                             }
                         },
                         "Door to Upper Burenia Hub": {
-                            "type": "resource",
+                            "type": "or",
                             "data": {
-                                "type": "events",
-                                "name": "BureniaDaironSpeedBlocks",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "BureniaDaironSpeedBlocks",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "s040_aqua:default:grapplepulloff1x2_000",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Pickup (Energy Part)": {
@@ -1405,64 +1450,6 @@
                                 ]
                             }
                         },
-                        "Fan Platform - Below": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Event - Dairon Hub Speed Blocks Destroyed": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Speed",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Fan Platform - Below": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 3550.0,
-                        "y": 3100.0,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "connections": {
-                        "Door to Upper Burenia Hub": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s040_aqua:default:grapplepulloff1x2_000",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
                         "Event - Dairon Hub Grapple Block": {
                             "type": "resource",
                             "data": {
@@ -1477,6 +1464,15 @@
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        },
+                        "Event - Dairon Hub Speed Blocks Destroyed": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Speed",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -1642,7 +1638,7 @@
                                 ]
                             }
                         },
-                        "Fan Platform - Below": {
+                        "Fan Platform": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -1657,8 +1653,13 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Perform WBJ"
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s040_aqua:default:db_reg_aq_001",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     },
                                     {
                                         "type": "resource",
@@ -1670,13 +1671,8 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "s040_aqua:default:db_reg_aq_001",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
+                                        "type": "template",
+                                        "data": "Perform WBJ"
                                     }
                                 ]
                             }
@@ -1910,6 +1906,10 @@
                                     {
                                         "type": "template",
                                         "data": "Lay Bomb"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Lay Power Bomb"
                                     }
                                 ]
                             }
@@ -2029,7 +2029,7 @@
                     "extra": {},
                     "event_name": "BureniaDaironSpeedBlocks",
                     "connections": {
-                        "Fan Platform - Above": {
+                        "Fan Platform": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5521,41 +5521,12 @@
                     "major_location": true,
                     "connections": {
                         "Upper Left Magnet Wall": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Flash",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -7920,10 +7891,10 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "events",
-                                            "name": "BureniaStormMissileGateEtank",
+                                            "type": "misc",
+                                            "name": "DoorLocks",
                                             "amount": 1,
-                                            "negate": false
+                                            "negate": true
                                         }
                                     }
                                 ]
@@ -8238,6 +8209,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Screw",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -8284,6 +8264,15 @@
                                                     "data": "Simple IBJ"
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -10988,22 +10977,15 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 3368.1595692608907,
-                        "y": -8452.838962310328,
+                        "x": 3368.16,
+                        "y": -8452.84,
                         "z": 0.0
                     },
                     "description": "",
                     "layers": [
                         "default"
                     ],
-                    "extra": {
-                        "actor_name": "breakabletilegroup_014",
-                        "actor_def": "actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad",
-                        "actor_layer": "breakables",
-                        "tile_types": [
-                            "POWERBEAM"
-                        ]
-                    },
+                    "extra": {},
                     "connections": {
                         "Pickup (Missile+ Tank)": {
                             "type": "and",
@@ -11991,74 +11973,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Pickup (Missile+ Tank)": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Flash",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Use Spin Boost"
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "events",
-                                                                    "name": "BureniaDestroyGravitySuitFloor",
-                                                                    "amount": 1,
-                                                                    "negate": true
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "misc",
-                                                                    "name": "DoorLocks",
-                                                                    "amount": 1,
-                                                                    "negate": true
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        },
                         "Start Point 4": {
                             "type": "and",
                             "data": {
@@ -12067,9 +11981,18 @@
                             }
                         },
                         "Breakable Floor": {
-                            "type": "or",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
+                                "type": "events",
+                                "name": "BureniaDestroyGravitySuitFloor",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Blob Alcove": {
+                            "type": "and",
+                            "data": {
+                                "comment": "https://youtu.be/-NZ2QPUxno0",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -12077,34 +12000,102 @@
                                             "type": "events",
                                             "name": "BureniaDestroyGravitySuitFloor",
                                             "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "ADC",
+                                            "amount": 4,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "template",
+                                        "data": "Can SSC"
+                                    }
+                                ]
+                            }
+                        },
+                        "Next to Bottom Pickup": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
                                         "data": {
-                                            "comment": "https://youtu.be/-NZ2QPUxno0",
+                                            "type": "items",
+                                            "name": "Screw",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "events",
-                                                        "name": "BureniaDestroyGravitySuitFloor",
+                                                        "type": "items",
+                                                        "name": "Flash",
                                                         "amount": 1,
-                                                        "negate": true
+                                                        "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "template",
-                                                    "data": "Can SSC"
+                                                    "data": "Simple IBJ"
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "ADC",
-                                                        "amount": 3,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "events",
+                                                                                "name": "BureniaDestroyGravitySuitFloor",
+                                                                                "amount": 1,
+                                                                                "negate": true
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "DoorLocks",
+                                                                                "amount": 1,
+                                                                                "negate": true
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -12184,22 +12175,11 @@
                     "pickup_index": 88,
                     "major_location": true,
                     "connections": {
-                        "Door to Navigation Station South": {
-                            "type": "resource",
+                        "Next to Bottom Pickup": {
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Screw",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Shaft Base": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Screw",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -13354,15 +13334,6 @@
                     ],
                     "extra": {},
                     "connections": {
-                        "Pickup (Missile+ Tank)": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Screw",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
                         "Start Point 2": {
                             "type": "or",
                             "data": {
@@ -13482,6 +13453,15 @@
                                     }
                                 ]
                             }
+                        },
+                        "Next to Bottom Pickup": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
+                            }
                         }
                     }
                 },
@@ -13529,6 +13509,47 @@
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        }
+                    }
+                },
+                "Next to Bottom Pickup": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 6666.89,
+                        "y": -7424.31,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "connections": {
+                        "Door to Navigation Station South": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Pickup (Missile+ Tank)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Shaft Base": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -1208,8 +1208,9 @@ Extra - asset_id: collision_camera_010
           Space Jump or Speed Booster or Simple IBJ
   > Dock to Main Hub Tower Bottom
       All of the following:
-          # https://youtu.be/xfpOoAN3HVI
-          Gravity Suit and Shinesink Clip (Intermediate) and Can SSC
+          # Aim Down Clip - https://youtu.be/xfpOoAN3HVI
+          Gravity Suit and Can SSC
+          Aim Down Clip (Intermediate) or Shinesink Clip (Intermediate)
 
 > Event - Lower Magnet Wall; Heals? False
   * Layers: default
@@ -1338,7 +1339,7 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   > Inside Tunnel
       All of the following:
           # https://youtu.be/yb_tJYnFFIw
-          Gravity Suit and After Burenia - Storm Missile Gate for Etank and Shinesink Clip (Advanced) and Can SSC
+          Gravity Suit and After Burenia - Storm Missile Gate for Etank and Aim Down Clip (Advanced) and Can SSC
 
 > Event - Main Hub Bottom Blob, Left; Heals? False
   * Layers: default
@@ -1371,7 +1372,7 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
           Morph Ball and Screw Attack
           All of the following:
               # https://youtu.be/yb_tJYnFFIw
-              Gravity Suit and Shinesink Clip (Intermediate) and Can SSC
+              Gravity Suit and Aim Down Clip (Intermediate) and Can SSC
 
 > Dock to Gravity Suit Room Access; Heals? False
   * Layers: default
@@ -1666,10 +1667,11 @@ Extra - asset_id: collision_camera_015
       Destroy Enky
   > Upper Water Platform
       All of the following:
-          After Burenia - Early Gravity Pickup 1 and After Burenia - Ghavoran Teleport Enky and Shinesink Clip (Intermediate) and Speedbooster Conservation (Advanced) and Can SSC
+          After Burenia - Early Gravity Pickup 1 and After Burenia - Ghavoran Teleport Enky and Speedbooster Conservation (Advanced) and Can SSC
           Any of the following:
               # Cross Bomb - https://www.youtube.com/watch?v=1l7rJwAUSLE Power Bomb - https://www.youtube.com/watch?v=477-pmla1kU
               Lay Cross Bomb or Lay Power Bomb
+          Aim Down Clip (Intermediate) or Shinesink Clip (Intermediate)
   > Event - Ghavoran Teleport Speed Blocks Destroyed
       Speed Booster and After Burenia - Early Gravity Pickup 1
 
@@ -2112,7 +2114,7 @@ Extra - asset_id: collision_camera_021
           After Burenia - Destroy Gravity Suit Floor
           All of the following:
               # https://youtu.be/-NZ2QPUxno0
-              Before Burenia - Destroy Gravity Suit Floor and Shinesink Clip (Advanced) and Can SSC
+              Before Burenia - Destroy Gravity Suit Floor and Aim Down Clip (Advanced) and Can SSC
 
 > Dock to Ammo Recharge South (Lower); Heals? False
   * Layers: default
@@ -2434,6 +2436,10 @@ the blast shield issue.
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorshieldmissile_001
   * Extra - right_shield_def: actordef:actors/props/doorshieldmissile/charclasses/doorshieldmissile.bmsad
+  > Door to Gravity Suit Tower (Lower)
+      All of the following:
+          Gravity Suit and Can SSC
+          Aim Down Clip (Intermediate) or Shinesink Clip (Intermediate)
   > Event - Gravity Suit Blob, Above
       Shoot Diffusion or Wave
   > Start Point

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -89,7 +89,7 @@ Extra - asset_id: collision_camera_001
   * Pickup 92; Major Location? False
   * Extra - actor_name: item_missiletank_006
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Tile Group (MISSILE)
+  > Tunnel to Transport to Ghavoran
       Morph Ball
 
 > Start Point; Heals? False; Spawn Point
@@ -101,25 +101,13 @@ Extra - asset_id: collision_camera_001
   > Door to Navigation Station North
       Trivial
 
-> Tile Group (MISSILE); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_023
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('MISSILE',)
-  > Pickup (Missile Tank)
-      Morph Ball
-  > Tunnel to Transport to Ghavoran
-      Trivial
-
 > Tunnel to Transport to Ghavoran; Heals? False
   * Layers: default
   * Morph Ball Tunnel to Transport to Ghavoran/Tunnel to Upper Burenia Hub
   > Door to Navigation Station North
       After Quiet Robe and Can Slide
-  > Tile Group (MISSILE)
-      Trivial
+  > Pickup (Missile Tank)
+      Morph Ball and Shoot Missile
 
 ----------------
 Burenia Hub to Dairon
@@ -210,13 +198,13 @@ Extra - asset_id: collision_camera_002
   > Fan Platform - Above
       Trivial
 
-> Event - Water Blob Right, Adjacent; Heals? False
+> Event - Water Blob Right; Heals? False
   * Layers: default
   * Event Burenia - Dairon Hub Water Blob Right
   * Extra - actor_name: db_reg_aq_001
   * Extra - actor_def: actordef:actors/props/db_reg_aq_001/charclasses/db_reg_aq_001.bmsad
-  > Tile Group (BOMB)
-      Trivial
+  > Water Bottom
+      Lay Bomb
 
 > Event - Water Blob Left, Adjacent; Heals? False
   * Layers: default
@@ -239,32 +227,6 @@ Extra - asset_id: collision_camera_002
   * Event Burenia - Dairon Hub Grapple Block
   * Extra - actor_name: grapplepulloff1x2_000
   * Extra - actor_def: actordef:actors/props/grapplepulloff1x2/charclasses/grapplepulloff1x2.bmsad
-  > Fan Platform - Below
-      Trivial
-
-> Tile Group (BOMB); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_025
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('BOMB',)
-  > Event - Water Blob Right, Adjacent
-      All of the following:
-          Morph Ball
-          Lay Bomb or Shoot Beam
-  > Water Bottom
-      Morph Ball
-
-> Tile Group (POWERBEAM); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_033
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-  > Fan Platform - Above
-      Trivial
   > Fan Platform - Below
       Trivial
 
@@ -297,7 +259,7 @@ Extra - asset_id: collision_camera_002
               # A grounded bomb jump with cross bombs to get past the fan
               Infinite Bomb Jump (Beginner) and Lay Cross Bomb
           Flash Shift and Movement (Beginner)
-  > Tile Group (POWERBEAM)
+  > Fan Platform - Below
       Trivial
   > Event - Dairon Hub Speed Blocks Destroyed
       Speed Booster
@@ -308,8 +270,6 @@ Extra - asset_id: collision_camera_002
       Morph Ball and After Burenia - Dairon Hub Grapple Block
   > Event - Dairon Hub Grapple Block
       Grapple Beam
-  > Tile Group (POWERBEAM)
-      Trivial
   > Raft - Top Water Level
       Trivial
 
@@ -349,14 +309,12 @@ Extra - asset_id: collision_camera_002
               All of the following:
                   Before Burenia - Dairon Hub Water Blob Right and Before Burenia - Dairon Hub Water Blob Left and Enabled Highly Dangerous Logic
                   Simple IBJ or Use Spin Boost
-  > Tile Group (BOMB)
-      Morph Ball
+  > Event - Water Blob Right
+      Wave Beam or Lay Bomb
   > Bottom-left Corner
       Can Slide Underwater
   > Event - Water Blob Left, Through Wall
       Shoot Diffusion or Wave
-  > Event - Water Blob Right, Through Wall
-      Wave Beam
   > Event - Transport Blob from Below
       Any of the following:
           Shoot Diffusion or Wave
@@ -365,12 +323,6 @@ Extra - asset_id: collision_camera_002
 > Event - Water Blob Left, Through Wall; Heals? False
   * Layers: default
   * Event Burenia - Dairon Hub Water Blob Left
-  > Water Bottom
-      Trivial
-
-> Event - Water Blob Right, Through Wall; Heals? False
-  * Layers: default
-  * Event Burenia - Dairon Hub Water Blob Right
   > Water Bottom
       Trivial
 
@@ -795,27 +747,33 @@ Extra - asset_id: collision_camera_008
   * Extra - right_shield_def: None
   > Door to Map Station
       Trivial
-  > Tile Group (MISSILE)
-      Any of the following:
-          Flash Shift or Space Jump
-          All of the following:
-              # Carry it from the Map Station, or alternatively from the suction enemy below
-              Speed Booster
-              Any of the following:
-                  Disabled Door Lock Randomizer
-                  Morph Ball and After Burenia - Ferenia Teleport Grapple Block and Knowledge (Beginner) and Speedbooster Conservation (Intermediate)
-          All of the following:
-              # You can stand on the edge of a flash gate without it closing
-              Knowledge (Beginner)
-              Movement (Beginner) or Lay Cross Bomb or Use Spin Boost
+  > Pickup (Missile+ Tank)
+      All of the following:
+          Morph Ball and Shoot Missile
+          Any of the following:
+              Flash Shift or Space Jump
+              All of the following:
+                  # Carry it from the Map Station, or alternatively from the suction enemy below
+                  Speed Booster
+                  Any of the following:
+                      Disabled Door Lock Randomizer
+                      After Burenia - Ferenia Teleport Grapple Block and Knowledge (Beginner) and Speedbooster Conservation (Intermediate)
+              All of the following:
+                  # You can stand on the edge of a flash gate without it closing
+                  Knowledge (Beginner)
+                  Any of the following:
+                      All of the following:
+                          Flash Shift Skip (Beginner)
+                          Movement (Beginner) or Lay Cross Bomb or Use Spin Boost
+                      Flash Shift Skip (Intermediate) and Lay Bomb
 
 > Pickup (Missile+ Tank); Heals? False
   * Layers: default
   * Pickup 91; Major Location? True
   * Extra - actor_name: item_missiletankplus_000
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
-  > Tile Group (WEIGHT) 1
-      Morph Ball
+  > Door to Drogyga Eyedoor
+      Trivial
 
 > Event - Ferenia Teleport Blob; Heals? False
   * Layers: default
@@ -851,59 +809,6 @@ Extra - asset_id: collision_camera_008
   * Extra - target_spawn_point: teleporter_000_platform
   * Extra - start_point_actor_name: LE_Platform_Teleport_Secret
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad
-  > Tile Group (BOMB)
-      Trivial
-  > Tile Group (WEIGHT) 4
-      Trivial
-
-> Tile Group (BOMB); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_034
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('BOMB',)
-  > Teleporter to Ferenia - Teleport to Burenia (Cyan)
-      Trivial
-  > Lower Left Ledge
-      After Burenia - Storm Missile Gate for Teleport
-
-> Tile Group (WEIGHT) 1; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_027
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Door to Drogyga Eyedoor
-      Trivial
-
-> Tile Group (WEIGHT) 2; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_028
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Pickup (Missile+ Tank)
-      Morph Ball
-
-> Tile Group (MISSILE); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_029
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('MISSILE',)
-  > Door to Drogyga Eyedoor
-      Trivial
-  > Tile Group (WEIGHT) 2
-      Morph Ball
-
-> Tile Group (WEIGHT) 4; Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_037
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
   > Door to Main Hub Tower Top
       Trivial
 
@@ -925,8 +830,10 @@ Extra - asset_id: collision_camera_008
               Water Bomb Jump (Intermediate) and Perform WBJ
   > Event - Ferenia Teleport Blob
       Shoot Diffusion or Wave
-  > Tile Group (BOMB)
-      After Burenia - Storm Missile Gate for Teleport
+  > Teleporter to Ferenia - Teleport to Burenia (Cyan)
+      All of the following:
+          After Burenia - Storm Missile Gate for Teleport
+          Lay Bomb or Lay Power Bomb
   > Event - Storm Missile Gate
       After Burenia - Ferenia Teleport Blob and Activate Storm Missile Locks
 
@@ -1027,7 +934,7 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   * Extra - exclude_from_dock_rando: True
-  > Tile Group (POWERBEAM)
+  > Pickup (Missile Tank)
       All of the following:
           Morph Ball
           Any of the following:
@@ -1067,7 +974,7 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
 
 > Door to Flash Shift Room (Lower); Heals? False
   * Layers: default
-  * Power Beam Door to Flash Shift Room/Door from Main Hub Tower Top
+  * Missile Door to Flash Shift Room/Door from Main Hub Tower Top
   * Extra - actor_name: doorpowerclosed_000
   * Extra - actor_def: actordef:actors/props/doorpowerclosed/charclasses/doorpowerclosed.bmsad
   * Extra - left_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorshieldmissile_000
@@ -1082,8 +989,6 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
   * Pickup 82; Major Location? True
   * Extra - actor_name: item_energytank_000
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
-  > Tile Group (WEIGHT)
-      Trivial
   > Upper Left Magnet Wall
       All of the following:
           Morph Ball
@@ -1094,7 +999,7 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
   * Pickup 84; Major Location? False
   * Extra - actor_name: item_missiletank_005
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Tile Group (POWERBEAM)
+  > Door to Teleport to Ferenia
       Morph Ball
 
 > Start Point; Heals? False; Spawn Point
@@ -1103,27 +1008,6 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to Flash Shift Room (Lower)
       Trivial
-
-> Tile Group (WEIGHT); Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_018
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Upper Left Magnet Wall
-      Morph Ball
-
-> Tile Group (POWERBEAM); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_007
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-  > Door to Teleport to Ferenia
-      Morph Ball
-  > Pickup (Missile Tank)
-      Morph Ball
 
 > Upper Left Magnet Wall; Heals? False
   * Layers: default
@@ -1157,8 +1041,6 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
                   Any of the following:
                       Spider Magnet or Movement (Intermediate)
                       Damage Boost (Beginner) and Stand on Frozen Enemy (Intermediate) and Shoot Ice Missile
-  > Tile Group (WEIGHT)
-      Trivial
 
 ----------------
 Main Hub Tower Middle
@@ -1325,7 +1207,9 @@ Extra - asset_id: collision_camera_010
           Gravity Suit
           Space Jump or Speed Booster or Simple IBJ
   > Dock to Main Hub Tower Bottom
-      Shinesink Clip (Expert) and Can SSC
+      All of the following:
+          # https://youtu.be/xfpOoAN3HVI
+          Gravity Suit and Shinesink Clip (Intermediate) and Can SSC
 
 > Event - Lower Magnet Wall; Heals? False
   * Layers: default
@@ -1427,7 +1311,7 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Tile Group (SCREWATTACK)
+  > Above Screw Attack Blocks
       Trivial
   > Water Space Jump Platform
       Space Jump
@@ -1451,6 +1335,10 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
       Gravity Suit and Morph Ball and After Burenia - Main Hub Bottom Grapple Block
   > Water Space Jump Platform
       Morph Ball and After Burenia - Main Hub Bottom Grapple Block
+  > Inside Tunnel
+      All of the following:
+          # https://youtu.be/yb_tJYnFFIw
+          Gravity Suit and After Burenia - Storm Missile Gate for Etank and Shinesink Clip (Advanced) and Can SSC
 
 > Event - Main Hub Bottom Blob, Left; Heals? False
   * Layers: default
@@ -1468,34 +1356,33 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   > Alcove Across Grapple Block
       Trivial
 
-> Tile Group (SCREWATTACK); Heals? False
+> Above Screw Attack Blocks; Heals? False
   * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_008
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SCREWATTACK',)
   > Door to Save Station South Access (Lower)
       All of the following:
           Gravity Suit
           Speed Booster or Simple IBJ or Use Spin Boost
   > Dock to Gravity Suit Room Access
-      Trivial
-  > Tunnel to Storm Missile Gate Room
-      Morph Ball
+      Screw Attack
   > Water Space Jump Platform
       Gravity Suit or Morph Ball
+  > Inside Tunnel
+      Any of the following:
+          Morph Ball and Screw Attack
+          All of the following:
+              # https://youtu.be/yb_tJYnFFIw
+              Gravity Suit and Shinesink Clip (Intermediate) and Can SSC
 
 > Dock to Gravity Suit Room Access; Heals? False
   * Layers: default
   * Open Passage to Gravity Suit Room Access/Dock to Main Hub Tower Bottom
-  > Tile Group (SCREWATTACK)
+  > Above Screw Attack Blocks
       All of the following:
           Gravity Suit
           Any of the following:
               Space Jump or Speed Booster or Simple IBJ
               Flash Shift and Walljump (Beginner) and Use Spin Boost
-  > Tunnel to Storm Missile Gate Room
+  > Inside Tunnel
       All of the following:
           Gravity Suit
           Space Jump or Speed Booster or Simple IBJ
@@ -1503,7 +1390,7 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
 > Tunnel to Storm Missile Gate Room; Heals? False
   * Layers: default
   * Morph Ball Tunnel to Storm Missile Gate Room/Tunnel to Main Hub Tower Bottom
-  > Tile Group (SCREWATTACK)
+  > Inside Tunnel
       Morph Ball
 
 > Alcove Across Grapple Block; Heals? False
@@ -1565,7 +1452,7 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
       All of the following:
           Gravity Suit and Morph Ball and After Burenia - Main Hub Bottom Grapple Block
           Speed Booster or Single-wall Wall Jump (Beginner) or Simple IBJ or Use Spin Boost
-  > Tile Group (SCREWATTACK)
+  > Above Screw Attack Blocks
       Trivial
   > Alcove Across Grapple Block
       All of the following:
@@ -1589,6 +1476,15 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   * Layers: default
   * Event Burenia - Prepare Speedboost in Save Station
   > Door to Save Station South Access (Upper)
+      Trivial
+
+> Inside Tunnel; Heals? False
+  * Layers: default
+  > Above Screw Attack Blocks
+      Screw Attack
+  > Dock to Gravity Suit Room Access
+      Trivial
+  > Tunnel to Storm Missile Gate Room
       Trivial
 
 ----------------
@@ -1664,9 +1560,9 @@ Extra - asset_id: collision_camera_013
   * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
   > Door to Main Hub Tower Bottom
       Trivial
+  > Pickup (Missile Tank)
+      Lay Bomb or Lay Power Bomb
   > Life Recharge
-      Trivial
-  > Tile Group (BOMB) 1
       Trivial
 
 > Door to Main Hub Tower Bottom; Heals? False
@@ -1681,9 +1577,7 @@ Extra - asset_id: collision_camera_013
   > Door to Main Hub Tower Middle
       Trivial
   > Pickup (Missile Tank)
-      All of the following:
-          Gravity Suit and Morph Ball
-          Simple IBJ or Use Spin Boost
+      Gravity Suit and Morph Ball
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -1692,8 +1586,6 @@ Extra - asset_id: collision_camera_013
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
   > Door to Main Hub Tower Bottom
       Can Slide Underwater
-  > Tile Group (BOMB) 2
-      Morph Ball
 
 > Life Recharge; Heals? True; Spawn Point
   * Layers: default
@@ -1703,30 +1595,6 @@ Extra - asset_id: collision_camera_013
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_energy/charclasses/weightactivatedplatform_energy.bmsad
   > Door to Main Hub Tower Middle
       Trivial
-
-> Tile Group (BOMB) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_005
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('BOMB',)
-  > Door to Main Hub Tower Middle
-      Trivial
-  > Tile Group (BOMB) 2
-      Morph Ball
-
-> Tile Group (BOMB) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_006
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('BOMB',)
-  > Pickup (Missile Tank)
-      Can Slide Underwater
-  > Tile Group (BOMB) 1
-      Gravity Suit and Morph Ball
 
 ----------------
 Flash Shift Room
@@ -1796,6 +1664,12 @@ Extra - asset_id: collision_camera_015
       After Burenia - Ghavoran Teleport Enky
   > Event - Destroy all Enkys
       Destroy Enky
+  > Upper Water Platform
+      All of the following:
+          After Burenia - Early Gravity Pickup 1 and After Burenia - Ghavoran Teleport Enky and Shinesink Clip (Intermediate) and Speedbooster Conservation (Advanced) and Can SSC
+          Any of the following:
+              # Cross Bomb - https://www.youtube.com/watch?v=1l7rJwAUSLE Power Bomb - https://www.youtube.com/watch?v=477-pmla1kU
+              Lay Cross Bomb or Lay Power Bomb
   > Event - Ghavoran Teleport Speed Blocks Destroyed
       Speed Booster and After Burenia - Early Gravity Pickup 1
 
@@ -1855,8 +1729,8 @@ Extra - asset_id: collision_camera_015
       Trivial
   > Teleporter to Ghavoran - Teleport to Burenia
       Trivial
-  > Tile Group (BOMB)
-      Trivial
+  > Top of Enky Shaft
+      Lay Bomb or Lay Power Bomb
 
 > Event - Ghavoran Teleport Blob, Adjacent; Heals? False
   * Layers: default
@@ -1878,24 +1752,12 @@ Extra - asset_id: collision_camera_015
   > Door to Gravity Suit Tower
       Trivial
 
-> Tile Group (BOMB); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_003
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('BOMB',)
-  > Door to Gravity Suit Tower
-      Trivial
-  > Top of Enky Shaft
-      Can Slide
-
 > Top of Enky Shaft; Heals? False
   * Layers: default
   > Door to Early Gravity Speedboost Room 1 (Upper)
       After Burenia - Ghavoran Teleport Enky
-  > Tile Group (BOMB)
-      Morph Ball
+  > Door to Gravity Suit Tower
+      Lay Bomb or Lay Power Bomb
   > Event - Destroy all Enkys
       Destroy Enky
 
@@ -2002,9 +1864,9 @@ Extra - asset_id: collision_camera_017
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  > Pickup (Missile Tank)
+      Screw Attack
   > Elevator to Artaria - Transport to Burenia
-      Trivial
-  > Tile Group (SCREWATTACK) 1
       Trivial
 
 > Pickup (Missile Tank); Heals? False
@@ -2012,8 +1874,8 @@ Extra - asset_id: collision_camera_017
   * Pickup 83; Major Location? False
   * Extra - actor_name: item_missiletank_003
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Tile Group (SCREWATTACK) 2
-      Trivial
+  > Door to Navigation Station South
+      Screw Attack
 
 > Elevator to Artaria - Transport to Burenia; Heals? False; Spawn Point
   * Layers: default
@@ -2025,30 +1887,6 @@ Extra - asset_id: collision_camera_017
   * Extra - start_point_actor_name: elevator_cave_000_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad
   > Door to Navigation Station South
-      Trivial
-
-> Tile Group (SCREWATTACK) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_001
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SCREWATTACK',)
-  > Door to Navigation Station South
-      Trivial
-  > Tile Group (SCREWATTACK) 2
-      Trivial
-
-> Tile Group (SCREWATTACK) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_040
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SCREWATTACK',)
-  > Pickup (Missile Tank)
-      Trivial
-  > Tile Group (SCREWATTACK) 1
       Trivial
 
 ----------------
@@ -2080,7 +1918,7 @@ Extra - asset_id: collision_camera_018
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   * Extra - excluded_dock_weaknesses: ('Grapple Beam Door',)
-  > Tile Group (POWERBEAM) 2
+  > Above Water
       Can Slide
 
 > Pickup (Energy Part); Heals? False
@@ -2096,12 +1934,11 @@ Extra - asset_id: collision_camera_018
   * Pickup 87; Major Location? True
   * Extra - actor_name: item_missiletankplus_002
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
-  > Tile Group (POWERBEAM) 1
+  > Next to Exit Tunnel
       Trivial
 
-> Tile Group (POWERBEAM) 1; Heals? False
+> Next to Exit Tunnel; Heals? False
   * Layers: default
-  * Configurable Node
   * Extra - actor_name: breakabletilegroup_014
   * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
   * Extra - actor_layer: breakables
@@ -2113,13 +1950,8 @@ Extra - asset_id: collision_camera_018
   > Tunnel to Gravity Suit Tower
       Morph Ball
 
-> Tile Group (POWERBEAM) 2; Heals? False
+> Above Water; Heals? False
   * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_016
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
   > Door to Teleport to Ghavoran (Lower)
       All of the following:
           Morph Ball
@@ -2133,7 +1965,7 @@ Extra - asset_id: collision_camera_018
 
 > Water Bottom; Heals? False
   * Layers: default
-  > Tile Group (POWERBEAM) 2
+  > Above Water
       Any of the following:
           Spider Magnet or Simple IBJ
           Grapple Beam and Grapple Movement (Beginner)
@@ -2143,7 +1975,7 @@ Extra - asset_id: collision_camera_018
 > Dock to Early Gravity Speedboost Room 2 (Upper); Heals? False
   * Layers: default
   * Open Passage to Early Gravity Speedboost Room 2/Dock to Early Gravity Speedboost Room 1 (Upper)
-  > Tile Group (POWERBEAM) 2
+  > Above Water
       Use Spin Boost
   > Water Bottom
       Trivial
@@ -2151,13 +1983,13 @@ Extra - asset_id: collision_camera_018
 > Dock to Early Gravity Speedboost Room 2 (Lower); Heals? False
   * Layers: default
   * Open Passage to Early Gravity Speedboost Room 2/Dock to Early Gravity Speedboost Room 1 (Lower)
-  > Tile Group (POWERBEAM) 1
+  > Next to Exit Tunnel
       After Burenia - Early Gravity Speed Blocks Destroyed
 
 > Tunnel to Gravity Suit Tower; Heals? False
   * Layers: default
   * Morph Ball Tunnel to Gravity Suit Tower/Tunnel to Early Gravity Speedboost Room 1
-  > Tile Group (POWERBEAM) 1
+  > Next to Exit Tunnel
       Morph Ball
 
 > Event - Early Gravity Pickup 1; Heals? False
@@ -2248,8 +2080,8 @@ Extra - asset_id: collision_camera_021
                   Any of the following:
                       Simple IBJ or Use Spin Boost
                       Speed Booster and Disabled Door Lock Randomizer
-  > Tile Group (POWERBOMB)
-      Trivial
+  > Door to Gravity Suit Room (Lower)
+      Lay Power Bomb
   > Breakable Floor
       All of the following:
           Gravity Suit and After Burenia - Destroy Gravity Suit Floor
@@ -2267,16 +2099,20 @@ Extra - asset_id: collision_camera_021
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Start Point 4
-      Trivial
-  > Tile Group (SCREWATTACK) 2
+  > Pickup (Missile+ Tank)
       Any of the following:
           Flash Shift or Simple IBJ or Use Spin Boost
           All of the following:
               Speed Booster
               Before Burenia - Destroy Gravity Suit Floor or Disabled Door Lock Randomizer
+  > Start Point 4
+      Trivial
   > Breakable Floor
-      After Burenia - Destroy Gravity Suit Floor
+      Any of the following:
+          After Burenia - Destroy Gravity Suit Floor
+          All of the following:
+              # https://youtu.be/-NZ2QPUxno0
+              Before Burenia - Destroy Gravity Suit Floor and Shinesink Clip (Advanced) and Can SSC
 
 > Dock to Ammo Recharge South (Lower); Heals? False
   * Layers: default
@@ -2297,15 +2133,17 @@ Extra - asset_id: collision_camera_021
   * Pickup 88; Major Location? True
   * Extra - actor_name: item_missiletankplus
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
-  > Tile Group (SCREWATTACK) 2
-      Trivial
+  > Door to Navigation Station South
+      Screw Attack
+  > Shaft Base
+      Screw Attack
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
   * Pickup 93; Major Location? False
   * Extra - actor_name: item_missiletank_004
   * Extra - actor_def: actordef:actors/items/item_missiletank/charclasses/item_missiletank.bmsad
-  > Tile Group (MISSILE)
+  > Door to Teleport to Ghavoran
       Trivial
 
 > Door to Gravity Suit Room (Lower); Heals? False
@@ -2317,6 +2155,8 @@ Extra - asset_id: collision_camera_021
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  > Door to Gravity Suit Room (Upper)
+      Lay Power Bomb
   > Dock to Ammo Recharge South (Lower)
       All of the following:
           Before Burenia - Destroy Gravity Suit Floor
@@ -2325,8 +2165,6 @@ Extra - asset_id: collision_camera_021
               All of the following:
                   Gravity Suit
                   Flash Shift or Simple IBJ
-  > Tile Group (POWERBOMB)
-      Trivial
 
 > Door to Teleport to Ghavoran; Heals? False
   * Layers: default
@@ -2337,9 +2175,9 @@ Extra - asset_id: collision_camera_021
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
+  > Pickup (Missile Tank)
+      Shoot Missile
   > Start Point 3
-      Trivial
-  > Tile Group (MISSILE)
       Trivial
 
 > Dock to Ammo Recharge South (Upper); Heals? False
@@ -2389,8 +2227,8 @@ Extra - asset_id: collision_camera_021
   * Event Burenia - Early Gravity Blob
   * Extra - actor_name: db_reg_aq_005
   * Extra - actor_def: actordef:actors/props/db_reg_aq_005/charclasses/db_reg_aq_005.bmsad
-  > Tile Group (WEIGHT)
-      Trivial
+  > Breakable Floor
+      Can Slide Underwater
 
 > Start Point 1; Heals? False
   * Layers: default
@@ -2430,100 +2268,11 @@ Extra - asset_id: collision_camera_021
   > Door to Navigation Station South
       Trivial
 
-> Tile Group (POWERBOMB); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_011
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBOMB',)
-  > Door to Gravity Suit Room (Upper)
-      Trivial
-  > Door to Gravity Suit Room (Lower)
-      Trivial
-
-> Tile Group (WEIGHT); Heals? False
-  * Layers: default
-  * Extra - actor_name: breakabletilegroup_015
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('WEIGHT',)
-  > Event - Early Gravity Blob
-      Lay Bomb or Shoot Beam
-  > Breakable Floor
-      Morph Ball and After Burenia - Early Gravity Blob
-
-> Tile Group (SCREWATTACK) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_019
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SCREWATTACK',)
-  > Door to Navigation Station South
-      Trivial
-  > Pickup (Missile+ Tank)
-      Trivial
-  > Tile Group (POWERBEAM) 1
-      Trivial
-  > Tile Group (POWERBEAM) 2
-      Trivial
-  > Tile Group (SCREWATTACK) 4
-      Trivial
-
-> Tile Group (POWERBEAM) 1; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_020
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-  > Tile Group (SCREWATTACK) 2
-      Trivial
-  > Shaft Base
-      Trivial
-
-> Tile Group (MISSILE); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_022
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('MISSILE',)
-  > Pickup (Missile Tank)
-      Trivial
-  > Door to Teleport to Ghavoran
-      Trivial
-
-> Tile Group (POWERBEAM) 2; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_041
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-  > Tile Group (SCREWATTACK) 2
-      Trivial
-  > Shaft Base
-      Trivial
-
-> Tile Group (SCREWATTACK) 4; Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_042
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('SCREWATTACK',)
-  > Tile Group (SCREWATTACK) 2
-      Trivial
-  > Shaft Base
-      Trivial
-
 > Tunnel to Early Gravity Speedboost Room 1; Heals? False
   * Layers: default
   * Morph Ball Tunnel to Early Gravity Speedboost Room 1/Tunnel to Gravity Suit Tower
-  > Tile Group (WEIGHT)
-      Trivial
+  > Event - Early Gravity Blob
+      Lay Bomb or Shoot Beam
 
 > Breakable Floor; Heals? False
   * Layers: default
@@ -2591,6 +2340,8 @@ Extra - asset_id: collision_camera_021
 
 > Shaft Base; Heals? False
   * Layers: default
+  > Pickup (Missile+ Tank)
+      Screw Attack
   > Start Point 2
       Any of the following:
           Space Jump
@@ -2599,12 +2350,6 @@ Extra - asset_id: collision_camera_021
           All of the following:
               Speed Booster and Speedbooster Conservation (Intermediate)
               Before Burenia - Destroy Gravity Suit Floor or Disabled Door Lock Randomizer
-  > Tile Group (POWERBEAM) 1
-      Trivial
-  > Tile Group (POWERBEAM) 2
-      Trivial
-  > Tile Group (SCREWATTACK) 4
-      Trivial
 
 > Event - Early Gravity Blob through Wall; Heals? False
   * Layers: default
@@ -2708,8 +2453,8 @@ the blast shield issue.
   * Pickup 85; Major Location? False
   * Extra - actor_name: item_powerbombtank_000
   * Extra - actor_def: actordef:actors/items/item_powerbombtank/charclasses/item_powerbombtank.bmsad
-  > Tile Group (POWERBOMB)
-      Morph Ball
+  > Tunnel to Gravity Suit Room Access (Lower)
+      Trivial
 
 > Door to Gravity Suit Tower (Lower); Heals? False
   * Layers: default
@@ -2751,21 +2496,10 @@ the blast shield issue.
 > Tunnel to Gravity Suit Room Access (Lower); Heals? False
   * Layers: default
   * Morph Ball Tunnel to Gravity Suit Room Access/Tunnel to Gravity Suit Room (Lower)
-  > Tile Group (POWERBOMB)
-      Morph Ball
+  > Pickup (Power Bomb Tank)
+      Gravity Suit and Ballspark and Lay Power Bomb
   > Event - Gravity Suit Blob, Below
       Shoot Diffusion or Wave
-
-> Tile Group (POWERBOMB); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_036
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - tile_types: ('POWERBOMB',)
-  > Pickup (Power Bomb Tank)
-      Gravity Suit and Ballspark
-  > Tunnel to Gravity Suit Room Access (Lower)
-      Morph Ball
 
 > Event - Gravity Suit Blob, Right; Heals? False
   * Layers: default
@@ -2827,7 +2561,7 @@ Extra - asset_id: collision_camera_025
                   Flash Shift or Space Jump
                   Grapple Beam or Spider Magnet
               Grapple Beam and Grapple Movement (Beginner) and Use Spin Boost
-  > Tile Group (POWERBEAM)
+  > Tunnel to Main Hub Tower Bottom
       Morph Ball
   > Event - Storm Missile Gate
       Activate Storm Missile Locks
@@ -2840,23 +2574,11 @@ Extra - asset_id: collision_camera_025
   > Door to Main Hub Tower Bottom
       After Burenia - Storm Missile Gate for Etank
 
-> Tile Group (POWERBEAM); Heals? False
-  * Layers: default
-  * Configurable Node
-  * Extra - actor_name: breakabletilegroup_009
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
-  > Door to Main Hub Tower Bottom
-      Morph Ball
-  > Tunnel to Main Hub Tower Bottom
-      Morph Ball
-
 > Tunnel to Main Hub Tower Bottom; Heals? False
   * Layers: default
   * Morph Ball Tunnel to Main Hub Tower Bottom/Tunnel to Storm Missile Gate Room
-  > Tile Group (POWERBEAM)
-      Morph Ball
+  > Door to Main Hub Tower Bottom
+      Can Slide Underwater
 
 > Event - Storm Missile Gate; Heals? False
   * Layers: default

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -123,7 +123,7 @@ Extra - asset_id: collision_camera_002
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Fan Platform - Above
+  > Fan Platform
       Can Slide
 
 > Door to Upper Burenia Hub; Heals? False
@@ -135,10 +135,10 @@ Extra - asset_id: collision_camera_002
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Fan Platform - Above
-      After Burenia - Dairon Hub Speed Blocks Destroyed
-  > Fan Platform - Below
-      Morph Ball and After Burenia - Dairon Hub Grapple Block
+  > Fan Platform
+      Any of the following:
+          After Burenia - Dairon Hub Speed Blocks Destroyed
+          Morph Ball and After Burenia - Dairon Hub Grapple Block
   > Raft - Top Water Level
       Can Slide Underwater
   > Event - Dairon Hub Speed Blocks Destroyed
@@ -195,7 +195,7 @@ Extra - asset_id: collision_camera_002
   * Pickup 90; Major Location? False
   * Extra - actor_name: item_energyfragment_000
   * Extra - actor_def: actordef:actors/items/item_energyfragment/charclasses/item_energyfragment.bmsad
-  > Fan Platform - Above
+  > Fan Platform
       Trivial
 
 > Event - Water Blob Right; Heals? False
@@ -204,7 +204,7 @@ Extra - asset_id: collision_camera_002
   * Extra - actor_name: db_reg_aq_001
   * Extra - actor_def: actordef:actors/props/db_reg_aq_001/charclasses/db_reg_aq_001.bmsad
   > Water Bottom
-      Lay Bomb
+      Trivial
 
 > Event - Water Blob Left, Adjacent; Heals? False
   * Layers: default
@@ -227,7 +227,7 @@ Extra - asset_id: collision_camera_002
   * Event Burenia - Dairon Hub Grapple Block
   * Extra - actor_name: grapplepulloff1x2_000
   * Extra - actor_def: actordef:actors/props/grapplepulloff1x2/charclasses/grapplepulloff1x2.bmsad
-  > Fan Platform - Below
+  > Fan Platform
       Trivial
 
 > Bottom-left Corner; Heals? False
@@ -241,7 +241,7 @@ Extra - asset_id: collision_camera_002
   > Water Bottom
       Can Slide Underwater
 
-> Fan Platform - Above; Heals? False
+> Fan Platform; Heals? False
   * Layers: default
   > Door to Upper Transport to Dairon
       All of the following:
@@ -251,7 +251,9 @@ Extra - asset_id: collision_camera_002
               Grapple Beam and Grapple Movement (Beginner)
               Walljump (Beginner) and Use Spin Boost
   > Door to Upper Burenia Hub
-      After Burenia - Dairon Hub Speed Blocks Destroyed
+      Any of the following:
+          After Burenia - Dairon Hub Speed Blocks Destroyed
+          Morph Ball and After Burenia - Dairon Hub Grapple Block
   > Pickup (Energy Part)
       Any of the following:
           Speed Booster
@@ -259,19 +261,12 @@ Extra - asset_id: collision_camera_002
               # A grounded bomb jump with cross bombs to get past the fan
               Infinite Bomb Jump (Beginner) and Lay Cross Bomb
           Flash Shift and Movement (Beginner)
-  > Fan Platform - Below
-      Trivial
-  > Event - Dairon Hub Speed Blocks Destroyed
-      Speed Booster
-
-> Fan Platform - Below; Heals? False
-  * Layers: default
-  > Door to Upper Burenia Hub
-      Morph Ball and After Burenia - Dairon Hub Grapple Block
   > Event - Dairon Hub Grapple Block
       Grapple Beam
   > Raft - Top Water Level
       Trivial
+  > Event - Dairon Hub Speed Blocks Destroyed
+      Speed Booster
 
 > Raft - Top Water Level; Heals? False
   * Layers: default
@@ -284,7 +279,7 @@ Extra - asset_id: collision_camera_002
               Stand on Frozen Enemy (Beginner) and Shoot Ice Missile
   > Door to Underwater Horseshoe
       After Burenia - Dairon Hub Water Blob Right or After Burenia - Dairon Hub Water Blob Left
-  > Fan Platform - Below
+  > Fan Platform
       Gravity Suit or After Burenia - Dairon Hub Water Blob Right or After Burenia - Dairon Hub Water Blob Left or Perform WBJ
   > Event - Transport Blob from Above
       Wave Beam
@@ -310,7 +305,7 @@ Extra - asset_id: collision_camera_002
                   Before Burenia - Dairon Hub Water Blob Right and Before Burenia - Dairon Hub Water Blob Left and Enabled Highly Dangerous Logic
                   Simple IBJ or Use Spin Boost
   > Event - Water Blob Right
-      Wave Beam or Lay Bomb
+      Wave Beam or Lay Bomb or Lay Power Bomb
   > Bottom-left Corner
       Can Slide Underwater
   > Event - Water Blob Left, Through Wall
@@ -335,7 +330,7 @@ Extra - asset_id: collision_camera_002
 > Event - Dairon Hub Speed Blocks Destroyed; Heals? False
   * Layers: default
   * Event Burenia - Dairon Hub Speed Blocks Destroyed
-  > Fan Platform - Above
+  > Fan Platform
       Trivial
 
 ----------------
@@ -990,9 +985,7 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
   * Extra - actor_name: item_energytank_000
   * Extra - actor_def: actordef:actors/items/item_energytank/charclasses/item_energytank.bmsad
   > Upper Left Magnet Wall
-      All of the following:
-          Morph Ball
-          Flash Shift or Use Spin Boost
+      Morph Ball
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -1339,7 +1332,7 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   > Inside Tunnel
       All of the following:
           # https://youtu.be/yb_tJYnFFIw
-          Gravity Suit and After Burenia - Storm Missile Gate for Etank and Aim Down Clip (Advanced) and Can SSC
+          Gravity Suit and Aim Down Clip (Advanced) and Disabled Door Lock Randomizer and Can SSC
 
 > Event - Main Hub Bottom Blob, Left; Heals? False
   * Layers: default
@@ -1379,13 +1372,13 @@ Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-
   * Open Passage to Gravity Suit Room Access/Dock to Main Hub Tower Bottom
   > Above Screw Attack Blocks
       All of the following:
-          Gravity Suit
+          Gravity Suit and Screw Attack
           Any of the following:
               Space Jump or Speed Booster or Simple IBJ
               Flash Shift and Walljump (Beginner) and Use Spin Boost
   > Inside Tunnel
       All of the following:
-          Gravity Suit
+          Gravity Suit and Morph Ball
           Space Jump or Speed Booster or Simple IBJ
 
 > Tunnel to Storm Missile Gate Room; Heals? False
@@ -1941,10 +1934,6 @@ Extra - asset_id: collision_camera_018
 
 > Next to Exit Tunnel; Heals? False
   * Layers: default
-  * Extra - actor_name: breakabletilegroup_014
-  * Extra - actor_def: actordef:actors/logic/breakabletilegroup/charclasses/breakabletilegroup.bmsad
-  * Extra - actor_layer: breakables
-  * Extra - tile_types: ('POWERBEAM',)
   > Pickup (Missile+ Tank)
       Trivial
   > Dock to Early Gravity Speedboost Room 2 (Lower)
@@ -2101,20 +2090,22 @@ Extra - asset_id: collision_camera_021
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Pickup (Missile+ Tank)
-      Any of the following:
-          Flash Shift or Simple IBJ or Use Spin Boost
-          All of the following:
-              Speed Booster
-              Before Burenia - Destroy Gravity Suit Floor or Disabled Door Lock Randomizer
   > Start Point 4
       Trivial
   > Breakable Floor
-      Any of the following:
-          After Burenia - Destroy Gravity Suit Floor
-          All of the following:
-              # https://youtu.be/-NZ2QPUxno0
-              Before Burenia - Destroy Gravity Suit Floor and Aim Down Clip (Advanced) and Can SSC
+      After Burenia - Destroy Gravity Suit Floor
+  > Blob Alcove
+      All of the following:
+          # https://youtu.be/-NZ2QPUxno0
+          Before Burenia - Destroy Gravity Suit Floor and Aim Down Clip (Expert) and Can SSC
+  > Next to Bottom Pickup
+      All of the following:
+          Screw Attack
+          Any of the following:
+              Flash Shift or Simple IBJ or Use Spin Boost
+              All of the following:
+                  Speed Booster
+                  Before Burenia - Destroy Gravity Suit Floor or Disabled Door Lock Randomizer
 
 > Dock to Ammo Recharge South (Lower); Heals? False
   * Layers: default
@@ -2135,10 +2126,8 @@ Extra - asset_id: collision_camera_021
   * Pickup 88; Major Location? True
   * Extra - actor_name: item_missiletankplus
   * Extra - actor_def: actordef:actors/items/item_missiletankplus/charclasses/item_missiletankplus.bmsad
-  > Door to Navigation Station South
-      Screw Attack
-  > Shaft Base
-      Screw Attack
+  > Next to Bottom Pickup
+      Trivial
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -2342,8 +2331,6 @@ Extra - asset_id: collision_camera_021
 
 > Shaft Base; Heals? False
   * Layers: default
-  > Pickup (Missile+ Tank)
-      Screw Attack
   > Start Point 2
       Any of the following:
           Space Jump
@@ -2352,6 +2339,8 @@ Extra - asset_id: collision_camera_021
           All of the following:
               Speed Booster and Speedbooster Conservation (Intermediate)
               Before Burenia - Destroy Gravity Suit Floor or Disabled Door Lock Randomizer
+  > Next to Bottom Pickup
+      Screw Attack
 
 > Event - Early Gravity Blob through Wall; Heals? False
   * Layers: default
@@ -2364,6 +2353,15 @@ Extra - asset_id: collision_camera_021
   * Event Burenia - Twin Robot Fight
   > Start Point 3
       Trivial
+
+> Next to Bottom Pickup; Heals? False
+  * Layers: default
+  > Door to Navigation Station South
+      Screw Attack
+  > Pickup (Missile+ Tank)
+      Trivial
+  > Shaft Base
+      Screw Attack
 
 ----------------
 Ammo Recharge South

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1101,7 +1101,12 @@
             },
             "SSC": {
                 "long_name": "Shinesink Clip",
-                "description": "Utilizing Speedbooster, Flash Shift, and Grapple Beam, it is possible to clip through 1 or 2-tile floors. Full trick description: https://dreadwiki.hijumpboots.com/en/tricks/clipping#shine-sink-clip",
+                "description": "Utilizing Speedbooster, Flash Shift, and Grapple Beam, it is possible to clip through 1-tile floors. Full trick description: https://dreadwiki.hijumpboots.com/en/tricks/clipping#shine-sink-clip",
+                "extra": {}
+            },
+            "ADC": {
+                "long_name": "Aim Down Clip",
+                "description": "A type of shine sink clip that allows you to clip through 2-tile thick floors.",
                 "extra": {}
             },
             "Suitless": {

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1101,7 +1101,7 @@
             },
             "SSC": {
                 "long_name": "Shinesink Clip",
-                "description": "Shinesparking and firing the grapple beam in certain locations allows you to clip through 1-tile thick floors.",
+                "description": "Utilizing Speedbooster, Flash Shift, and Grapple Beam, it is possible to clip through 1 or 2-tile floors. Full trick description: https://dreadwiki.hijumpboots.com/en/tricks/clipping#shine-sink-clip",
                 "extra": {}
             },
             "Suitless": {
@@ -1146,14 +1146,14 @@
                 "description": "Flash Shift can be manipulated to allow you to charge Speed Booster in a smaller area than intended.",
                 "extra": {}
             },
-            "ADC": {
-                "long_name": "Aim Down Clip",
-                "description": "A type of shine sink clip that allows you to clip through 2-tile thick floors.",
-                "extra": {}
-            },
             "DiffusionAbuse": {
                 "long_name": "Diffusion Abuse",
                 "description": "Using Diffusion Beam in certain situations can bypass the usual requirements for some objects. https://youtu.be/p9XJHW10QC8",
+                "extra": {}
+            },
+            "FlashSkip": {
+                "long_name": "Flash Shift Skip",
+                "description": "With certain items or movement techniques, the Shutter Platforms can be bypassed without the use of Flash Shift.",
                 "extra": {}
             }
         },
@@ -4943,7 +4943,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Knowledge",
+                                                        "name": "FlashSkip",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -4951,6 +4951,27 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Lay Cross Bomb"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "FlashSkip",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Bomb"
                                                 }
                                             ]
                                         }

--- a/randovania/games/dread/json_data/header.txt
+++ b/randovania/games/dread/json_data/header.txt
@@ -472,7 +472,8 @@ Dock Weaknesses
       Open:
           Any of the following:
               Flash Shift
-              Knowledge (Beginner) and Lay Cross Bomb
+              Flash Shift Skip (Beginner) and Lay Cross Bomb
+              Flash Shift Skip (Intermediate) and Lay Bomb
       No lock
 
 


### PR DESCRIPTION
- Added: New trick "Flash Shift Skip" to account for skipping Flash Shift gates.
- Added: Flash Shift Skip (Intermediate) with Bombs to skip the Flash Shift gate in Teleport to Ferenia.
- Added: Shine Sink Clips (Intermediate/Advanced) to go to and from Storm Missile Gate Room without Morph Ball.
- Added: Shine Sink Clip (Intermediate) and Speedbooster Conservation (Advanced) to reach the bottom of Teleport to Ghavoran from the top level.
- Added: Shine Sink Clip (Advanced) to reach the blobs in Gravity Suit Tower from the top level.
- Changed: Shine Sink Clip in Main Hub Tower Middle to Main Hub Tower Bottom is now Intermediate (from Expert).
- Fixed: Collecting the Power Bomb Tank in Gravity Suit Room now properly requires Speed Booster and Gravity Suit.
- Removed all block nodes from Burenia.