### PR TITLE
Add Death Counter cosmetic option

### DIFF
--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -279,7 +279,12 @@ class DreadPatchDataFactory(BasePatchDataFactory):
                     "bShowEnemyDamage": c.show_enemy_damage,
                     "bShowPlayerDamage": c.show_player_damage
                 }
-            }
+            },
+            "lua": {
+                "custom_init": {
+                    "enable_death_counter": c.show_death_counter
+                },
+            },
         }
 
     def _door_patches(self):

--- a/randovania/games/dread/gui/dialog/dread_cosmetic_patches_dialog.py
+++ b/randovania/games/dread/gui/dialog/dread_cosmetic_patches_dialog.py
@@ -25,12 +25,14 @@ class DreadCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_DreadCosmeticPatc
         self.show_enemy_life.stateChanged.connect(self._persist_option_then_notify("show_enemy_life"))
         self.show_enemy_damage.stateChanged.connect(self._persist_option_then_notify("show_enemy_damage"))
         self.show_player_damage.stateChanged.connect(self._persist_option_then_notify("show_player_damage"))
+        self.show_death_counter.stateChanged.connect(self._persist_option_then_notify("show_death_counter"))
 
     def on_new_cosmetic_patches(self, patches: DreadCosmeticPatches):
         self.show_boss_life.setChecked(patches.show_boss_lifebar)
         self.show_enemy_life.setChecked(patches.show_enemy_life)
         self.show_enemy_damage.setChecked(patches.show_enemy_damage)
         self.show_player_damage.setChecked(patches.show_player_damage)
+        self.show_death_counter.setChecked(patches.show_death_counter)
 
     def _persist_option_then_notify(self, attribute_name: str):
         def persist(value: int):

--- a/randovania/games/dread/layout/dread_cosmetic_patches.py
+++ b/randovania/games/dread/layout/dread_cosmetic_patches.py
@@ -10,6 +10,7 @@ class DreadCosmeticPatches(BaseCosmeticPatches):
     show_enemy_life: bool = False
     show_enemy_damage: bool = False
     show_player_damage: bool = False
+    show_death_counter: bool = False
 
     @classmethod
     def default(cls) -> "DreadCosmeticPatches":

--- a/randovania/gui/ui_files/dread_cosmetic_patches_dialog.ui
+++ b/randovania/gui/ui_files/dread_cosmetic_patches_dialog.ui
@@ -84,6 +84,13 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="show_death_counter">
+            <property name="text">
+             <string>Show player death count in HUD</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/randovania/gui/ui_files/dread_cosmetic_patches_dialog.ui
+++ b/randovania/gui/ui_files/dread_cosmetic_patches_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>424</width>
-    <height>228</height>
+    <height>260</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/test/test_files/dread_expected_data.json
+++ b/test/test_files/dread_expected_data.json
@@ -3844,6 +3844,11 @@
                 "bShowEnemyDamage": false,
                 "bShowPlayerDamage": false
             }
+        },
+        "lua": {
+            "custom_init": {
+                "enable_death_counter": false
+            }
         }
     },
     "energy_per_tank": 100,


### PR DESCRIPTION
This adds the cosmetic option for randovania/open-dread-rando#186.

![image](https://user-images.githubusercontent.com/816612/216481349-8ad77176-9deb-4aec-98dd-82f0f901c30e.png)

When enabled:
![image](https://user-images.githubusercontent.com/816612/216481294-97589b93-8b6c-4e28-bb23-3530920a8e38.png)
