### PR TITLE
flatpak: Add metainfo XML, needed for submission

### DIFF
--- a/tools/flatpak/io.github.randovania.Randovania.metainfo.xml
+++ b/tools/flatpak/io.github.randovania.Randovania.metainfo.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.randovania.Randovania</id>
+  <name>Randovania</name>
+  <summary>A randomizer platform for a multitude of games</summary>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+  <content_rating type="oars-1.0">
+    <content_attribute id="social-chat">moderate</content_attribute>
+  </content_rating>
+  <description>
+    <p>
+      Randovania is a program for randomizing multiple aspects of several games, making a fresh experience out of the familiar.
+    </p>
+    <p>
+      Depending on the game, users can randomize where items appear, how areas connect to each other, and more. And after things are changed, Randovania checks each randomized game to make sure it&apos;s beatable. Experienced players can also turn up the difficulty by making glitches and unintended tricks potentially required to win. (Randovania will not expect players to use glitches to win otherwise.)
+    </p>
+  </description>
+  <launchable type="desktop-id">io.github.randovania.Randovania.desktop</launchable>
+  <url type="homepage">https://randovania.github.io/</url>
+  <url type="donation">https://opencollective.com/randovania</url>
+  <url type="bugtracker">https://github.com/randovania/randovania/issues</url>
+  <url type="help">https://github.com/randovania/randovania#documentation</url>
+  <url type="contribute">https://github.com/randovania/randovania/blob/main/CONTRIBUTING.md</url>
+</component>

--- a/tools/flatpak/io.github.randovania.Randovania.yml
+++ b/tools/flatpak/io.github.randovania.Randovania.yml
@@ -24,13 +24,23 @@ modules:
       - mv /app/share/randovania/xdg_assets/io.github.randovania.Randovania.desktop /app/share/applications/io.github.randovania.Randovania.desktop
       - desktop-file-edit /app/share/applications/io.github.randovania.Randovania.desktop --set-key=Exec --set-value=/app/bin/randovania
       - rmdir /app/share/randovania/xdg_assets
-      - echo '#!/bin/sh' > randovania
-      - echo 'exec /app/share/randovania $@' >> randovania
-      - install -Dm 755 randovania /app/bin/randovania
+      - install -Dm 644 io.github.randovania.Randovania.metainfo.xml /app/share/appdata/io.github.randovania.Randovania.metainfo.xml
+      - install -Dm 755 randovania-wrapper /app/bin/randovania
     sources:
       - type: archive
         archive-type: tar-gzip
         path: randovania-linux.tar.gz
+      - type: file
+        path: io.github.randovania.Randovania.metainfo.xml
+      - type: script
+        commands:
+          - |
+            for i in {0..9}; do
+              test -S $XDG_RUNTIME_DIR/discord-ipc-$i ||
+                ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
+            done
+            exec /app/share/randovania/randovania "$@"
+        dest-filename: randovania-wrapper
 
   - name: mono6
     buildsystem: simple


### PR DESCRIPTION
This adds the final _required_ piece of the puzzle for RDV on Flathub. Notably absent is screenshots, which can be added to the flathub repo after it's accepted.

With this file, in addition to the application working, there's now also information that app stores can use when browsing:

![Screenshot from 2023-02-11 13-57-50](https://user-images.githubusercontent.com/1396814/218276257-46c9afac-86f9-4d13-882e-8b61a2169723.png)
![Screenshot from 2023-02-11 13-58-00](https://user-images.githubusercontent.com/1396814/218276259-3609508b-8e27-4e14-826d-21f04db062e2.png)

As a bonus, I found a less horrifying way to do the wrapper script, so that's in here too.