### PR TITLE
Fix error when selecting / deselecting Credits in Elevator tab

### DIFF
--- a/randovania/gui/lib/node_list_helper.py
+++ b/randovania/gui/lib/node_list_helper.py
@@ -6,6 +6,7 @@ from PySide6 import QtWidgets, QtCore
 from randovania.game_description.game_description import GameDescription
 from randovania.game_description.world.area import Area
 from randovania.game_description.world.area_identifier import AreaIdentifier
+from randovania.game_description.world.node import Node
 from randovania.game_description.world.node_identifier import NodeIdentifier
 from randovania.game_description.world.world import World
 from randovania.patching.prime import elevators
@@ -21,14 +22,14 @@ class NodeListHelper:
     during_batch_check_update: bool
 
     def nodes_by_areas_by_world_from_locations(self, all_node_locations: list[NodeIdentifier]
-                                      ) -> tuple[list[World], dict[str, list[Area]], dict[str, list[str]]]:
+                                      ) -> tuple[list[World], dict[str, list[Area]], dict[AreaIdentifier, list[Node]]]:
         world_list = self.game_description.world_list
         worlds = []
         areas_by_world = {}
         nodes_by_area = {}
 
         for identifier in all_node_locations:
-            world, area = world_list.world_and_area_by_area_identifier(identifier)
+            world, area = world_list.world_and_area_by_area_identifier(identifier.area_identifier)
 
             if world.name not in areas_by_world:
                 worlds.append(world)
@@ -36,26 +37,29 @@ class NodeListHelper:
 
             if area not in areas_by_world[world.name]:
                 areas_by_world[world.name].append(area)
-                for starting_node in area.get_start_nodes():
-                    if area.name not in nodes_by_area:
-                        nodes_by_area[area.name] = []
-                    nodes_by_area[area.name].append(starting_node.name)
+                if identifier.area_identifier not in nodes_by_area:
+                    nodes_by_area[identifier.area_identifier] = []
+                nodes_by_area[identifier.area_identifier].append(area.node_with_name(identifier.node_name))
 
         return worlds, areas_by_world, nodes_by_area
 
     def create_node_list_selection(
             self,
             parent: QtWidgets.QWidget, layout: QtWidgets.QGridLayout,
-            all_area_locations: list[AreaIdentifier],
-            on_check: Callable[[list[AreaIdentifier], bool], None],
-    ) -> tuple[dict[str, QtWidgets.QCheckBox], dict[AreaIdentifier, QtWidgets.QCheckBox]]:
+            all_node_locations: list[NodeIdentifier],
+            on_check: Callable[[list[NodeIdentifier], bool], None],
+    ) -> tuple[
+            dict[str, QtWidgets.QCheckBox],
+            dict[AreaIdentifier, QtWidgets.QCheckBox],
+            dict[NodeIdentifier, QtWidgets.QCheckBox]
+         ]:
         """"""
         world_to_group: dict[str, QtWidgets.QGroupBox] = {}
         checks_for_world = {}
         checks_for_area: dict[AreaIdentifier, QtWidgets.QCheckBox] = {}
         checks_for_node: dict[NodeIdentifier, QtWidgets.QCheckBox] = {}
 
-        worlds, areas_by_world, nodes_by_area = self.nodes_by_areas_by_world_from_locations(all_area_locations)
+        worlds, areas_by_world, nodes_by_area = self.nodes_by_areas_by_world_from_locations(all_node_locations)
         worlds.sort(key=lambda it: it.name)
     
         def _on_check_node(c: QtWidgets.QCheckBox, _):
@@ -64,11 +68,11 @@ class NodeListHelper:
 
         def _on_check_area(c: QtWidgets.QCheckBox, _):
             if not self.during_batch_check_update:
-                area_name = c.area_location.area_name
+                area_identifier = c.area_location
                 new_node_list = [
                     identifier
-                    for node in nodes_by_area[area_name]
-                    if (identifier := NodeIdentifier(c.area_location, node)) in checks_for_node
+                    for node in nodes_by_area[area_identifier]
+                    if (identifier := node.identifier) in checks_for_node
                 ]
 
                 on_check(new_node_list, c.isChecked())
@@ -80,8 +84,8 @@ class NodeListHelper:
                 new_node_list = [
                     identifier
                     for area in areas if c.is_dark_world == area.in_dark_aether
-                    for node in nodes_by_area[area.name]
-                    if (identifier := NodeIdentifier(world_list.identifier_for_area(area), node)) in checks_for_node
+                    for node in nodes_by_area[world_list.identifier_for_area(area)]
+                    if (identifier := node.identifier) in checks_for_node
                 ]
 
                 on_check(new_node_list, c.isChecked())
@@ -124,14 +128,13 @@ class NodeListHelper:
                 group_box.vertical_layout.addWidget(area_check)
                 checks_for_area[area_check.area_location] = area_check
 
-                area_start_nodes = area.get_start_nodes()
-                for node in area_start_nodes:
+                for node in nodes_by_area[area_check.area_location]:
                     node_check = QtWidgets.QCheckBox(group_box)
                     node_check.setText(f"    {node.name}")
-                    node_check.node_location = NodeIdentifier(area_check.area_location, node.name)
+                    node_check.node_location = node.identifier
                     node_check.stateChanged.connect(functools.partial(_on_check_node, node_check))
                     group_box.vertical_layout.addWidget(node_check)
-                    if len(area_start_nodes) == 1:
+                    if len(nodes_by_area[area_check.area_location]) == 1:
                         node_check.setVisible(False)
                     checks_for_node[node_check.node_location] = node_check
 
@@ -159,10 +162,12 @@ class NodeListHelper:
                     area_identifier = self.game_description.world_list.identifier_for_area(area)
                     all_nodes = True
                     no_nodes = True
-                    starting_locations_for_area = area.get_start_nodes()
+                    starting_locations_for_area = [
+                        k for k, v in location_for_nodes.items()
+                        if k.area_identifier == area_identifier
+                    ]
                     if len(starting_locations_for_area) != 0:
-                        for node in starting_locations_for_area:
-                            node_identifier = NodeIdentifier(area_identifier, node.name)
+                        for node_identifier in starting_locations_for_area:
                             if node_identifier in location_for_nodes:
                                 is_checked = node_identifier in nodes_to_check
                                 if invert_check:

--- a/randovania/gui/preset_settings/elevators_tab.py
+++ b/randovania/gui/preset_settings/elevators_tab.py
@@ -49,7 +49,7 @@ class PresetElevators(PresetTab, Ui_PresetElevators, NodeListHelper):
         result = self.create_node_list_selection(
             self.elevators_target_group,
             self.elevators_target_layout,
-            TeleporterTargetList.areas_list(self.game_enum),
+            TeleporterTargetList.nodes_list(self.game_enum),
             self._on_elevator_target_check_changed,
         )
         self._elevator_target_for_world, self._elevator_target_for_area, self._elevator_target_for_node = result
@@ -111,8 +111,8 @@ class PresetElevators(PresetTab, Ui_PresetElevators, NodeListHelper):
                 "Sanctuary Fortress": 3,  # Sanctuary Fortress
                 "Temple Grounds": 5,  # Temple Grounds
             }
-        locations = TeleporterList.areas_list(self.game_enum)
-        areas: dict[NodeIdentifier, Area] = {
+        locations = TeleporterList.nodes_list(self.game_enum)
+        node_identifiers: dict[NodeIdentifier, Area] = {
             loc: world_list.area_by_area_location(loc.area_location)
             for loc in locations
         }
@@ -132,7 +132,7 @@ class PresetElevators(PresetTab, Ui_PresetElevators, NodeListHelper):
 
             other_locations = [
                 node.default_connection
-                for node in areas[location].nodes
+                for node in node_identifiers[location].nodes
                 if isinstance(node, TeleporterNode) and world_list.identifier_for_node(node) == location
             ]
             assert len(other_locations) == 1

--- a/randovania/gui/preset_settings/starting_area_tab.py
+++ b/randovania/gui/preset_settings/starting_area_tab.py
@@ -31,7 +31,7 @@ class PresetStartingArea(PresetTab, Ui_PresetStartingArea, NodeListHelper):
 
         (self._starting_location_for_world,
          self._starting_location_for_area,
-         self._starting_location_for_start_node) = self.create_node_list_selection(
+         self._starting_location_for_node) = self.create_node_list_selection(
             self.starting_locations_contents,
             self.starting_locations_layout,
             StartingLocationList.nodes_list(self.game_description.game),
@@ -97,7 +97,7 @@ class PresetStartingArea(PresetTab, Ui_PresetStartingArea, NodeListHelper):
             False,
             self._starting_location_for_world,
             self._starting_location_for_area,
-            self._starting_location_for_start_node
+            self._starting_location_for_node
         )
 
 

--- a/randovania/layout/lib/teleporters.py
+++ b/randovania/layout/lib/teleporters.py
@@ -6,6 +6,7 @@ from randovania.bitpacking.json_dataclass import JsonDataclass
 from randovania.bitpacking.type_enforcement import DataclassPostInitTypeCheck
 from randovania.game_description import default_database
 from randovania.game_description.world.area import Area
+from randovania.game_description.world.node import Node
 from randovania.game_description.world.area_identifier import AreaIdentifier
 from randovania.game_description.world.node_identifier import NodeIdentifier
 from randovania.game_description.world.teleporter_node import TeleporterNode
@@ -49,17 +50,17 @@ def _has_editable_teleporter(area: Area) -> bool:
 
 class TeleporterList(location_list.LocationList):
     @classmethod
-    def areas_list(cls, game: RandovaniaGame) -> list[NodeIdentifier]:
+    def nodes_list(cls, game: RandovaniaGame) -> list[NodeIdentifier]:
         world_list = default_database.game_description_for(game).world_list
-        areas = [
+        nodes = [
             world_list.identifier_for_node(node)
             for world in world_list.worlds
             for area in world.areas
             for node in area.nodes
             if isinstance(node, TeleporterNode) and node.editable
         ]
-        areas.sort()
-        return areas
+        nodes.sort()
+        return nodes
 
     @classmethod
     def element_type(cls):
@@ -72,18 +73,23 @@ class TeleporterList(location_list.LocationList):
         return super().ensure_has_locations(area_locations, enabled)
 
 
-def _valid_teleporter_target(area: Area, game: RandovaniaGame):
-    if game in (RandovaniaGame.METROID_PRIME, RandovaniaGame.METROID_PRIME_ECHOES) and area.name == "Credits":
+def _valid_teleporter_target(area: Area, node: Node, game: RandovaniaGame):
+    if (game in (RandovaniaGame.METROID_PRIME, RandovaniaGame.METROID_PRIME_ECHOES) and 
+            area.name == "Credits" and node.name == area.default_node):
         return True
 
     has_save_station = any(node.name == "Save Station" for node in area.nodes)
-    return area.has_start_node() and area.default_node is not None and not has_save_station
+    return (area.has_start_node() and area.default_node is not None and 
+        area.default_node == node.name and not has_save_station)
 
 
 class TeleporterTargetList(location_list.LocationList):
     @classmethod
-    def areas_list(cls, game: RandovaniaGame):
-        return location_list.area_locations_with_filter(game, lambda area: _valid_teleporter_target(area, game))
+    def nodes_list(cls, game: RandovaniaGame):
+        return location_list.node_and_area_with_filter(
+            game,
+            lambda area, node: _valid_teleporter_target(area, node, game)
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -112,7 +118,7 @@ class TeleporterConfiguration(BitPackDataclass, JsonDataclass, DataclassPostInit
 
     @property
     def editable_teleporters(self) -> list[NodeIdentifier]:
-        return [teleporter for teleporter in self.excluded_teleporters.areas_list(self.game)
+        return [teleporter for teleporter in self.excluded_teleporters.nodes_list(self.game)
                 if teleporter not in self.excluded_teleporters.locations]
 
     @property
@@ -135,7 +141,7 @@ class TeleporterConfiguration(BitPackDataclass, JsonDataclass, DataclassPostInit
     @property
     def valid_targets(self) -> list[AreaIdentifier]:
         if self.mode == TeleporterShuffleMode.ONE_WAY_ANYTHING:
-            return [location for location in self.excluded_targets.areas_list(self.game)
+            return [location.area_identifier for location in self.excluded_targets.nodes_list(self.game)
                     if location not in self.excluded_targets.locations]
 
         elif self.mode in {TeleporterShuffleMode.ONE_WAY_ELEVATOR, TeleporterShuffleMode.ONE_WAY_ELEVATOR_REPLACEMENT}:

--- a/test/gui/preset_settings/test_preset_elevator.py
+++ b/test/gui/preset_settings/test_preset_elevator.py
@@ -1,14 +1,17 @@
 import dataclasses
 import uuid
 from unittest.mock import MagicMock
+from PySide6 import QtCore
 
 import pytest
 
 from randovania.game_description import default_database
+from randovania.game_description.world.area_identifier import AreaIdentifier
 from randovania.games.game import RandovaniaGame
+from randovania.games.prime1.layout import prime_configuration
 from randovania.gui.preset_settings.elevators_tab import PresetElevators
 from randovania.interface_common.preset_editor import PresetEditor
-from randovania.layout.lib.teleporters import TeleporterTargetList
+from randovania.layout.lib.teleporters import TeleporterShuffleMode, TeleporterTargetList
 
 
 @pytest.mark.parametrize("game", [RandovaniaGame.METROID_PRIME, RandovaniaGame.METROID_PRIME_ECHOES,
@@ -24,6 +27,32 @@ def test_on_preset_changed(skip_qtbot, preset_manager, game):
     window.on_preset_changed(editor.create_custom_preset_with())
 
     # Assert
-    num_areas = len(TeleporterTargetList.areas_list(preset.game))
+    num_areas = len(TeleporterTargetList.nodes_list(preset.game))
     assert len(window._elevator_target_for_area) == num_areas
     assert "Elevators"
+
+def test_check_credits(skip_qtbot, preset_manager):
+    # Setup
+    game = RandovaniaGame.METROID_PRIME
+    base = preset_manager.default_preset_for_game(game).get_preset()
+    assert isinstance(base.configuration, prime_configuration.PrimeConfiguration)
+    preset = dataclasses.replace(
+        base,
+        uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'),
+        configuration=dataclasses.replace(
+            base.configuration,
+            elevators=dataclasses.replace(
+                base.configuration.elevators,
+                mode=TeleporterShuffleMode.ONE_WAY_ANYTHING,
+            ),
+        )
+    )
+    editor = PresetEditor(preset)
+    window = PresetElevators(editor, default_database.game_description_for(preset.game), MagicMock())
+    window.on_preset_changed(editor.create_custom_preset_with())
+
+    # Run
+    skip_qtbot.mouseClick(
+        window._elevator_target_for_area[AreaIdentifier("End of Game", "Credits")],
+        QtCore.Qt.MouseButton.LeftButton,
+    )

--- a/test/gui/preset_settings/test_starting_area.py
+++ b/test/gui/preset_settings/test_starting_area.py
@@ -11,6 +11,7 @@ from randovania.game_description.world.area_identifier import AreaIdentifier
 from randovania.game_description.world.node_identifier import NodeIdentifier
 from randovania.games.cave_story.gui.preset_settings.cs_starting_area_tab import PresetCSStartingArea
 from randovania.games.game import RandovaniaGame
+from randovania.games.prime1.layout import prime_configuration
 from randovania.gui.preset_settings.starting_area_tab import PresetMetroidStartingArea, PresetStartingArea
 from randovania.interface_common.preset_editor import PresetEditor
 from randovania.layout.base.base_configuration import StartingLocationList
@@ -93,3 +94,16 @@ def test_quick_fill_cs_classic(skip_qtbot, preset_manager):
         NodeIdentifier.create("Labyrinth", "Camp", "Room Spawn")
     }
     assert set(editor.configuration.starting_location.locations) == expected
+
+def test_check_credits(skip_qtbot, preset_manager):
+    # Setup
+    base = preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME).get_preset()
+    preset = dataclasses.replace(base, uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'))
+    editor = PresetEditor(preset)
+    window = PresetMetroidStartingArea(editor, default_database.game_description_for(preset.game), MagicMock())
+    skip_qtbot.addWidget(window)
+
+    not_expected = NodeIdentifier.create("End of Game", "Credits", "Event - Credits")
+
+    checkbox_list = window._starting_location_for_node
+    assert checkbox_list.get(not_expected, None) == None

--- a/test/layout/test_teleporters.py
+++ b/test/layout/test_teleporters.py
@@ -39,7 +39,7 @@ def _a(world, area, instance_id=None):
         _m(b'\x08', 5),
         _m(b'\x18', 5, skip_final_bosses=True),
         _m(b'\xb1', 8, mode="one-way-elevator"),
-        _m(b'\xb8\x00\xc6,@', 34, mode="one-way-elevator", excluded_teleporters=[
+        _m(b'\xb81d', 22, mode="one-way-elevator", excluded_teleporters=[
             _a("Temple Grounds", "Temple Transport C", "Elevator to Great Temple - Temple Transport C")
         ]),
     ],


### PR DESCRIPTION
Fix for the regression from discord channel.
Summary:
Elevators can be shuffled to use any starting location. There is one corner case: You can activate a warp to the credits for MP1 and MP2. These areas in MP1 and MP2 have a `default_node` which is not a `valid_starting_location`. This means the logic doesn't find this node when builidng the internal nodes list and crashes when try to mark them as selected.
Setting `valid_starting_location` to true for these nodes is wrong because it will appear selectable in `Starting area` tab.

In the call to `nodes_by_areas_by_world_from_locations` the area is not present for `Starting area`.
In the call to `nodes_by_areas_by_world_from_locations` the area is present for `Elevators`.

I just added the check for the special case. I don't like the fact that it needs to be checked at 3 places. Once for building the list, twice when checking if all start nodes are selected (basically for doing the tristate checkbox).

Maybe it's  better to mark them as `valid_starting_location` and just hide them on the `Starting area` tab?

While debugging I just realised that the types were wrong on some parameters and it was only working because `NodeIdentifier` can be used as `AreaIdentifier`  due to the same names for certain methods. 