### PR TITLE
Dread: Add Random Starting Locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet.
 
+### Metroid Dread
+
+- **Major** - Added: Random Starting Locations is now supported. This enables all Save Stations, Navigation Stations, and Map Stations as possible starting options.
+
+#### Logic Database
+
+- Added: Grapple Movement (Beginner) for going up the left side of Burenia - Main Hub Tower Middle.
+- Added: Movement (Intermediate) and Water Bomb Jump (Intermediate) for getting out of the water at the same spot.
+- Added: Grapple Movement (Beginner) for the Grapple only method of reaching the Missile Tank in Main Hub Tower Top.
+- Changed: Walljump from Flash Shift for reaching the left Dock to Main Hub Tower Top in Main Hub Tower Middle has been removed; it is now trickless.
+
 ## [5.6.1] - 2023-04-??
 
 - Nothing.
@@ -31,18 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
-- **Major** - Added: Random Starting Locations is now supported. This enables all Save Stations, Navigation Stations, and Map Stations as possible starting options.
-
 #### Logic Database
 
-- Added: Grapple Movement (Beginner) for going up the left side of Burenia - Main Hub Tower Middle.
-- Added: Movement (Intermediate) and Water Bomb Jump (Intermediate) for getting out of the water at the same spot.
-- Added: Grapple Movement (Beginner) for the Grapple only method of reaching the Missile Tank in Main Hub Tower Top.
 - Added: Use Flash Shift and Spin Boost with Walljump (Beginner) in Burenia Main Hub Tower Bottom to reach the tunnel.
 - Changed: The logic for Spin Boost Room in Ghavoran now requires either the template to fight the Chozo X or Highly Dangerous logic to climb out of the room.
 - Changed: Simplified various database connections.
 - Changed: All three kinds of Chozo X fights now consider Use Spin Boost a valid means of dodging. 
-- Changed: Walljump from Flash Shift for reaching the left Dock to Main Hub Tower Top in Main Hub Tower Middle has been removed; it is now trickless.
 - Fixed: Missile ammo requirement when fighting Chozo X with Storm Missile. The numbers were previously too high and the numbers with and without the combat trick were swapped.
 - Fixed: Resolve bug with fighting the Twin Robots fights, where to fight them using only missiles for damage always required both the expert level combat trick and the 153 missiles that are intended for trickless.
 - Fixed: Add missing fight requirement to fight the Chozo X in Elun when entering the arena from the left.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
+- **Major** - Added: Random Starting Locations is now supported. This enables all Save Stations, Navigation Stations, and Map Stations as possible starting options.
+
 #### Logic Database
 
+- Added: Grapple Movement (Beginner) for going up the left side of Burenia - Main Hub Tower Middle.
+- Added: Movement (Intermediate) and Water Bomb Jump (Intermediate) for getting out of the water at the same spot.
+- Added: Grapple Movement (Beginner) for the Grapple only method of reaching the Missile Tank in Main Hub Tower Top.
 - Changed: The logic for Spin Boost Room in Ghavoran now requires either the template to fight the Chozo X or Highly Dangerous logic to climb out of the room.
 - Changed: Simplified various database connections.
+- Removed: Walljump from Flash Shift for reaching the left Dock to Main Hub Tower Top in Main Hub Tower Middle; it is now trickless.
 
 ## [5.5.2] - 2023-??-??
 

--- a/randovania/games/dread/gui/preset_settings/__init__.py
+++ b/randovania/games/dread/gui/preset_settings/__init__.py
@@ -1,4 +1,3 @@
-import randovania
 from randovania.gui.lib.window_manager import WindowManager
 from randovania.interface_common.preset_editor import PresetEditor
 

--- a/randovania/games/dread/gui/preset_settings/__init__.py
+++ b/randovania/games/dread/gui/preset_settings/__init__.py
@@ -16,9 +16,7 @@ def dread_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
 
     return [
         PresetTrickLevel,
-        *([
-              PresetMetroidDreadStartingArea,
-          ] if window_manager.is_preview_mode and randovania.is_dev_version() else []),
+        PresetMetroidDreadStartingArea,
         PresetDockRando,
         PresetDreadGeneration,
         PresetLocationPool,

--- a/randovania/games/dread/gui/preset_settings/__init__.py
+++ b/randovania/games/dread/gui/preset_settings/__init__.py
@@ -4,7 +4,7 @@ from randovania.interface_common.preset_editor import PresetEditor
 
 def dread_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
     from randovania.gui.preset_settings.trick_level_tab import PresetTrickLevel
-    from randovania.gui.preset_settings.starting_area_tab import PresetMetroidDreadStartingArea
+    from randovania.gui.preset_settings.starting_area_tab import PresetMetroidStartingArea
     from randovania.gui.preset_settings.location_pool_tab import PresetLocationPool
     from randovania.games.dread.gui.preset_settings.dread_generation_tab import PresetDreadGeneration
     from randovania.games.dread.gui.preset_settings.dread_patches_tab import PresetDreadPatches
@@ -15,7 +15,7 @@ def dread_preset_tabs(editor: PresetEditor, window_manager: WindowManager):
 
     return [
         PresetTrickLevel,
-        PresetMetroidDreadStartingArea,
+        PresetMetroidStartingArea,
         PresetDockRando,
         PresetDreadGeneration,
         PresetLocationPool,

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -319,7 +319,7 @@
                         "start_point_actor_name": "SP_Checkpoint_AccessPoint_1B",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Navigation Station South": {
                             "type": "and",
@@ -809,7 +809,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to First Tutorial": {
                             "type": "and",
@@ -1044,7 +1044,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Charge Tutorial": {
                             "type": "and",
@@ -1714,7 +1714,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Proto EMMI Introduction (Lower)": {
                             "type": "and",
@@ -2412,7 +2412,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Save Station South": {
                             "type": "and",
@@ -2904,7 +2904,7 @@
                         "start_point_actor_name": "SP_Checkpoint_EmmyCave",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to White EMMI Arena": {
                             "type": "and",
@@ -3749,7 +3749,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Teleport to Dairon (Lower)": {
                             "type": "resource",
@@ -4285,7 +4285,7 @@
                         "start_point_actor_name": "teleport_baselab_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Dairon",
                         "area_name": "Teleport to Artaria"
@@ -4390,7 +4390,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to Arbitrary Enky Room (Upper)": {
                             "type": "and",
@@ -4414,7 +4414,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to White EMMI Introduction (Lower)": {
                             "type": "and",
@@ -4764,7 +4764,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Teleport to Dairon (Power)": {
                             "type": "and",
@@ -4847,6 +4847,13 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to EMMI Zone Exit Southwest (Upper)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Top Door": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6102,7 +6109,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to EMMI Zone Exit Southwest (Lower)": {
                             "type": "and",
@@ -6126,8 +6133,16 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
-                    "connections": {}
+                    "valid_starting_location": false,
+                    "connections": {
+                        "Door to EMMI Zone Exit Northwest": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -6979,7 +6994,7 @@
                         "start_point_actor_name": "LE_Platform_Teleport_FromMagma",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Cataris",
                         "area_name": "Teleport to Artaria (Red)"
@@ -8336,7 +8351,7 @@
                         "start_point_actor_name": "SP_Checkpoint_ChargeBeam",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Charge Beam Access": {
                             "type": "and",
@@ -9020,7 +9035,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Wide Beam Block Room": {
                             "type": "and",
@@ -9630,7 +9645,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Melee Tutorial Room (Upper)": {
                             "type": "and",
@@ -10193,7 +10208,7 @@
                         "start_point_actor_name": "SP_Checkpoint_MagnetGlove",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Central Unit Access (Charge)": {
                             "type": "and",
@@ -11007,7 +11022,7 @@
                         "start_point_actor_name": "SP_Checkpoint_AccessPoint_2B",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Navigation Station North": {
                             "type": "and",
@@ -11534,7 +11549,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to David Jaffe Room": {
                             "type": "and",
@@ -11558,7 +11573,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to Invisible Corpius Room": {
                             "type": "and",
@@ -12381,7 +12396,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Save Station East": {
                             "type": "and",
@@ -14701,7 +14716,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Save Station North": {
                             "type": "and",
@@ -14866,7 +14881,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Grapple",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Grapple Beam Tutorial": {
                             "type": "resource",
@@ -14987,7 +15002,7 @@
                         "start_point_actor_name": "elevator_baselab_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Dairon",
                         "area_name": "Transport to Artaria"
@@ -15122,7 +15137,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Energy Recharge Station South": {
                             "type": "and",
@@ -15653,7 +15668,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to EMMI Zone Exit North": {
                             "type": "and",
@@ -15862,7 +15877,7 @@
                         "start_point_actor_name": "SP_Checkpoint_CentralUnit",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to White EMMI Arena (Top)": {
                             "type": "and",
@@ -16229,7 +16244,7 @@
                         "start_point_actor_name": "SP_Checkpoint_AccessPoint_002",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Navigation Station North": {
                             "type": "and",
@@ -16674,7 +16689,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to EMMI Zone Dome": {
                             "type": "and",
@@ -17006,7 +17021,7 @@
                         "start_point_actor_name": "PRP_CV_EnergyStation001_WeightPlate",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_energy/charclasses/weightactivatedplatform_energy.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to First Tutorial Access": {
                             "type": "and",
@@ -17872,7 +17887,7 @@
                             "type": "template",
                             "data": "Shoot Diffusion or Wave"
                         },
-                        "Start Point": {
+                        "Below Rotatable": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -17883,7 +17898,7 @@
                         }
                     }
                 },
-                "Start Point": {
+                "Below Rotatable": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -18189,7 +18204,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Save Station West": {
                             "type": "and",
@@ -19077,7 +19092,7 @@
                         "start_point_actor_name": "SP_Checkpoint_WaterValve",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Map Station": {
                             "type": "and",
@@ -19410,7 +19425,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to Energy Recharge Station South": {
                             "type": "and",
@@ -20743,7 +20758,7 @@
                         "start_point_actor_name": "SP_Checkpoint_ThermalDevice",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Path to Thermal Device (Lower)": {
                             "type": "and",
@@ -21785,7 +21800,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Navigation Station North (Upper)": {
                             "type": "or",
@@ -22248,7 +22263,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Teleport to Dairon (Middle)": {
                             "type": "and",
@@ -22389,7 +22404,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Scorpius",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to Phantom Cloak Tutorial": {
                             "type": "template",
@@ -22578,7 +22593,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Path to Corpius": {
                             "type": "and",
@@ -22942,7 +22957,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to Water Reservoir": {
                             "type": "and",
@@ -23233,7 +23248,7 @@
                         "start_point_actor_name": "LE_Platform_Elevator_FromMagma",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Cataris",
                         "area_name": "Transport to Artaria"
@@ -24212,7 +24227,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Transport to Cataris": {
                             "type": "and",
@@ -24346,7 +24361,7 @@
                         "start_point_actor_name": "elevator_aqua_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Burenia",
                         "area_name": "Transport to Artaria"
@@ -25192,7 +25207,7 @@
                         "start_point_actor_name": "SP_Checkpoint_ScrewAttack",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Pickup (Screw Attack)": {
                             "type": "and",
@@ -25265,7 +25280,7 @@
                         "start_point_actor_name": "teleporter_magma_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Cataris",
                         "area_name": "Teleport to Artaria (Blue)"
@@ -25961,7 +25976,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Start Point 2": {
                             "type": "and",
@@ -26408,7 +26423,7 @@
                         "start_point_actor_name": "SP_Checkpoint_ChozoWarriorCave",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Screw Attack Room (Power)": {
                             "type": "and",
@@ -26439,7 +26454,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Screw Attack Room (Grapple)": {
                             "type": "and",
@@ -26530,7 +26545,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to Speed Hallway": {
                             "type": "resource",
@@ -26716,7 +26731,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Screw Attack Room": {
                             "type": "and",
@@ -27111,7 +27126,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Cold Introduction": {
                             "type": "and",
@@ -27243,7 +27258,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to EMMI Zone Exit North": {
                             "type": "and",
@@ -27839,7 +27854,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Dead_ChozoWarriorX",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Freezer": {
                             "type": "or",

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -18609,7 +18609,7 @@
             }
         },
         "Map Station": {
-            "default_node": "Map Station",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": -14200.0,
@@ -18716,7 +18716,7 @@
                                 "items": []
                             }
                         },
-                        "Map Station": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -18725,7 +18725,7 @@
                         }
                     }
                 },
-                "Map Station": {
+                "Save Station": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -20083,7 +20083,7 @@
             }
         },
         "Navigation Station North": {
-            "default_node": "Navigation Room",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": 10800.0,
@@ -20143,7 +20143,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -20183,7 +20183,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -20223,7 +20223,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -20263,7 +20263,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -20272,7 +20272,7 @@
                         }
                     }
                 },
-                "Navigation Room": {
+                "Save Station": {
                     "node_type": "hint",
                     "heal": false,
                     "coordinates": {
@@ -20853,7 +20853,7 @@
             }
         },
         "Navigation Station South": {
-            "default_node": "Navigation Room",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": 6800.0,
@@ -20913,7 +20913,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -20953,7 +20953,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -20962,7 +20962,7 @@
                         }
                     }
                 },
-                "Navigation Room": {
+                "Save Station": {
                     "node_type": "hint",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -954,7 +954,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to First Tutorial": {
                             "type": "and",
@@ -1189,7 +1189,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Charge Tutorial": {
                             "type": "and",
@@ -2583,7 +2583,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Save Station South": {
                             "type": "and",
@@ -3953,7 +3953,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Teleport to Dairon (Lower)": {
                             "type": "resource",
@@ -4111,6 +4111,13 @@
                         "Door to EMMI First Chase End (Bottom)": {
                             "type": "template",
                             "data": "Can Slide"
+                        },
+                        "Lower Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -4262,6 +4269,13 @@
                             }
                         },
                         "Tile Group (BOMB MISSILE)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Before Slide": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4692,6 +4706,54 @@
                             }
                         }
                     }
+                },
+                "Before Slide": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 8450.0,
+                        "y": 3300.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": true,
+                    "connections": {
+                        "Dock to Arbitrary Enky Room (Upper)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Lower Room": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 6250.0,
+                        "y": 500.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": true,
+                    "connections": {
+                        "Door to White EMMI Introduction (Lower)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -5061,8 +5123,8 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 5472.096743195677,
-                        "y": 2260.3309619449965,
+                        "x": 3350.0,
+                        "y": 2600.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -5070,7 +5132,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Teleport to Dairon (Power)": {
                             "type": "and",
@@ -5084,7 +5146,7 @@
             }
         },
         "EMMI Zone Hub": {
-            "default_node": "Start Point",
+            "default_node": "Bottom Section",
             "extra": {
                 "total_boundings": {
                     "x1": -5200.0,
@@ -6395,12 +6457,12 @@
                         }
                     }
                 },
-                "Start Point": {
+                "Bottom Section": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": -4883.215130023641,
-                        "y": -2386.2152425982213,
+                        "x": -4883.22,
+                        "y": -2386.22,
                         "z": 0.0
                     },
                     "description": "",
@@ -6408,7 +6470,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to EMMI Zone Exit Southwest (Lower)": {
                             "type": "and",
@@ -6418,6 +6480,22 @@
                             }
                         }
                     }
+                },
+                "Top Door": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -4750.0,
+                        "y": 1900.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": true,
+                    "connections": {}
                 }
             }
         },
@@ -8155,7 +8233,7 @@
                         "start_point_actor_name": "PRP_CV_SaveStation003_WeightPlate",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Waterfall": {
                             "type": "and",
@@ -9508,7 +9586,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Wide Beam Block Room": {
                             "type": "and",
@@ -10153,7 +10231,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Melee Tutorial Room (Upper)": {
                             "type": "and",
@@ -11112,7 +11190,7 @@
                         "start_point_actor_name": "SP_Checkpoint_OpticalCamo",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Phantom Cloak Tutorial": {
                             "type": "resource",
@@ -11633,7 +11711,7 @@
             }
         },
         "Thermal Door Tutorial": {
-            "default_node": "Start Point",
+            "default_node": "Above Blobs",
             "extra": {
                 "total_boundings": {
                     "x1": 15800.0,
@@ -11943,6 +12021,13 @@
                                     }
                                 ]
                             }
+                        },
+                        "Below Blobs": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -12075,12 +12160,12 @@
                         }
                     }
                 },
-                "Start Point": {
+                "Above Blobs": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 16146.859169199595,
-                        "y": 3176.190476190476,
+                        "x": 16146.86,
+                        "y": 3176.19,
                         "z": 0.0
                     },
                     "description": "",
@@ -12088,9 +12173,33 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to David Jaffe Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Below Blobs": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 16400.0,
+                        "y": 2400.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": true,
+                    "connections": {
+                        "Dock to Invisible Corpius Room": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -12911,7 +13020,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Save Station East": {
                             "type": "and",
@@ -13052,7 +13161,7 @@
                         "start_point_actor_name": "PRP_CV_SaveStation002_WeightPlate",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Path to Thermal Device": {
                             "type": "and",
@@ -13408,7 +13517,7 @@
                         "start_point_actor_name": "SP_Checkpoint_ChainReaction",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Varia Suit Tutorial North": {
                             "type": "and",
@@ -14576,7 +14685,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Post_ChainReaction",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Tile Group (POWERBEAM)": {
                             "type": "and",
@@ -14956,7 +15065,7 @@
                         "start_point_actor_name": "SP_Checkpoint_VariaSuit",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Pickup (Varia Suit)": {
                             "type": "and",
@@ -15381,7 +15490,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Save Station North": {
                             "type": "and",
@@ -15667,7 +15776,7 @@
                         "start_point_actor_name": "elevator_baselab_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "destination": {
                         "world_name": "Dairon",
                         "area_name": "Transport to Artaria"
@@ -15802,7 +15911,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Energy Recharge Station South": {
                             "type": "and",
@@ -16447,7 +16556,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to EMMI Zone Exit North": {
                             "type": "and",
@@ -17468,7 +17577,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to EMMI Zone Dome": {
                             "type": "and",
@@ -17800,7 +17909,7 @@
                         "start_point_actor_name": "PRP_CV_EnergyStation001_WeightPlate",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_energy/charclasses/weightactivatedplatform_energy.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to First Tutorial Access": {
                             "type": "and",
@@ -18289,7 +18398,7 @@
             }
         },
         "Waterfall": {
-            "default_node": "Start Point",
+            "default_node": "Tower Middle",
             "extra": {
                 "total_boundings": {
                     "x1": -17100.0,
@@ -18693,7 +18802,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Pre_ChozoWarriorX",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Freezer": {
                             "type": "resource",
@@ -18705,10 +18814,12 @@
                             }
                         },
                         "Dock to Red Chozo Arena": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "events",
+                                "name": "s010_cave:default:db_dif_cv_002",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -18972,8 +19083,8 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": -15734.265445846737,
-                        "y": 306.91990431411386,
+                        "x": -15734.27,
+                        "y": 850.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -18981,7 +19092,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Save Station West": {
                             "type": "and",
@@ -19520,7 +19631,7 @@
                         "start_point_actor_name": "PRP_CV_MapStation001_WeightPlate",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_map/charclasses/weightactivatedplatform_map.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Water Reservoir": {
                             "type": "and",
@@ -19657,8 +19768,8 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": -12415.051395007342,
-                        "y": -452.60442855319604,
+                        "x": -12515.05,
+                        "y": -452.6,
                         "z": 0.0
                     },
                     "description": "",
@@ -20202,7 +20313,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Dock to Energy Recharge Station South": {
                             "type": "and",
@@ -20736,7 +20847,7 @@
                         "start_point_actor_name": "PRP_CV_SaveStation001_WeightPlate",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Melee Tutorial Room": {
                             "type": "and",
@@ -21104,7 +21215,7 @@
                         "hint_id": "CAVE_2",
                         "string_asset_id": 1
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "kind": "generic",
                     "requirement_to_collect": {
                         "type": "and",
@@ -21794,7 +21905,7 @@
                         "hint_id": "CAVE_1",
                         "string_asset_id": 2
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "kind": "generic",
                     "requirement_to_collect": {
                         "type": "and",
@@ -22640,7 +22751,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Navigation Station North (Upper)": {
                             "type": "or",
@@ -23103,7 +23214,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Teleport to Dairon (Middle)": {
                             "type": "and",
@@ -23433,7 +23544,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Path to Corpius": {
                             "type": "and",
@@ -23520,7 +23631,7 @@
                         "start_point_actor_name": "SP_Checkpoint_CURoom",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Event - Proto Central Unit": {
                             "type": "and",
@@ -23797,7 +23908,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Dock to Water Reservoir": {
                             "type": "and",
@@ -23938,7 +24049,7 @@
                         "start_point_actor_name": "PRP_CV_SaveStation004_WeightPlate",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Shinespark Tower to Grapple": {
                             "type": "and",
@@ -24088,7 +24199,7 @@
                         "start_point_actor_name": "LE_Platform_Elevator_FromMagma",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "destination": {
                         "world_name": "Cataris",
                         "area_name": "Transport to Artaria"
@@ -24713,7 +24824,7 @@
             }
         },
         "Lower Path to Cataris": {
-            "default_node": null,
+            "default_node": "Start Point",
             "extra": {
                 "total_boundings": {
                     "x1": 26800.0,
@@ -25044,6 +25155,37 @@
                                     }
                                 ]
                             }
+                        },
+                        "Start Point": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Start Point": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 31350.0,
+                        "y": 2400.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": true,
+                    "connections": {
+                        "Door to Transport to Cataris": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 }
@@ -25168,7 +25310,7 @@
                         "start_point_actor_name": "elevator_aqua_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "destination": {
                         "world_name": "Burenia",
                         "area_name": "Transport to Artaria"
@@ -26134,7 +26276,7 @@
                         "start_point_actor_name": "SP_Checkpoint_ScrewAttack",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Pickup (Screw Attack)": {
                             "type": "and",
@@ -27127,7 +27269,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Start Point 2": {
                             "type": "and",
@@ -27174,7 +27316,7 @@
             }
         },
         "Freezer": {
-            "default_node": "Start Point",
+            "default_node": "Cold Room",
             "extra": {
                 "total_boundings": {
                     "x1": -19200.0,
@@ -27327,6 +27469,13 @@
                                     }
                                 ]
                             }
+                        },
+                        "Cold Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
                         }
                     }
                 },
@@ -27361,7 +27510,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Start Point": {
+                        "Corridor": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -27542,7 +27691,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Start Point": {
+                        "Corridor": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -27551,7 +27700,7 @@
                         }
                     }
                 },
-                "Start Point": {
+                "Corridor": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -27577,6 +27726,30 @@
                             }
                         },
                         "Door to Waterfall": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Cold Room": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -18750.0,
+                        "y": -4300.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": true,
+                    "connections": {
+                        "Door to Screw Attack Room (Grapple)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -27665,7 +27838,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Dock to Speed Hallway": {
                             "type": "resource",
@@ -27851,7 +28024,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Screw Attack Room": {
                             "type": "and",
@@ -28268,7 +28441,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Cold Introduction": {
                             "type": "and",
@@ -28590,7 +28763,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Dock to EMMI Zone Exit North": {
                             "type": "and",
@@ -28901,7 +29074,7 @@
                         "start_point_actor_name": "SP_Checkpoint_EmmyCavePhase2",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Event - Artaria Central Unit": {
                             "type": "template",

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -217,7 +217,7 @@ Extra - asset_id: collision_camera_001
   > Door to First Tutorial
       Can Slide
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to First Tutorial
       Trivial
@@ -265,7 +265,7 @@ Extra - asset_id: collision_camera_002
   > Door to Charge Tutorial
       Trivial
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Charge Tutorial
       Trivial
@@ -539,7 +539,7 @@ Extra - asset_id: collision_camera_004
   > Event - Early Cloak Blob
       Lay Bomb or Shoot Beam
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Save Station South
       Trivial
@@ -773,7 +773,7 @@ Extra - asset_id: collision_camera_006
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Teleport to Dairon (Lower)
       After Artaria - First Chase Blob
@@ -816,6 +816,8 @@ Extra - asset_id: collision_camera_008
       Trivial
   > Door to EMMI First Chase End (Bottom)
       Can Slide
+  > Lower Room
+      Trivial
 
 > Door to White EMMI Introduction (Thermal); Heals? False
   * Layers: default
@@ -851,6 +853,8 @@ Extra - asset_id: collision_camera_008
   > Dock to Arbitrary Enky Room (Lower)
       Trivial
   > Tile Group (BOMB MISSILE)
+      Trivial
+  > Before Slide
       Trivial
 
 > Door to EMMI First Chase End (Top); Heals? False
@@ -972,6 +976,16 @@ Extra - asset_id: collision_camera_008
   > Dock to Arbitrary Enky Room (Upper)
       Trivial
 
+> Before Slide; Heals? False; Spawn Point
+  * Layers: default
+  > Dock to Arbitrary Enky Room (Upper)
+      Trivial
+
+> Lower Room; Heals? False; Spawn Point
+  * Layers: default
+  > Door to White EMMI Introduction (Lower)
+      Trivial
+
 ----------------
 EMMI Zone Exit North
 Extra - total_boundings: {'x1': 699.9979858398438, 'x2': 5900.0, 'y1': 1800.0, 'y2': 4900.0}
@@ -1063,7 +1077,7 @@ Extra - asset_id: collision_camera_009
   > Door to EMMI Zone Dome
       Morph Ball
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Teleport to Dairon (Power)
       Trivial
@@ -1263,10 +1277,13 @@ Extra - asset_id: collision_camera_010
           Morph Ball
           Slide and After Artaria - EMMI Zone Water Device
 
-> Start Point; Heals? False; Default Node
+> Bottom Section; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to EMMI Zone Exit Southwest (Lower)
       Trivial
+
+> Top Door; Heals? False; Spawn Point
+  * Layers: default
 
 ----------------
 Teleport to Cataris
@@ -1576,7 +1593,7 @@ Extra - asset_id: collision_camera_012
   > Door to Waterfall
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: PRP_CV_SaveStation003
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
@@ -1889,7 +1906,7 @@ Extra - asset_id: collision_camera_015
   > Door to White EMMI Arena (Top)
       Trivial
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Wide Beam Block Room
       Trivial
@@ -1983,7 +2000,7 @@ Extra - asset_id: collision_camera_016
   > Door to Proto EMMI Battle
       After Artaria - Proto Central Unit or Can Slide
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Melee Tutorial Room (Upper)
       Trivial
@@ -2167,7 +2184,7 @@ Extra - asset_id: collision_camera_020
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_OpticalCamo
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2345,6 +2362,8 @@ Extra - asset_id: collision_camera_022
       After Artaria - Thermal Device West Blob
   > Event - Thermal Device West Blob
       Lay Bomb or Shoot Beam
+  > Below Blobs
+      Trivial
 
 > Event - Thermal Device East Blob; Heals? False
   * Layers: default
@@ -2380,9 +2399,14 @@ Extra - asset_id: collision_camera_022
   > Door to David Jaffe Room
       Trivial
 
-> Start Point; Heals? False; Default Node
+> Above Blobs; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to David Jaffe Room
+      Trivial
+
+> Below Blobs; Heals? False; Spawn Point
+  * Layers: default
+  > Dock to Invisible Corpius Room
       Trivial
 
 ----------------
@@ -2536,7 +2560,7 @@ Extra - asset_id: collision_camera_024
   > Door to Hot Cataris Shortcut
       Trivial
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Save Station East
       Trivial
@@ -2570,7 +2594,7 @@ Extra - asset_id: collision_camera_025
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: PRP_CV_SaveStation002
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
@@ -2645,7 +2669,7 @@ Extra - asset_id: collision_camera_026
           Morph Ball
           Lay Bomb or Lay Power Bomb or Shoot Beam
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_ChainReaction
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2829,7 +2853,7 @@ Extra - asset_id: collision_camera_030
   > Door to Varia Suit Room
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Post_ChainReaction
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2913,7 +2937,7 @@ Extra - asset_id: collision_camera_031
   > Door to Varia Suit Tutorial North
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_VariaSuit
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2978,7 +3002,7 @@ Extra - asset_id: collision_camera_032
               Spider Magnet or Grapple Movement (Beginner)
           Speed Booster and Disabled Door Lock Randomizer
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Save Station North
       Trivial
@@ -3047,7 +3071,7 @@ Extra - asset_id: collision_camera_034
   > Elevator to Dairon
       Trivial
 
-> Elevator to Dairon; Heals? False; Default Node
+> Elevator to Dairon; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Teleporter to Dairon - Transport to Artaria
   * Extra - actor_name: elevator_baselab_000
@@ -3082,7 +3106,7 @@ Extra - asset_id: collision_camera_045
   > Door to Energy Recharge Station South
       Trivial
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Energy Recharge Station South
       Trivial
@@ -3200,7 +3224,7 @@ Extra - asset_id: collision_camera_048
   > Below Slide
       Can Slide
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to EMMI Zone Exit North
       Trivial
@@ -3425,7 +3449,7 @@ Extra - asset_id: collision_camera_051
   > Dock to Teleport to Cataris
       Trivial
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to EMMI Zone Dome
       Trivial
@@ -3503,7 +3527,7 @@ Extra - asset_id: collision_camera_054
   > Energy Recharge
       Trivial
 
-> Energy Recharge; Heals? True; Default Node
+> Energy Recharge; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: PRP_CV_EnergyStation001
   * Extra - actor_def: actordef:actors/props/energyrecharge/charclasses/energyrecharge.bmsad
@@ -3696,14 +3720,14 @@ Extra - asset_id: collision_camera_056
   > Start Point
       After Artaria - Waterfall Rotatable
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Pre_ChozoWarriorX
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to Freezer
       After Artaria - Waterfall Rotatable
   > Dock to Red Chozo Arena
-      Trivial
+      After Artaria - Waterfall Rotatable
 
 > Tunnel to Chain Reaction Access; Heals? False
   * Layers: default
@@ -3733,7 +3757,7 @@ Extra - asset_id: collision_camera_056
   * Layers: default
   * Open Passage to Red Chozo Arena/Dock to Waterfall
 
-> Tower Middle; Heals? False
+> Tower Middle; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Save Station West
       Trivial
@@ -3827,7 +3851,7 @@ Extra - asset_id: collision_camera_058
   > Map Station
       Trivial
 
-> Map Station; Heals? False; Default Node
+> Map Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: PRP_CV_MapStation001
   * Extra - actor_def: actordef:actors/props/maproom/charclasses/maproom.bmsad
@@ -3974,7 +3998,7 @@ Extra - asset_id: collision_camera_061
   > Dock to Energy Recharge Station South
       Trivial
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Dock to Energy Recharge Station South
       Trivial
@@ -4088,7 +4112,7 @@ Extra - asset_id: collision_camera_063
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: PRP_CV_SaveStation001
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
@@ -4181,7 +4205,7 @@ Extra - asset_id: collision_camera_065
   > Navigation Room
       Trivial
 
-> Navigation Room; Heals? False; Default Node
+> Navigation Room; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: PRP_CV_AccessPoint002
@@ -4356,7 +4380,7 @@ Extra - asset_id: collision_camera_068
   > Navigation Room
       Trivial
 
-> Navigation Room; Heals? False; Default Node
+> Navigation Room; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: PRP_CV_AccessPoint001
@@ -4544,7 +4568,7 @@ Extra - asset_id: collision_camera_070
   > Tile Group (BOMB)
       Morph Ball
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Navigation Station North (Upper)
       Morph Ball or Before Artaria - ArbEnky Blob West
@@ -4617,7 +4641,7 @@ Extra - asset_id: collision_camera_071
   > Door to Teleport to Dairon (Middle)
       Trivial
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Teleport to Dairon (Middle)
       Trivial
@@ -4705,7 +4729,7 @@ Extra - asset_id: collision_camera_073
   > Door to Path to Corpius
       Trivial
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Path to Corpius
       Trivial
@@ -4723,7 +4747,7 @@ Extra - asset_id: collision_camera_074
   > Dock to Proto EMMI Battle
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_CURoom
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -4781,7 +4805,7 @@ Extra - asset_id: collision_camera_075
   > Door to EMMI Zone Hub (Upper)
       Trivial
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Dock to Water Reservoir
       Trivial
@@ -4815,7 +4839,7 @@ Extra - asset_id: collision_camera_076
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: PRP_CV_SaveStation004
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
@@ -4855,7 +4879,7 @@ Extra - asset_id: collision_camera_077
   > Elevator to Cataris - Transport to Artaria
       Trivial
 
-> Elevator to Cataris - Transport to Artaria; Heals? False; Default Node
+> Elevator to Cataris - Transport to Artaria; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Teleporter to Cataris - Transport to Artaria
   * Extra - actor_name: LE_Elevator_FromMagma
@@ -4985,6 +5009,13 @@ Extra - asset_id: collision_camera_079
       Any of the following:
           Flash Shift or Speed Booster or Can Slide or Use Spin Boost
           Stand on Frozen Enemy (Beginner) and Shoot Ice Missile
+  > Start Point
+      Trivial
+
+> Start Point; Heals? False; Spawn Point; Default Node
+  * Layers: default
+  > Door to Transport to Cataris
+      Trivial
 
 ----------------
 Transport to Burenia
@@ -5011,7 +5042,7 @@ Extra - asset_id: collision_camera_080
   > Tile Group (SCREWATTACK) 1
       Trivial
 
-> Elevator to Burenia - Transport to Artaria; Heals? False; Default Node
+> Elevator to Burenia - Transport to Artaria; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Teleporter to Burenia - Transport to Artaria
   * Extra - actor_name: elevator_with_cutscene_aqua_000
@@ -5205,7 +5236,7 @@ Extra - asset_id: collision_camera_081
               Water Bomb Jump (Intermediate) and Perform WBJ
               Space Jump or Walljump (Beginner)
 
-> Start Point - Screw Attack; Heals? False
+> Start Point - Screw Attack; Heals? False; Spawn Point
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_ScrewAttack
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -5392,7 +5423,7 @@ Extra - asset_id: collision_camera_081
   > Teleporter to Cataris
       After Artaria - Screw Attack Grapple Block
 
-> Early SA Platform; Heals? False
+> Early SA Platform; Heals? False; Spawn Point
   * Layers: default
   > Start Point 2
       Space Jump and Water Space Jump (Intermediate)
@@ -5423,6 +5454,8 @@ Extra - asset_id: collision_camera_082
       Any of the following:
           Gravity Suit
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
+  > Cold Room
+      Trivial
 
 > Door to Screw Attack Room (Power); Heals? False
   * Layers: default
@@ -5433,7 +5466,7 @@ Extra - asset_id: collision_camera_082
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Start Point
+  > Corridor
       Trivial
 
 > Pickup (Missile Tank); Heals? False
@@ -5469,16 +5502,21 @@ Extra - asset_id: collision_camera_082
   * Extra - left_shield_def: actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:door_shield_plasma_001
   * Extra - right_shield_def: actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad
-  > Start Point
+  > Corridor
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Corridor; Heals? False; Spawn Point
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_ChozoWarriorCave
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
   > Door to Screw Attack Room (Power)
       Trivial
   > Door to Waterfall
+      Trivial
+
+> Cold Room; Heals? False; Spawn Point; Default Node
+  * Layers: default
+  > Door to Screw Attack Room (Grapple)
       Trivial
 
 ----------------
@@ -5492,7 +5530,7 @@ Extra - asset_id: collision_camera_083
   > Start Point
       Speed Booster
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Dock to Speed Hallway
       Speed Booster
@@ -5536,7 +5574,7 @@ Extra - asset_id: collision_camera_085
   > Door to Screw Attack Room
       After Artaria - Screw Attack Grapple Block
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Screw Attack Room
       Trivial
@@ -5628,7 +5666,7 @@ Extra - asset_id: collision_camera_086
   > Door to Cold Introduction
       Ballspark
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Door to Cold Introduction
       Trivial
@@ -5718,7 +5756,7 @@ Extra - asset_id: collision_camera_088
   > Tile Group (POWERBEAM) 4
       Trivial
 
-> Start Point; Heals? False; Default Node
+> Start Point; Heals? False; Spawn Point; Default Node
   * Layers: default
   > Dock to EMMI Zone Exit North
       Trivial
@@ -5786,7 +5824,7 @@ Extra - asset_id: collision_camera_090
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_EmmyCavePhase2
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -56,7 +56,7 @@ Extra - asset_id: collision_camera_000
   > Tunnel to First Tutorial Access
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_AccessPoint_1B
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -161,7 +161,7 @@ Extra - asset_id: collision_camera_001
   > Door to First Tutorial
       Can Slide
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to First Tutorial
       Trivial
@@ -209,7 +209,7 @@ Extra - asset_id: collision_camera_002
   > Door to Charge Tutorial
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Charge Tutorial
       Trivial
@@ -340,7 +340,7 @@ Extra - asset_id: collision_camera_003
   > West of Blob
       Trivial
 
-> West of Blob; Heals? False; Spawn Point; Default Node
+> West of Blob; Heals? False; Default Node
   * Layers: default
   > Door to Proto EMMI Introduction (Lower)
       Trivial
@@ -471,7 +471,7 @@ Extra - asset_id: collision_camera_004
   > Event - Early Cloak Blob
       Lay Bomb or Shoot Beam
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Save Station South
       Trivial
@@ -558,7 +558,7 @@ Extra - asset_id: collision_camera_005
           # If this lock is unmoved, it can cause death if the room has been loaded
           After Artaria - EMMI Magnet Door Lock or Knowledge (Intermediate)
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_EmmyCave
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -693,7 +693,7 @@ Extra - asset_id: collision_camera_006
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Teleport to Dairon (Lower)
       After Artaria - First Chase Blob
@@ -772,12 +772,12 @@ Extra - asset_id: collision_camera_008
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Dock to Arbitrary Enky Room (Lower)
       Trivial
-  > Before Slide
-      Trivial
   > Tunnel to Arbitrary Enky Room
       All of the following:
           Shoot Missile
           Lay Bomb or Lay Power Bomb
+  > Before Slide
+      Trivial
 
 > Door to EMMI First Chase End (Top); Heals? False
   * Layers: default
@@ -829,7 +829,7 @@ Extra - asset_id: collision_camera_008
   > Teleporter to Dairon - Teleport to Artaria
       Trivial
 
-> Teleporter to Dairon - Teleport to Artaria; Heals? False; Spawn Point; Default Node
+> Teleporter to Dairon - Teleport to Artaria; Heals? False; Default Node
   * Layers: default
   * Teleporter to Dairon - Teleport to Artaria
   * Extra - actor_name: teleport_baselab_000
@@ -853,12 +853,12 @@ Extra - asset_id: collision_camera_008
   > Dock to Arbitrary Enky Room (Upper)
       Trivial
 
-> Before Slide; Heals? False; Spawn Point
+> Before Slide; Heals? False
   * Layers: default
   > Dock to Arbitrary Enky Room (Upper)
       Trivial
 
-> Lower Room; Heals? False; Spawn Point
+> Lower Room; Heals? False
   * Layers: default
   > Door to White EMMI Introduction (Lower)
       Trivial
@@ -942,7 +942,7 @@ Extra - asset_id: collision_camera_009
   > Door to EMMI Zone Dome
       Morph Ball
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Teleport to Dairon (Power)
       Trivial
@@ -962,6 +962,8 @@ Extra - asset_id: collision_camera_010
   * Extra - right_shield_entity: Root:pScenario:rEntitiesLayer:dctSublayers:default:dctActors:doorwavebeam_000
   * Extra - right_shield_def: actordef:actors/props/doorwavebeam/charclasses/doorwavebeam.bmsad
   > Door to EMMI Zone Exit Southwest (Upper)
+      Trivial
+  > Top Door
       Trivial
 
 > Door to EMMI Zone Exit Southwest (Upper); Heals? False
@@ -1142,13 +1144,15 @@ Extra - asset_id: collision_camera_010
           Morph Ball
           Slide and After Artaria - EMMI Zone Water Device
 
-> Bottom Section; Heals? False; Spawn Point; Default Node
+> Bottom Section; Heals? False; Default Node
   * Layers: default
   > Door to EMMI Zone Exit Southwest (Lower)
       Trivial
 
-> Top Door; Heals? False; Spawn Point
+> Top Door; Heals? False
   * Layers: default
+  > Door to EMMI Zone Exit Northwest
+      Trivial
 
 ----------------
 Teleport to Cataris
@@ -1283,7 +1287,7 @@ Extra - asset_id: collision_camera_011
           After Artaria - Early SA Shortcut Blob
           Lay Bomb or Lay Power Bomb
 
-> Teleporter to Cataris - Teleport to Artaria (Red); Heals? False; Spawn Point; Default Node
+> Teleporter to Cataris - Teleport to Artaria (Red); Heals? False; Default Node
   * Layers: default
   * Teleporter to Cataris - Teleport to Artaria (Red)
   * Extra - actor_name: LE_Teleport_FromMagma
@@ -1549,7 +1553,7 @@ Extra - asset_id: collision_camera_014
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_ChargeBeam
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1695,7 +1699,7 @@ Extra - asset_id: collision_camera_015
   > Door to White EMMI Arena (Top)
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Wide Beam Block Room
       Trivial
@@ -1777,7 +1781,7 @@ Extra - asset_id: collision_camera_016
           Infinite Bomb Jump (Expert) and Lay Cross Bomb
           Bomb and Infinite Bomb Jump (Advanced) and Lay Cross Bomb
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Melee Tutorial Room (Upper)
       Trivial
@@ -1888,7 +1892,7 @@ Extra - asset_id: collision_camera_017
   > Door to EMMI Zone First Entrance
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_MagnetGlove
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2049,7 +2053,7 @@ Extra - asset_id: collision_camera_021
   > Start Point
       Can Slide
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_AccessPoint_2B
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2164,12 +2168,12 @@ Extra - asset_id: collision_camera_022
   > Door to David Jaffe Room
       Trivial
 
-> Above Blobs; Heals? False; Spawn Point; Default Node
+> Above Blobs; Heals? False; Default Node
   * Layers: default
   > Door to David Jaffe Room
       Trivial
 
-> Below Blobs; Heals? False; Spawn Point
+> Below Blobs; Heals? False
   * Layers: default
   > Dock to Invisible Corpius Room
       Trivial
@@ -2325,7 +2329,7 @@ Extra - asset_id: collision_camera_024
   > Door to Hot Cataris Shortcut
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Save Station East
       Trivial
@@ -2734,7 +2738,7 @@ Extra - asset_id: collision_camera_032
               Spider Magnet or Grapple Movement (Beginner)
           Speed Booster and Disabled Door Lock Randomizer
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Save Station North
       Trivial
@@ -2775,7 +2779,7 @@ Extra - asset_id: collision_camera_033
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Grapple
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2803,7 +2807,7 @@ Extra - asset_id: collision_camera_034
   > Elevator to Dairon
       Trivial
 
-> Elevator to Dairon; Heals? False; Spawn Point; Default Node
+> Elevator to Dairon; Heals? False; Default Node
   * Layers: default
   * Teleporter to Dairon - Transport to Artaria
   * Extra - actor_name: elevator_baselab_000
@@ -2838,7 +2842,7 @@ Extra - asset_id: collision_camera_045
   > Door to Energy Recharge Station South
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Energy Recharge Station South
       Trivial
@@ -2920,7 +2924,7 @@ Extra - asset_id: collision_camera_048
   > Below Slide
       Can Slide
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to EMMI Zone Exit North
       Trivial
@@ -2968,7 +2972,7 @@ Extra - asset_id: collision_camera_049
   > Dock to Central Unit
       After Artaria - Central Unit
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_CentralUnit
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -3059,7 +3063,7 @@ Extra - asset_id: collision_camera_050
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_AccessPoint_002
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -3145,7 +3149,7 @@ Extra - asset_id: collision_camera_051
   > Dock to Teleport to Cataris
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to EMMI Zone Dome
       Trivial
@@ -3223,7 +3227,7 @@ Extra - asset_id: collision_camera_054
   > Energy Recharge
       Trivial
 
-> Energy Recharge; Heals? True; Spawn Point; Default Node
+> Energy Recharge; Heals? True; Default Node
   * Layers: default
   * Extra - actor_name: PRP_CV_EnergyStation001
   * Extra - actor_def: actordef:actors/props/energyrecharge/charclasses/energyrecharge.bmsad
@@ -3413,10 +3417,10 @@ Extra - asset_id: collision_camera_056
   * Extra - right_shield_def: actordef:actors/props/door_shield_plasma/charclasses/door_shield_plasma.bmsad
   > Event - Waterfall Rotatable
       Shoot Diffusion or Wave
-  > Start Point
+  > Below Rotatable
       After Artaria - Waterfall Rotatable
 
-> Start Point; Heals? False
+> Below Rotatable; Heals? False
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Pre_ChozoWarriorX
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -3453,7 +3457,7 @@ Extra - asset_id: collision_camera_056
   * Layers: default
   * Open Passage to Red Chozo Arena/Dock to Waterfall
 
-> Tower Middle; Heals? False; Spawn Point; Default Node
+> Tower Middle; Heals? False; Default Node
   * Layers: default
   > Door to Save Station West
       Trivial
@@ -3638,7 +3642,7 @@ Extra - asset_id: collision_camera_060
   > Dock to Water Tunnel under Map
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_WaterValve
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -3694,7 +3698,7 @@ Extra - asset_id: collision_camera_061
   > Dock to Energy Recharge Station South
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Dock to Energy Recharge Station South
       Trivial
@@ -4016,7 +4020,7 @@ Extra - asset_id: collision_camera_067
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_ThermalDevice
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -4240,7 +4244,7 @@ Extra - asset_id: collision_camera_070
   > Pickup (Missile Tank)
       Lay Bomb or Lay Power Bomb
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Navigation Station North (Upper)
       Morph Ball or Before Artaria - ArbEnky Blob West
@@ -4313,7 +4317,7 @@ Extra - asset_id: collision_camera_071
   > Door to Teleport to Dairon (Middle)
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Teleport to Dairon (Middle)
       Trivial
@@ -4347,7 +4351,7 @@ Extra - asset_id: collision_camera_072
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Scorpius
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -4401,7 +4405,7 @@ Extra - asset_id: collision_camera_073
   > Door to Path to Corpius
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Path to Corpius
       Trivial
@@ -4477,7 +4481,7 @@ Extra - asset_id: collision_camera_075
   > Door to EMMI Zone Hub (Upper)
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Dock to Water Reservoir
       Trivial
@@ -4551,7 +4555,7 @@ Extra - asset_id: collision_camera_077
   > Elevator to Cataris - Transport to Artaria
       Trivial
 
-> Elevator to Cataris - Transport to Artaria; Heals? False; Spawn Point; Default Node
+> Elevator to Cataris - Transport to Artaria; Heals? False; Default Node
   * Layers: default
   * Teleporter to Cataris - Transport to Artaria
   * Extra - actor_name: LE_Elevator_FromMagma
@@ -4684,7 +4688,7 @@ Extra - asset_id: collision_camera_079
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Transport to Cataris
       Trivial
@@ -4714,7 +4718,7 @@ Extra - asset_id: collision_camera_080
   > Elevator to Burenia - Transport to Artaria
       Screw Attack
 
-> Elevator to Burenia - Transport to Artaria; Heals? False; Spawn Point; Default Node
+> Elevator to Burenia - Transport to Artaria; Heals? False; Default Node
   * Layers: default
   * Teleporter to Burenia - Transport to Artaria
   * Extra - actor_name: elevator_with_cutscene_aqua_000
@@ -4868,7 +4872,7 @@ Extra - asset_id: collision_camera_081
               Simple IBJ or Use Spin Boost
               Morph Ball or Screw Attack
 
-> Start Point - Screw Attack; Heals? False; Spawn Point
+> Start Point - Screw Attack; Heals? False
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_ScrewAttack
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -4879,7 +4883,7 @@ Extra - asset_id: collision_camera_081
           Screw Attack
           Walljump (Beginner) or Simple IBJ or Use Spin Boost
 
-> Teleporter to Cataris; Heals? False; Spawn Point; Default Node
+> Teleporter to Cataris; Heals? False; Default Node
   * Layers: default
   * Teleporter to Cataris - Teleport to Artaria (Blue)
   * Extra - actor_name: teleporter_magma_000
@@ -4979,7 +4983,7 @@ Extra - asset_id: collision_camera_081
   > Teleporter to Cataris
       After Artaria - Screw Attack Grapple Block
 
-> Early SA Platform; Heals? False; Spawn Point
+> Early SA Platform; Heals? False
   * Layers: default
   > Start Point 2
       Space Jump and Water Space Jump (Intermediate)
@@ -5061,7 +5065,7 @@ Extra - asset_id: collision_camera_082
   > Corridor
       Trivial
 
-> Corridor; Heals? False; Spawn Point
+> Corridor; Heals? False
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_ChozoWarriorCave
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -5070,7 +5074,7 @@ Extra - asset_id: collision_camera_082
   > Door to Waterfall
       Trivial
 
-> Cold Room; Heals? False; Spawn Point; Default Node
+> Cold Room; Heals? False; Default Node
   * Layers: default
   > Door to Screw Attack Room (Grapple)
       Trivial
@@ -5086,7 +5090,7 @@ Extra - asset_id: collision_camera_083
   > Start Point
       Speed Booster
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Dock to Speed Hallway
       Speed Booster
@@ -5130,7 +5134,7 @@ Extra - asset_id: collision_camera_085
   > Door to Screw Attack Room
       After Artaria - Screw Attack Grapple Block
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Screw Attack Room
       Trivial
@@ -5210,7 +5214,7 @@ Extra - asset_id: collision_camera_086
   > Door to Cold Introduction
       Ballspark
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Cold Introduction
       Trivial
@@ -5240,7 +5244,7 @@ Extra - asset_id: collision_camera_088
   > Dock to EMMI Zone Exit North
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Dock to EMMI Zone Exit North
       Trivial
@@ -5362,7 +5366,7 @@ Extra - asset_id: collision_camera_091
           Gravity Suit
           Heat/Cold Runs (Intermediate) and Cold Damage ≥ 50
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Dead_ChozoWarriorX
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -3548,10 +3548,10 @@ Extra - asset_id: collision_camera_058
   * Extra - right_shield_def: None
   > Door to Water Reservoir
       Trivial
-  > Map Station
+  > Save Station
       Trivial
 
-> Map Station; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: PRP_CV_MapStation001
   * Extra - actor_def: actordef:actors/props/maproom/charclasses/maproom.bmsad
@@ -3854,7 +3854,7 @@ Extra - asset_id: collision_camera_065
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Navigation Room
+  > Save Station
       Trivial
 
 > Door to Invisible Corpius Room; Heals? False
@@ -3866,7 +3866,7 @@ Extra - asset_id: collision_camera_065
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Navigation Room
+  > Save Station
       Trivial
 
 > Door to Arbitrary Enky Room (Upper); Heals? False
@@ -3878,7 +3878,7 @@ Extra - asset_id: collision_camera_065
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Navigation Room
+  > Save Station
       Trivial
 
 > Door to Arbitrary Enky Room (Thermal); Heals? False
@@ -3890,10 +3890,10 @@ Extra - asset_id: collision_camera_065
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Navigation Room
+  > Save Station
       Trivial
 
-> Navigation Room; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: PRP_CV_AccessPoint002
@@ -4053,7 +4053,7 @@ Extra - asset_id: collision_camera_068
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Navigation Room
+  > Save Station
       Trivial
 
 > Door to First Tutorial; Heals? False
@@ -4065,10 +4065,10 @@ Extra - asset_id: collision_camera_068
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Navigation Room
+  > Save Station
       Trivial
 
-> Navigation Room; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: PRP_CV_AccessPoint001

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -5362,15 +5362,6 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
                                                         "name": "Magnet",
                                                         "amount": 1,
                                                         "negate": false
@@ -5410,6 +5401,32 @@
                                                                     "name": "DoorLocks",
                                                                     "amount": 1,
                                                                     "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Grapple",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "GrappleMovement",
+                                                                    "amount": 1,
+                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]
@@ -6709,6 +6726,32 @@
                                     {
                                         "type": "template",
                                         "data": "Perform WBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "GrappleMovement",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -6751,82 +6794,6 @@
                                             "name": "Grapple",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Dock to Main Hub Tower Top (Left)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Magnet",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Gravity",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Flash",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Walljump",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
                                         }
                                     }
                                 ]
@@ -6889,6 +6856,95 @@
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        },
+                        "Dock to Main Hub Tower Top (Left)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Gravity",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Magnet",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "WBJ",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Lay Bomb"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Flash",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -10,7 +10,7 @@
     },
     "areas": {
         "Map Station": {
-            "default_node": "Map Station",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": -5000.0,
@@ -117,7 +117,7 @@
                                 "items": []
                             }
                         },
-                        "Map Station": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -126,7 +126,7 @@
                         }
                     }
                 },
-                "Map Station": {
+                "Save Station": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -5006,7 +5006,7 @@
             }
         },
         "Navigation Station North": {
-            "default_node": "Navigation Room",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": -5000.0,
@@ -5113,7 +5113,7 @@
                                 "items": []
                             }
                         },
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5122,7 +5122,7 @@
                         }
                     }
                 },
-                "Navigation Room": {
+                "Save Station": {
                     "node_type": "hint",
                     "heal": false,
                     "coordinates": {
@@ -10677,7 +10677,7 @@
             }
         },
         "Navigation Station South": {
-            "default_node": "Navigation Room",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": 9000.0,
@@ -10784,7 +10784,7 @@
                                 "items": []
                             }
                         },
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -10793,7 +10793,7 @@
                         }
                     }
                 },
-                "Navigation Room": {
+                "Save Station": {
                     "node_type": "hint",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -144,7 +144,7 @@
                         "start_point_actor_name": "maproom_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_map/charclasses/weightactivatedplatform_map.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Teleport to Ferenia": {
                             "type": "and",
@@ -422,7 +422,7 @@
                         "start_point_actor_name": "SP_Checkpoint_DoorProfessor",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Burenia Hub to Dairon": {
                             "type": "template",
@@ -2154,7 +2154,7 @@
                         "start_point_actor_name": "wagontrain_baselab_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_train/charclasses/weightactivatedplatform_train.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Dairon",
                         "area_name": "Upper Transport to Burenia"
@@ -2409,7 +2409,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Hydrogiga",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Drogyga Access": {
                             "type": "and",
@@ -4666,7 +4666,7 @@
                         "start_point_actor_name": "LE_Platform_Teleport_Secret",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Ferenia",
                         "area_name": "Teleport to Burenia (Cyan)"
@@ -5142,7 +5142,7 @@
                         "hint_id": "AQUA_1",
                         "string_asset_id": 7
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "kind": "generic",
                     "requirement_to_collect": {
                         "type": "and",
@@ -5645,7 +5645,7 @@
                         "start_point_actor_name": "SP_Checkpoint_GhostDash",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Flash Shift Room (Lower)": {
                             "type": "and",
@@ -9236,7 +9236,7 @@
                         "start_point_actor_name": "savestation_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Main Hub Tower Top": {
                             "type": "and",
@@ -9742,7 +9742,7 @@
                         "start_point_actor_name": "SP_Checkpoint_GhostDashObtained",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door from Main Hub Tower Top": {
                             "type": "and",
@@ -10232,7 +10232,7 @@
                         "start_point_actor_name": "teleporter_forest_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Ghavoran",
                         "area_name": "Teleport to Burenia"
@@ -10757,7 +10757,7 @@
                         "hint_id": "AQUA_2",
                         "string_asset_id": 8
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "kind": "generic",
                     "requirement_to_collect": {
                         "type": "and",
@@ -10912,7 +10912,7 @@
                         "start_point_actor_name": "elevator_cave_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Artaria",
                         "area_name": "Transport to Burenia"
@@ -12896,7 +12896,7 @@
                         "start_point_actor_name": "SP_AccessPoint_9",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Navigation Station South": {
                             "type": "and",
@@ -14271,7 +14271,7 @@
                         "start_point_actor_name": "SP_Checkpoint_GravitySuit",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Gravity Suit Tower (Upper)": {
                             "type": "and",
@@ -15129,7 +15129,7 @@
                         "start_point_actor_name": "savestation_001_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Save Station South Access": {
                             "type": "and",
@@ -15200,7 +15200,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Hydrogiga_Dead",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Event - Drogyga": {
                             "type": "and",
@@ -15698,7 +15698,7 @@
                         "start_point_actor_name": "savestation_002_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Transport to Ghavoran": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -26,10 +26,10 @@ Extra - asset_id: collision_camera_000
   * Extra - right_shield_def: None
   > Door to Upper Burenia Hub
       Trivial
-  > Map Station
+  > Save Station
       Trivial
 
-> Map Station; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: maproom
   * Extra - actor_def: actordef:actors/props/maproom/charclasses/maproom.bmsad
@@ -871,10 +871,10 @@ Extra - asset_id: collision_camera_009
   * Extra - right_shield_def: None
   > Door to Upper Burenia Hub
       Trivial
-  > Navigation Room
+  > Save Station
       Trivial
 
-> Navigation Room; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_000
@@ -1825,10 +1825,10 @@ Extra - asset_id: collision_camera_016
   * Extra - right_shield_def: None
   > Door to Gravity Suit Tower
       Trivial
-  > Navigation Room
+  > Save Station
       Trivial
 
-> Navigation Room; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_001

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -928,8 +928,9 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
       All of the following:
           Morph Ball
           Any of the following:
-              Flash Shift or Grapple Beam or Spider Magnet or Use Spin Boost
+              Flash Shift or Spider Magnet or Use Spin Boost
               Speed Booster and Speedbooster Conservation (Beginner) and Disabled Door Lock Randomizer
+              Grapple Beam and Grapple Movement (Beginner)
   > Upper Left Magnet Wall
       Morph Ball
 
@@ -1136,15 +1137,11 @@ Extra - asset_id: collision_camera_010
 > Mid-Left Spider Magnet Pit; Heals? False
   * Layers: default
   > Left of Central Grapple Block
-      Gravity Suit or Spider Magnet or Perform WBJ
+      Any of the following:
+          Gravity Suit or Spider Magnet or Perform WBJ
+          Grapple Beam and Grapple Movement (Beginner)
   > Upper Water Ledge - Left
       Grapple Beam or Gravity Suit or Spider Magnet or Perform WBJ or Use Spin Boost
-  > Dock to Main Hub Tower Top (Left)
-      All of the following:
-          Gravity Suit or Spider Magnet
-          Any of the following:
-              Simple IBJ or Use Spin Boost
-              Flash Shift and Walljump (Beginner)
 
 > Left of Central Grapple Block; Heals? False
   * Layers: default
@@ -1154,6 +1151,12 @@ Extra - asset_id: collision_camera_010
       Grapple Beam
   > Mid-Left Spider Magnet Pit
       Trivial
+  > Dock to Main Hub Tower Top (Left)
+      All of the following:
+          Any of the following:
+              Gravity Suit or Spider Magnet or Movement (Intermediate)
+              Water Bomb Jump (Intermediate) and Lay Bomb
+          Flash Shift or Simple IBJ or Use Spin Boost
 
 > Missile Tank Plus Platform; Heals? False
   * Layers: default

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -29,7 +29,7 @@ Extra - asset_id: collision_camera_000
   > Map Station
       Trivial
 
-> Map Station; Heals? False; Default Node
+> Map Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: maproom
   * Extra - actor_def: actordef:actors/props/maproom/charclasses/maproom.bmsad
@@ -91,7 +91,7 @@ Extra - asset_id: collision_camera_001
   > Tunnel to Transport to Ghavoran
       Morph Ball
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_DoorProfessor
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -349,7 +349,7 @@ Extra - asset_id: collision_camera_003
   > Tram to Dairon - Upper Transport to Burenia
       Trivial
 
-> Tram to Dairon - Upper Transport to Burenia; Heals? False; Spawn Point; Default Node
+> Tram to Dairon - Upper Transport to Burenia; Heals? False; Default Node
   * Layers: default
   * Teleporter to Dairon - Upper Transport to Burenia
   * Extra - actor_name: wagontrain_baselab_000
@@ -420,7 +420,7 @@ Extra - asset_id: collision_camera_005
   > Tunnel to Underneath Drogyga (Lower)
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Hydrogiga
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -791,7 +791,7 @@ Extra - asset_id: collision_camera_008
   > Ammo Recharge Alcove
       Trivial
 
-> Teleporter to Ferenia - Teleport to Burenia (Cyan); Heals? False; Spawn Point; Default Node
+> Teleporter to Ferenia - Teleport to Burenia (Cyan); Heals? False; Default Node
   * Layers: default
   * Teleporter to Ferenia - Teleport to Burenia (Cyan)
   * Extra - actor_name: LE_Teleport_Secret
@@ -874,7 +874,7 @@ Extra - asset_id: collision_camera_009
   > Navigation Room
       Trivial
 
-> Navigation Room; Heals? False; Default Node
+> Navigation Room; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_000
@@ -990,7 +990,7 @@ Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900
   > Door to Teleport to Ferenia
       Morph Ball
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_GhostDash
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1494,7 +1494,7 @@ Extra - asset_id: collision_camera_011
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: savestation_000
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
@@ -1624,7 +1624,7 @@ Extra - asset_id: collision_camera_014
   > Door from Main Hub Tower Top
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_GhostDashObtained
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1728,7 +1728,7 @@ Extra - asset_id: collision_camera_015
   > Upper Water Platform
       Trivial
 
-> Teleporter to Ghavoran - Teleport to Burenia; Heals? False; Spawn Point; Default Node
+> Teleporter to Ghavoran - Teleport to Burenia; Heals? False; Default Node
   * Layers: default
   * Teleporter to Ghavoran - Teleport to Burenia
   * Extra - actor_name: teleporter_forest_000
@@ -1825,7 +1825,7 @@ Extra - asset_id: collision_camera_016
   > Navigation Room
       Trivial
 
-> Navigation Room; Heals? False; Default Node
+> Navigation Room; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_001
@@ -1864,7 +1864,7 @@ Extra - asset_id: collision_camera_017
   > Door to Navigation Station South
       Screw Attack
 
-> Elevator to Artaria - Transport to Burenia; Heals? False; Spawn Point; Default Node
+> Elevator to Artaria - Transport to Burenia; Heals? False; Default Node
   * Layers: default
   * Teleporter to Artaria - Transport to Burenia
   * Extra - actor_name: elevator_cave_000
@@ -2243,7 +2243,7 @@ Extra - asset_id: collision_camera_021
   > Event - Twin Robot Fight
       Fight Twin Robots
 
-> Start Point 4; Heals? False; Spawn Point; Default Node
+> Start Point 4; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_AccessPoint_9
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2473,7 +2473,7 @@ the blast shield issue.
   > Door to Gravity Suit Tower (Upper)
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_GravitySuit
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2643,7 +2643,7 @@ Extra - asset_id: collision_camera_027
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: savestation_001
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
@@ -2657,7 +2657,7 @@ Drogyga Arena
 Extra - total_boundings: {'x1': -1900.0, 'x2': 1000.0, 'y1': 10300.0, 'y2': 11550.0}
 Extra - polygon: [[1000.0, 11500.0], [-1400.0, 11500.0], [-1500.0, 11550.0], [-1800.0, 11550.0], [-1900.0, 11500.0], [-1900.0, 10300.0], [1000.0, 10300.0]]
 Extra - asset_id: collision_camera_028
-> Before Fight; Heals? False; Spawn Point; Default Node
+> Before Fight; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Hydrogiga_Dead
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2754,7 +2754,7 @@ Extra - asset_id: collision_camera_030
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: savestation_002
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -583,7 +583,7 @@
             }
         },
         "Navigation Station Southeast": {
-            "default_node": "Navigation Room",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": 6400.0,
@@ -650,7 +650,7 @@
                                 "items": []
                             }
                         },
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -699,7 +699,7 @@
                         }
                     }
                 },
-                "Navigation Room": {
+                "Save Station": {
                     "node_type": "hint",
                     "heal": false,
                     "coordinates": {
@@ -14157,7 +14157,7 @@
             }
         },
         "Map Station": {
-            "default_node": "Map Station",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": -2700.0,
@@ -14260,7 +14260,7 @@
                                 "items": []
                             }
                         },
-                        "Map Station": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -14269,7 +14269,7 @@
                         }
                     }
                 },
-                "Map Station": {
+                "Save Station": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -24339,7 +24339,7 @@
             }
         },
         "Navigation Station Northwest": {
-            "default_node": "Navigation Room",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": -14500.0,
@@ -24406,7 +24406,7 @@
                                 "items": []
                             }
                         },
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -24455,7 +24455,7 @@
                         }
                     }
                 },
-                "Navigation Room": {
+                "Save Station": {
                     "node_type": "hint",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -276,7 +276,7 @@
                         "start_point_actor_name": "LE_Platform_Elevator_FromCave",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Artaria",
                         "area_name": "Transport to Cataris"
@@ -719,7 +719,7 @@
                         "hint_id": "MAGMA_1",
                         "string_asset_id": 3
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "kind": "generic",
                     "requirement_to_collect": {
                         "type": "and",
@@ -976,7 +976,7 @@
                         "start_point_actor_name": "SP_Checkpoint_CooldownX",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Navigation Station Southeast": {
                             "type": "and",
@@ -3445,7 +3445,7 @@
                         "start_point_actor_name": "SP_Checkpoint_PistonRight",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to Lava Button East Access": {
                             "type": "template",
@@ -5334,7 +5334,7 @@
                         "start_point_actor_name": "teleporter_cave_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Artaria",
                         "area_name": "Screw Attack Room"
@@ -11705,7 +11705,7 @@
                         "start_point_actor_name": "LE_Platform_Teleport_FromCave",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Artaria",
                         "area_name": "Teleport to Cataris"
@@ -12028,7 +12028,7 @@
                         "start_point_actor_name": "teleporter_forest_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Ghavoran",
                         "area_name": "Golzuna Tower"
@@ -14287,7 +14287,7 @@
                         "start_point_actor_name": "maproom_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_map/charclasses/weightactivatedplatform_map.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Dock to EMMI Zone Exit to Map Station": {
                             "type": "and",
@@ -15528,7 +15528,7 @@
                         "start_point_actor_name": "savestation_001_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Hall Thermal Device Room": {
                             "type": "and",
@@ -16045,7 +16045,7 @@
                         "start_point_actor_name": "SP_Checkpoint_MorphBall",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Tunnel to EMMI Zone Exits West": {
                             "type": "and",
@@ -16531,7 +16531,7 @@
                         "start_point_actor_name": "SP_Checkpoint_EmmyMagmaPhase2",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Central Unit Access": {
                             "type": "and",
@@ -16645,7 +16645,7 @@
                         "start_point_actor_name": "SP_Checkpoint_PistonLeft",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to Thermal Device Room North (Mid)": {
                             "type": "and",
@@ -17515,7 +17515,7 @@
                         "start_point_actor_name": "wagontrain_baselab_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_train/charclasses/weightactivatedplatform_train.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Dairon",
                         "area_name": "Transport to Cataris"
@@ -19496,7 +19496,7 @@
                         "start_point_actor_name": "SP_DiffusionBeam",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door from Teleport to Dairon": {
                             "type": "and",
@@ -21962,7 +21962,7 @@
                         "start_point_actor_name": "teleport_baselab_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Dairon",
                         "area_name": "Teleport to Cataris"
@@ -23213,7 +23213,7 @@
                         "start_point_actor_name": "SP_Checkpoint_EmmyMagma",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to Green EMMI Introduction": {
                             "type": "and",
@@ -24475,7 +24475,7 @@
                         "hint_id": "MAGMA_2",
                         "string_asset_id": 4
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "kind": "generic",
                     "requirement_to_collect": {
                         "type": "and",
@@ -25182,7 +25182,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Kraid",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Safe Ledge": {
                             "type": "and",
@@ -25939,7 +25939,7 @@
                         "start_point_actor_name": "savestation_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Teleport to Artaria (Red)": {
                             "type": "and",
@@ -25998,7 +25998,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Dead_Kraid",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Right Ledge": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -116,7 +116,7 @@ Extra - asset_id: collision_camera_002
   * Extra - right_shield_def: None
   > Door to Thermal Device Room South
       Trivial
-  > Navigation Room
+  > Save Station
       Trivial
 
 > Door to Thermal Device Room South; Heals? False
@@ -131,7 +131,7 @@ Extra - asset_id: collision_camera_002
   > Door to Transport to Artaria
       Trivial
 
-> Navigation Room; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint
@@ -2291,10 +2291,10 @@ Extra - asset_id: collision_camera_030
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Door to Moving Magnet Walls (Small)
       Trivial
-  > Map Station
+  > Save Station
       Trivial
 
-> Map Station; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: maproom
   * Extra - actor_def: actordef:actors/props/maproom/charclasses/maproom.bmsad
@@ -3974,7 +3974,7 @@ Extra - asset_id: collision_camera_058
   * Extra - right_shield_def: None
   > Door to Ghavoran Teleport Access
       Trivial
-  > Navigation Room
+  > Save Station
       Trivial
 
 > Door to Ghavoran Teleport Access; Heals? False
@@ -3989,7 +3989,7 @@ Extra - asset_id: collision_camera_058
   > Door to Teleport to Artaria (Red)
       Trivial
 
-> Navigation Room; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_000

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -49,7 +49,7 @@ Extra - asset_id: collision_camera_000
   > Tunnel to Total Recharge Station South
       Trivial
 
-> Elevator to Artaria - Transport to Cataris; Heals? False; Spawn Point; Default Node
+> Elevator to Artaria - Transport to Cataris; Heals? False; Default Node
   * Layers: default
   * Teleporter to Artaria - Transport to Cataris
   * Extra - actor_name: LE_Elevator_FromCave
@@ -131,7 +131,7 @@ Extra - asset_id: collision_camera_002
   > Door to Transport to Artaria
       Trivial
 
-> Navigation Room; Heals? False; Default Node
+> Navigation Room; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint
@@ -206,7 +206,7 @@ Extra - asset_id: collision_camera_004
   > Door to Total Recharge Station South (Thermal Device)
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_CooldownX
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -639,7 +639,7 @@ Extra - asset_id: collision_camera_012
   * Extra - start_point_actor_name: shootactivatormag01_000
   * Extra - start_point_actor_def: actordef:actors/props/shootactivatormag01/charclasses/shootactivatormag01.bmsad
 
-> Start Point 2; Heals? False; Spawn Point; Default Node
+> Start Point 2; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_PistonRight
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -925,7 +925,7 @@ Extra - asset_id: collision_camera_015
   > Center Room
       Trivial
 
-> Teleporter to Artaria - Screw Attack Room; Heals? False; Spawn Point; Default Node
+> Teleporter to Artaria - Screw Attack Room; Heals? False; Default Node
   * Layers: default
   * Teleporter to Artaria - Screw Attack Room
   * Extra - actor_name: teleporter_cave_000
@@ -1870,7 +1870,7 @@ Extra - asset_id: collision_camera_025
   > Door to West Teleport Access
       Trivial
 
-> Teleporter to Artaria - Teleport to Cataris; Heals? False; Spawn Point; Default Node
+> Teleporter to Artaria - Teleport to Cataris; Heals? False; Default Node
   * Layers: default
   * Teleporter to Artaria - Teleport to Cataris
   * Extra - actor_name: LE_Teleport_FromCave
@@ -1941,7 +1941,7 @@ Extra - asset_id: collision_camera_026
   > Teleporter to Ghavoran - Teleport to Cataris
       Trivial
 
-> Teleporter to Ghavoran - Teleport to Cataris; Heals? False; Spawn Point; Default Node
+> Teleporter to Ghavoran - Teleport to Cataris; Heals? False; Default Node
   * Layers: default
   * Teleporter to Ghavoran - Golzuna Tower
   * Extra - actor_name: teleporter_forest_000
@@ -2294,7 +2294,7 @@ Extra - asset_id: collision_camera_030
   > Map Station
       Trivial
 
-> Map Station; Heals? False; Default Node
+> Map Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: maproom
   * Extra - actor_def: actordef:actors/props/maproom/charclasses/maproom.bmsad
@@ -2512,7 +2512,7 @@ Extra - asset_id: collision_camera_033
   > Door to Hall Thermal Device Room
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: savestation_001
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
@@ -2636,7 +2636,7 @@ Extra - asset_id: collision_camera_036
   > Room Center
       After Cataris - Central Unit and Combat (Beginner)
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_MorphBall
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2715,7 +2715,7 @@ Central Unit
 Extra - total_boundings: {'x1': -9700.0, 'x2': -7600.0, 'y1': 5100.0, 'y2': 6242.0}
 Extra - polygon: [[-7600.0, 6242.0], [-9700.0, 6242.0], [-9700.0, 5100.0], [-7600.0, 5100.0]]
 Extra - asset_id: collision_camera_037
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_EmmyMagmaPhase2
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2739,7 +2739,7 @@ Lava Button West
 Extra - total_boundings: {'x1': -700.0, 'x2': 4500.0, 'y1': 4400.0, 'y2': 5875.0}
 Extra - polygon: [[4500.0, 5875.0], [-700.0, 5875.0], [-700.0, 4400.0], [4500.0, 4400.0]]
 Extra - asset_id: collision_camera_038
-> Start Point 2; Heals? False; Spawn Point; Default Node
+> Start Point 2; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_PistonLeft
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2882,7 +2882,7 @@ Extra - asset_id: collision_camera_041
   > Elevator to Dairon - Transport to Cataris
       Trivial
 
-> Elevator to Dairon - Transport to Cataris; Heals? False; Spawn Point; Default Node
+> Elevator to Dairon - Transport to Cataris; Heals? False; Default Node
   * Layers: default
   * Teleporter to Dairon - Transport to Cataris
   * Extra - actor_name: wagontrain_baselab_000
@@ -3186,7 +3186,7 @@ Extra - asset_id: collision_camera_044
   > Alcove
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_DiffusionBeam
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -3610,7 +3610,7 @@ Extra - asset_id: collision_camera_051
   > Tunnel to Diffusion Beam Room
       Trivial
 
-> Teleporter to Dairon - Teleport to Cataris; Heals? False; Spawn Point; Default Node
+> Teleporter to Dairon - Teleport to Cataris; Heals? False; Default Node
   * Layers: default
   * Teleporter to Dairon - Teleport to Cataris
   * Extra - actor_name: teleport_baselab_000
@@ -3791,7 +3791,7 @@ Extra - asset_id: collision_camera_052
   > Dock to Green EMMI Introduction
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_EmmyMagma
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -3989,7 +3989,7 @@ Extra - asset_id: collision_camera_058
   > Door to Teleport to Artaria (Red)
       Trivial
 
-> Navigation Room; Heals? False; Default Node
+> Navigation Room; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_000
@@ -4113,7 +4113,7 @@ Extra - asset_id: collision_camera_061
   > Ledge below blob
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Kraid
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -4203,7 +4203,7 @@ Extra - asset_id: collision_camera_062
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: savestation_000
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
@@ -4217,7 +4217,7 @@ Kraid Arena
 Extra - total_boundings: {'x1': -17900.0, 'x2': -12400.0, 'y1': -7700.0, 'y2': -4128.35986328125}
 Extra - polygon: [[-12400.0, -4128.35986328125], [-17900.0, -4128.35986328125], [-17900.0, -7700.0], [-12400.0, -7700.0]]
 Extra - asset_id: collision_camera_063
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Dead_Kraid
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad

--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -144,7 +144,7 @@
                         "start_point_actor_name": "savestation_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Teleport to Artaria": {
                             "type": "and",
@@ -548,7 +548,7 @@
                         "start_point_actor_name": "teleport_cave_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Artaria",
                         "area_name": "Teleport to Dairon"
@@ -1836,7 +1836,7 @@
                         "start_point_actor_name": "SP_Checkpoint_EmmyBaseLab",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to Yellow EMMI Introduction": {
                             "type": "and",
@@ -2409,7 +2409,7 @@
                         "start_point_actor_name": "SP_WideBeam",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Big Hub": {
                             "type": "and",
@@ -2914,7 +2914,7 @@
                         "start_point_actor_name": "teleport_magma_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Cataris",
                         "area_name": "Teleport to Dairon"
@@ -6812,7 +6812,7 @@
                         "start_point_actor_name": "SP_AccessPoint_4",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Navigation Station South": {
                             "type": "or",
@@ -6998,7 +6998,7 @@
                         "hint_id": "LAB_1",
                         "string_asset_id": 5
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "kind": "generic",
                     "requirement_to_collect": {
                         "type": "and",
@@ -8633,7 +8633,7 @@
                         "start_point_actor_name": "elevator_sanctuary_001_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Ferenia",
                         "area_name": "Transport to Dairon"
@@ -9051,7 +9051,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Blackout2",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to EMMI Zone Exit North": {
                             "type": "and",
@@ -9260,7 +9260,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Bomb",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door from Total Recharge Station West": {
                             "type": "and",
@@ -9795,7 +9795,7 @@
                         "start_point_actor_name": "maproom_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_map/charclasses/weightactivatedplatform_map.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Total Recharge Station West": {
                             "type": "and",
@@ -13870,7 +13870,7 @@
                         "start_point_actor_name": "savestation_001_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Save Station West Tunnels": {
                             "type": "and",
@@ -15610,7 +15610,7 @@
                         "start_point_actor_name": "SP_Checkpoint_EmmyLabPhase2",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Central Unit Access": {
                             "type": "and",
@@ -16021,7 +16021,7 @@
                         "start_point_actor_name": "SP_Checkpoint_CentralUnit",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Central Unit": {
                             "type": "and",
@@ -16649,7 +16649,7 @@
                         "start_point_actor_name": "wagontrain_magma_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_train/charclasses/weightactivatedplatform_train.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Cataris",
                         "area_name": "Transport to Dairon"
@@ -16805,7 +16805,7 @@
                         "hint_id": "LAB_2",
                         "string_asset_id": 6
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "kind": "generic",
                     "requirement_to_collect": {
                         "type": "and",
@@ -16916,7 +16916,7 @@
                         "start_point_actor_name": "wagontrain_aqua_001_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_train/charclasses/weightactivatedplatform_train.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Burenia",
                         "area_name": "Lower Transport to Dairon"

--- a/randovania/games/dread/json_data/Dairon.json
+++ b/randovania/games/dread/json_data/Dairon.json
@@ -6862,7 +6862,7 @@
             }
         },
         "Navigation Station South": {
-            "default_node": "Navigation Room",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": -1000.0,
@@ -6969,7 +6969,7 @@
                                 "items": []
                             }
                         },
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6978,7 +6978,7 @@
                         }
                     }
                 },
-                "Navigation Room": {
+                "Save Station": {
                     "node_type": "hint",
                     "heal": false,
                     "coordinates": {
@@ -9657,7 +9657,7 @@
             }
         },
         "Map Station": {
-            "default_node": "Map Station",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": -10000.0,
@@ -9725,7 +9725,7 @@
                                 "items": []
                             }
                         },
-                        "Map Station": {
+                        "Save Station": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -9777,7 +9777,7 @@
                         }
                     }
                 },
-                "Map Station": {
+                "Save Station": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
@@ -16669,7 +16669,7 @@
             }
         },
         "Navigation Station North": {
-            "default_node": "Navigation Room",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": 3000.0,
@@ -16736,7 +16736,7 @@
                                 "items": []
                             }
                         },
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -16785,7 +16785,7 @@
                         }
                     }
                 },
-                "Navigation Room": {
+                "Save Station": {
                     "node_type": "hint",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -29,7 +29,7 @@ Extra - asset_id: collision_camera_000
   > Door to Teleport to Artaria
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: savestation_000
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
@@ -99,7 +99,7 @@ Extra - asset_id: collision_camera_001
   > Door to Save Station East
       Trivial
 
-> Teleporter to Artaria - Teleport to Dairon; Heals? False; Spawn Point; Default Node
+> Teleporter to Artaria - Teleport to Dairon; Heals? False; Default Node
   * Layers: default
   * Teleporter to Artaria - Teleport to Dairon
   * Extra - actor_name: teleport_cave_000
@@ -338,7 +338,7 @@ Extra - asset_id: collision_camera_004
   > Dock to Hub Access
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_EmmyBaseLab
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -457,7 +457,7 @@ Extra - asset_id: collision_camera_006
   > Start Point
       Can Slide
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_WideBeam
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -586,7 +586,7 @@ Extra - asset_id: collision_camera_008
   > Bottom-Left Corner
       Trivial
 
-> Teleporter to Cataris - Teleport to Dairon; Heals? False; Spawn Point; Default Node
+> Teleporter to Cataris - Teleport to Dairon; Heals? False; Default Node
   * Layers: default
   * Teleporter to Cataris - Teleport to Dairon
   * Extra - actor_name: teleport_magma_000
@@ -1119,7 +1119,7 @@ Extra - asset_id: collision_camera_013
           Varia Suit
           Heat/Cold Runs (Intermediate) and Heat Damage ≥ 100
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_AccessPoint_4
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1159,7 +1159,7 @@ Extra - asset_id: collision_camera_014
   > Navigation Room
       Trivial
 
-> Navigation Room; Heals? False; Default Node
+> Navigation Room; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_000
@@ -1483,7 +1483,7 @@ Extra - asset_id: collision_camera_019
   > Elevator to Ferenia - Transport to Dairon
       Trivial
 
-> Elevator to Ferenia - Transport to Dairon; Heals? False; Spawn Point; Default Node
+> Elevator to Ferenia - Transport to Dairon; Heals? False; Default Node
   * Layers: default
   * Teleporter to Ferenia - Transport to Dairon
   * Extra - actor_name: elevator_sanctuary_001
@@ -1561,7 +1561,7 @@ Extra - asset_id: collision_camera_020
   > Door to Total Recharge Station West
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Blackout2
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1611,7 +1611,7 @@ Extra - asset_id: collision_camera_021
   > Tunnel to Total Recharge Station West
       Lay Bomb
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Bomb
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1741,7 +1741,7 @@ Extra - asset_id: collision_camera_023
   > Door to Total Recharge Station West
       Trivial
 
-> Map Station; Heals? False; Default Node
+> Map Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: maproom_000
   * Extra - actor_def: actordef:actors/props/maproom/charclasses/maproom.bmsad
@@ -2388,7 +2388,7 @@ Extra - asset_id: collision_camera_032
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: savestation_001
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
@@ -2699,7 +2699,7 @@ Central Unit
 Extra - total_boundings: {'x1': -12900.0, 'x2': -10800.0, 'y1': -5400.0, 'y2': -4258.0}
 Extra - polygon: [[-10800.0, -4258.0], [-12900.0, -4258.0], [-12900.0, -5400.0], [-10800.0, -5400.0]]
 Extra - asset_id: collision_camera_038
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_EmmyLabPhase2
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2796,7 +2796,7 @@ Extra - asset_id: collision_camera_040
   > Door to Central Unit
       Morph Ball or Speed Booster or Use Spin Boost
 
-> Start Point 2; Heals? False; Spawn Point; Default Node
+> Start Point 2; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_CentralUnit
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2938,7 +2938,7 @@ Extra - asset_id: collision_camera_043
   > Elevator to Cataris - Transport to Dairon
       Trivial
 
-> Elevator to Cataris - Transport to Dairon; Heals? False; Spawn Point; Default Node
+> Elevator to Cataris - Transport to Dairon; Heals? False; Default Node
   * Layers: default
   * Teleporter to Cataris - Transport to Dairon
   * Extra - actor_name: wagontrain_magma_000
@@ -2981,7 +2981,7 @@ Extra - asset_id: collision_camera_044
   > Door to West Transport to Ferenia (Lower)
       Trivial
 
-> Navigation Room; Heals? False; Default Node
+> Navigation Room; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_001
@@ -3010,7 +3010,7 @@ Extra - asset_id: collision_camera_045
   > Tram to Burenia - Lower Transport to Dairon
       Trivial
 
-> Tram to Burenia - Lower Transport to Dairon; Heals? False; Spawn Point; Default Node
+> Tram to Burenia - Lower Transport to Dairon; Heals? False; Default Node
   * Layers: default
   * Teleporter to Burenia - Lower Transport to Dairon
   * Extra - actor_name: wagontrain_with_portal_aqua_001

--- a/randovania/games/dread/json_data/Dairon.txt
+++ b/randovania/games/dread/json_data/Dairon.txt
@@ -1156,10 +1156,10 @@ Extra - asset_id: collision_camera_014
   * Extra - right_shield_def: None
   > Door to Energy Recharge Station Middle
       Trivial
-  > Navigation Room
+  > Save Station
       Trivial
 
-> Navigation Room; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_000
@@ -1725,7 +1725,7 @@ Extra - asset_id: collision_camera_023
   * Extra - exclude_from_dock_rando: True
   > Door to Freezer
       Trivial
-  > Map Station
+  > Save Station
       After Dairon - Power Switch 2
 
 > Door to Freezer; Heals? False
@@ -1741,7 +1741,7 @@ Extra - asset_id: collision_camera_023
   > Door to Total Recharge Station West
       Trivial
 
-> Map Station; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: maproom_000
   * Extra - actor_def: actordef:actors/props/maproom/charclasses/maproom.bmsad
@@ -2966,7 +2966,7 @@ Extra - asset_id: collision_camera_044
   * Extra - right_shield_def: None
   > Door to West Transport to Ferenia (Upper)
       Trivial
-  > Navigation Room
+  > Save Station
       Trivial
 
 > Door to West Transport to Ferenia (Upper); Heals? False
@@ -2981,7 +2981,7 @@ Extra - asset_id: collision_camera_044
   > Door to West Transport to Ferenia (Lower)
       Trivial
 
-> Navigation Room; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_001

--- a/randovania/games/dread/json_data/Elun.json
+++ b/randovania/games/dread/json_data/Elun.json
@@ -238,7 +238,7 @@
                         "start_point_actor_name": "wagontrain_forest_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_train/charclasses/weightactivatedplatform_train.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Ghavoran",
                         "area_name": "Transport to Elun"
@@ -826,7 +826,7 @@
                         "start_point_actor_name": "SP_Checkpoint_PlasmaBeam",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Plasma Beam Room (Lower)": {
                             "type": "and",
@@ -1179,7 +1179,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Dead_ChozoWarriorX",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Spider Magnet Room": {
                             "type": "and",
@@ -1588,7 +1588,7 @@
                         "start_point_actor_name": "SP_PlasmaBeam",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Ammo Recharge Station": {
                             "type": "and",
@@ -1776,7 +1776,7 @@
                         "start_point_actor_name": "SP_Checkpoint_ChozoWarriorX",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Chozo Soldier Arena": {
                             "type": "and",
@@ -3169,7 +3169,7 @@
                         "start_point_actor_name": "weightactivatedplatform_save",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Transport to Ghavoran": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Elun.json
+++ b/randovania/games/dread/json_data/Elun.json
@@ -3169,7 +3169,7 @@
                         "start_point_actor_name": "weightactivatedplatform_save",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Transport to Ghavoran": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Elun.txt
+++ b/randovania/games/dread/json_data/Elun.txt
@@ -43,7 +43,7 @@ Extra - asset_id: collision_camera_001
   > Door to Save Station
       Trivial
 
-> Tram to Ghavoran - Transport to Elun; Heals? False; Spawn Point; Default Node
+> Tram to Ghavoran - Transport to Elun; Heals? False; Default Node
   * Layers: default
   * Teleporter to Ghavoran - Transport to Elun
   * Extra - actor_name: wagontrain_forest_000
@@ -196,7 +196,7 @@ Extra - asset_id: collision_camera_003
   > Door to Plasma Beam Room (Upper)
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_PlasmaBeam
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -273,7 +273,7 @@ Extra - asset_id: collision_camera_004
   > Event - Chozo Soldier Fight
       Fight Chozo-X
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Dead_ChozoWarriorX
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -376,7 +376,7 @@ Extra - asset_id: collision_camera_006
   > Door to Ammo Recharge Station
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_PlasmaBeam
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -417,7 +417,7 @@ Extra - asset_id: collision_camera_007
           After Elun - Vertical Bomb Maze Grapple Block
           Lay Bomb or Lay Power Bomb
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_ChozoWarriorX
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -663,7 +663,7 @@ Extra - asset_id: collision_camera_012
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: savestation
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad

--- a/randovania/games/dread/json_data/Elun.txt
+++ b/randovania/games/dread/json_data/Elun.txt
@@ -663,7 +663,7 @@ Extra - asset_id: collision_camera_012
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Default Node
   * Layers: default
   * Extra - actor_name: savestation
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad

--- a/randovania/games/dread/json_data/Ferenia.json
+++ b/randovania/games/dread/json_data/Ferenia.json
@@ -99,7 +99,7 @@
                         "start_point_actor_name": "elevator_baselab_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Dairon",
                         "area_name": "East Transport to Ferenia"
@@ -1422,7 +1422,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Dead_ChozoRobotSoldier",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Fan Room Access": {
                             "type": "and",
@@ -1902,7 +1902,7 @@
                         "start_point_actor_name": "teleporter_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Burenia",
                         "area_name": "Teleport to Ferenia"
@@ -4089,7 +4089,7 @@
                         "start_point_actor_name": "SP_AccessPoint_8",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Navigation Station": {
                             "type": "and",
@@ -5680,7 +5680,7 @@
                         "hint_id": "SANC_1",
                         "string_asset_id": 9
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "kind": "generic",
                     "requirement_to_collect": {
                         "type": "and",
@@ -6147,7 +6147,7 @@
                         "start_point_actor_name": "SP_Checkpoint_TwoChozoRobots_TopRight",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Cold Room (Energy Recharge Station)": {
                             "type": "and",
@@ -7386,7 +7386,7 @@
                         "start_point_actor_name": "SP_Checkpoint_TwoChozoRobots",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Twin Robot Arena": {
                             "type": "and",
@@ -8704,7 +8704,7 @@
                         "start_point_actor_name": "maproom_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_map/charclasses/weightactivatedplatform_map.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Map Station Access": {
                             "type": "and",
@@ -9384,7 +9384,7 @@
                         "start_point_actor_name": "SP_Checkpoint_SuperQuetzoa",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Escue Arena": {
                             "type": "and",
@@ -9824,7 +9824,7 @@
                         "start_point_actor_name": "SP_Checkpoint_MultiLockOn",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Escue Eyedoor Room": {
                             "type": "and",
@@ -10306,7 +10306,7 @@
                         "start_point_actor_name": "savestation_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Dock to Wave Beam Tutorial": {
                             "type": "and",
@@ -12406,7 +12406,7 @@
                         "start_point_actor_name": "SP_Checkpoint_EmmySancPhase2_CURoom",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {}
                 }
             }
@@ -12801,7 +12801,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Professor",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to Purple EMMI Introduction Access": {
                             "type": "and",
@@ -13212,7 +13212,7 @@
                         "start_point_actor_name": "savestation_001_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Path to Escue": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Ferenia.json
+++ b/randovania/games/dread/json_data/Ferenia.json
@@ -5544,7 +5544,7 @@
             }
         },
         "Navigation Station": {
-            "default_node": "Navigation Room",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": -12500.0,
@@ -5651,7 +5651,7 @@
                                 "items": []
                             }
                         },
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5660,7 +5660,7 @@
                         }
                     }
                 },
-                "Navigation Room": {
+                "Save Station": {
                     "node_type": "hint",
                     "heal": false,
                     "coordinates": {
@@ -8616,7 +8616,7 @@
             }
         },
         "Map Station": {
-            "default_node": "Map Station",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": 1500.0,
@@ -8677,7 +8677,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Map Station": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8686,7 +8686,7 @@
                         }
                     }
                 },
-                "Map Station": {
+                "Save Station": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -1029,10 +1029,10 @@ Extra - asset_id: collision_camera_016
   * Extra - right_shield_def: None
   > Door to Twin Robot Arena
       Trivial
-  > Navigation Room
+  > Save Station
       Trivial
 
-> Navigation Room; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_000
@@ -1579,10 +1579,10 @@ Extra - asset_id: collision_camera_023
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   * Extra - exclude_from_dock_rando: True
-  > Map Station
+  > Save Station
       Trivial
 
-> Map Station; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: maproom
   * Extra - actor_def: actordef:actors/props/maproom/charclasses/maproom.bmsad

--- a/randovania/games/dread/json_data/Ferenia.txt
+++ b/randovania/games/dread/json_data/Ferenia.txt
@@ -15,7 +15,7 @@ Extra - asset_id: collision_camera_000
   > Elevator to Dairon - East Transport to Ferenia
       Trivial
 
-> Elevator to Dairon - East Transport to Ferenia; Heals? False; Spawn Point; Default Node
+> Elevator to Dairon - East Transport to Ferenia; Heals? False; Default Node
   * Layers: default
   * Teleporter to Dairon - East Transport to Ferenia
   * Extra - actor_name: elevator_baselab_000
@@ -240,7 +240,7 @@ Extra - asset_id: collision_camera_005
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Dead_ChozoRobotSoldier
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -349,7 +349,7 @@ Extra - asset_id: collision_camera_007
   > Door to Cold Room (Small)
       Trivial
 
-> Teleporter to Burenia - Teleport to Ferenia; Heals? False; Spawn Point; Default Node
+> Teleporter to Burenia - Teleport to Ferenia; Heals? False; Default Node
   * Layers: default
   * Teleporter to Burenia - Teleport to Ferenia
   * Extra - actor_name: teleporter_000
@@ -759,7 +759,7 @@ Extra - asset_id: collision_camera_012
   > Pickup (Space Jump)
       Trivial
 
-> Start Point 2; Heals? False; Spawn Point; Default Node
+> Start Point 2; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_AccessPoint_8
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1032,7 +1032,7 @@ Extra - asset_id: collision_camera_016
   > Navigation Room
       Trivial
 
-> Navigation Room; Heals? False; Default Node
+> Navigation Room; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_000
@@ -1145,7 +1145,7 @@ Extra - asset_id: collision_camera_017
   > Door to Navigation Station
       Trivial
 
-> Start Point 3; Heals? False; Spawn Point; Default Node
+> Start Point 3; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_TwoChozoRobots_TopRight
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1344,7 +1344,7 @@ Extra - asset_id: collision_camera_019
   > Bomb Ledge
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_TwoChozoRobots
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1582,7 +1582,7 @@ Extra - asset_id: collision_camera_023
   > Map Station
       Trivial
 
-> Map Station; Heals? False; Default Node
+> Map Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: maproom
   * Extra - actor_def: actordef:actors/props/maproom/charclasses/maproom.bmsad
@@ -1746,7 +1746,7 @@ Extra - asset_id: collision_camera_026
   > Tunnel to Path to Escue
       Morph Ball
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_SuperQuetzoa
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1814,7 +1814,7 @@ Extra - asset_id: collision_camera_027
                       # Energy Requirements, not needed if using SA
                       Combat (Beginner) or Normal Damage ≥ 599
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_MultiLockOn
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1925,7 +1925,7 @@ Extra - asset_id: collision_camera_029
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: savestation_000
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
@@ -2300,7 +2300,7 @@ Central Unit
 Extra - total_boundings: {'x1': 11500.0, 'x2': 13600.0, 'y1': 4800.0, 'y2': 5942.0}
 Extra - polygon: [[13600.0, 5942.0], [11500.0, 5942.0], [11500.0, 4800.0], [13600.0, 4800.0]]
 Extra - asset_id: collision_camera_035
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_EmmySancPhase2_CURoom
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2356,7 +2356,7 @@ Extra - asset_id: collision_camera_040
   > Central Platform
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Professor
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2427,7 +2427,7 @@ Extra - asset_id: collision_camera_041
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: savestation_001
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -2357,7 +2357,7 @@
             }
         },
         "Navigation Station": {
-            "default_node": "Navigation Room",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": -5000.0,
@@ -2424,7 +2424,7 @@
                                 "items": []
                             }
                         },
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2473,7 +2473,7 @@
                         }
                     }
                 },
-                "Navigation Room": {
+                "Save Station": {
                     "node_type": "hint",
                     "heal": false,
                     "coordinates": {
@@ -4960,7 +4960,7 @@
             }
         },
         "Map Station": {
-            "default_node": "Map Station",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": -3000.0,
@@ -5021,7 +5021,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Map Station": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5030,7 +5030,7 @@
                         }
                     }
                 },
-                "Map Station": {
+                "Save Station": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -146,7 +146,7 @@
                         "start_point_actor_name": "elevator_aqua_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Burenia",
                         "area_name": "Transport to Ghavoran"
@@ -747,7 +747,7 @@
                         "start_point_actor_name": "SP_Checkpoint_ChozoRobotForest",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Robot Fight Arena": {
                             "type": "and",
@@ -1085,7 +1085,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Dead_ChozoRobotSoldier",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Left Entrance": {
                             "type": "and",
@@ -2343,7 +2343,7 @@
                         "start_point_actor_name": "SP_AccessPoint_7",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Navigation Station": {
                             "type": "and",
@@ -2493,7 +2493,7 @@
                         "hint_id": "FOREST_1",
                         "string_asset_id": 10
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "kind": "generic",
                     "requirement_to_collect": {
                         "type": "and",
@@ -2718,7 +2718,7 @@
                         "start_point_actor_name": "SP_AccessPoint_7B",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Navigation Station": {
                             "type": "and",
@@ -3912,7 +3912,7 @@
                         "start_point_actor_name": "SP_Checkpoint_SuperMissiles",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Super Missile Room Access (Missile Lock)": {
                             "type": "and",
@@ -5048,7 +5048,7 @@
                         "start_point_actor_name": "maproom_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_map/charclasses/weightactivatedplatform_map.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Map Station Access": {
                             "type": "and",
@@ -5902,7 +5902,7 @@
                         "start_point_actor_name": "SP_Checkpoint_EmmyForestPhase2",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to Central Unit Access": {
                             "type": "and",
@@ -6516,7 +6516,7 @@
                         "start_point_actor_name": "SP_Checkpoint_IceMissiles",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to EMMI Zone Exit Northeast (Upper)": {
                             "type": "or",
@@ -8640,7 +8640,7 @@
                         "start_point_actor_name": "savestation_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Chozo Warrior Arena": {
                             "type": "and",
@@ -8862,7 +8862,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Dead_ChozoWarriorX",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Save Station Center": {
                             "type": "and",
@@ -9426,7 +9426,7 @@
                         "start_point_actor_name": "teleporter_magma_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Cataris",
                         "area_name": "Teleport to Ghavoran"
@@ -9956,7 +9956,7 @@
                         "start_point_actor_name": "teleporter_aqua_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_teleport/charclasses/weightactivatedplatform_teleport.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Burenia",
                         "area_name": "Teleport to Ghavoran"
@@ -10946,7 +10946,7 @@
                         "start_point_actor_name": "SP_Checkpoint_ChozoWarriorForest",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Teleport to Burenia (Power Beam)": {
                             "type": "and",
@@ -11844,7 +11844,7 @@
                         "default"
                     ],
                     "extra": {},
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Cross Bomb Tutorial": {
                             "type": "and",
@@ -12462,7 +12462,7 @@
                         "start_point_actor_name": "SP_Checkpoint_DoubleJump",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Pickup (Spin Boost)": {
                             "type": "and",
@@ -13408,7 +13408,7 @@
                         "start_point_actor_name": "SP_Checkpoint_SonarObtained",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Pickup (Pulse Radar)": {
                             "type": "and",
@@ -15030,7 +15030,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Sonar",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door from Spin Boost Tower": {
                             "type": "and",
@@ -15196,7 +15196,7 @@
                         "start_point_actor_name": "weightactivatedplatform_save",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {
                         "Door to Golzuna Tower": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -29,7 +29,7 @@ Extra - asset_id: collision_camera_000
   > Elevator to Burenia - Transport to Ghavoran
       Trivial
 
-> Elevator to Burenia - Transport to Ghavoran; Heals? False; Spawn Point; Default Node
+> Elevator to Burenia - Transport to Ghavoran; Heals? False; Default Node
   * Layers: default
   * Teleporter to Burenia - Transport to Ghavoran
   * Extra - actor_name: elevator_aqua_000
@@ -134,7 +134,7 @@ Extra - asset_id: collision_camera_001
   > Door to Super Missile Room
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_ChozoRobotForest
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -195,7 +195,7 @@ Extra - asset_id: collision_camera_002
           After Elun - Release X Parasites
           Before Elun - Release X Parasites and Fight Gold Robot
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Dead_ChozoRobotSoldier
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -395,7 +395,7 @@ Extra - asset_id: collision_camera_005
   > Dock to Blue EMMI Introduction
       Trivial
 
-> Start Point 2; Heals? False; Spawn Point; Default Node
+> Start Point 2; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_AccessPoint_7
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -433,7 +433,7 @@ Extra - asset_id: collision_camera_006
   > Door to Navigation Station Access
       Trivial
 
-> Navigation Room; Heals? False; Default Node
+> Navigation Room; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_000
@@ -486,7 +486,7 @@ Extra - asset_id: collision_camera_007
   > Tunnel to Spider Magnet Elevator
       Before Ghavoran - Super Missile Rotatable
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_AccessPoint_7B
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -723,7 +723,7 @@ Extra - asset_id: collision_camera_010
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_SuperMissiles
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -889,7 +889,7 @@ Extra - asset_id: collision_camera_013
   > Map Station
       Trivial
 
-> Map Station; Heals? False; Default Node
+> Map Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: maproom
   * Extra - actor_def: actordef:actors/props/maproom/charclasses/maproom.bmsad
@@ -1060,7 +1060,7 @@ Central Unit
 Extra - total_boundings: {'x1': -9100.0, 'x2': -7000.0, 'y1': 4100.0, 'y2': 5242.0}
 Extra - polygon: [[-7000.0, 5242.0], [-9100.0, 5242.0], [-9100.0, 4100.0], [-7000.0, 4100.0]]
 Extra - asset_id: collision_camera_017
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_EmmyForestPhase2
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1191,7 +1191,7 @@ Extra - asset_id: collision_camera_019
   > Dock to Central Unit
       Trivial
 
-> Room Center; Heals? False; Spawn Point; Default Node
+> Room Center; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_IceMissiles
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1531,7 +1531,7 @@ Extra - asset_id: collision_camera_022
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: savestation_000
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
@@ -1574,7 +1574,7 @@ Extra - asset_id: collision_camera_023
   > Event - Chozo-X
       After Ghavoran - Chozo-X Trigger and Fight Chozo-X
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Dead_ChozoWarriorX
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -1672,7 +1672,7 @@ Extra - asset_id: collision_camera_024
   > Teleporter to Cataris
       Trivial
 
-> Teleporter to Cataris; Heals? False; Spawn Point; Default Node
+> Teleporter to Cataris; Heals? False; Default Node
   * Layers: default
   * Teleporter to Cataris - Teleport to Ghavoran
   * Extra - actor_name: teleporter_magma_000
@@ -1749,7 +1749,7 @@ Teleport to Burenia
 Extra - total_boundings: {'x1': 4000.0, 'x2': 7100.0, 'y1': 870.0, 'y2': 3190.0}
 Extra - polygon: [[7100.0, 3190.0], [4000.0, 3190.0], [4000.0, 870.0], [6400.0, 870.0], [6400.0, 2000.0], [7100.0, 2000.0]]
 Extra - asset_id: collision_camera_024
-> Teleporter to Burenia - Teleport to Ghavoran; Heals? False; Spawn Point; Default Node
+> Teleporter to Burenia - Teleport to Ghavoran; Heals? False; Default Node
   * Layers: default
   * Teleporter to Burenia - Teleport to Ghavoran
   * Extra - actor_name: teleporter_aqua_000
@@ -1928,7 +1928,7 @@ Extra - asset_id: collision_camera_025_B
   > Door to Teleport to Burenia (Missile)
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_ChozoWarriorForest
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2091,7 +2091,7 @@ Extra - asset_id: collision_camera_026
   > Door to Cross Bomb Tutorial
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   > Door to Cross Bomb Tutorial
       Trivial
@@ -2223,7 +2223,7 @@ Extra - asset_id: collision_camera_030
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_DoubleJump
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2368,7 +2368,7 @@ Extra - asset_id: collision_camera_032
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_SonarObtained
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2701,7 +2701,7 @@ Extra - asset_id: collision_camera_039
   > Pickup (Missile Tank)
       Can Slide
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Sonar
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -2738,7 +2738,7 @@ Extra - asset_id: collision_camera_040
   > Save Station
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: savestation
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -418,7 +418,7 @@ Extra - asset_id: collision_camera_006
   * Extra - right_shield_def: None
   > Door to Flipper Room
       Trivial
-  > Navigation Room
+  > Save Station
       Trivial
 
 > Door to Flipper Room; Heals? False
@@ -433,7 +433,7 @@ Extra - asset_id: collision_camera_006
   > Door to Navigation Station Access
       Trivial
 
-> Navigation Room; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_000
@@ -886,10 +886,10 @@ Extra - asset_id: collision_camera_013
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   * Extra - exclude_from_dock_rando: True
-  > Map Station
+  > Save Station
       Trivial
 
-> Map Station; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: maproom
   * Extra - actor_def: actordef:actors/props/maproom/charclasses/maproom.bmsad

--- a/randovania/games/dread/json_data/Hanubia.json
+++ b/randovania/games/dread/json_data/Hanubia.json
@@ -99,7 +99,7 @@
                         "start_point_actor_name": "elevator_sanctuary_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Ferenia",
                         "area_name": "Transport to Hanubia"
@@ -242,7 +242,7 @@
                         "start_point_actor_name": "wagontrain_forest_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_train/charclasses/weightactivatedplatform_train.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Ghavoran",
                         "area_name": "Transport to Hanubia"
@@ -885,7 +885,7 @@
                         "hint_id": "SHIP_1",
                         "string_asset_id": 11
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "kind": "generic",
                     "requirement_to_collect": {
                         "type": "and",
@@ -1473,7 +1473,7 @@
                         "start_point_actor_name": "SP_AccessPoint_10",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Navigation Station": {
                             "type": "and",
@@ -1624,7 +1624,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Dead_CWX_Elite",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Transport to Itorash": {
                             "type": "and",
@@ -1875,7 +1875,7 @@
                         "start_point_actor_name": "SP_Checkpoint_EliteChozoWarriorX",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Entrance Tall Room": {
                             "type": "and",
@@ -2056,7 +2056,7 @@
                         "start_point_actor_name": "elevator_skybase_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Itorash",
                         "area_name": "Transport to Hanubia"
@@ -2137,7 +2137,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Endgame",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "event_name": "Ship",
                     "connections": {
                         "Dock to Entrance Tall Room": {
@@ -2690,7 +2690,7 @@
                         "start_point_actor_name": "SP_AccessPoint_10B",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Navigation Station (Top)": {
                             "type": "and",
@@ -3260,7 +3260,7 @@
                         "start_point_actor_name": "SP_Checkpoint_PowerBomb",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Dock to Tank Room (Bottom)": {
                             "type": "and",
@@ -4041,7 +4041,7 @@
                         "start_point_actor_name": "SP_Checkpoint_Dead_ChozoWarriorX",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Door from EMMI Zone Exit West": {
                             "type": "resource",
@@ -5056,7 +5056,7 @@
                         "start_point_actor_name": "SP_Checkpoint_CommanderX",
                         "start_point_actor_def": "actordef:actors/logic/startpoint/charclasses/startpoint.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "connections": {
                         "Event - Escape Sequence": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Hanubia.json
+++ b/randovania/games/dread/json_data/Hanubia.json
@@ -709,7 +709,7 @@
             }
         },
         "Navigation Station": {
-            "default_node": "Navigation Room",
+            "default_node": "Save Station",
             "extra": {
                 "total_boundings": {
                     "x1": -500.0,
@@ -769,7 +769,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -816,7 +816,7 @@
                                 "items": []
                             }
                         },
-                        "Navigation Room": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -865,7 +865,7 @@
                         }
                     }
                 },
-                "Navigation Room": {
+                "Save Station": {
                     "node_type": "hint",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/dread/json_data/Hanubia.txt
+++ b/randovania/games/dread/json_data/Hanubia.txt
@@ -15,7 +15,7 @@ Extra - asset_id: collision_camera_000
   > Elevator to Ferenia - Transport to Hanubia
       Trivial
 
-> Elevator to Ferenia - Transport to Hanubia; Heals? False; Spawn Point; Default Node
+> Elevator to Ferenia - Transport to Hanubia; Heals? False; Default Node
   * Layers: default
   * Teleporter to Ferenia - Transport to Hanubia
   * Extra - actor_name: elevator_sanctuary_000
@@ -53,7 +53,7 @@ Extra - asset_id: collision_camera_001
   > Tram to Ghavoran - Transport to Hanubia
       Trivial
 
-> Tram to Ghavoran - Transport to Hanubia; Heals? False; Spawn Point; Default Node
+> Tram to Ghavoran - Transport to Hanubia; Heals? False; Default Node
   * Layers: default
   * Teleporter to Ghavoran - Transport to Hanubia
   * Extra - actor_name: wagontrain_forest_000
@@ -183,7 +183,7 @@ Extra - asset_id: collision_camera_003
   > Door to Speedboost Puzzle Room
       Trivial
 
-> Navigation Room; Heals? False; Default Node
+> Navigation Room; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_000
@@ -305,7 +305,7 @@ Extra - asset_id: collision_camera_004
   > Door to Navigation Station
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_AccessPoint_10
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -345,7 +345,7 @@ Extra - asset_id: collision_camera_005
   > Event - Gold Chozo Fight
       Fight Gold Chozo-X
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Dead_CWX_Elite
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -405,7 +405,7 @@ Extra - asset_id: collision_camera_006
   > Door to Entrance Tall Room
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_EliteChozoWarriorX
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -444,7 +444,7 @@ Extra - asset_id: collision_camera_007
   > Elevator to Itorash - Transport to Hanubia
       Trivial
 
-> Elevator to Itorash - Transport to Hanubia; Heals? False; Spawn Point; Default Node
+> Elevator to Itorash - Transport to Hanubia; Heals? False; Default Node
   * Layers: default
   * Teleporter to Itorash - Transport to Hanubia
   * Extra - actor_name: capsulelaunchershipyard_000
@@ -461,7 +461,7 @@ Ship Room
 Extra - total_boundings: {'x1': -19100.0, 'x2': -6400.0, 'y1': 1700.0, 'y2': 9000.0}
 Extra - polygon: [[-7600.0, 9000.0], [-19100.0, 9000.0], [-19100.0, 6400.0], [-12100.0, 5300.0], [-12100.0, 1700.0], [-6400.0, 1700.0], [-6400.0, 4300.0], [-7600.0, 4900.0]]
 Extra - asset_id: collision_camera_008
-> Event - Ship; Heals? False; Spawn Point; Default Node
+> Event - Ship; Heals? False; Default Node
   * Layers: default
   * Event Ship
   * Extra - start_point_actor_name: SP_Checkpoint_Endgame
@@ -573,7 +573,7 @@ Extra - asset_id: collision_camera_009
   > Event - Grapple Block
       Grapple Beam
 
-> Start Point 2; Heals? False; Spawn Point; Default Node
+> Start Point 2; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_AccessPoint_10B
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -687,7 +687,7 @@ Extra - asset_id: collision_camera_011
   > Start Point
       After Escape Sequence
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_PowerBomb
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -829,7 +829,7 @@ Extra - asset_id: collision_camera_014
   > Start Point
       Trivial
 
-> Start Point; Heals? False; Spawn Point; Default Node
+> Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_Dead_ChozoWarriorX
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad
@@ -965,7 +965,7 @@ Extra - asset_id: collision_camera_020
   > Raven Beak X Checkpoint
       Trivial
 
-> Raven Beak X Checkpoint; Heals? False; Spawn Point; Default Node
+> Raven Beak X Checkpoint; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: SP_Checkpoint_CommanderX
   * Extra - start_point_actor_def: actordef:actors/logic/startpoint/charclasses/startpoint.bmsad

--- a/randovania/games/dread/json_data/Hanubia.txt
+++ b/randovania/games/dread/json_data/Hanubia.txt
@@ -154,7 +154,7 @@ Extra - asset_id: collision_camera_003
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Navigation Room
+  > Save Station
       Trivial
 
 > Door to Speedboost Puzzle Room; Heals? False
@@ -168,7 +168,7 @@ Extra - asset_id: collision_camera_003
   * Extra - right_shield_def: None
   > Door from Speedboost Puzzle Room
       Trivial
-  > Navigation Room
+  > Save Station
       Trivial
 
 > Door from Speedboost Puzzle Room; Heals? False
@@ -183,7 +183,7 @@ Extra - asset_id: collision_camera_003
   > Door to Speedboost Puzzle Room
       Trivial
 
-> Navigation Room; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Hint
   * Extra - actor_name: accesspoint_000

--- a/randovania/games/dread/json_data/Itorash.json
+++ b/randovania/games/dread/json_data/Itorash.json
@@ -70,7 +70,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Elevator to Raven Beak": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -110,7 +110,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Transport to Hanubia": {
+                        "Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -137,8 +137,23 @@
                         "start_point_actor_name": "savestation_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": true,
-                    "connections": {}
+                    "valid_starting_location": false,
+                    "connections": {
+                        "Door to Transport to Hanubia": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Door to Elevator to Raven Beak": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -474,7 +489,7 @@
                         "start_point_actor_name": "elevator_shipyard_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "destination": {
                         "world_name": "Hanubia",
                         "area_name": "Transport to Itorash"

--- a/randovania/games/dread/json_data/Itorash.json
+++ b/randovania/games/dread/json_data/Itorash.json
@@ -137,7 +137,7 @@
                         "start_point_actor_name": "savestation_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad"
                     },
-                    "valid_starting_location": false,
+                    "valid_starting_location": true,
                     "connections": {}
                 }
             }
@@ -474,7 +474,7 @@
                         "start_point_actor_name": "elevator_shipyard_000_platform",
                         "start_point_actor_def": "actordef:actors/props/weightactivatedplatform_elevator/charclasses/weightactivatedplatform_elevator.bmsad"
                     },
-                    "valid_starting_location": true,
+                    "valid_starting_location": false,
                     "destination": {
                         "world_name": "Hanubia",
                         "area_name": "Transport to Itorash"

--- a/randovania/games/dread/json_data/Itorash.txt
+++ b/randovania/games/dread/json_data/Itorash.txt
@@ -12,7 +12,7 @@ Extra - asset_id: collision_camera_000
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Elevator to Raven Beak
+  > Save Station
       Trivial
 
 > Door to Elevator to Raven Beak; Heals? False
@@ -24,15 +24,19 @@ Extra - asset_id: collision_camera_000
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Transport to Hanubia
+  > Save Station
       Trivial
 
-> Save Station; Heals? False; Spawn Point; Default Node
+> Save Station; Heals? False; Default Node
   * Layers: default
   * Extra - actor_name: savestation_000
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
   * Extra - start_point_actor_name: savestation_000_platform
   * Extra - start_point_actor_def: actordef:actors/props/weightactivatedplatform_save/charclasses/weightactivatedplatform_save.bmsad
+  > Door to Transport to Hanubia
+      Trivial
+  > Door to Elevator to Raven Beak
+      Trivial
 
 ----------------
 Transport to Hanubia
@@ -72,7 +76,7 @@ Extra - asset_id: collision_camera_001
           Flash Shift and Walljump (Beginner)
           Morph Ball and Single-wall Wall Jump (Intermediate)
 
-> Elevator to Hanubia; Heals? False; Default Node
+> Elevator to Hanubia; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Teleporter to Hanubia - Transport to Itorash
   * Extra - actor_name: capsuleelevatorskybase_000

--- a/randovania/games/dread/json_data/Itorash.txt
+++ b/randovania/games/dread/json_data/Itorash.txt
@@ -27,7 +27,7 @@ Extra - asset_id: collision_camera_000
   > Door to Transport to Hanubia
       Trivial
 
-> Save Station; Heals? False; Default Node
+> Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Extra - actor_name: savestation_000
   * Extra - actor_def: actordef:actors/props/savestation/charclasses/savestation.bmsad
@@ -72,7 +72,7 @@ Extra - asset_id: collision_camera_001
           Flash Shift and Walljump (Beginner)
           Morph Ball and Single-wall Wall Jump (Intermediate)
 
-> Elevator to Hanubia; Heals? False; Spawn Point; Default Node
+> Elevator to Hanubia; Heals? False; Default Node
   * Layers: default
   * Teleporter to Hanubia - Transport to Itorash
   * Extra - actor_name: capsuleelevatorskybase_000

--- a/randovania/games/dread/layout/dread_configuration.py
+++ b/randovania/games/dread/layout/dread_configuration.py
@@ -48,9 +48,6 @@ class DreadConfiguration(BaseConfiguration):
             if trick.hide_from_ui and self.trick_level.level_for_trick(trick) != LayoutTrickLevel.DISABLED:
                 result.append(f"Enabled {trick.long_name}")
 
-        if self.starting_location.locations != (gd.starting_location,):
-            result.append("Custom Starting Location")
-
         if not self.elevators.is_vanilla:
             result.append("Random Elevators")
 

--- a/randovania/gui/preset_settings/starting_area_tab.py
+++ b/randovania/gui/preset_settings/starting_area_tab.py
@@ -109,8 +109,10 @@ class PresetMetroidStartingArea(PresetStartingArea):
 
     def _starting_location_on_select_save_station(self):
         world_list = self.game_description.world_list
-        save_rooms = ["Save Station", "Navigation Room", "Map Station"]
-        save_stations = [node.identifier for node in world_list.iterate_nodes() if node.name in save_rooms]
+        save_stations = [
+            node.identifier for node in world_list.iterate_nodes()
+            if node.name in ["Save Station", "Navigation Room", "Map Station"]
+        ]
 
         with self._editor as editor:
             editor.set_configuration_field(

--- a/randovania/gui/preset_settings/starting_area_tab.py
+++ b/randovania/gui/preset_settings/starting_area_tab.py
@@ -128,4 +128,4 @@ class PresetMetroidStartingArea(PresetStartingArea):
 class PresetMetroidDreadStartingArea(PresetMetroidStartingArea):
     @classmethod
     def tab_title(cls) -> str:
-        return "Starting Area [Unsupported]"
+        return "Starting Area"

--- a/randovania/gui/preset_settings/starting_area_tab.py
+++ b/randovania/gui/preset_settings/starting_area_tab.py
@@ -102,22 +102,14 @@ class PresetStartingArea(PresetTab, Ui_PresetStartingArea, NodeListHelper):
 
 
 class PresetMetroidStartingArea(PresetStartingArea):
-    starting_area_quick_fill_save_station: QtWidgets.QPushButton
-
     def create_quick_fill_buttons(self):
         super().create_quick_fill_buttons()
         self.starting_area_quick_fill_save_station = self._quick_fill_button("Save Station",
                                                                              self._starting_location_on_select_save_station)
-
-    def _save_station_nodes(self):
-        return [
-            node.identifier
-            for node in self.game_description.world_list.iterate_nodes()
-            if node.name == "Save Station"
-        ]
         
     def _starting_location_on_select_save_station(self):
-        save_stations = self._save_station_nodes()
+        world_list = self.game_description.world_list
+        save_stations = [node.identifier for node in world_list.iterate_nodes() if node.name == "Save Station"]
 
         with self._editor as editor:
             editor.set_configuration_field(
@@ -128,12 +120,3 @@ class PresetMetroidStartingArea(PresetStartingArea):
     @property
     def quick_fill_description(self) -> str:
         return super().quick_fill_description + "<br/>Save Stations: All areas with Save Stations."
-
-
-class PresetMetroidDreadStartingArea(PresetMetroidStartingArea):
-    def _save_station_nodes(self):
-        return [
-            node.identifier
-            for node in self.game_description.world_list.iterate_nodes()
-            if node.name in ["Save Station", "Navigation Room", "Map Station"]
-        ]

--- a/randovania/gui/preset_settings/starting_area_tab.py
+++ b/randovania/gui/preset_settings/starting_area_tab.py
@@ -109,7 +109,8 @@ class PresetMetroidStartingArea(PresetStartingArea):
 
     def _starting_location_on_select_save_station(self):
         world_list = self.game_description.world_list
-        save_stations = [node.identifier for node in world_list.iterate_nodes() if node.name in ["Save Station", "Navigation Room", "Map Station"]]
+        save_rooms = ["Save Station", "Navigation Room", "Map Station"]
+        save_stations = [node.identifier for node in world_list.iterate_nodes() if node.name in save_rooms]
 
         with self._editor as editor:
             editor.set_configuration_field(

--- a/randovania/gui/preset_settings/starting_area_tab.py
+++ b/randovania/gui/preset_settings/starting_area_tab.py
@@ -109,7 +109,7 @@ class PresetMetroidStartingArea(PresetStartingArea):
 
     def _starting_location_on_select_save_station(self):
         world_list = self.game_description.world_list
-        save_stations = [node.identifier for node in world_list.iterate_nodes() if node.name == "Save Station"]
+        save_stations = [node.identifier for node in world_list.iterate_nodes() if node.name in ["Save Station", "Navigation Room", "Map Station"]]
 
         with self._editor as editor:
             editor.set_configuration_field(

--- a/randovania/gui/preset_settings/starting_area_tab.py
+++ b/randovania/gui/preset_settings/starting_area_tab.py
@@ -102,6 +102,8 @@ class PresetStartingArea(PresetTab, Ui_PresetStartingArea, NodeListHelper):
 
 
 class PresetMetroidStartingArea(PresetStartingArea):
+    starting_area_quick_fill_save_station: QtWidgets.QPushButton
+
     def create_quick_fill_buttons(self):
         super().create_quick_fill_buttons()
         self.starting_area_quick_fill_save_station = self._quick_fill_button("Save Station",

--- a/randovania/gui/preset_settings/starting_area_tab.py
+++ b/randovania/gui/preset_settings/starting_area_tab.py
@@ -109,10 +109,8 @@ class PresetMetroidStartingArea(PresetStartingArea):
 
     def _starting_location_on_select_save_station(self):
         world_list = self.game_description.world_list
-        save_stations = [
-            node.identifier for node in world_list.iterate_nodes()
-            if node.name in ["Save Station", "Navigation Room", "Map Station"]
-        ]
+        save_rooms = ["Save Station", "Navigation Room", "Map Station"]
+        save_stations = [node.identifier for node in world_list.iterate_nodes() if node.name in save_rooms]
 
         with self._editor as editor:
             editor.set_configuration_field(

--- a/randovania/gui/preset_settings/starting_area_tab.py
+++ b/randovania/gui/preset_settings/starting_area_tab.py
@@ -135,7 +135,3 @@ class PresetMetroidDreadStartingArea(PresetMetroidStartingArea):
             for node in self.game_description.world_list.iterate_nodes()
             if node.name in ["Save Station", "Navigation Room", "Map Station"]
         ]
-        
-    @classmethod
-    def tab_title(cls) -> str:
-        return "Starting Area"

--- a/randovania/gui/preset_settings/starting_area_tab.py
+++ b/randovania/gui/preset_settings/starting_area_tab.py
@@ -107,12 +107,15 @@ class PresetMetroidStartingArea(PresetStartingArea):
         self.starting_area_quick_fill_save_station = self._quick_fill_button("Save Station",
                                                                              self._starting_location_on_select_save_station)
 
-    def _starting_location_on_select_save_station(self):
-        world_list = self.game_description.world_list
-        save_stations = [
-            node.identifier for node in world_list.iterate_nodes()
-            if node.name in ["Save Station", "Navigation Room", "Map Station"]
+    def _save_station_nodes(self):
+        return [
+            node.identifier
+            for node in self.game_description.world_list.iterate_nodes()
+            if node.name == "Save Station"
         ]
+        
+    def _starting_location_on_select_save_station(self):
+        save_stations = self._save_station_nodes()
 
         with self._editor as editor:
             editor.set_configuration_field(
@@ -126,6 +129,13 @@ class PresetMetroidStartingArea(PresetStartingArea):
 
 
 class PresetMetroidDreadStartingArea(PresetMetroidStartingArea):
+    def _save_station_nodes(self):
+        return [
+            node.identifier
+            for node in self.game_description.world_list.iterate_nodes()
+            if node.name in ["Save Station", "Navigation Room", "Map Station"]
+        ]
+        
     @classmethod
     def tab_title(cls) -> str:
         return "Starting Area"

--- a/test/games/dread/layout/test_dread_configuration.py
+++ b/test/games/dread/layout/test_dread_configuration.py
@@ -36,7 +36,6 @@ def test_has_unsupported_features(preset_manager):
     assert configuration.unsupported_features() == [
         'Metroid DNA on non-boss/EMMI',
         'Enabled Heat/Cold Runs',
-        "Custom Starting Location",
         'Random Elevators',
     ]
 

--- a/test/games/dread/layout/test_dread_configuration.py
+++ b/test/games/dread/layout/test_dread_configuration.py
@@ -36,6 +36,7 @@ def test_has_unsupported_features(preset_manager):
     assert configuration.unsupported_features() == [
         'Metroid DNA on non-boss/EMMI',
         'Enabled Heat/Cold Runs',
+        "Custom Starting Location",
         'Random Elevators',
     ]
 

--- a/test/games/dread/layout/test_dread_configuration.py
+++ b/test/games/dread/layout/test_dread_configuration.py
@@ -3,7 +3,6 @@ import dataclasses
 from randovania.game_description import default_database
 from randovania.game_description.resources.resource_type import ResourceType
 from randovania.game_description.world.area_identifier import AreaIdentifier
-from randovania.game_description.world.node_identifier import NodeIdentifier
 from randovania.games.dread.layout.dread_configuration import DreadConfiguration, DreadArtifactConfig
 from randovania.games.game import RandovaniaGame
 from randovania.layout.base.trick_level import LayoutTrickLevel
@@ -22,9 +21,6 @@ def test_has_unsupported_features(preset_manager):
     configuration = dataclasses.replace(
         configuration,
         trick_level=configuration.trick_level.set_level_for_trick(suitless, LayoutTrickLevel.HYPERMODE),
-        starting_location=configuration.starting_location.ensure_has_location(
-            NodeIdentifier.create("Burenia", "Navigation Station North", "Navigation Room"), True,
-        ),
         elevators=dataclasses.replace(configuration.elevators, mode=TeleporterShuffleMode.TWO_WAY_RANDOMIZED),
         artifacts=DreadArtifactConfig(
             prefer_emmi=False,

--- a/test/games/dread/layout/test_dread_configuration.py
+++ b/test/games/dread/layout/test_dread_configuration.py
@@ -23,7 +23,7 @@ def test_has_unsupported_features(preset_manager):
         configuration,
         trick_level=configuration.trick_level.set_level_for_trick(suitless, LayoutTrickLevel.HYPERMODE),
         starting_location=configuration.starting_location.ensure_has_location(
-            NodeIdentifier.create("Burenia", "Upper Burenia Hub", "Start Point"), True,
+            NodeIdentifier.create("Burenia", "Navigation Station North", "Navigation Room"), True,
         ),
         elevators=dataclasses.replace(configuration.elevators, mode=TeleporterShuffleMode.TWO_WAY_RANDOMIZED),
         artifacts=DreadArtifactConfig(

--- a/test/games/dread/layout/test_dread_configuration.py
+++ b/test/games/dread/layout/test_dread_configuration.py
@@ -36,7 +36,6 @@ def test_has_unsupported_features(preset_manager):
     assert configuration.unsupported_features() == [
         'Metroid DNA on non-boss/EMMI',
         'Enabled Heat/Cold Runs',
-        'Custom Starting Location',
         'Random Elevators',
     ]
 

--- a/test/gui/preset_settings/test_starting_area.py
+++ b/test/gui/preset_settings/test_starting_area.py
@@ -87,7 +87,8 @@ def test_quick_fill_save_station(skip_qtbot, preset_manager, game_enum: Randovan
     skip_qtbot.mouseClick(window.starting_area_quick_fill_save_station, QtCore.Qt.LeftButton)
 
     # Assert
-    assert editor.configuration.starting_location.locations == (window._save_station_nodes,)
+    save_stations = self.PresetMetroidStartingArea._save_station_nodes
+    assert editor.configuration.starting_location.locations == save_stations
 
 
 def test_quick_fill_cs_classic(skip_qtbot, preset_manager):

--- a/test/gui/preset_settings/test_starting_area.py
+++ b/test/gui/preset_settings/test_starting_area.py
@@ -74,28 +74,6 @@ def test_quick_fill_default(skip_qtbot, preset_manager, game_enum: RandovaniaGam
     # Assert
     assert editor.configuration.starting_location.locations == (window.game_description.starting_location,)
 
-
-def test_quick_fill_save_station(skip_qtbot, preset_manager, game_enum: RandovaniaGame):
-    # Setup
-    base = preset_manager.default_preset_for_game(game_enum).get_preset()
-    preset = dataclasses.replace(base, uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'))
-    editor = PresetEditor(preset)
-    window = PresetMetroidStartingArea(editor, default_database.game_description_for(preset.game), MagicMock())
-    skip_qtbot.addWidget(window)
-
-    # Run
-    skip_qtbot.mouseClick(window.starting_area_quick_fill_save_station, QtCore.Qt.LeftButton)
-
-    # Assert
-    save_stations = [
-        NodeIdentifier.as_string("Save Station"),
-        NodeIdentifier.as_string("Save Point"),
-        NodeIdentifier.as_string("Navigation Room"),
-        NodeIdentifier.as_string("Map Station")
-    ]
-    assert editor.configuration.starting_location.locations == save_stations
-
-
 def test_quick_fill_cs_classic(skip_qtbot, preset_manager):
     # Setup
     base = preset_manager.default_preset_for_game(RandovaniaGame.CAVE_STORY).get_preset()

--- a/test/gui/preset_settings/test_starting_area.py
+++ b/test/gui/preset_settings/test_starting_area.py
@@ -87,7 +87,7 @@ def test_quick_fill_save_station(skip_qtbot, preset_manager, game_enum: Randovan
     skip_qtbot.mouseClick(window.starting_area_quick_fill_save_station, QtCore.Qt.LeftButton)
 
     # Assert
-    assert editor.configuration.starting_location.locations == (window.game_description.starting_location,)
+    assert editor.configuration.starting_location.locations == (window.save_stations,)
 
 
 def test_quick_fill_cs_classic(skip_qtbot, preset_manager):

--- a/test/gui/preset_settings/test_starting_area.py
+++ b/test/gui/preset_settings/test_starting_area.py
@@ -87,7 +87,12 @@ def test_quick_fill_save_station(skip_qtbot, preset_manager, game_enum: Randovan
     skip_qtbot.mouseClick(window.starting_area_quick_fill_save_station, QtCore.Qt.LeftButton)
 
     # Assert
-    save_stations = self.PresetMetroidStartingArea._save_station_nodes
+    save_stations = [
+        NodeIdentifier.as_string("Save Station"),
+        NodeIdentifier.as_string("Save Point"),
+        NodeIdentifier.as_string("Navigation Room"),
+        NodeIdentifier.as_string("Map Station")
+    ]
     assert editor.configuration.starting_location.locations == save_stations
 
 

--- a/test/gui/preset_settings/test_starting_area.py
+++ b/test/gui/preset_settings/test_starting_area.py
@@ -87,7 +87,7 @@ def test_quick_fill_save_station(skip_qtbot, preset_manager, game_enum: Randovan
     skip_qtbot.mouseClick(window.starting_area_quick_fill_save_station, QtCore.Qt.LeftButton)
 
     # Assert
-    assert editor.configuration.starting_location.locations == (window.save_stations,)
+    assert editor.configuration.starting_location.locations == (window._save_station_nodes,)
 
 
 def test_quick_fill_cs_classic(skip_qtbot, preset_manager):

--- a/test/gui/preset_settings/test_starting_area.py
+++ b/test/gui/preset_settings/test_starting_area.py
@@ -75,6 +75,21 @@ def test_quick_fill_default(skip_qtbot, preset_manager, game_enum: RandovaniaGam
     assert editor.configuration.starting_location.locations == (window.game_description.starting_location,)
 
 
+def test_quick_fill_save_station(skip_qtbot, preset_manager, game_enum: RandovaniaGame):
+    # Setup
+    base = preset_manager.default_preset_for_game(game_enum).get_preset()
+    preset = dataclasses.replace(base, uuid=uuid.UUID('b41fde84-1f57-4b79-8cd6-3e5a78077fa6'))
+    editor = PresetEditor(preset)
+    window = PresetMetroidStartingArea(editor, default_database.game_description_for(preset.game), MagicMock())
+    skip_qtbot.addWidget(window)
+
+    # Run
+    skip_qtbot.mouseClick(window.starting_area_quick_fill_save_station, QtCore.Qt.LeftButton)
+
+    # Assert
+    assert editor.configuration.starting_location.locations == (window.game_description.starting_location,)
+
+
 def test_quick_fill_cs_classic(skip_qtbot, preset_manager):
     # Setup
     base = preset_manager.default_preset_for_game(RandovaniaGame.CAVE_STORY).get_preset()

--- a/test/test_files/log_files/dread_1.rdvgame
+++ b/test/test_files/log_files/dread_1.rdvgame
@@ -13297,7 +13297,7 @@
                 }
             },
             "hints": {
-                "Artaria/Navigation Station South/Navigation Room": {
+                "Artaria/Navigation Station South/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -13308,7 +13308,7 @@
                     "target": 0,
                     "dark_temple": null
                 },
-                "Cataris/Navigation Station Southeast/Navigation Room": {
+                "Cataris/Navigation Station Southeast/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -13319,7 +13319,7 @@
                     "target": 47,
                     "dark_temple": null
                 },
-                "Artaria/Navigation Station North/Navigation Room": {
+                "Artaria/Navigation Station North/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -13330,7 +13330,7 @@
                     "target": 9,
                     "dark_temple": null
                 },
-                "Cataris/Navigation Station Northwest/Navigation Room": {
+                "Cataris/Navigation Station Northwest/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -13341,7 +13341,7 @@
                     "target": 43,
                     "dark_temple": null
                 },
-                "Burenia/Navigation Station North/Navigation Room": {
+                "Burenia/Navigation Station North/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -13352,7 +13352,7 @@
                     "target": 113,
                     "dark_temple": null
                 },
-                "Dairon/Navigation Station South/Navigation Room": {
+                "Dairon/Navigation Station South/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -13363,7 +13363,7 @@
                     "target": 129,
                     "dark_temple": null
                 },
-                "Ghavoran/Navigation Station/Navigation Room": {
+                "Ghavoran/Navigation Station/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -13374,7 +13374,7 @@
                     "target": 82,
                     "dark_temple": null
                 },
-                "Dairon/Navigation Station North/Navigation Room": {
+                "Dairon/Navigation Station North/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -13385,7 +13385,7 @@
                     "target": 96,
                     "dark_temple": null
                 },
-                "Ferenia/Navigation Station/Navigation Room": {
+                "Ferenia/Navigation Station/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -13396,7 +13396,7 @@
                     "target": 79,
                     "dark_temple": null
                 },
-                "Hanubia/Navigation Station/Navigation Room": {
+                "Hanubia/Navigation Station/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -13407,7 +13407,7 @@
                     "target": 36,
                     "dark_temple": null
                 },
-                "Burenia/Navigation Station South/Navigation Room": {
+                "Burenia/Navigation Station South/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -13424,27 +13424,27 @@
     "item_order": [
         "Grapple Beam at Artaria/Melee Tutorial Room/Pickup (Missile Tank 2)",
         "Progressive Charge Beam at Artaria/Invisible Corpius Room/Pickup (Missile Tank)",
-        "Speed Booster at Artaria/Charge Beam Room/Pickup (Charge Beam) with hint at Artaria/Navigation Station South/Navigation Room",
+        "Speed Booster at Artaria/Charge Beam Room/Pickup (Charge Beam) with hint at Artaria/Navigation Station South/Save Station",
         "Spider Magnet at Artaria/EMMI Zone Spinner/Pickup (Missile Tank)",
         "Progressive Beam at Artaria/EMMI Zone Exit North/Pickup (Missile Tank)",
         "Phantom Cloak at Artaria/Corpius Arena/Pickup (Phantom Cloak)",
         "Morph Ball at Artaria/Central Unit Access/Pickup (Spider Magnet)",
         "Cross Bomb at Cataris/Transport to Artaria/Pickup (Missile Tank)",
-        "Progressive Missile at Cataris/EMMI Zone Hidden Missile Room/Pickup (Missile Tank) with hint at Cataris/Navigation Station Southeast/Navigation Room",
-        "Progressive Suit at Artaria/David Jaffe Room/Pickup (Missile Tank) with hint at Artaria/Navigation Station North/Navigation Room",
-        "Power Bomb at Cataris/Double Obsydomithon Room/Pickup (Missile Tank) with hint at Cataris/Navigation Station Northwest/Navigation Room",
+        "Progressive Missile at Cataris/EMMI Zone Hidden Missile Room/Pickup (Missile Tank) with hint at Cataris/Navigation Station Southeast/Save Station",
+        "Progressive Suit at Artaria/David Jaffe Room/Pickup (Missile Tank) with hint at Artaria/Navigation Station North/Save Station",
+        "Power Bomb at Cataris/Double Obsydomithon Room/Pickup (Missile Tank) with hint at Cataris/Navigation Station Northwest/Save Station",
         "Progressive Spin at Dairon/Wide Beam Room/Pickup (Wide Beam)",
         "Energy Tank at Cataris/Teleport to Artaria (Blue)/Pickup (Missile Tank)",
-        "Storm Missile at Ghavoran/Golzuna Tower/Pickup (Missile Tank) with hint at Burenia/Navigation Station North/Navigation Room",
+        "Storm Missile at Ghavoran/Golzuna Tower/Pickup (Missile Tank) with hint at Burenia/Navigation Station North/Save Station",
         "Energy Tank at Artaria/Melee Tutorial Room/Pickup (Missile Tank 1)",
         "Progressive Suit at Dairon/Big Hub/Pickup (Missile Tank)",
         "Bomb at Dairon/Cross Bomb Puzzle Room/Pickup (Missile Tank)",
         "Screw Attack at Ghavoran/Above Pulse Radar/Pickup (Missile Tank)",
         "Progressive Missile at Artaria/Energy Recharge Station South/Pickup (Missile Tank)",
-        "Progressive Beam at Ferenia/Space Jump Room/Pickup (Missile Tank) with hint at Dairon/Navigation Station South/Navigation Room",
+        "Progressive Beam at Ferenia/Space Jump Room/Pickup (Missile Tank) with hint at Dairon/Navigation Station South/Save Station",
         "Flash Shift at Ferenia/Space Jump Room/Pickup (Missile+ Tank)",
-        "Progressive Charge Beam at Burenia/Main Hub Tower Top/Pickup (Energy Tank) with hint at Ghavoran/Navigation Station/Navigation Room",
-        "Progressive Spin at Ghavoran/Spin Boost Tower/Pickup (Power Bomb Tank) with hint at Dairon/Navigation Station North/Navigation Room",
-        "Progressive Beam at Burenia/Gravity Suit Room/Pickup (Gravity Suit) with hint at Ferenia/Navigation Station/Navigation Room"
+        "Progressive Charge Beam at Burenia/Main Hub Tower Top/Pickup (Energy Tank) with hint at Ghavoran/Navigation Station/Save Station",
+        "Progressive Spin at Ghavoran/Spin Boost Tower/Pickup (Power Bomb Tank) with hint at Dairon/Navigation Station North/Save Station",
+        "Progressive Beam at Burenia/Gravity Suit Room/Pickup (Gravity Suit) with hint at Ferenia/Navigation Station/Save Station"
     ]
 }

--- a/test/test_files/log_files/dread_2.rdvgame
+++ b/test/test_files/log_files/dread_2.rdvgame
@@ -2612,7 +2612,7 @@
                 }
             },
             "hints": {
-                "Artaria/Navigation Station North/Navigation Room": {
+                "Artaria/Navigation Station North/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -2623,7 +2623,7 @@
                     "target": 12,
                     "dark_temple": null
                 },
-                "Artaria/Navigation Station South/Navigation Room": {
+                "Artaria/Navigation Station South/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -2634,7 +2634,7 @@
                     "target": 50,
                     "dark_temple": null
                 },
-                "Cataris/Navigation Station Northwest/Navigation Room": {
+                "Cataris/Navigation Station Northwest/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -2645,7 +2645,7 @@
                     "target": 47,
                     "dark_temple": null
                 },
-                "Cataris/Navigation Station Southeast/Navigation Room": {
+                "Cataris/Navigation Station Southeast/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -2656,7 +2656,7 @@
                     "target": 72,
                     "dark_temple": null
                 },
-                "Dairon/Navigation Station South/Navigation Room": {
+                "Dairon/Navigation Station South/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -2667,7 +2667,7 @@
                     "target": 37,
                     "dark_temple": null
                 },
-                "Burenia/Navigation Station North/Navigation Room": {
+                "Burenia/Navigation Station North/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -2678,7 +2678,7 @@
                     "target": 146,
                     "dark_temple": null
                 },
-                "Ghavoran/Navigation Station/Navigation Room": {
+                "Ghavoran/Navigation Station/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -2689,7 +2689,7 @@
                     "target": 26,
                     "dark_temple": null
                 },
-                "Burenia/Navigation Station South/Navigation Room": {
+                "Burenia/Navigation Station South/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -2700,7 +2700,7 @@
                     "target": 104,
                     "dark_temple": null
                 },
-                "Hanubia/Navigation Station/Navigation Room": {
+                "Hanubia/Navigation Station/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -2711,7 +2711,7 @@
                     "target": 124,
                     "dark_temple": null
                 },
-                "Dairon/Navigation Station North/Navigation Room": {
+                "Dairon/Navigation Station North/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -2722,7 +2722,7 @@
                     "target": 135,
                     "dark_temple": null
                 },
-                "Ferenia/Navigation Station/Navigation Room": {
+                "Ferenia/Navigation Station/Save Station": {
                     "hint_type": "location",
                     "precision": {
                         "location": "world-only",
@@ -2739,25 +2739,25 @@
     "item_order": [
         "Speed Booster at Artaria/Melee Tutorial Room/Pickup (Missile Tank 2)",
         "Morph Ball at Artaria/EMMI Zone Exit North/Pickup (Missile Tank)",
-        "Progressive Bomb at Artaria/Melee Tutorial Room/Pickup (Missile Tank 1) with hint at Artaria/Navigation Station North/Navigation Room",
-        "Flash Shift at Cataris/Teleport to Artaria (Red)/Pickup (Missile+ Tank) with hint at Artaria/Navigation Station South/Navigation Room",
+        "Progressive Bomb at Artaria/Melee Tutorial Room/Pickup (Missile Tank 1) with hint at Artaria/Navigation Station North/Save Station",
+        "Flash Shift at Cataris/Teleport to Artaria (Red)/Pickup (Missile+ Tank) with hint at Artaria/Navigation Station South/Save Station",
         "Progressive Charge Beam at Artaria/EMMI Zone First Entrance/Pickup (Missile Tank)",
-        "Progressive Beam at Cataris/EMMI Zone Hidden Missile Room/Pickup (Missile Tank) with hint at Cataris/Navigation Station Northwest/Navigation Room",
+        "Progressive Beam at Cataris/EMMI Zone Hidden Missile Room/Pickup (Missile Tank) with hint at Cataris/Navigation Station Northwest/Save Station",
         "Progressive Beam at Artaria/Charge Tutorial/Pickup (Energy Tank)",
         "Spider Magnet at Cataris/Central Unit Access/Pickup (Morph Ball)",
         "Progressive Suit at Cataris/EMMI Zone Exits West/Pickup (Missile Tank)",
         "Progressive Beam at Ghavoran/Above Pulse Radar/Pickup (Missile Tank)",
-        "Screw Attack at Dairon/Central Unit Access/Pickup (Energy Part) with hint at Cataris/Navigation Station Southeast/Navigation Room",
-        "Progressive Missile at Cataris/Above Z-57 Fight/Pickup (Missile Tank) with hint at Dairon/Navigation Station South/Navigation Room",
+        "Screw Attack at Dairon/Central Unit Access/Pickup (Energy Part) with hint at Cataris/Navigation Station Southeast/Save Station",
+        "Progressive Missile at Cataris/Above Z-57 Fight/Pickup (Missile Tank) with hint at Dairon/Navigation Station South/Save Station",
         "Progressive Missile at Dairon/Save Station West Tunnels/Pickup (Missile Tank)",
         "Progressive Spin at Dairon/Wide Beam Room/Pickup (Wide Beam)",
-        "Power Bomb at Ghavoran/Central Unit Access/Pickup (Ice Missile) with hint at Burenia/Navigation Station North/Navigation Room",
-        "Progressive Suit at Artaria/Screw Attack Room/Pickup (Missile Tank, Underwater) with hint at Ghavoran/Navigation Station/Navigation Room",
+        "Power Bomb at Ghavoran/Central Unit Access/Pickup (Ice Missile) with hint at Burenia/Navigation Station North/Save Station",
+        "Progressive Suit at Artaria/Screw Attack Room/Pickup (Missile Tank, Underwater) with hint at Ghavoran/Navigation Station/Save Station",
         "Phantom Cloak at Burenia/Transport to Artaria/Pickup (Missile Tank)",
-        "Storm Missile at Ghavoran/Spin Boost Room/Pickup (Spin Boost) with hint at Burenia/Navigation Station South/Navigation Room",
+        "Storm Missile at Ghavoran/Spin Boost Room/Pickup (Spin Boost) with hint at Burenia/Navigation Station South/Save Station",
         "Progressive Bomb at Ferenia/Space Jump Room/Pickup (Missile+ Tank)",
         "Grapple Beam at Hanubia/Speedboost Puzzle Room/Pickup (Power Bomb Tank)",
-        "Progressive Spin at Ferenia/Energy Recharge Station Secret/Pickup (Energy Part) with hint at Hanubia/Navigation Station/Navigation Room",
+        "Progressive Spin at Ferenia/Energy Recharge Station Secret/Pickup (Energy Part) with hint at Hanubia/Navigation Station/Save Station",
         "Energy Tank at Dairon/Yellow EMMI Introduction/Pickup (Energy Part)",
         "Energy Tank at Elun/Plasma Beam Room/Pickup (Plasma Beam)",
         "Energy Tank at Ferenia/Space Jump Room/Pickup (Space Jump)",


### PR DESCRIPTION
Starting Locations
- Removes all existing starting locations except Intro Room
- Adds every Save Station or save-like room as an option to start in, except Elun
-- Exception is Itorash where it is instead the Transport to Hanubia
- Moves the option out of Unsupported status

Logic
- Added Grapple Movement (Beginner) for going up the left side of Burenia - Main Hub Tower Middle.
- Added Movement (Intermediate) and Water Bomb Jump (Intermediate) for getting out of the water at the same spot.
- Removed Walljump from Flash Shift for reaching the left Dock to Main Hub Tower Top in Main Hub Tower Middle; it is now trickless.
- Added Grapple Movement (Beginner) for the Grapple only method of reaching the Missile Tank in Main Hub Tower Top.