### PR TITLE
Fix room+door rando incompatibility

### DIFF
--- a/randovania/game_description/game_patches.py
+++ b/randovania/game_description/game_patches.py
@@ -188,7 +188,10 @@ class GamePatches:
         return self.dock_weakness[node.node_index] or node.default_dock_weakness
 
     def has_default_weakness(self, node: DockNode) -> bool:
-        return self.dock_weakness[node.node_index] is None
+        if self.dock_weakness[node.node_index] is None:
+            return True
+        
+        return self.dock_weakness[node.node_index] == node.default_dock_weakness
 
     def should_shuffle_weakness(self, node: DockNode) -> bool:
         return self.weaknesses_to_shuffle[node.node_index]

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -1,5 +1,4 @@
 from random import Random
-from typing import Generator
 
 import randovania
 from randovania.exporter import pickup_exporter, item_names

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -1,4 +1,5 @@
 from random import Random
+from typing import Generator
 
 import randovania
 from randovania.exporter import pickup_exporter, item_names
@@ -13,7 +14,7 @@ from randovania.game_description.world.dock_node import DockNode
 from randovania.game_description.world.node_identifier import NodeIdentifier
 from randovania.game_description.world.pickup_node import PickupNode
 from randovania.game_description.world.teleporter_node import TeleporterNode
-from randovania.game_description.world.world_list import WorldList
+from randovania.game_description.world.world_list import WorldList, World
 from randovania.games.game import RandovaniaGame
 from randovania.games.prime1.exporter.hint_namer import PrimeHintNamer
 from randovania.games.prime1.exporter.vanilla_maze_seeds import VANILLA_MAZE_SEEDS
@@ -97,6 +98,19 @@ _LOCATIONS_GROUPED_TOGETHER = [
     ({52, 53}, None),  # Research Lab Aether
 ]
 
+def _remove_empty(d):
+    """recursively remove empty lists, empty dicts, or None elements from a dictionary"""
+
+    def empty(x):
+        return x is None or x == {} or x == []
+
+    if not isinstance(d, (dict, list)):
+        return d
+    elif isinstance(d, list):
+        return [v for v in (_remove_empty(v) for v in d) if not empty(v)]
+    else:
+        return {k: v for k, v in ((k, _remove_empty(v)) for k, v in d.items()) if not empty(v)}
+
 
 def prime1_pickup_details_to_patcher(detail: pickup_exporter.ExportedPickupDetails,
                                      modal_hud_override: bool,
@@ -171,8 +185,8 @@ def _starting_items_value_for(resource_database: ResourceDatabase,
 
 def _name_for_location(world_list: WorldList, location: AreaIdentifier) -> str:
     loc = location.as_tuple
-    if loc in prime1_elevators.RANDOM_PRIME_CUSTOM_NAMES and loc != ("Frigate Orpheon", "Exterior Docking Hangar"):
-        return prime1_elevators.RANDOM_PRIME_CUSTOM_NAMES[loc]
+    if loc in prime1_elevators.RANDOMPRIME_CUSTOM_NAMES and loc != ("Frigate Orpheon", "Exterior Docking Hangar"):
+        return prime1_elevators.RANDOMPRIME_CUSTOM_NAMES[loc]
     else:
         return world_list.area_name(world_list.area_by_area_location(location), separator=":")
 
@@ -186,6 +200,379 @@ def _name_for_start_location(world_list: WorldList, location: NodeIdentifier) ->
 def _create_results_screen_text(description: LayoutDescription) -> str:
     return "{} | Seed Hash - {} ({})".format(
         randovania.VERSION, description.shareable_word_hash, description.shareable_hash)
+
+def _random_factor(rng: Random, min: float, max: float, target: float):
+    # return a random float between (min, max) biased towards target (up to 1 re-roll to get closer)
+    a = rng.uniform(min, max)
+    b = rng.uniform(min, max)
+    a_diff = abs(a - target)
+    b_diff = abs(b - target)
+    if a_diff > b_diff:
+        return a
+    return b
+
+def _pick_random_point_in_aabb(rng: Random, aabb: list, room_name: str):
+    # return a quasi-random point within the provided aabb, but bias towards being closer to in-bounds
+    offset_xy = 0.0
+    offset_max_z = 0.0
+
+    ROOMS_THAT_NEED_HELP = [
+        "Landing Site",
+        "Alcove",
+        "Frigate Crash Site",
+        "Sunchamber",
+        "Triclops Pit",
+        "Elite Quarters",
+        "Quarantine Cave",
+        "Burn Dome",
+        "Research Lab Hydra",
+        "Research Lab Aether",
+    ]
+
+    if room_name in ROOMS_THAT_NEED_HELP:
+        offset_xy = 0.1
+        offset_max_z = -0.3
+
+    x_factor = _random_factor(rng, 0.15 + offset_xy, 0.85 - offset_xy, 0.5)
+    y_factor = _random_factor(rng, 0.15 + offset_xy, 0.85 - offset_xy, 0.5)
+    z_factor = _random_factor(rng, 0.1, 0.8 + offset_max_z, 0.35)
+
+    return [
+        aabb[0] + (aabb[3] - aabb[0]) * x_factor,
+        aabb[1] + (aabb[4] - aabb[1]) * y_factor,
+        aabb[2] + (aabb[5] - aabb[2]) * z_factor,
+    ]
+
+def _serialize_dock_modifications(world_data, worlds: list[World], room_rando_mode: RoomRandoMode, rng: Random):
+    if room_rando_mode == RoomRandoMode.NONE:
+        return
+
+    for world in worlds:
+        area_dock_nums = dict()
+        attached_areas = dict()
+        size_indices = dict()
+        candidates = list()
+        default_connections_node_name = dict()
+        dock_num_by_area_node = dict()
+        is_nonstandard = dict()
+        disabled_doors = set()
+
+        # collect dock info for all areas
+        for area in world.areas:
+            area_dock_nums[area.name] = list()
+            attached_areas[area.name] = list()
+            for node in area.nodes:
+                if not isinstance(node, DockNode):
+                    continue
+                index = node.extra["dock_index"]
+                dock_num_by_area_node[(area.name, node.name)] = index
+                is_nonstandard[(area.name, index)] = node.extra["nonstandard"]
+                default_connections_node_name[(area.name, index)] = (
+                    node.default_connection.area_name, node.default_connection.node_name)
+
+                if node.default_dock_weakness.name == "Permanently Locked":
+                    disabled_doors.add((area.name, index))
+
+                if node.extra["nonstandard"]:
+                    continue
+                area_dock_nums[area.name].append(index)
+                attached_areas[area.name].append(node.default_connection.area_name)
+                candidates.append((area.name, index))
+            size_indices[area.name] = area.extra["size_index"]
+
+        default_connections = dict()
+        for (src_name, src_dock) in default_connections_node_name:
+            (dst_name, dst_node_name) = default_connections_node_name[(src_name, src_dock)]
+
+            try:
+                dst_dock = dock_num_by_area_node[(dst_name, dst_node_name)]
+            except KeyError:
+                continue
+
+            default_connections[(src_name, src_dock)] = (dst_name, dst_dock)
+
+        for area_name, dock_num in candidates:
+            room = world_data[world.name]["rooms"][area_name]
+            if "doors" not in room:
+                room["doors"] = dict()
+
+            def helper(_dock_num):
+                dock_num_key = str(_dock_num)
+
+                if dock_num_key not in room["doors"]:
+                    room["doors"][dock_num_key] = dict()
+
+                if "destination" not in room["doors"][dock_num_key]:
+                    room["doors"][dock_num_key]["destination"] = dict()
+
+            helper(dock_num)
+
+            for dock_num in area_dock_nums[area.name]:
+                helper(dock_num)
+
+        # Shuffle order which candidates are processed
+        rng.shuffle(candidates)
+
+        used_room_pairings = list()
+
+        def are_rooms_compatible(src_name, src_dock, dst_name, dst_dock, mode: RoomRandoMode):
+            if src_name is None or dst_name is None:
+                # print("none name")
+                return False
+
+            # both rooms must have patchable docks
+            if len(area_dock_nums[src_name]) == 0 or len(area_dock_nums[dst_name]) == 0:
+                # print("unpatchable room(s)")
+                return False
+
+            # destinations cannot be in the same room
+            if src_name == dst_name:
+                # print("same room")
+                return False
+
+            # src/dst must not be exempt
+            if src_dock is not None and is_nonstandard[(src_name, src_dock)]:
+                # print("src exempt")
+                return False
+            if dst_dock is not None and is_nonstandard[(dst_name, dst_dock)]:
+                # print("dst exempt")
+                return False
+
+            # rooms cannot be neighbors
+            if src_name in attached_areas[dst_name]:
+                if mode == RoomRandoMode.ONE_WAY:
+                    # print("neighbor")
+                    return False
+
+                # Unless it's a vanilla 2-way connection
+                if default_connections[(src_name, src_dock)] != (dst_name, dst_dock):
+                    # print("two-way non-neighbor")
+                    return False
+
+            # rooms can only connect to another room up to once
+            if {src_name, dst_name} in used_room_pairings:
+                # Except for one-way in impact crater, this edge case works fine and is desireable
+                if not (mode == RoomRandoMode.ONE_WAY and world.name == "Impact Crater"):
+                    # print("double connection")
+                    return False
+
+            # The two rooms must not crash if drawn at the same time (size_index > 1.0)
+            if size_indices[src_name] + size_indices[dst_name] >= 1.0:
+                # print("too big")
+                return False
+
+            return True
+
+        if room_rando_mode == RoomRandoMode.ONE_WAY:
+            for area in world.areas:
+                for dock_num in area_dock_nums[area.name]:
+                    # First try each of the unused docks
+                    dst_name = None
+                    dst_dock = None
+                    for (name, dock) in candidates:
+                        if are_rooms_compatible(area.name, None, name, None, room_rando_mode):
+                            dst_name = name
+                            dst_dock = dock
+                            break
+
+                    # If that wasn't successful, pick random destinations until it works out
+                    deadman_count = 1000
+                    while dst_name is None or dst_dock is None or not are_rooms_compatible(area.name, dock_num,
+                                                                                            dst_name, dst_dock,
+                                                                                            room_rando_mode):
+
+                        deadman_count -= 1
+                        if deadman_count == 0:
+                            raise Exception(
+                                f"Failed to find suitible destination for {area.name}:{dock_num}")
+
+                        dst_name = rng.choice(world.areas).name
+                        dst_dock = None
+
+                        if len(area_dock_nums[dst_name]) == 0:
+                            continue
+
+                        dst_dock = rng.choice(area_dock_nums[dst_name])
+
+                    # Don't use this dock as a destination again unless there are no other options
+                    try:
+                        candidates.remove((dst_name, dst_dock))
+                    except ValueError:
+                        # print("re-used %s:%d" % (dst_name, dst_dock))
+                        pass
+
+                    used_room_pairings.append({area.name, dst_name})
+
+                    d = world_data[world.name]["rooms"][area.name]["doors"][str(dock_num)]["destination"]
+                    d["roomName"] = name
+                    d["dockNum"] = dst_dock
+ 
+        elif room_rando_mode == RoomRandoMode.TWO_WAY:
+            # List containing:
+            #   - set of len=2, each containing
+            #       - tuple of len=2 for (room_name, dock)
+            shuffled = list()
+
+            def next_candidate(max_index):
+                for (src_name, src_dock) in candidates:
+                    if size_indices[src_name] > max_index:
+                        return (src_name, src_dock)
+                return (None, None)
+
+            def pick_random_dst(src_name, src_dock):
+                for (dst_name, dst_dock) in candidates:
+                    if are_rooms_compatible(src_name, src_dock, dst_name, dst_dock,
+                                            room_rando_mode):
+                        return (dst_name, dst_dock)
+                return (None, None)
+
+            def remove_pair(shuffled_pair: set):
+                shuffled.remove(shuffled_pair)
+
+                shuffled_pair = sorted(list(shuffled_pair))
+                assert len(shuffled_pair) == 2
+                a = shuffled_pair[0]
+                b = shuffled_pair[1]
+
+                candidates.append(a)
+                candidates.append(b)
+
+                (a_name, a_dock) = a
+                (b_name, b_dock) = b
+                used_room_pairings.remove({a_name, b_name})
+
+                world_data[world.name]["rooms"][a_name]["doors"][str(a_dock)]["destination"] = dict()
+                world_data[world.name]["rooms"][b_name]["doors"][str(b_dock)]["destination"] = dict()
+
+            # Randomly pick room sources, starting with the largest room first, then randomly
+            # pick a compatible destination
+            max_index = 1.01
+            while len(candidates) != 0:
+                assert len(candidates) % 2 == 0
+
+                if max_index < -0.00001:
+                    raise Exception("Failed to find pairings for %s" % str(candidates))
+
+                (src_name, src_dock) = next_candidate(max_index)
+
+                if src_name is None:
+                    # lower the room size criteria and try again
+                    max_index -= 0.01
+                    continue
+
+                (dst_name, dst_dock) = pick_random_dst(src_name, src_dock)
+                if dst_name is None:
+                    # This room have no valid destinations in the pool, randomly unpair two rooms and try again
+                    remove_pair(rng.choice(shuffled))
+                    continue
+
+                assert {(src_name, src_dock), (dst_name, dst_dock)} not in shuffled
+
+                candidates.remove((src_name, src_dock))
+                candidates.remove((dst_name, dst_dock))
+                shuffled.append({(src_name, src_dock), (dst_name, dst_dock)})
+                used_room_pairings.append({src_name, dst_name})
+
+                d = world_data[world.name]["rooms"][src_name]["doors"][str(src_dock)]["destination"]
+                d["roomName"] = dst_name
+                d["dockNum"] = dst_dock
+
+                d = world_data[world.name]["rooms"][dst_name]["doors"][str(dst_dock)]["destination"]
+                d["roomName"] = src_name
+                d["dockNum"] = src_dock
+
+                # print("%s:%d <--> %s:%d" % (src_name, src_dock, dst_name, dst_dock))
+
+                # If we just finished placing all rooms, check if there are unconnected components
+                # and if so, re-roll some rooms
+                if len(candidates) == 0:
+                    import networkx
+
+                    # Model as networkx graph object
+                    room_connections = list()
+                    for room_name in world_data[world.name]["rooms"]:
+                        room = world_data[world.name]["rooms"][room_name]
+                        if "doors" not in room:
+                            continue
+
+                        for dock_num in room["doors"]:
+                            if "destination" not in room["doors"][dock_num] or len(room["doors"][dock_num]["destination"]) == 0:
+                                continue
+
+                            if (room_name, int(dock_num)) in disabled_doors:
+                                continue
+
+                            dst_room_name = room["doors"][dock_num]["destination"]["roomName"]
+
+                            assert {room_name, dst_room_name} in used_room_pairings
+
+                            room_connections.append((room_name, dst_room_name))
+
+                    # Handle unrandomized connections
+                    for (src_name, src_dock) in is_nonstandard:
+                        if (src_name, src_dock) in disabled_doors:
+                            continue
+
+                        if is_nonstandard[(src_name, src_dock)]:
+                            (dst_name, dst_dock) = default_connections[(src_name, src_dock)]
+                            room_connections.append((src_name, dst_name))
+
+                    # model this world's connections as a graph
+                    graph = networkx.DiGraph()
+                    graph.add_edges_from(room_connections)
+
+                    if not networkx.is_strongly_connected(graph):
+                        # Split graph into strongly connected components
+                        strongly_connected_components = sorted(networkx.strongly_connected_components(graph),
+                                                                key=len, reverse=True)
+                        assert len(strongly_connected_components) > 1
+
+                        def component_number(name):
+                            i = 0
+                            for component in strongly_connected_components:
+                                if name in list(component):
+                                    return i
+                                i += 1
+
+                        # randomly pick two room pairs which are not members of the same strongly connected
+                        # component and # put back into pool for re-randomization (cross fingers that they
+                        # connect the two strong components)
+                        assert len(shuffled) > 2
+
+                        # pick one randomly
+                        rng.shuffle(shuffled)
+                        a = shuffled[-1]
+                        a = sorted(list(a))
+                        (src_name_a, src_dock_a) = a[0]
+                        (dst_name_a, dst_dock_a) = a[1]
+                        a_component_num = component_number(src_name_a)
+
+                        # pick a second which is not part of the same component
+                        (src_name_b, src_dock_b, dst_name_b, dst_dock_b) = (None, None, None, None)
+                        for b in shuffled:
+                            b = sorted(list(b))
+                            (src_name, src_dock) = b[0]
+                            (dst_name, dst_dock) = b[1]
+                            if component_number(src_name) == a_component_num:
+                                continue
+                            (src_name_b, src_dock_b, dst_name_b, dst_dock_b) = (
+                                src_name, src_dock, dst_name, dst_dock)
+                            break
+
+                        # If we could not find two rooms that were part of two different components, still
+                        # remove a random room pairing (this can happen if rooms exempt from randomization
+                        # are causing fractured connectivity)
+                        if src_name_b is None:
+                            b = sorted(list(shuffled[0]))
+                            (src_name_b, src_dock_b) = b[0]
+                            (dst_name_b, dst_dock_b) = b[1]
+
+                        # put back into pool
+                        remove_pair({(src_name_a, src_dock_a), (dst_name_a, dst_dock_a)})
+                        remove_pair({(src_name_b, src_dock_b), (dst_name_b, dst_dock_b)})
+
+                        # do something different this time
+                        rng.shuffle(candidates)
 
 
 class PrimePatchDataFactory(BasePatchDataFactory):
@@ -214,6 +601,7 @@ class PrimePatchDataFactory(BasePatchDataFactory):
         }
 
     def create_data(self) -> dict:
+        # Setup
         db = self.game
         namer = PrimeHintNamer(self.description.all_patches, self.players_config)
 
@@ -240,25 +628,43 @@ class PrimePatchDataFactory(BasePatchDataFactory):
             visual_etm=pickup_creator.create_visual_etm(),
         )
         modal_hud_override = _create_locations_with_modal_hud_memo(pickup_list)
+        worlds = [world for world in db.world_list.worlds if world.name != "End of Game"]
 
-        world_data = {}
-
-        for world in db.world_list.worlds:
-            if world.name == "End of Game":
-                continue
-
+        # Initialize serialized world data
+        world_data = dict()
+        for world in worlds:
             world_data[world.name] = {
-                "transports": {},
-                "rooms": {}
+                "transports": dict(),
+                "rooms": dict(),
             }
 
             for area in world.areas:
-                world_data[world.name]["rooms"][area.name] = {"pickups": [], "doors": {}}
+                world_data[world.name]["rooms"][area.name] = {
+                    "pickups": list(),
+                    "doors": dict(),
+                }
+        
+        # serialize elevator modifications
+        for world in worlds:
+            for area in world.areas:
+                for node in area.nodes:
+                    if not isinstance(node, TeleporterNode) or not node.editable:
+                        continue
 
-                def node_len(a: PickupNode):
-                    return a.pickup_index
+                    identifier = db.world_list.identifier_for_node(node)
+                    target = _name_for_location(db.world_list, self.patches.get_elevator_connection_for(node))
 
-                pickup_nodes = sorted((node for node in area.nodes if isinstance(node, PickupNode)), key=node_len)
+                    source_name = prime1_elevators.RANDOMPRIME_CUSTOM_NAMES[(
+                        identifier.area_location.world_name,
+                        identifier.area_location.area_name,
+                    )]
+                    world_data[world.name]["transports"][source_name] = target
+
+        # serialize pickup modifications
+        for world in worlds:
+            for area in world.areas:
+                pickup_nodes = (node for node in area.nodes if isinstance(node, PickupNode))
+                pickup_nodes = sorted(pickup_nodes, key=lambda n: n.pickup_index)
                 for node in pickup_nodes:
                     pickup_index = node.pickup_index.index
                     pickup = prime1_pickup_details_to_patcher(pickup_list[pickup_index],
@@ -269,409 +675,50 @@ class PrimePatchDataFactory(BasePatchDataFactory):
                     if node.extra.get("position_required"):
                         assert self.configuration.items_every_room
                         aabb = area.extra["aabb"]
-
-                        # return a random float between (min, max) biased towards target (up to 1 re-roll to get closer)
-                        def random_factor(rng: Random, min: float, max: float, target: float):
-                            a = rng.uniform(min, max)
-                            b = rng.uniform(min, max)
-                            a_diff = abs(a - target)
-                            b_diff = abs(b - target)
-                            if a_diff > b_diff:
-                                return a
-                            return b
-
-                        # return a quasi-random point within the provided aabb, but bias towards being closer to
-                        # in-bounds
-                        def pick_random_point_in_aabb(rng: Random, aabb: list, room_name: str):
-                            offset_xy = 0.0
-                            offset_max_z = 0.0
-
-                            ROOMS_THAT_NEED_HELP = [
-                                "Landing Site",
-                                "Alcove",
-                                "Frigate Crash Site",
-                                "Sunchamber",
-                                "Triclops Pit",
-                                "Elite Quarters",
-                                "Quarantine Cave",
-                                "Burn Dome",
-                                "Research Lab Hydra",
-                                "Research Lab Aether",
-                            ]
-
-                            if room_name in ROOMS_THAT_NEED_HELP:
-                                offset_xy = 0.1
-                                offset_max_z = -0.3
-
-                            x_factor = random_factor(rng, 0.15 + offset_xy, 0.85 - offset_xy, 0.5)
-                            y_factor = random_factor(rng, 0.15 + offset_xy, 0.85 - offset_xy, 0.5)
-                            z_factor = random_factor(rng, 0.1, 0.8 + offset_max_z, 0.35)
-
-                            return [
-                                aabb[0] + (aabb[3] - aabb[0]) * x_factor,
-                                aabb[1] + (aabb[4] - aabb[1]) * y_factor,
-                                aabb[2] + (aabb[5] - aabb[2]) * z_factor,
-                            ]
-
-                        pickup["position"] = pick_random_point_in_aabb(self.rng, aabb, area.name)
+                        pickup["position"] = _pick_random_point_in_aabb(self.rng, aabb, area.name)
                         pickup["jumboScan"] = True  # Scan this item through walls
 
                     world_data[world.name]["rooms"][area.name]["pickups"].append(pickup)
 
-                dock_nodes = sorted(
-                    (node for node in area.nodes if isinstance(node, DockNode)),
-                    key=lambda n: n.extra["dock_index"]
-                )
+        # serialize room modifications
+        if self.configuration.superheated_probability != 0:
+            probability = self.configuration.superheated_probability / 1000.0
+            for world in worlds:
+                for area in world.areas:
+                    world_data[world.name]["rooms"][area.name]["superheated"] = self.rng.random() < probability
+
+        if self.configuration.submerged_probability != 0:
+            probability = self.configuration.submerged_probability / 1000.0
+            for world in worlds:
+                for area in world.areas:
+                    world_data[world.name]["rooms"][area.name]["submerge"] = self.rng.random() < probability
+
+        # serialize door modifications
+        for world in worlds:
+            for area in world.areas:
+                dock_nodes = (node for node in area.nodes if isinstance(node, DockNode))
+                dock_nodes = sorted(dock_nodes, key=lambda n: n.extra["dock_index"])
                 for node in dock_nodes:
-                    weakness = self.patches.get_dock_weakness_for(node)
-                    if weakness == node.default_dock_weakness or node.extra.get("exclude_dock_rando", False):
+                    node: DockNode = node
+                    if node.extra.get("exclude_dock_rando", False):
                         continue
 
+                    if self.patches.has_default_weakness(node):
+                        continue
+
+                    weakness = self.patches.get_dock_weakness_for(node)
                     dock_index = node.extra["dock_index"]
                     dock_data = {
                         "shieldType": weakness.extra["shieldType"],
                         "blastShieldType": weakness.extra.get("blastShieldType", "Empty")
                     }
 
-                    world_data[world.name]["rooms"][area.name]["doors"][dock_index] = dock_data
+                    world_data[world.name]["rooms"][area.name]["doors"][str(dock_index)] = dock_data
 
-                if self.configuration.superheated_probability != 0:
-                    world_data[world.name]["rooms"][area.name][
-                        "superheated"] = self.rng.random() < self.configuration.superheated_probability / 1000.0
+        # serialize dock destination modifications
+        _serialize_dock_modifications(world_data, worlds, self.configuration.room_rando, self.rng)
 
-                if self.configuration.submerged_probability != 0:
-                    world_data[world.name]["rooms"][area.name][
-                        "submerge"] = self.rng.random() < self.configuration.submerged_probability / 1000.0
-
-                for node in area.nodes:
-                    if not isinstance(node, TeleporterNode) or not node.editable:
-                        continue
-
-                    identifier = db.world_list.identifier_for_node(node)
-                    target = _name_for_location(db.world_list, self.patches.get_elevator_connection_for(node))
-
-                    source_name = prime1_elevators.RANDOM_PRIME_CUSTOM_NAMES[(
-                        identifier.area_location.world_name,
-                        identifier.area_location.area_name,
-                    )]
-                    world_data[world.name]["transports"][source_name] = target
-
-        if self.configuration.room_rando != RoomRandoMode.NONE:
-            for world in db.world_list.worlds:
-                if world.name == "End of Game":
-                    continue
-
-                area_dock_nums = dict()
-                attached_areas = dict()
-                size_indices = dict()
-                candidates = list()
-                default_connections_node_name = dict()
-                dock_num_by_area_node = dict()
-                is_nonstandard = dict()
-                disabled_doors = set()
-
-                for area in world.areas:
-                    world_data[world.name]["rooms"][area.name]["doors"] = dict()
-                    area_dock_nums[area.name] = list()
-                    attached_areas[area.name] = list()
-                    for node in area.nodes:
-                        if not isinstance(node, DockNode):
-                            continue
-                        index = node.extra["dock_index"]
-                        dock_num_by_area_node[(area.name, node.name)] = index
-                        is_nonstandard[(area.name, index)] = node.extra["nonstandard"]
-                        default_connections_node_name[(area.name, index)] = (
-                            node.default_connection.area_name, node.default_connection.node_name)
-
-                        if node.default_dock_weakness.name == "Permanently Locked":
-                            disabled_doors.add((area.name, index))
-
-                        if node.extra["nonstandard"]:
-                            continue
-                        area_dock_nums[area.name].append(index)
-                        attached_areas[area.name].append(node.default_connection.area_name)
-                        candidates.append((area.name, index))
-                    size_indices[area.name] = area.extra["size_index"]
-
-                default_connections = dict()
-                for (src_name, src_dock) in default_connections_node_name:
-                    (dst_name, dst_node_name) = default_connections_node_name[(src_name, src_dock)]
-
-                    try:
-                        dst_dock = dock_num_by_area_node[(dst_name, dst_node_name)]
-                    except KeyError:
-                        continue
-
-                    default_connections[(src_name, src_dock)] = (dst_name, dst_dock)
-
-                self.rng.shuffle(candidates)
-
-                used_room_pairings = list()
-
-                def are_rooms_compatible(src_name, src_dock, dst_name, dst_dock, mode: RoomRandoMode):
-                    if src_name is None or dst_name is None:
-                        # print("none name")
-                        return False
-
-                    # both rooms must have patchable docks
-                    if len(area_dock_nums[src_name]) == 0 or len(area_dock_nums[dst_name]) == 0:
-                        # print("unpatchable room(s)")
-                        return False
-
-                    # destinations cannot be in the same room
-                    if src_name == dst_name:
-                        # print("same room")
-                        return False
-
-                    # src/dst must not be exempt
-                    if src_dock is not None and is_nonstandard[(src_name, src_dock)]:
-                        # print("src exempt")
-                        return False
-                    if dst_dock is not None and is_nonstandard[(dst_name, dst_dock)]:
-                        # print("dst exempt")
-                        return False
-
-                    # rooms cannot be neighbors
-                    if src_name in attached_areas[dst_name]:
-                        if mode == RoomRandoMode.ONE_WAY:
-                            # print("neighbor")
-                            return False
-
-                        # Unless it's a vanilla 2-way connection
-                        if default_connections[(src_name, src_dock)] != (dst_name, dst_dock):
-                            # print("two-way non-neighbor")
-                            return False
-
-                    # rooms can only connect to another room up to once
-                    if {src_name, dst_name} in used_room_pairings:
-                        # Except for one-way in impact crater, this edge case works fine and is desireable
-                        if not (mode == RoomRandoMode.ONE_WAY and world.name == "Impact Crater"):
-                            # print("double connection")
-                            return False
-
-                    # The two rooms must not crash if drawn at the same time (size_index > 1.0)
-                    if size_indices[src_name] + size_indices[dst_name] >= 1.0:
-                        # print("too big")
-                        return False
-
-                    return True
-
-                if self.configuration.room_rando == RoomRandoMode.ONE_WAY:
-                    for area in world.areas:
-                        for dock_num in area_dock_nums[area.name]:
-                            # First try each of the unused docks
-                            dst_name = None
-                            dst_dock = None
-                            for (name, dock) in candidates:
-                                if are_rooms_compatible(area.name, None, name, None, self.configuration.room_rando):
-                                    dst_name = name
-                                    dst_dock = dock
-                                    break
-
-                            # If that wasn't successful, pick random destinations until it works out
-                            deadman_count = 1000
-                            while dst_name is None or dst_dock is None or not are_rooms_compatible(area.name, dock_num,
-                                                                                                   dst_name, dst_dock,
-                                                                                                   self.configuration.room_rando):
-
-                                deadman_count -= 1
-                                if deadman_count == 0:
-                                    raise Exception(
-                                        f"Failed to find suitible destination for {area.name}:{dock_num}")
-
-                                dst_name = self.rng.choice(world.areas).name
-                                dst_dock = None
-
-                                if len(area_dock_nums[dst_name]) == 0:
-                                    continue
-
-                                dst_dock = self.rng.choice(area_dock_nums[dst_name])
-
-                            # Don't use this dock as a destination again unless there are no other options
-                            try:
-                                candidates.remove((dst_name, dst_dock))
-                            except ValueError:
-                                # print("re-used %s:%d" % (dst_name, dst_dock))
-                                pass
-
-                            used_room_pairings.append({area.name, dst_name})
-
-                            world_data[world.name]["rooms"][area.name]["doors"][str(dock_num)] = {
-                                "destination": {
-                                    "roomName": dst_name,
-                                    "dockNum": dst_dock,
-                                }
-                            }
-                elif self.configuration.room_rando == RoomRandoMode.TWO_WAY:
-                    # List containing:
-                    #   - set of len=2, each containing
-                    #       - tuple of len=2 for (room_name, dock)
-                    shuffled = list()
-
-                    def next_candidate(max_index):
-                        for (src_name, src_dock) in candidates:
-                            if size_indices[src_name] > max_index:
-                                return (src_name, src_dock)
-                        return (None, None)
-
-                    def pick_random_dst(src_name, src_dock):
-                        for (dst_name, dst_dock) in candidates:
-                            if are_rooms_compatible(src_name, src_dock, dst_name, dst_dock,
-                                                    self.configuration.room_rando):
-                                return (dst_name, dst_dock)
-                        return (None, None)
-
-                    def remove_pair(shuffled_pair: set):
-                        shuffled.remove(shuffled_pair)
-
-                        shuffled_pair = sorted(list(shuffled_pair))
-                        assert len(shuffled_pair) == 2
-                        a = shuffled_pair[0]
-                        b = shuffled_pair[1]
-
-                        candidates.append(a)
-                        candidates.append(b)
-
-                        (a_name, a_dock) = a
-                        (b_name, b_dock) = b
-                        used_room_pairings.remove({a_name, b_name})
-
-                        del world_data[world.name]["rooms"][a_name]["doors"][str(a_dock)]["destination"]
-                        del world_data[world.name]["rooms"][b_name]["doors"][str(b_dock)]["destination"]
-
-                    # Randomly pick room sources, starting with the largest room first, then randomly
-                    # pick a compatible destination
-                    max_index = 1.01
-                    while len(candidates) != 0:
-                        assert len(candidates) % 2 == 0
-
-                        if max_index < -0.00001:
-                            raise Exception("Failed to find pairings for %s" % str(candidates))
-
-                        (src_name, src_dock) = next_candidate(max_index)
-
-                        if src_name is None:
-                            # lower the room size criteria and try again
-                            max_index -= 0.01
-                            continue
-
-                        (dst_name, dst_dock) = pick_random_dst(src_name, src_dock)
-                        if dst_name is None:
-                            # This room have no valid destinations in the pool, randomly unpair two rooms and try again
-                            remove_pair(self.rng.choice(shuffled))
-                            continue
-
-                        assert {(src_name, src_dock), (dst_name, dst_dock)} not in shuffled
-
-                        candidates.remove((src_name, src_dock))
-                        candidates.remove((dst_name, dst_dock))
-                        shuffled.append({(src_name, src_dock), (dst_name, dst_dock)})
-                        used_room_pairings.append({src_name, dst_name})
-
-                        world_data[world.name]["rooms"][src_name]["doors"][str(src_dock)] = {
-                            "destination": {
-                                "roomName": dst_name,
-                                "dockNum": dst_dock,
-                            }
-                        }
-                        world_data[world.name]["rooms"][dst_name]["doors"][str(dst_dock)] = {
-                            "destination": {
-                                "roomName": src_name,
-                                "dockNum": src_dock,
-                            }
-                        }
-
-                        # print("%s:%d <--> %s:%d" % (src_name, src_dock, dst_name, dst_dock))
-
-                        # If we just finished placing all rooms, check if there are unconnected components
-                        # and if so, re-roll some rooms
-                        if len(candidates) == 0:
-                            import networkx
-
-                            # Model as networkx graph object
-                            room_connections = list()
-                            for room_name in world_data[world.name]["rooms"].keys():
-                                room = world_data[world.name]["rooms"][room_name]
-                                if "doors" not in room.keys():
-                                    continue
-                                for dock_num in room["doors"]:
-                                    if "destination" not in room["doors"][dock_num].keys():
-                                        continue
-
-                                    if (room_name, int(dock_num)) in disabled_doors:
-                                        continue
-
-                                    dst_room_name = room["doors"][dock_num]["destination"]["roomName"]
-
-                                    assert {room_name, dst_room_name} in used_room_pairings
-
-                                    room_connections.append((room_name, dst_room_name))
-
-                            # Handle unrandomized connections
-                            for (src_name, src_dock) in is_nonstandard:
-                                if (src_name, src_dock) in disabled_doors:
-                                    continue
-                                if is_nonstandard[(src_name, src_dock)]:
-                                    (dst_name, dst_dock) = default_connections[(src_name, src_dock)]
-                                    room_connections.append((src_name, dst_name))
-
-                            # model this world's connections as a graph
-                            graph = networkx.DiGraph()
-                            graph.add_edges_from(room_connections)
-
-                            if not networkx.is_strongly_connected(graph):
-                                # Split graph into strongly connected components
-                                strongly_connected_components = sorted(networkx.strongly_connected_components(graph),
-                                                                       key=len, reverse=True)
-                                assert len(strongly_connected_components) > 1
-
-                                def component_number(name):
-                                    i = 0
-                                    for component in strongly_connected_components:
-                                        if name in list(component):
-                                            return i
-                                        i += 1
-
-                                # randomly pick two room pairs which are not members of the same strongly connected
-                                # component and # put back into pool for re-randomization (cross fingers that they
-                                # connect the two strong components)
-                                assert len(shuffled) > 2
-
-                                # pick one randomly
-                                self.rng.shuffle(shuffled)
-                                a = shuffled[-1]
-                                a = sorted(list(a))
-                                (src_name_a, src_dock_a) = a[0]
-                                (dst_name_a, dst_dock_a) = a[1]
-                                a_component_num = component_number(src_name_a)
-
-                                # pick a second which is not part of the same component
-                                (src_name_b, src_dock_b, dst_name_b, dst_dock_b) = (None, None, None, None)
-                                for b in shuffled:
-                                    b = sorted(list(b))
-                                    (src_name, src_dock) = b[0]
-                                    (dst_name, dst_dock) = b[1]
-                                    if component_number(src_name) == a_component_num:
-                                        continue
-                                    (src_name_b, src_dock_b, dst_name_b, dst_dock_b) = (
-                                        src_name, src_dock, dst_name, dst_dock)
-                                    break
-
-                                # If we could not find two rooms that were part of two different components, still
-                                # remove a random room pairing (this can happen if rooms exempt from randomization
-                                # are causing fractured connectivity)
-                                if src_name_b is None:
-                                    b = sorted(list(shuffled[0]))
-                                    (src_name_b, src_dock_b) = b[0]
-                                    (dst_name_b, dst_dock_b) = b[1]
-
-                                # put back into pool
-                                remove_pair({(src_name_a, src_dock_a), (dst_name_a, dst_dock_a)})
-                                remove_pair({(src_name_b, src_dock_b), (dst_name_b, dst_dock_b)})
-
-                                # do something different this time
-                                self.rng.shuffle(candidates)
-
+        # serialize text modifications
         if self.configuration.hints.phazon_suit != PhazonSuitHintMode.DISABLED:
             try:
                 phazon_suit_resource_info = self.game.resource_database.get_item_by_name("Phazon Suit")
@@ -686,6 +733,18 @@ class PrimePatchDataFactory(BasePatchDataFactory):
                 )
 
                 phazon_hint_text = hint_texts[phazon_suit_resource_info]
+
+                if "Impact Crater" not in world_data:
+                    world_data["Impact Crater"] = {
+                        "transports": dict(),
+                        "rooms": dict(),
+                    }
+
+                if "Crater Entry Point" not in world_data["Impact Crater"]["rooms"]:
+                    world_data["Impact Crater"]["rooms"]["Crater Entry Point"] = {
+                        "pickups": list(),
+                        "doors": dict()
+                    }
 
                 world_data["Impact Crater"]["rooms"]["Crater Entry Point"]["extraScans"] = [
                     {
@@ -704,6 +763,9 @@ class PrimePatchDataFactory(BasePatchDataFactory):
                 ]
             except ValueError:
                 pass  # Skip making the hint if Phazon Suit is not in the seed
+
+        # strip extraneous info
+        world_data = _remove_empty(world_data)
 
         starting_memo = None
         extra_starting = item_names.additional_starting_equipment(self.configuration, db, self.patches)

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -496,7 +496,10 @@ def _serialize_dock_modifications(world_data, worlds: list[World], room_rando_mo
                             continue
 
                         for dock_num in room["doors"]:
-                            if "destination" not in room["doors"][dock_num] or len(room["doors"][dock_num]["destination"]) == 0:
+                            if "destination" not in room["doors"][dock_num]:
+                                continue
+
+                            if len(room["doors"][dock_num]["destination"]) == 0:
                                 continue
 
                             if (room_name, int(dock_num)) in disabled_doors:

--- a/randovania/games/prime1/patcher/prime1_elevators.py
+++ b/randovania/games/prime1/patcher/prime1_elevators.py
@@ -1,6 +1,6 @@
 # These are hard-coded into the Randomprime API
 # Used by the prime1 patcher
-RANDOM_PRIME_CUSTOM_NAMES = {
+RANDOMPRIME_CUSTOM_NAMES = {
     ("Impact Crater", "Crater Entry Point"): 'Crater Entry Point',  # 2818083
     ("Impact Crater", "Metroid Prime Lair"): 'Essence Dead Cutscene',
 

--- a/test/test_files/randomprime_expected_data.json
+++ b/test/test_files/randomprime_expected_data.json
@@ -34,7 +34,7 @@
         "forceFusion": false
     },
     "gameConfig": {
-        "resultsString": "5.2.0.dev65 | Seed Hash - Putrid Shriekbat Polluted (AAAAAAAA)",
+        "resultsString": "5.5.0.dev206-dirty | Seed Hash - Putrid Shriekbat Polluted (AAAAAAAA)",
         "bossSizes": null,
         "noDoors": false,
         "shufflePickupPosition": false,
@@ -107,7 +107,7 @@
             "gameNameFull": "Metroid Prime: Randomizer - AAAAAAAA",
             "description": "Seed Hash: Putrid Shriekbat Polluted"
         },
-        "mainMenuMessage": "Randovania v5.2.0.dev65\nPutrid Shriekbat Polluted",
+        "mainMenuMessage": "Randovania v5.5.0.dev206-dirty\nPutrid Shriekbat Polluted",
         "creditsString": "&push;&font=C29C51F1;&main-color=#89D6FF;Major Item Locations&pop;\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Charge Beam&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Sanctuary Fortress - Sanctuary Energy Controller\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wave Beam&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Torvus Bog - Great Bridge\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Beam&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Temple Grounds - Temple Assembly Site\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Plasma Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Root Cave\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Grapple Beam&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Dark Agon Wastes - Junction Site\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Thermal Visor&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Torvus Bog - Torvus Energy Controller\n\n&push;&font=C29C51F1;&main-color=#33ffd6;X-Ray Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Alcove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Boost Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Life Grove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Spider Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Storage Depot A\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Power Bomb&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Main Plaza\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Varia Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Landing Site\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Gravity Suit&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Great Temple - Transport B Access\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Phazon Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Cargo Freight Lift to Deck Gamma\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Super Missile&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Temple Grounds - Windchamber Gateway\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wavebuster&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Sunchamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Spreader&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Sandcanyon\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Flamethrower&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Torvus Bog - Training Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Chozo&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Dark Agon Wastes - Ing Cache 1\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Elder&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Sand Cache\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Lifegiver&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Temple Grounds - Storage Cavern B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Nature&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Sanctuary Fortress - Hall of Combat Mastery\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Newborn&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Great Temple - Transport A Access\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Spirit&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Temple Grounds - Transport to Agon Wastes\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Strength&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Storage D\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Truth&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Mining Station Access\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Warrior&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Portal Access A\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Wild&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Transport Tunnel B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of World&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Ing Hive - Culling Chamber",
         "artifactHints": {
             "Artifact of Sun": "&push;&main-color=#c300ff;Artifact of Sun&pop; has no need to be located.",
@@ -153,8 +153,6 @@
             },
             "rooms": {
                 "Crater Entry Point": {
-                    "pickups": [],
-                    "doors": {},
                     "extraScans": [
                         {
                             "position": [
@@ -170,50 +168,6 @@
                             "logbookCategory": 5
                         }
                     ]
-                },
-                "Crater Tunnel A": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Phazon Core": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Crater Missile Station": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Crater Tunnel B": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Phazon Infusion Chamber": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Subchamber One": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Subchamber Two": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Subchamber Three": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Subchamber Four": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Subchamber Five": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Metroid Prime Lair": {
-                    "pickups": [],
-                    "doors": {}
                 }
             }
         },
@@ -223,14 +177,6 @@
                 "Phendrana Drifts South\u0000(Quarantine Cave)": "Magmoor Caverns West\u0000(Monitor Station)"
             },
             "rooms": {
-                "Transport to Magmoor Caverns West": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Shoreline Entrance": {
-                    "pickups": [],
-                    "doors": {}
-                },
                 "Phendrana Shorelines": {
                     "pickups": [
                         {
@@ -259,28 +205,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Temple Entryway": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Save Station B": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Ruins Entryway": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Plaza Walkway": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Ice Ruins Access": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Chozo Ice Temple": {
                     "pickups": [
@@ -297,8 +222,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Ice Ruins West": {
                     "pickups": [
@@ -315,8 +239,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Ice Ruins East": {
                     "pickups": [
@@ -346,20 +269,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Chapel Tunnel": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Courtyard Entryway": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Canyon Entryway": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Chapel of the Elders": {
                     "pickups": [
@@ -376,8 +286,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Ruined Courtyard": {
                     "pickups": [
@@ -394,8 +303,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Phendrana Canyon": {
                     "pickups": [
@@ -412,36 +320,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Save Station A": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Specimen Storage": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Quarantine Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Research Entrance": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "North Quarantine Tunnel": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Map Station": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Hydra Lab Entryway": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Quarantine Cave": {
                     "pickups": [
@@ -458,8 +337,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Research Lab Hydra": {
                     "pickups": [
@@ -476,12 +354,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "South Quarantine Tunnel": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Quarantine Monitor": {
                     "pickups": [
@@ -498,16 +371,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Observatory Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport to Magmoor Caverns South": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Observatory": {
                     "pickups": [
@@ -524,8 +388,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Transport Access": {
                     "pickups": [
@@ -542,36 +405,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "West Tower Entrance": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Save Station D": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Frozen Pike": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "West Tower": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Pike Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Frost Cave Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Hunter Cave Access": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Control Tower": {
                     "pickups": [
@@ -588,8 +422,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Research Core": {
                     "pickups": [
@@ -606,8 +439,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Frost Cave": {
                     "pickups": [
@@ -624,44 +456,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Hunter Cave": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "East Tower": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Research Core Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Save Station C": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Upper Edge Tunnel": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Lower Edge Tunnel": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Chamber Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Lake Tunnel": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Aether Lab Entryway": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Research Lab Aether": {
                     "pickups": [
@@ -693,12 +488,7 @@
                             "showIcon": true,
                             "modalHudmemo": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Phendrana's Edge": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Gravity Chamber": {
                     "pickups": [
@@ -728,8 +518,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Storage Cave": {
                     "pickups": [
@@ -746,8 +535,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Security Cave": {
                     "pickups": [
@@ -764,128 +552,13 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 }
             }
         },
         "Frigate Orpheon": {
             "transports": {
                 "Frigate Escape Cutscene": "Tallon Overworld:Landing Site"
-            },
-            "rooms": {
-                "Exterior Docking Hangar": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Air Lock": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Deck Alpha Access Hall": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Deck Alpha Mech Shaft": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Emergency Evacuation Area": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Connection Elevator to Deck Alpha": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Deck Alpha Umbilical Hall": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Biotech Research Area 2": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Map Facility": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Main Ventilation Shaft Section F": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Connection Elevator to Deck Beta": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Main Ventilation Shaft Section E": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Deck Beta Conduit Hall": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Main Ventilation Shaft Section D": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Biotech Research Area 1": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Main Ventilation Shaft Section C": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Deck Beta Security Hall": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Connection Elevator to Deck Beta (2)": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Subventilation Shaft Section A": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Main Ventilation Shaft Section B": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Biohazard Containment": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Deck Gamma Monitor Hall": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Subventilation Shaft Section B": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Main Ventilation Shaft Section A": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Deck Beta Transit Hall": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Reactor Core": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Cargo Freight Lift to Deck Gamma": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Reactor Core Entrance": {
-                    "pickups": [],
-                    "doors": {}
-                }
             }
         },
         "Magmoor Caverns": {
@@ -897,22 +570,6 @@
                 "Magmoor Caverns South\u0000(Magmoor Workstation, Save Station)": "Phazon Mines West\u0000(Phazon Processing Center)"
             },
             "rooms": {
-                "Transport to Chozo Ruins North": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Burning Trail": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Lake Tunnel": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Save Station Magmoor A": {
-                    "pickups": [],
-                    "doors": {}
-                },
                 "Lava Lake": {
                     "pickups": [
                         {
@@ -928,12 +585,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Pit Tunnel": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Triclops Pit": {
                     "pickups": [
@@ -950,12 +602,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Monitor Tunnel": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Storage Cavern": {
                     "pickups": [
@@ -972,12 +619,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Monitor Station": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Transport Tunnel A": {
                     "pickups": [
@@ -994,8 +636,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Warrior Shrine": {
                     "pickups": [
@@ -1012,8 +653,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Shore Tunnel": {
                     "pickups": [
@@ -1030,12 +670,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Transport to Phendrana Drifts North": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Fiery Shores": {
                     "pickups": [
@@ -1065,32 +700,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Transport Tunnel B": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport to Tallon Overworld West": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Twin Fires Tunnel": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Twin Fires": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "North Core Tunnel": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Geothermal Core": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Plasma Processing": {
                     "pickups": [
@@ -1107,12 +717,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "South Core Tunnel": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Magmoor Workstation": {
                     "pickups": [
@@ -1129,28 +734,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Workstation Tunnel": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport Tunnel C": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport to Phazon Mines West": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport to Phendrana Drifts South": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Save Station Magmoor B": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 }
             }
         },
@@ -1160,14 +744,6 @@
                 "Phazon Mines West\u0000(Phazon Processing Center)": "Magmoor Caverns South\u0000(Magmoor Workstation, Save Station)"
             },
             "rooms": {
-                "Transport to Tallon Overworld South": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Quarry Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
                 "Main Quarry": {
                     "pickups": [
                         {
@@ -1183,16 +759,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Waste Disposal": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Save Station Mines A": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Security Access A": {
                     "pickups": [
@@ -1209,20 +776,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Ore Processing": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Mine Security Station": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Research Access": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Storage Depot B": {
                     "pickups": [
@@ -1239,16 +793,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Elevator Access A": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Security Access B": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Storage Depot A": {
                     "pickups": [
@@ -1265,8 +810,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Elite Research": {
                     "pickups": [
@@ -1296,12 +840,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Elevator A": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Elite Control Access": {
                     "pickups": [
@@ -1318,16 +857,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Elite Control": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Maintenance Tunnel": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Ventilation Shaft": {
                     "pickups": [
@@ -1344,8 +874,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Phazon Processing Center": {
                     "pickups": [
@@ -1362,16 +891,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Omega Research": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport Access": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Processing Center Access": {
                     "pickups": [
@@ -1388,20 +908,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Map Station Mines": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Dynamo Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport to Magmoor Caverns South": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Elite Quarters": {
                     "pickups": [
@@ -1418,8 +925,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Central Dynamo": {
                     "pickups": [
@@ -1436,20 +942,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Elite Quarters Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Quarantine Access A": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Save Station Mines B": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Metroid Quarantine B": {
                     "pickups": [
@@ -1466,8 +959,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Metroid Quarantine A": {
                     "pickups": [
@@ -1484,20 +976,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Quarantine Access B": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Save Station Mines C": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Elevator Access B": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Fungal Hall B": {
                     "pickups": [
@@ -1514,16 +993,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Elevator B": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Missile Station Mines": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Phazon Mining Tunnel": {
                     "pickups": [
@@ -1540,8 +1010,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Fungal Hall Access": {
                     "pickups": [
@@ -1558,12 +1027,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Fungal Hall A": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 }
             }
         },
@@ -1592,20 +1056,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Gully": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Canyon Cavern": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Temple Hall": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Alcove": {
                     "pickups": [
@@ -1622,20 +1073,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Waterfall Cavern": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Tallon Canyon": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Temple Security Station": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Frigate Crash Site": {
                     "pickups": [
@@ -1652,24 +1090,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Transport Tunnel A": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Root Tunnel": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Temple Lobby": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Frigate Access Tunnel": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Overgrown Cavern": {
                     "pickups": [
@@ -1686,12 +1107,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Transport to Chozo Ruins West": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Root Cave": {
                     "pickups": [
@@ -1708,8 +1124,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Artifact Temple": {
                     "pickups": [
@@ -1727,16 +1142,7 @@
                             "showIcon": true,
                             "modalHudmemo": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Main Ventilation Shaft Section C": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport Tunnel C": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Transport Tunnel B": {
                     "pickups": [
@@ -1753,8 +1159,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Arbor Chamber": {
                     "pickups": [
@@ -1771,32 +1176,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Main Ventilation Shaft Section B": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport to Chozo Ruins East": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport to Magmoor Caverns East": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Main Ventilation Shaft Section A": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Reactor Core": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Reactor Access": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Cargo Freight Lift to Deck Gamma": {
                     "pickups": [
@@ -1813,16 +1193,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Savestation": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Deck Beta Transit Hall": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Biohazard Containment": {
                     "pickups": [
@@ -1839,24 +1210,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Deck Beta Security Hall": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Biotech Research Area 1": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Deck Beta Conduit Hall": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Connection Elevator to Deck Beta": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Hydro Access Tunnel": {
                     "pickups": [
@@ -1873,12 +1227,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Great Tree Hall": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Great Tree Chamber": {
                     "pickups": [
@@ -1895,12 +1244,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Transport Tunnel D": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Life Grove Tunnel": {
                     "pickups": [
@@ -1917,16 +1261,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Transport Tunnel E": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport to Chozo Ruins South": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Life Grove": {
                     "pickups": [
@@ -1956,12 +1291,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Transport to Phazon Mines East": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 }
             }
         },
@@ -1973,14 +1303,6 @@
                 "Chozo Ruins South\u0000(Reflecting Pool, Far End)": "Magmoor Caverns South\u0000(Magmoor Workstation, Debris)"
             },
             "rooms": {
-                "Transport to Tallon Overworld North": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Ruins Entrance": {
-                    "pickups": [],
-                    "doors": {}
-                },
                 "Main Plaza": {
                     "pickups": [
                         {
@@ -2035,28 +1357,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Ruined Fountain Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Ruined Shrine Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Nursery Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Plaza Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Piston Tunnel": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Ruined Fountain": {
                     "pickups": [
@@ -2073,8 +1374,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Ruined Shrine": {
                     "pickups": [
@@ -2120,12 +1420,7 @@
                             "showIcon": true,
                             "modalHudmemo": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Eyon Tunnel": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Vault": {
                     "pickups": [
@@ -2142,8 +1437,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Training Chamber": {
                     "pickups": [
@@ -2160,20 +1454,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Arboretum Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Meditation Fountain": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Tower of Light Access": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Ruined Nursery": {
                     "pickups": [
@@ -2190,12 +1471,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Vault Access": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Training Chamber Access": {
                     "pickups": [
@@ -2212,12 +1488,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Arboretum": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Magma Pool": {
                     "pickups": [
@@ -2234,8 +1505,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Tower of Light": {
                     "pickups": [
@@ -2252,28 +1522,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Save Station 1": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "North Atrium": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport to Magmoor Caverns North": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Sunchamber Lobby": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Gathering Hall Access": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Tower Chamber": {
                     "pickups": [
@@ -2290,8 +1539,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Ruined Gallery": {
                     "pickups": [
@@ -2321,12 +1569,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Sun Tower": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Transport Access North": {
                     "pickups": [
@@ -2344,12 +1587,7 @@
                             "showIcon": true,
                             "modalHudmemo": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Sunchamber Access": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Gathering Hall": {
                     "pickups": [
@@ -2366,20 +1604,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Totem Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Map Station": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Sun Tower Access": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Hive Totem": {
                     "pickups": [
@@ -2397,8 +1622,7 @@
                             "showIcon": true,
                             "modalHudmemo": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Sunchamber": {
                     "pickups": [
@@ -2428,8 +1652,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Watery Hall Access": {
                     "pickups": [
@@ -2446,16 +1669,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Save Station 2": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "East Atrium": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Watery Hall": {
                     "pickups": [
@@ -2485,20 +1699,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Energy Core Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Dynamo Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Energy Core": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Dynamo": {
                     "pickups": [
@@ -2528,16 +1729,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Burn Dome Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "West Furnace Access": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Burn Dome": {
                     "pickups": [
@@ -2567,8 +1759,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Furnace": {
                     "pickups": [
@@ -2598,16 +1789,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "East Furnace Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Crossway Access West": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Hall of the Elders": {
                     "pickups": [
@@ -2624,8 +1806,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
+                    ]
                 },
                 "Crossway": {
                     "pickups": [
@@ -2642,20 +1823,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Reflecting Pool Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Elder Hall Access": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Crossway Access South": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Elder Chamber": {
                     "pickups": [
@@ -2672,20 +1840,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Reflecting Pool": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Save Station 3": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport Access South": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 },
                 "Antechamber": {
                     "pickups": [
@@ -2702,16 +1857,7 @@
                             "respawn": false,
                             "showIcon": true
                         }
-                    ],
-                    "doors": {}
-                },
-                "Transport to Tallon Overworld East": {
-                    "pickups": [],
-                    "doors": {}
-                },
-                "Transport to Tallon Overworld South": {
-                    "pickups": [],
-                    "doors": {}
+                    ]
                 }
             }
         }

--- a/test/test_files/randomprime_expected_data_crazy.json
+++ b/test/test_files/randomprime_expected_data_crazy.json
@@ -34,7 +34,7 @@
         "forceFusion": false
     },
     "gameConfig": {
-        "resultsString": "5.2.0.dev65 | Seed Hash - Geemer Shriekbat Fission (AAAAAAAA)",
+        "resultsString": "5.5.0.dev206-dirty | Seed Hash - Geemer Shriekbat Fission (AAAAAAAA)",
         "bossSizes": null,
         "noDoors": true,
         "shufflePickupPosition": true,
@@ -48,13 +48,13 @@
             "eyeWaitRandomTime": 0.0,
             "eyeStayUpRandomTime": 0.0,
             "resetContraptionRandomTime": 0.0,
-            "eyeWaitInitialMinimumTime": 9.33333369553819,
-            "eyeWaitMinimumTime": 15.151810078628461,
-            "eyeStayUpMinimumTime": 8.897779328206717,
-            "resetContraptionMinimumTime": 3.570792137042231
+            "eyeWaitInitialMinimumTime": 8.664648420057842,
+            "eyeWaitMinimumTime": 15.014414698198438,
+            "eyeStayUpMinimumTime": 8.811394995771401,
+            "resetContraptionMinimumTime": 3.683239490926963
         },
         "mazeSeeds": [
-            159872324
+            221932206
         ],
         "nonvariaHeatDamage": true,
         "staggeredSuitDamage": false,
@@ -107,7 +107,7 @@
             "gameNameFull": "Metroid Prime: Randomizer - AAAAAAAA",
             "description": "Seed Hash: Geemer Shriekbat Fission"
         },
-        "mainMenuMessage": "Randovania v5.2.0.dev65\nGeemer Shriekbat Fission",
+        "mainMenuMessage": "Randovania v5.5.0.dev206-dirty\nGeemer Shriekbat Fission",
         "creditsString": "&push;&font=C29C51F1;&main-color=#89D6FF;Major Item Locations&pop;\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Charge Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Dynamo\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wave Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Lava Lake\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Research Core\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Plasma Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Research Lab Aether\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Missile Launcher&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Transport Tunnel A\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Grapple Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Fiery Shores\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Combat Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Control Tower\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Thermal Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Storage Depot B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;X-Ray Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Storage Cavern\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Space Jump Boots&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Gravity Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Boost Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Research Lab Aether\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Spider Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Elite Research\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Power Bomb&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Main Plaza\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Gravity Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Ruined Nursery\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Phazon Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Gravity Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Super Missile&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Antechamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wavebuster&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Hydra Lab Entryway\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Spreader&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Security Access B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Flamethrower&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Phendrana's Edge\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Chozo&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Life Grove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Elder&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Life Grove Tunnel\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Lifegiver&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Arbor Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Nature&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Transport Tunnel B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Strength&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Overgrown Cavern\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Sun&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Ventilation Shaft\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Truth&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Metroid Quarantine A\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Warrior&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Cargo Freight Lift to Deck Gamma\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Wild&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Storage Depot A",
         "artifactHints": {
             "Artifact of World": "&push;&main-color=#c300ff;Artifact of World&pop; has no need to be located.",
@@ -181,11 +181,11 @@
                         "0": {
                             "destination": {
                                 "roomName": "Phazon Core",
-                                "dockNum": 0
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false,
                     "extraScans": [
                         {
@@ -218,9 +218,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -3.522330149678144,
-                                -19.478768616671584,
-                                12.661065650984247
+                                -9.198978819756729,
+                                4.668104315539516,
+                                -0.30318810076361435
                             ],
                             "jumboScan": true
                         }
@@ -234,8 +234,8 @@
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Crater Missile Station",
-                                "dockNum": 0
+                                "roomName": "Crater Tunnel B",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -257,14 +257,20 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                58.83229964725824,
-                                -158.41134918093218,
-                                62.555634999218
+                                59.073953592456135,
+                                -85.43109916283049,
+                                77.93452051133066
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Crater Missile Station",
+                                "dockNum": 0
+                            }
+                        },
                         "1": {
                             "destination": {
                                 "roomName": "Crater Tunnel A",
@@ -273,18 +279,12 @@
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Crater Tunnel B",
-                                "dockNum": 1
-                            }
-                        },
-                        "0": {
-                            "destination": {
                                 "roomName": "Crater Entry Point",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Crater Missile Station": {
@@ -302,9 +302,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -83.26148537102861,
-                                -118.8658140358778,
-                                38.128646021665496
+                                -86.79511602551871,
+                                -137.36100459195174,
+                                47.43850248519149
                             ],
                             "jumboScan": true
                         }
@@ -312,8 +312,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Crater Tunnel A",
-                                "dockNum": 1
+                                "roomName": "Phazon Core",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -335,9 +335,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                50.057254749455666,
-                                -186.64461022499418,
-                                61.77744344493494
+                                36.23361323406706,
+                                -181.29996249000186,
+                                47.15303218153195
                             ],
                             "jumboScan": true
                         }
@@ -351,8 +351,8 @@
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Phazon Core",
-                                "dockNum": 2
+                                "roomName": "Crater Tunnel A",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -374,9 +374,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                19.579080628734236,
-                                -252.96274083724248,
-                                64.33067178375813
+                                33.14493088327861,
+                                -272.9884539386984,
+                                92.37599458567857
                             ],
                             "jumboScan": true
                         }
@@ -389,7 +389,7 @@
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Subchamber One": {
@@ -407,16 +407,15 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -0.9830738272859918,
-                                -376.64568366723375,
-                                18.2210397224517
+                                -19.146806300754818,
+                                -344.01797436732477,
+                                12.556506811299903
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Subchamber Two": {
                     "pickups": [
@@ -433,14 +432,13 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -13.030323029023343,
-                                -315.49973382439504,
-                                -9.133381867447603
+                                -6.057669535027941,
+                                -356.11692106482207,
+                                -22.46131238634063
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
                     "superheated": true,
                     "submerge": false
                 },
@@ -459,14 +457,13 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -16.209256768452775,
-                                -221.90864581828123,
-                                -81.21002271917938
+                                -31.474262810190037,
+                                -296.55594036253956,
+                                -84.57080454553447
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
                     "superheated": true,
                     "submerge": false
                 },
@@ -485,16 +482,15 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -27.431726969253774,
-                                -234.8119840657085,
-                                -107.0623859892047
+                                35.29941897068663,
+                                -216.8421848435205,
+                                -112.37227057739761
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Subchamber Five": {
                     "pickups": [
@@ -511,15 +507,14 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                54.92205591956206,
-                                -265.280877402446,
-                                -220.5046867746399
+                                53.80931797536665,
+                                -269.56474041467357,
+                                -151.19715924837968
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": true
                 },
                 "Metroid Prime Lair": {
@@ -537,14 +532,13 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                4.801562410078098,
-                                -266.0724086015932,
-                                -302.95274934117197
+                                84.28882762257629,
+                                -306.1991718178699,
+                                -288.42914816510734
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
                     "superheated": true,
                     "submerge": false
                 }
@@ -571,9 +565,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -23.72707325963637,
-                                28.971736188160996,
-                                11.950669791452192
+                                -52.1761198174156,
+                                49.71690707501491,
+                                9.551356267337091
                             ],
                             "jumboScan": true
                         }
@@ -586,7 +580,7 @@
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Shoreline Entrance": {
@@ -604,28 +598,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                24.75922704958473,
-                                -59.611247281044285,
-                                10.382485784520092
+                                -21.29725264762509,
+                                0.9891718742358364,
+                                18.532831195098748
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Control Tower",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
                                 "roomName": "Save Station C",
                                 "dockNum": 0
                             }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Research Lab Hydra",
+                                "dockNum": 1
+                            }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Phendrana Shorelines": {
@@ -658,16 +652,10 @@
                         }
                     ],
                     "doors": {
-                        "4": {
+                        "0": {
                             "destination": {
-                                "roomName": "Specimen Storage",
-                                "dockNum": 1
-                            }
-                        },
-                        "3": {
-                            "destination": {
-                                "roomName": "Quarantine Access",
-                                "dockNum": 1
+                                "roomName": "Map Station",
+                                "dockNum": 0
                             }
                         },
                         "1": {
@@ -678,7 +666,19 @@
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Lower Edge Tunnel",
+                                "roomName": "Chamber Access",
+                                "dockNum": 1
+                            }
+                        },
+                        "3": {
+                            "destination": {
+                                "roomName": "Quarantine Access",
+                                "dockNum": 1
+                            }
+                        },
+                        "4": {
+                            "destination": {
+                                "roomName": "Specimen Storage",
                                 "dockNum": 1
                             }
                         },
@@ -687,16 +687,10 @@
                                 "roomName": "Hydra Lab Entryway",
                                 "dockNum": 1
                             }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Map Station",
-                                "dockNum": 0
-                            }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Temple Entryway": {
                     "pickups": [
@@ -713,9 +707,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -172.22429117487522,
-                                -126.73660887836152,
-                                12.849345525216723
+                                -162.7246775231428,
+                                -107.64584938154472,
+                                10.279832000630506
                             ],
                             "jumboScan": true
                         }
@@ -723,18 +717,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Chozo Ice Temple",
+                                "roomName": "Frost Cave",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Pike Access",
-                                "dockNum": 1
+                                "roomName": "Quarantine Cave",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Save Station B": {
@@ -752,9 +746,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -74.0483688869738,
-                                -221.50045812175446,
-                                4.795054141427591
+                                -74.27767425418209,
+                                -228.83063235989485,
+                                6.602220606469046
                             ],
                             "jumboScan": true
                         }
@@ -762,13 +756,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Research Lab Hydra",
-                                "dockNum": 1
+                                "roomName": "Observatory",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Ruins Entryway": {
                     "pickups": [
@@ -785,9 +779,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -30.69125074685492,
-                                -227.13433296657186,
-                                28.53386211619138
+                                -15.011844792162677,
+                                -220.24661812956214,
+                                52.80411276470634
                             ],
                             "jumboScan": true
                         }
@@ -795,13 +789,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Frost Cave",
+                                "roomName": "Transport to Magmoor Caverns South",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Security Cave",
+                                "roomName": "Specimen Storage",
                                 "dockNum": 0
                             }
                         }
@@ -824,29 +818,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -0.11311445424190225,
-                                -209.17374165845357,
-                                26.248206507352915
+                                1.0803786601960788,
+                                -226.39017605199135,
+                                25.235199411526523
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Research Entrance",
+                                "dockNum": 0
+                            }
+                        },
                         "1": {
                             "destination": {
                                 "roomName": "Research Core",
                                 "dockNum": 0
                             }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Control Tower",
-                                "dockNum": 0
-                            }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Ice Ruins Access": {
                     "pickups": [
@@ -863,23 +857,23 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                21.457487078921865,
-                                -162.9739447439918,
-                                14.386263208550822
+                                71.34007231195562,
+                                -183.32538703556136,
+                                13.957226638065784
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Hunter Cave",
-                                "dockNum": 3
-                            }
-                        },
                         "0": {
                             "destination": {
                                 "roomName": "Ice Ruins West",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Observatory",
                                 "dockNum": 1
                             }
                         }
@@ -906,8 +900,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Temple Entryway",
-                                "dockNum": 0
+                                "roomName": "Hunter Cave Access",
+                                "dockNum": 1
                             }
                         },
                         "1": {
@@ -937,12 +931,6 @@
                         }
                     ],
                     "doors": {
-                        "2": {
-                            "destination": {
-                                "roomName": "Chapel Tunnel",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
                                 "roomName": "South Quarantine Tunnel",
@@ -952,6 +940,12 @@
                         "1": {
                             "destination": {
                                 "roomName": "Ice Ruins Access",
+                                "dockNum": 0
+                            }
+                        },
+                        "2": {
+                            "destination": {
+                                "roomName": "East Tower",
                                 "dockNum": 0
                             }
                         }
@@ -989,20 +983,20 @@
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Hunter Cave Access",
+                                "roomName": "Chamber Access",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Frost Cave Access",
-                                "dockNum": 1
+                                "roomName": "Quarantine Monitor",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Chapel Tunnel": {
@@ -1020,29 +1014,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -312.61131166930153,
-                                -175.1825090954951,
-                                40.35889611470279
+                                -275.283095762119,
+                                -169.45615519690116,
+                                45.282194238197334
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Frozen Pike",
-                                "dockNum": 3
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Ice Ruins West",
+                                "roomName": "Hunter Cave Access",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Hunter Cave",
                                 "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Courtyard Entryway": {
                     "pickups": [
@@ -1059,28 +1053,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -4.848822219164376,
-                                -419.4808475757749,
-                                34.39333597178684
+                                -10.770882037991772,
+                                -418.8258371526611,
+                                30.311720836096804
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Phendrana Shorelines",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
                                 "roomName": "Observatory",
                                 "dockNum": 2
                             }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Phendrana Shorelines",
+                                "dockNum": 1
+                            }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Canyon Entryway": {
@@ -1098,9 +1092,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -105.02623135135894,
-                                -323.31395411274855,
-                                19.847971777050482
+                                -95.87968652813093,
+                                -340.16800299352707,
+                                19.323756960745087
                             ],
                             "jumboScan": true
                         }
@@ -1108,19 +1102,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Observatory",
-                                "dockNum": 0
+                                "roomName": "Frozen Pike",
+                                "dockNum": 3
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Specimen Storage",
-                                "dockNum": 0
+                                "roomName": "Pike Access",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Chapel of the Elders": {
                     "pickups": [
@@ -1146,8 +1140,8 @@
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Ruined Courtyard": {
                     "pickups": [
@@ -1166,9 +1160,23 @@
                         }
                     ],
                     "doors": {
+                        "1": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
+                            "destination": {
+                                "roomName": "Upper Edge Tunnel",
+                                "dockNum": 1
+                            }
+                        },
                         "0": {
                             "destination": {
                                 "roomName": "West Tower",
+                                "dockNum": 0
+                            }
+                        },
+                        "2": {
+                            "destination": {
+                                "roomName": "Observatory Access",
                                 "dockNum": 0
                             }
                         },
@@ -1176,18 +1184,6 @@
                             "destination": {
                                 "roomName": "Transport to Magmoor Caverns West",
                                 "dockNum": 0
-                            }
-                        },
-                        "2": {
-                            "destination": {
-                                "roomName": "South Quarantine Tunnel",
-                                "dockNum": 0
-                            }
-                        },
-                        "1": {
-                            "destination": {
-                                "roomName": "Aether Lab Entryway",
-                                "dockNum": 1
                             }
                         }
                     },
@@ -1213,8 +1209,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Lake Tunnel",
-                                "dockNum": 1
+                                "roomName": "Upper Edge Tunnel",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -1236,9 +1232,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -68.25374204918538,
-                                -461.37773432511864,
-                                70.13832211074303
+                                -86.3194314742781,
+                                -456.8338694671355,
+                                71.92790643129963
                             ],
                             "jumboScan": true
                         }
@@ -1246,7 +1242,7 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Observatory",
+                                "roomName": "Hunter Cave",
                                 "dockNum": 1
                             }
                         }
@@ -1269,29 +1265,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -20.639046211325127,
-                                -522.0061028194436,
-                                65.01156679610553
+                                -4.984782430200866,
+                                -556.7182623503224,
+                                63.560896272910554
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Ruins Entryway",
+                                "dockNum": 1
+                            }
+                        },
                         "1": {
                             "destination": {
                                 "roomName": "Phendrana Shorelines",
                                 "dockNum": 4
                             }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Canyon Entryway",
-                                "dockNum": 1
-                            }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Quarantine Access": {
                     "pickups": [
@@ -1308,29 +1304,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                68.6367507453624,
-                                -507.65811257807,
-                                67.88456906259876
+                                58.43899557496698,
+                                -469.34369573004574,
+                                72.95257367186744
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Frost Cave",
+                                "dockNum": 1
+                            }
+                        },
                         "1": {
                             "destination": {
                                 "roomName": "Phendrana Shorelines",
                                 "dockNum": 3
                             }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Frozen Pike",
-                                "dockNum": 1
-                            }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Research Entrance": {
                     "pickups": [
@@ -1347,34 +1343,34 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                9.616489113669147,
-                                -593.272041724637,
-                                60.14077198453212
+                                0.9820343970856058,
+                                -659.846940852488,
+                                85.35121528456216
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Plaza Walkway",
+                                "dockNum": 0
+                            }
+                        },
                         "1": {
                             "destination": {
-                                "roomName": "Observatory Access",
+                                "roomName": "North Quarantine Tunnel",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Storage Cave",
-                                "dockNum": 0
-                            }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "West Tower Entrance",
+                                "roomName": "Lake Tunnel",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "North Quarantine Tunnel": {
@@ -1392,29 +1388,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                17.664281996792305,
-                                -683.3201337917752,
-                                42.26635558161156
+                                67.86206300643497,
+                                -681.0287298847019,
+                                28.241357765213916
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Research Lab Aether",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Research Lab Hydra",
+                                "roomName": "Research Entrance",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Control Tower",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Map Station": {
                     "pickups": [
@@ -1431,9 +1427,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -40.44284569845201,
-                                -646.30259440049,
-                                69.51143511515279
+                                -38.51271932296769,
+                                -662.3772287750315,
+                                69.2171931127389
                             ],
                             "jumboScan": true
                         }
@@ -1446,7 +1442,7 @@
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Hydra Lab Entryway": {
@@ -1464,29 +1460,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -20.55970710093026,
-                                -735.2512272144742,
-                                76.70893191746613
+                                -4.81062877979755,
+                                -727.6314072441243,
+                                75.35472572874221
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Phendrana Shorelines",
-                                "dockNum": 5
-                            }
-                        },
                         "0": {
                             "destination": {
                                 "roomName": "Quarantine Cave",
                                 "dockNum": 2
                             }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Phendrana Shorelines",
+                                "dockNum": 5
+                            }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Quarantine Cave": {
                     "pickups": [
@@ -1505,16 +1501,16 @@
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Temple Entryway",
+                                "dockNum": 1
+                            }
+                        },
                         "1": {
                             "destination": {
                                 "roomName": "Research Core Access",
-                                "dockNum": 0
-                            }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Pike Access",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         },
                         "2": {
@@ -1544,21 +1540,21 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Save Station B",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "North Quarantine Tunnel",
-                                "dockNum": 0
+                                "roomName": "Transport to Magmoor Caverns South",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Shoreline Entrance",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "South Quarantine Tunnel": {
                     "pickups": [
@@ -1575,24 +1571,24 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                98.15401953911291,
-                                -785.0421002803582,
-                                73.8010434149834
+                                176.76301119824325,
+                                -800.5724576855971,
+                                59.70272268395695
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Gravity Chamber",
+                                "dockNum": 1
+                            }
+                        },
                         "1": {
                             "destination": {
                                 "roomName": "Ice Ruins West",
                                 "dockNum": 0
-                            }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Ruined Courtyard",
-                                "dockNum": 2
                             }
                         }
                     },
@@ -1618,8 +1614,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hunter Cave",
-                                "dockNum": 0
+                                "roomName": "Ice Ruins East",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -1641,28 +1637,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -67.98187886227777,
-                                -788.0367614833698,
-                                106.72543710549188
+                                -69.0690666186276,
+                                -792.5386352348236,
+                                106.8163048892425
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Ruined Courtyard",
+                                "dockNum": 2
+                            }
+                        },
                         "1": {
                             "destination": {
                                 "roomName": "Chozo Ice Temple",
                                 "dockNum": 1
                             }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Research Entrance",
-                                "dockNum": 1
-                            }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Transport to Magmoor Caverns South": {
@@ -1680,24 +1676,24 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                165.97405404246834,
-                                -835.2614632784549,
-                                54.75339842378533
+                                182.5517629733001,
+                                -841.9219920830506,
+                                91.03500017762755
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Research Lab Aether",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Research Core Access",
-                                "dockNum": 1
+                                "roomName": "Ruins Entryway",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Research Lab Hydra",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -1721,27 +1717,29 @@
                         }
                     ],
                     "doors": {
+                        "2": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
+                            "destination": {
+                                "roomName": "Courtyard Entryway",
+                                "dockNum": 0
+                            }
+                        },
                         "0": {
                             "destination": {
-                                "roomName": "Canyon Entryway",
+                                "roomName": "Save Station B",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Save Station A",
-                                "dockNum": 0
-                            }
-                        },
-                        "2": {
-                            "destination": {
-                                "roomName": "Courtyard Entryway",
-                                "dockNum": 0
+                                "roomName": "Ice Ruins Access",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Transport Access": {
                     "pickups": [
@@ -1760,16 +1758,16 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Chapel of the Elders",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
                                 "roomName": "West Tower",
                                 "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Chapel of the Elders",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -1791,29 +1789,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -50.18109790789328,
-                                -842.109752708125,
-                                127.06898778912242
+                                -69.27518060060909,
+                                -813.9875587731486,
+                                129.53208548967794
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Frost Cave",
-                                "dockNum": 2
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Research Entrance",
+                                "roomName": "Frozen Pike",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Hunter Cave",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Save Station D": {
                     "pickups": [
@@ -1830,9 +1828,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -63.35992154246841,
-                                -965.437649698323,
-                                132.49666218545627
+                                -62.992663526364794,
+                                -963.7117464029677,
+                                127.55276101981299
                             ],
                             "jumboScan": true
                         }
@@ -1840,13 +1838,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phendrana's Edge",
-                                "dockNum": 3
+                                "roomName": "Frost Cave",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Frozen Pike": {
                     "pickups": [
@@ -1863,40 +1861,40 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                185.1844922016831,
-                                -1015.514464235897,
-                                6.6430285985606
+                                166.06019798512452,
+                                -988.463980639713,
+                                78.93027491758465
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "3": {
-                            "destination": {
-                                "roomName": "Chapel Tunnel",
-                                "dockNum": 1
-                            }
-                        },
-                        "2": {
-                            "destination": {
-                                "roomName": "Chamber Access",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Lake Tunnel",
+                                "roomName": "Aether Lab Entryway",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Quarantine Access",
+                                "roomName": "West Tower Entrance",
+                                "dockNum": 0
+                            }
+                        },
+                        "2": {
+                            "destination": {
+                                "roomName": "Lake Tunnel",
+                                "dockNum": 1
+                            }
+                        },
+                        "3": {
+                            "destination": {
+                                "roomName": "Canyon Entryway",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "West Tower": {
@@ -1914,9 +1912,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -35.201388513778596,
-                                -771.729511226475,
-                                132.53727684084333
+                                -33.04155097173398,
+                                -794.7223253063416,
+                                158.83582223362748
                             ],
                             "jumboScan": true
                         }
@@ -1935,8 +1933,8 @@
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Pike Access": {
                     "pickups": [
@@ -1953,9 +1951,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                129.26208564775848,
-                                -1000.1088459767027,
-                                49.42363789807837
+                                109.65631238897811,
+                                -999.984268033537,
+                                57.15743216565292
                             ],
                             "jumboScan": true
                         }
@@ -1963,19 +1961,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Quarantine Cave",
-                                "dockNum": 0
+                                "roomName": "Phendrana's Edge",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Temple Entryway",
+                                "roomName": "Canyon Entryway",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Frost Cave Access": {
                     "pickups": [
@@ -1992,24 +1990,24 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                180.28995256533938,
-                                -1075.6351460980932,
-                                63.75141397540577
+                                159.41274613297531,
+                                -1060.146864041741,
+                                54.509526557520374
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Ice Ruins East",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
                                 "roomName": "Phendrana's Edge",
                                 "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Research Lab Aether",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -2031,9 +2029,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                186.75351570092658,
-                                -1143.8162969070847,
-                                6.518658887885244
+                                218.7002714439309,
+                                -1128.880318092394,
+                                28.261290452985563
                             ],
                             "jumboScan": true
                         }
@@ -2041,14 +2039,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ice Ruins East",
-                                "dockNum": 1
+                                "roomName": "Chapel Tunnel",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Phendrana's Edge",
-                                "dockNum": 2
+                                "roomName": "Chozo Ice Temple",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -2072,21 +2070,21 @@
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Shoreline Entrance",
+                                "roomName": "North Quarantine Tunnel",
                                 "dockNum": 1
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Plaza Walkway",
+                                "roomName": "Research Core Access",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Research Core": {
                     "pickups": [
@@ -2113,12 +2111,12 @@
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Upper Edge Tunnel",
+                                "roomName": "Lower Edge Tunnel",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Frost Cave": {
@@ -2139,20 +2137,22 @@
                     ],
                     "doors": {
                         "0": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
                             "destination": {
-                                "roomName": "Ruins Entryway",
+                                "roomName": "Temple Entryway",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Quarantine Access",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "West Tower Entrance",
-                                "dockNum": 1
-                            }
-                        },
-                        "1": {
-                            "destination": {
-                                "roomName": "Lower Edge Tunnel",
+                                "roomName": "Save Station D",
                                 "dockNum": 0
                             }
                         }
@@ -2175,41 +2175,41 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                257.4538655350665,
-                                -1211.8131148747473,
-                                23.725888430290716
+                                212.54144278896808,
+                                -1251.5550499795067,
+                                25.825381785016226
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "3": {
-                            "destination": {
-                                "roomName": "Ice Ruins Access",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Quarantine Monitor",
-                                "dockNum": 0
+                                "roomName": "West Tower Entrance",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "East Tower",
-                                "dockNum": 1
+                                "roomName": "Save Station A",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Aether Lab Entryway",
+                                "roomName": "Chapel Tunnel",
+                                "dockNum": 1
+                            }
+                        },
+                        "3": {
+                            "destination": {
+                                "roomName": "Storage Cave",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "East Tower": {
                     "pickups": [
@@ -2226,29 +2226,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                23.55569613446732,
-                                -771.9138823685452,
-                                158.68872377861695
+                                23.296328636175517,
+                                -771.6563634639899,
+                                159.30821029650724
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Hunter Cave",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Gravity Chamber",
-                                "dockNum": 0
+                                "roomName": "Ice Ruins West",
+                                "dockNum": 2
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Phendrana's Edge",
+                                "dockNum": 3
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Research Core Access": {
                     "pickups": [
@@ -2265,9 +2265,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                42.510498490666365,
-                                -931.1668851176637,
-                                96.20971888726348
+                                41.77454361037988,
+                                -923.6381033591205,
+                                101.34896985715132
                             ],
                             "jumboScan": true
                         }
@@ -2275,19 +2275,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Quarantine Cave",
+                                "roomName": "Control Tower",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Magmoor Caverns South",
-                                "dockNum": 0
+                                "roomName": "Quarantine Cave",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Save Station C": {
                     "pickups": [
@@ -2304,23 +2304,25 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                46.36811821579235,
-                                -1229.4928566113663,
-                                64.43442809497719
+                                43.823848364739156,
+                                -1247.1035962749268,
+                                52.06599309230825
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
                         "0": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
                             "destination": {
                                 "roomName": "Shoreline Entrance",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Upper Edge Tunnel": {
                     "pickups": [
@@ -2337,9 +2339,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                138.59987517206918,
-                                -1355.3090323893414,
-                                42.09220092464308
+                                170.20434345850316,
+                                -1297.8238823110498,
+                                42.284656703998756
                             ],
                             "jumboScan": true
                         }
@@ -2347,19 +2349,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Research Core",
-                                "dockNum": 1
+                                "roomName": "Phendrana Canyon",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Gravity Chamber",
+                                "roomName": "Ruined Courtyard",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Lower Edge Tunnel": {
                     "pickups": [
@@ -2376,24 +2378,24 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                193.18698210618476,
-                                -1333.4258382636153,
-                                21.056981580047733
+                                201.11922468925832,
+                                -1291.897443726338,
+                                13.065398474013694
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Phendrana Shorelines",
-                                "dockNum": 2
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Frost Cave",
+                                "roomName": "Research Core",
                                 "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Research Lab Aether",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -2415,28 +2417,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                294.2568403537259,
-                                -1192.8916729898365,
-                                26.142421465900018
+                                308.98829846562495,
+                                -1194.649451985807,
+                                25.939144978107507
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Frozen Pike",
-                                "dockNum": 2
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Phendrana's Edge",
-                                "dockNum": 1
+                                "roomName": "Ice Ruins East",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Phendrana Shorelines",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Lake Tunnel": {
@@ -2454,28 +2456,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                327.37718223737664,
-                                -1225.4180408101379,
-                                9.951809005609725
+                                324.608566948484,
+                                -1235.1958765840116,
+                                11.33471157134471
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Phendrana Canyon",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
+                                "roomName": "Research Entrance",
+                                "dockNum": 2
+                            }
+                        },
+                        "1": {
+                            "destination": {
                                 "roomName": "Frozen Pike",
-                                "dockNum": 0
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Aether Lab Entryway": {
@@ -2493,9 +2495,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                45.840803960781564,
-                                -824.9989777501011,
-                                130.96294482222027
+                                37.94213320431041,
+                                -817.1224477740483,
+                                129.45108836223446
                             ],
                             "jumboScan": true
                         }
@@ -2503,18 +2505,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hunter Cave",
-                                "dockNum": 2
+                                "roomName": "Frozen Pike",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Ruined Courtyard",
-                                "dockNum": 1
+                                "roomName": "Phendrana's Edge",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Research Lab Aether": {
@@ -2549,18 +2551,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "North Quarantine Tunnel",
+                                "roomName": "Lower Edge Tunnel",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Magmoor Caverns South",
+                                "roomName": "Frost Cave Access",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Phendrana's Edge": {
@@ -2578,36 +2580,36 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                185.1322343162619,
-                                -1419.5540833362704,
-                                61.68410874182714
+                                151.61440896473533,
+                                -1376.3853099476014,
+                                18.72576444249079
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "2": {
-                            "destination": {
-                                "roomName": "Hunter Cave Access",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
                                 "roomName": "Frost Cave Access",
                                 "dockNum": 0
                             }
                         },
-                        "3": {
+                        "1": {
                             "destination": {
-                                "roomName": "Save Station D",
+                                "roomName": "Pike Access",
                                 "dockNum": 0
                             }
                         },
-                        "1": {
+                        "2": {
                             "destination": {
-                                "roomName": "Chamber Access",
-                                "dockNum": 0
+                                "roomName": "Aether Lab Entryway",
+                                "dockNum": 1
+                            }
+                        },
+                        "3": {
+                            "destination": {
+                                "roomName": "East Tower",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -2644,15 +2646,15 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Upper Edge Tunnel",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "East Tower",
+                                "roomName": "Security Cave",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "South Quarantine Tunnel",
                                 "dockNum": 0
                             }
                         }
@@ -2679,13 +2681,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Research Entrance",
-                                "dockNum": 2
+                                "roomName": "Hunter Cave",
+                                "dockNum": 3
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Security Cave": {
                     "pickups": [
@@ -2706,8 +2708,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruins Entryway",
-                                "dockNum": 1
+                                "roomName": "Gravity Chamber",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -2736,16 +2738,15 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -53.11003982876556,
-                                188.6920444374275,
-                                38.96035174057416
+                                112.46940601285874,
+                                195.37590819066173,
+                                44.41598117808115
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Air Lock": {
                     "pickups": [
@@ -2762,9 +2763,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                25.505154326752333,
-                                49.41986160032132,
-                                6.269315277851199
+                                23.536541982516695,
+                                62.354306846683976,
+                                8.97842561770286
                             ],
                             "jumboScan": true
                         }
@@ -2772,13 +2773,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Biotech Research Area 1",
+                                "roomName": "Deck Beta Conduit Hall",
                                 "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Deck Alpha Access Hall": {
                     "pickups": [
@@ -2795,24 +2796,24 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                20.1263184458667,
-                                28.24707041256659,
-                                8.532362357677918
+                                24.256858772524346,
+                                6.927301434224488,
+                                0.2737583986770855
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Connection Elevator to Deck Beta (2)",
+                                "roomName": "Main Ventilation Shaft Section C",
                                 "dockNum": 1
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Biotech Research Area 1",
-                                "dockNum": 0
+                                "roomName": "Deck Gamma Monitor Hall",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -2834,16 +2835,15 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                10.638038787782024,
-                                48.10909861884736,
-                                9.445084547268468
+                                10.460855834860416,
+                                53.80053268541544,
+                                9.502144774528423
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Emergency Evacuation Area": {
                     "pickups": [
@@ -2860,23 +2860,23 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -6.581909821823125,
-                                -48.06689742739827,
-                                11.91274813775787
+                                13.525633861300353,
+                                -13.782354079704376,
+                                2.168429155487873
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Reactor Core Entrance",
+                                "roomName": "Deck Beta Transit Hall",
                                 "dockNum": 1
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Deck Beta Conduit Hall",
+                                "roomName": "Main Ventilation Shaft Section B",
                                 "dockNum": 1
                             }
                         }
@@ -2899,9 +2899,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                48.27988782325965,
-                                62.46367250091734,
-                                -43.586470747821075
+                                7.323137637556185,
+                                49.960744370947246,
+                                -9.481339648996617
                             ],
                             "jumboScan": true
                         }
@@ -2909,13 +2909,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section F",
+                                "roomName": "Map Facility",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Deck Alpha Umbilical Hall": {
                     "pickups": [
@@ -2932,29 +2932,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                5.252239989983924,
-                                -98.66756176356004,
-                                -0.21702406028173815
+                                6.975590399202336,
+                                -93.52337834122665,
+                                4.256216823247491
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section F",
+                                "roomName": "Reactor Core",
                                 "dockNum": 1
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Biohazard Containment",
-                                "dockNum": 0
+                                "roomName": "Main Ventilation Shaft Section E",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Biotech Research Area 2": {
                     "pickups": [
@@ -2971,23 +2971,23 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                135.4868198013179,
-                                76.99811882972526,
-                                -22.93432707001503
+                                151.18984985578373,
+                                76.19172383012018,
+                                83.86811827169478
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Map Facility",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Reactor Core Entrance",
+                                "roomName": "Main Ventilation Shaft Section D",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Deck Gamma Monitor Hall",
                                 "dockNum": 0
                             }
                         }
@@ -3010,24 +3010,24 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                0.4122118848490217,
-                                -130.22172884871654,
-                                0.8626030658565349
+                                0.46864118124341303,
+                                -128.7402986206326,
+                                7.929837106524807
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Deck Gamma Monitor Hall",
+                                "roomName": "Connection Elevator to Deck Alpha",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Biotech Research Area 2",
-                                "dockNum": 1
+                                "roomName": "Cargo Freight Lift to Deck Gamma",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -3049,24 +3049,24 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                191.15936701343935,
-                                -0.9776255622601262,
-                                -42.50822213335245
+                                173.58834814783583,
+                                2.055012572219928,
+                                -46.62236550016058
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Deck Alpha Umbilical Hall",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Connection Elevator to Deck Alpha",
+                                "roomName": "Biotech Research Area 1",
                                 "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Biohazard Containment",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -3088,9 +3088,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                2.532811859543862,
-                                -152.07149308628567,
-                                -4.748678160555976
+                                11.827903843686592,
+                                -153.4718225297023,
+                                -33.25513119198483
                             ],
                             "jumboScan": true
                         }
@@ -3098,13 +3098,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Subventilation Shaft Section B",
+                                "roomName": "Connection Elevator to Deck Beta (2)",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Cargo Freight Lift to Deck Gamma",
+                                "roomName": "Main Ventilation Shaft Section C",
                                 "dockNum": 0
                             }
                         }
@@ -3127,28 +3127,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                228.37699979164643,
-                                -33.06715470568719,
-                                -55.040939617765034
+                                227.72027112028024,
+                                -27.051148918915295,
+                                -60.59617666901795
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Subventilation Shaft Section A",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Biotech Research Area 1",
-                                "dockNum": 2
+                                "roomName": "Biohazard Containment",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Deck Alpha Umbilical Hall",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Deck Beta Conduit Hall": {
@@ -3166,9 +3166,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                23.907404735355332,
-                                -191.70143347770372,
-                                -35.87225189818727
+                                12.50083021784844,
+                                -193.7957540671797,
+                                -32.83932908397763
                             ],
                             "jumboScan": true
                         }
@@ -3176,13 +3176,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Deck Beta Transit Hall",
+                                "roomName": "Biotech Research Area 1",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Emergency Evacuation Area",
+                                "roomName": "Air Lock",
                                 "dockNum": 0
                             }
                         }
@@ -3205,29 +3205,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                232.10014157302825,
-                                -51.68031877360202,
-                                -63.506477808674944
+                                257.34302191766915,
+                                -79.88505081710807,
+                                -58.20424172240268
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Biohazard Containment",
+                                "roomName": "Reactor Core Entrance",
                                 "dockNum": 1
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Reactor Core",
-                                "dockNum": 1
+                                "roomName": "Biotech Research Area 2",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Biotech Research Area 1": {
                     "pickups": [
@@ -3244,35 +3244,35 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                53.61915787370364,
-                                -212.54407536991468,
-                                -36.74175567153358
+                                49.18149744393958,
+                                -211.91053920586126,
+                                -7.070074984937953
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Main Ventilation Shaft Section F",
+                                "dockNum": 0
+                            }
+                        },
                         "1": {
                             "destination": {
-                                "roomName": "Air Lock",
+                                "roomName": "Deck Beta Conduit Hall",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section E",
-                                "dockNum": 0
-                            }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Deck Alpha Access Hall",
-                                "dockNum": 0
+                                "roomName": "Main Ventilation Shaft Section A",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Main Ventilation Shaft Section C": {
                     "pickups": [
@@ -3289,28 +3289,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                287.6189195339075,
-                                -97.73094965888768,
-                                -45.48522610587648
+                                323.561030883343,
+                                -96.73252365983201,
+                                -41.84573431839543
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section B",
+                                "roomName": "Connection Elevator to Deck Beta",
                                 "dockNum": 1
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Cargo Freight Lift to Deck Gamma",
-                                "dockNum": 3
+                                "roomName": "Deck Alpha Access Hall",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Deck Beta Security Hall": {
@@ -3328,9 +3328,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                99.8412004439682,
-                                -160.65860671564255,
-                                -32.48578050375254
+                                111.45321007006675,
+                                -143.1191696824582,
+                                -31.99698705428931
                             ],
                             "jumboScan": true
                         }
@@ -3338,18 +3338,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Reactor Core",
+                                "roomName": "Reactor Core Entrance",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section A",
-                                "dockNum": 1
+                                "roomName": "Cargo Freight Lift to Deck Gamma",
+                                "dockNum": 3
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Connection Elevator to Deck Beta (2)": {
@@ -3367,9 +3367,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                96.77282345449437,
-                                -255.91986692836517,
-                                -101.52806323244164
+                                94.2861312913804,
+                                -225.39721318734397,
+                                -57.75387169249537
                             ],
                             "jumboScan": true
                         }
@@ -3377,14 +3377,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Deck Beta Transit Hall",
+                                "roomName": "Reactor Core",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Deck Alpha Access Hall",
-                                "dockNum": 1
+                                "roomName": "Connection Elevator to Deck Beta",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -3406,9 +3406,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                117.5575004336937,
-                                -263.5225966212993,
-                                -38.51793162436299
+                                112.65828601481837,
+                                -193.73474954454542,
+                                -47.72902344034409
                             ],
                             "jumboScan": true
                         }
@@ -3416,13 +3416,13 @@
                     "doors": {
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section E",
-                                "dockNum": 1
+                                "roomName": "Main Ventilation Shaft Section B",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Main Ventilation Shaft Section B": {
                     "pickups": [
@@ -3439,9 +3439,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                254.26919145600147,
-                                -141.97920652000624,
-                                -82.2970961208044
+                                250.30039697469954,
+                                -145.8986053848029,
+                                -41.01274607038763
                             ],
                             "jumboScan": true
                         }
@@ -3449,19 +3449,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Deck Gamma Monitor Hall",
+                                "roomName": "Subventilation Shaft Section A",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section C",
+                                "roomName": "Emergency Evacuation Area",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Biohazard Containment": {
                     "pickups": [
@@ -3478,24 +3478,24 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                125.64293045792661,
-                                -96.66050296265647,
-                                -33.32776794472314
+                                102.16087657070821,
+                                -95.93347542354456,
+                                -18.138876338135162
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Main Ventilation Shaft Section D",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Deck Alpha Umbilical Hall",
+                                "roomName": "Main Ventilation Shaft Section E",
                                 "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Main Ventilation Shaft Section F",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -3517,9 +3517,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                131.55835746407269,
-                                -294.5225973262694,
-                                -95.51382022970009
+                                125.18210653991673,
+                                -277.93790524010774,
+                                -95.80121563411379
                             ],
                             "jumboScan": true
                         }
@@ -3527,19 +3527,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Map Facility",
+                                "roomName": "Biotech Research Area 2",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section B",
-                                "dockNum": 0
+                                "roomName": "Deck Alpha Access Hall",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Subventilation Shaft Section B": {
                     "pickups": [
@@ -3556,9 +3556,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                164.679124773475,
-                                -243.05184106835014,
-                                -54.6987605575808
+                                165.36506629992962,
+                                -243.0902533884297,
+                                -72.57629747780537
                             ],
                             "jumboScan": true
                         }
@@ -3566,13 +3566,13 @@
                     "doors": {
                         "1": {
                             "destination": {
-                                "roomName": "Connection Elevator to Deck Beta",
+                                "roomName": "Deck Beta Transit Hall",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Main Ventilation Shaft Section A": {
                     "pickups": [
@@ -3589,9 +3589,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                202.71142901032778,
-                                -156.00701121658116,
-                                -66.66711320475838
+                                230.14818891631924,
+                                -158.61612961829303,
+                                -76.94486699736136
                             ],
                             "jumboScan": true
                         }
@@ -3599,8 +3599,8 @@
                     "doors": {
                         "1": {
                             "destination": {
-                                "roomName": "Deck Beta Security Hall",
-                                "dockNum": 1
+                                "roomName": "Biotech Research Area 1",
+                                "dockNum": 2
                             }
                         }
                     },
@@ -3622,23 +3622,23 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                141.34220654403092,
-                                -116.57371589020927,
-                                -17.424432000838067
+                                168.5443149217936,
+                                -116.39387763505341,
+                                -17.40504121181729
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Deck Beta Conduit Hall",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Connection Elevator to Deck Beta (2)",
+                                "roomName": "Subventilation Shaft Section B",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Emergency Evacuation Area",
                                 "dockNum": 0
                             }
                         }
@@ -3661,29 +3661,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                210.7049058927542,
-                                -351.9245380446941,
-                                -133.0718783944091
+                                156.14399119170608,
+                                -298.7035033919005,
+                                -48.60250774197442
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section D",
+                                "roomName": "Connection Elevator to Deck Beta (2)",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Deck Beta Security Hall",
+                                "roomName": "Deck Alpha Umbilical Hall",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Cargo Freight Lift to Deck Gamma": {
                     "pickups": [
@@ -3700,9 +3700,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                190.08377040088513,
-                                -211.89431484804797,
-                                -52.97043884270508
+                                185.19082747234955,
+                                -223.1931822213232,
+                                -20.06616345146466
                             ],
                             "jumboScan": true
                         }
@@ -3710,14 +3710,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Connection Elevator to Deck Beta",
+                                "roomName": "Map Facility",
                                 "dockNum": 1
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section C",
-                                "dockNum": 0
+                                "roomName": "Deck Beta Security Hall",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -3739,9 +3739,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                180.4343989198659,
-                                -249.40320858379866,
-                                -82.86737429486038
+                                206.7840047694368,
+                                -264.75932598667924,
+                                -76.24834601605151
                             ],
                             "jumboScan": true
                         }
@@ -3749,19 +3749,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Biotech Research Area 2",
+                                "roomName": "Deck Beta Security Hall",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Emergency Evacuation Area",
-                                "dockNum": 1
+                                "roomName": "Main Ventilation Shaft Section D",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 }
             }
         },
@@ -3789,9 +3789,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -139.38242221180124,
-                                308.42230497231566,
-                                49.7245451261454
+                                -128.90255956312384,
+                                311.9629383723488,
+                                71.96831189309646
                             ],
                             "jumboScan": true
                         }
@@ -3799,13 +3799,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Burning Trail",
-                                "dockNum": 1
+                                "roomName": "Transport Tunnel C",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Burning Trail": {
                     "pickups": [
@@ -3822,35 +3822,37 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -121.99797969024928,
-                                155.95771628439553,
-                                47.134662567761644
+                                -129.75516509015245,
+                                269.30120067370194,
+                                42.414114335275876
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
                         "2": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
                             "destination": {
-                                "roomName": "Triclops Pit",
-                                "dockNum": 2
-                            }
-                        },
-                        "1": {
-                            "destination": {
-                                "roomName": "Transport to Chozo Ruins North",
+                                "roomName": "Warrior Shrine",
                                 "dockNum": 0
                             }
                         },
                         "0": {
                             "destination": {
-                                "roomName": "Lake Tunnel",
-                                "dockNum": 1
+                                "roomName": "Triclops Pit",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Pit Tunnel",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Lake Tunnel": {
                     "pickups": [
@@ -3867,9 +3869,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -74.45840389239127,
-                                99.00819324419524,
-                                6.37816894294444
+                                -96.14458207448217,
+                                55.80286107194526,
+                                14.765215481426722
                             ],
                             "jumboScan": true
                         }
@@ -3877,19 +3879,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Magmoor Workstation",
-                                "dockNum": 1
+                                "roomName": "Monitor Station",
+                                "dockNum": 3
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Burning Trail",
+                                "roomName": "Transport to Phendrana Drifts North",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Save Station Magmoor A": {
                     "pickups": [
@@ -3906,9 +3908,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -91.60107556357029,
-                                238.37362733253127,
-                                18.387431634579414
+                                -111.49227258602153,
+                                221.91150788342551,
+                                18.707120486271094
                             ],
                             "jumboScan": true
                         }
@@ -3916,7 +3918,7 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "North Core Tunnel",
+                                "roomName": "Geothermal Core",
                                 "dockNum": 1
                             }
                         }
@@ -3943,13 +3945,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Twin Fires Tunnel",
+                                "roomName": "Warrior Shrine",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Phendrana Drifts North",
+                                "roomName": "Twin Fires",
                                 "dockNum": 0
                             }
                         }
@@ -3972,9 +3974,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                54.99715508829004,
-                                -40.6960339124301,
-                                22.63173418876027
+                                72.98724332610647,
+                                -68.12140803960207,
+                                26.615945435288705
                             ],
                             "jumboScan": true
                         }
@@ -3982,14 +3984,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Fiery Shores",
-                                "dockNum": 0
+                                "roomName": "Burning Trail",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Tallon Overworld West",
-                                "dockNum": 1
+                                "roomName": "Fiery Shores",
+                                "dockNum": 2
                             }
                         }
                     },
@@ -4013,27 +4015,27 @@
                         }
                     ],
                     "doors": {
-                        "2": {
+                        "0": {
                             "destination": {
                                 "roomName": "Burning Trail",
-                                "dockNum": 2
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Tallon Overworld West",
+                                "roomName": "Shore Tunnel",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "2": {
                             "destination": {
-                                "roomName": "Twin Fires",
+                                "roomName": "Plasma Processing",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Monitor Tunnel": {
                     "pickups": [
@@ -4050,9 +4052,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                199.6763153872669,
-                                -182.03166928910588,
-                                37.218064841160846
+                                210.98490841231916,
+                                -134.30915715985725,
+                                36.52317298840101
                             ],
                             "jumboScan": true
                         }
@@ -4066,12 +4068,12 @@
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Shore Tunnel",
-                                "dockNum": 1
+                                "roomName": "Magmoor Workstation",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Storage Cavern": {
@@ -4093,7 +4095,7 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Monitor Station",
+                                "roomName": "Fiery Shores",
                                 "dockNum": 1
                             }
                         }
@@ -4116,27 +4118,21 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                252.75387181276096,
-                                -238.77420376878985,
-                                84.46996255704681
+                                166.93217487287774,
+                                -320.26067207562414,
+                                96.30566553285682
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Storage Cavern",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
                                 "roomName": "Monitor Tunnel",
                                 "dockNum": 0
                             }
                         },
-                        "3": {
+                        "1": {
                             "destination": {
                                 "roomName": "Workstation Tunnel",
                                 "dockNum": 1
@@ -4147,10 +4143,16 @@
                                 "roomName": "South Core Tunnel",
                                 "dockNum": 1
                             }
+                        },
+                        "3": {
+                            "destination": {
+                                "roomName": "Lake Tunnel",
+                                "dockNum": 0
+                            }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Transport Tunnel A": {
                     "pickups": [
@@ -4171,13 +4173,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Magmoor Workstation",
-                                "dockNum": 2
+                                "roomName": "Save Station Magmoor B",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Shore Tunnel",
+                                "roomName": "Twin Fires Tunnel",
                                 "dockNum": 0
                             }
                         }
@@ -4204,19 +4206,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Twin Fires",
-                                "dockNum": 1
+                                "roomName": "Burning Trail",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Workstation Tunnel",
+                                "roomName": "Lava Lake",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Shore Tunnel": {
                     "pickups": [
@@ -4235,16 +4237,16 @@
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Monitor Tunnel",
+                                "roomName": "Triclops Pit",
                                 "dockNum": 1
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Transport Tunnel A",
-                                "dockNum": 1
+                                "roomName": "South Core Tunnel",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -4266,9 +4268,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                52.24459528765951,
-                                -267.48238332394953,
-                                40.943834273060126
+                                49.24379490223815,
+                                -282.0837928481998,
+                                65.33637939434857
                             ],
                             "jumboScan": true
                         }
@@ -4276,13 +4278,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Lava Lake",
+                                "roomName": "Lake Tunnel",
                                 "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Fiery Shores": {
                     "pickups": [
@@ -4314,22 +4316,22 @@
                         }
                     ],
                     "doors": {
-                        "2": {
+                        "0": {
                             "destination": {
-                                "roomName": "Transport to Phazon Mines West",
-                                "dockNum": 0
+                                "roomName": "Transport Tunnel C",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Plasma Processing",
+                                "roomName": "Storage Cavern",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "2": {
                             "destination": {
                                 "roomName": "Pit Tunnel",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         }
                     },
@@ -4351,29 +4353,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                346.28346573226565,
-                                -457.4807369380844,
-                                41.682198072464985
+                                361.9207375111381,
+                                -501.9519996088158,
+                                36.527494951423655
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Geothermal Core",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
+                                "roomName": "Geothermal Core",
+                                "dockNum": 2
+                            }
+                        },
+                        "1": {
+                            "destination": {
                                 "roomName": "Magmoor Workstation",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Transport to Tallon Overworld West": {
                     "pickups": [
@@ -4390,9 +4392,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                353.8977936898295,
-                                -527.050536367248,
-                                60.01598631444135
+                                364.8248936028336,
+                                -540.362279414976,
+                                48.98629552599116
                             ],
                             "jumboScan": true
                         }
@@ -4400,18 +4402,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Triclops Pit",
+                                "roomName": "Twin Fires",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Pit Tunnel",
+                                "roomName": "Transport to Phendrana Drifts South",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Twin Fires Tunnel": {
@@ -4429,29 +4431,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                352.8005980794548,
-                                -583.6816532293906,
-                                64.38251609457991
+                                313.9795410951648,
+                                -631.6482889873955,
+                                54.593888796597994
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Lava Lake",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Phendrana Drifts South",
+                                "roomName": "Transport Tunnel A",
                                 "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Workstation Tunnel",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Twin Fires": {
                     "pickups": [
@@ -4468,9 +4470,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                281.25360792539215,
-                                -679.4846132057245,
-                                47.8126049476589
+                                345.61972604351,
+                                -733.6972074265932,
+                                31.552395203915964
                             ],
                             "jumboScan": true
                         }
@@ -4478,13 +4480,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Triclops Pit",
-                                "dockNum": 0
+                                "roomName": "Lava Lake",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Warrior Shrine",
+                                "roomName": "Transport to Tallon Overworld West",
                                 "dockNum": 0
                             }
                         }
@@ -4507,24 +4509,24 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                311.49447761810023,
-                                -844.8763295000331,
-                                48.61303473429079
+                                285.814254236432,
+                                -839.8165562479859,
+                                33.789189018459446
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Save Station Magmoor A",
+                                "roomName": "Magmoor Workstation",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Transport Tunnel C",
-                                "dockNum": 1
+                                "roomName": "Geothermal Core",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -4546,9 +4548,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                418.53795480021176,
-                                -852.4647988948187,
-                                76.65317094049271
+                                352.6259452621819,
+                                -810.4050047645347,
+                                93.26563804912226
                             ],
                             "jumboScan": true
                         }
@@ -4556,25 +4558,25 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport Tunnel B",
+                                "roomName": "North Core Tunnel",
                                 "dockNum": 1
-                            }
-                        },
-                        "2": {
-                            "destination": {
-                                "roomName": "Save Station Magmoor B",
-                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport Tunnel C",
+                                "roomName": "Save Station Magmoor A",
+                                "dockNum": 0
+                            }
+                        },
+                        "2": {
+                            "destination": {
+                                "roomName": "Transport Tunnel B",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Plasma Processing": {
                     "pickups": [
@@ -4595,13 +4597,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Fiery Shores",
-                                "dockNum": 1
+                                "roomName": "Triclops Pit",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "South Core Tunnel": {
                     "pickups": [
@@ -4618,9 +4620,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                479.64971877445726,
-                                -874.7466958606256,
-                                52.32228312401766
+                                462.5864263908252,
+                                -918.54365213567,
+                                46.05172501132563
                             ],
                             "jumboScan": true
                         }
@@ -4628,8 +4630,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Phendrana Drifts South",
-                                "dockNum": 0
+                                "roomName": "Shore Tunnel",
+                                "dockNum": 1
                             }
                         },
                         "1": {
@@ -4639,7 +4641,7 @@
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Magmoor Workstation": {
@@ -4659,27 +4661,27 @@
                         }
                     ],
                     "doors": {
-                        "2": {
+                        "0": {
                             "destination": {
-                                "roomName": "Transport Tunnel A",
+                                "roomName": "North Core Tunnel",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Lake Tunnel",
-                                "dockNum": 0
+                                "roomName": "Transport Tunnel B",
+                                "dockNum": 1
                             }
                         },
-                        "0": {
+                        "2": {
                             "destination": {
-                                "roomName": "Transport Tunnel B",
-                                "dockNum": 0
+                                "roomName": "Monitor Tunnel",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Workstation Tunnel": {
                     "pickups": [
@@ -4696,23 +4698,23 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                465.5256018082006,
-                                -1106.7802572323628,
-                                53.62873931882032
+                                454.56356832603484,
+                                -1062.212095329987,
+                                53.28285141814177
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Twin Fires Tunnel",
+                                "dockNum": 1
+                            }
+                        },
                         "1": {
                             "destination": {
                                 "roomName": "Monitor Station",
-                                "dockNum": 3
-                            }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Warrior Shrine",
                                 "dockNum": 1
                             }
                         }
@@ -4735,9 +4737,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                382.0695423582245,
-                                -971.7462476787093,
-                                49.509696149997865
+                                353.7218750105773,
+                                -990.1002610038232,
+                                49.18709258760138
                             ],
                             "jumboScan": true
                         }
@@ -4745,13 +4747,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Geothermal Core",
-                                "dockNum": 1
+                                "roomName": "Transport to Chozo Ruins North",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "North Core Tunnel",
+                                "roomName": "Fiery Shores",
                                 "dockNum": 0
                             }
                         }
@@ -4774,9 +4776,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                509.74023700802695,
-                                -1142.1204262488927,
-                                59.436452636541816
+                                491.6352643523299,
+                                -1181.5388475308077,
+                                52.38322401835316
                             ],
                             "jumboScan": true
                         }
@@ -4784,13 +4786,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Fiery Shores",
-                                "dockNum": 2
+                                "roomName": "Transport to Phendrana Drifts South",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Transport to Phendrana Drifts South": {
                     "pickups": [
@@ -4807,29 +4809,31 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                333.77245723678516,
-                                -972.6705542867595,
-                                80.3023831219636
+                                307.80671701520964,
+                                -960.8313756206513,
+                                78.33034851797952
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
                         "0": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
                             "destination": {
-                                "roomName": "South Core Tunnel",
+                                "roomName": "Transport to Phazon Mines West",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Twin Fires Tunnel",
-                                "dockNum": 0
+                                "roomName": "Transport to Tallon Overworld West",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Save Station Magmoor B": {
                     "pickups": [
@@ -4846,9 +4850,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                299.09038817530046,
-                                -976.0457271639018,
-                                53.45657298287067
+                                283.5596741468723,
+                                -971.1101593785274,
+                                46.08819169381257
                             ],
                             "jumboScan": true
                         }
@@ -4856,12 +4860,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Geothermal Core",
-                                "dockNum": 2
+                                "roomName": "Transport Tunnel A",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 }
             }
@@ -4887,9 +4891,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                297.1403719772117,
-                                89.5703039549374,
-                                37.084144976688535
+                                267.3971554125139,
+                                114.47504285728333,
+                                51.500469568580186
                             ],
                             "jumboScan": true
                         }
@@ -4898,11 +4902,11 @@
                         "0": {
                             "destination": {
                                 "roomName": "Main Quarry",
-                                "dockNum": 1
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": true
                 },
                 "Quarry Access": {
@@ -4920,29 +4924,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                246.75515167294049,
-                                93.12353082724346,
-                                16.22299018275257
+                                211.7806352179249,
+                                91.84299090858319,
+                                38.615540551590655
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Omega Research",
+                                "roomName": "Elite Quarters Access",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Fungal Hall B",
-                                "dockNum": 1
+                                "roomName": "Mine Security Station",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Main Quarry": {
                     "pickups": [
@@ -4961,32 +4965,34 @@
                         }
                     ],
                     "doors": {
-                        "0": {
-                            "destination": {
-                                "roomName": "Research Access",
-                                "dockNum": 1
-                            }
-                        },
-                        "1": {
+                        "2": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
                             "destination": {
                                 "roomName": "Transport to Tallon Overworld South",
                                 "dockNum": 0
                             }
                         },
-                        "2": {
+                        "0": {
                             "destination": {
-                                "roomName": "Ventilation Shaft",
+                                "roomName": "Save Station Mines B",
                                 "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Quarantine Access B",
+                                "dockNum": 1
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Elite Quarters Access",
+                                "roomName": "Processing Center Access",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Waste Disposal": {
@@ -5004,9 +5010,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                102.14989163663509,
-                                105.98563757279204,
-                                50.801970765240895
+                                112.93256902557775,
+                                127.79917138754695,
+                                49.13176117139475
                             ],
                             "jumboScan": true
                         }
@@ -5014,18 +5020,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elite Control",
-                                "dockNum": 0
+                                "roomName": "Fungal Hall A",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Elevator A",
-                                "dockNum": 1
+                                "roomName": "Mine Security Station",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Save Station Mines A": {
@@ -5043,23 +5049,25 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                136.18277918330415,
-                                -23.426046297657717,
-                                17.60779098117751
+                                152.3207961213324,
+                                -24.36506863666482,
+                                14.053966568313296
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
                         "0": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
                             "destination": {
-                                "roomName": "Omega Research",
+                                "roomName": "Mine Security Station",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Security Access A": {
                     "pickups": [
@@ -5078,21 +5086,21 @@
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Mine Security Station",
+                                "roomName": "Elite Research",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Metroid Quarantine B",
-                                "dockNum": 0
+                                "roomName": "Omega Research",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Ore Processing": {
                     "pickups": [
@@ -5109,9 +5117,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                78.91479548948006,
-                                189.90001411823252,
-                                49.37169147462686
+                                82.59416201786374,
+                                145.2249762099638,
+                                57.52852629417214
                             ],
                             "jumboScan": true
                         }
@@ -5119,30 +5127,30 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elevator B",
-                                "dockNum": 1
+                                "roomName": "Ventilation Shaft",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Save Station Mines C",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Phazon Mining Tunnel",
+                                "roomName": "Elite Control Access",
                                 "dockNum": 0
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Elite Control Access",
+                                "roomName": "Dynamo Access",
                                 "dockNum": 1
-                            }
-                        },
-                        "1": {
-                            "destination": {
-                                "roomName": "Map Station Mines",
-                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Mine Security Station": {
@@ -5160,35 +5168,35 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -10.308518769360294,
-                                44.57149410761201,
-                                9.326739428307057
+                                -23.440657533322735,
+                                30.675635537737968,
+                                15.227948847486655
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "2": {
-                            "destination": {
-                                "roomName": "Dynamo Access",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Security Access A",
+                                "roomName": "Quarry Access",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Maintenance Tunnel",
+                                "roomName": "Save Station Mines A",
+                                "dockNum": 0
+                            }
+                        },
+                        "2": {
+                            "destination": {
+                                "roomName": "Waste Disposal",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Research Access": {
                     "pickups": [
@@ -5205,29 +5213,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                56.659524411594276,
-                                161.94254098333522,
-                                49.48498349131249
+                                33.119388342795894,
+                                155.74040866622013,
+                                45.462332733052676
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Main Quarry",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Metroid Quarantine A",
-                                "dockNum": 0
+                                "roomName": "Elite Control",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Elevator Access B",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Storage Depot B": {
                     "pickups": [
@@ -5248,7 +5256,7 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phazon Processing Center",
+                                "roomName": "Elite Control Access",
                                 "dockNum": 1
                             }
                         }
@@ -5271,29 +5279,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                59.71478601848131,
-                                172.52111329406793,
-                                52.72209428403481
+                                45.91685434063467,
+                                176.20993491637154,
+                                38.17341405880163
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Fungal Hall B",
-                                "dockNum": 2
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Elevator B",
-                                "dockNum": 0
+                                "roomName": "Fungal Hall Access",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Elite Quarters",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Security Access B": {
                     "pickups": [
@@ -5310,28 +5318,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -20.5441293989903,
-                                84.13140878688456,
-                                24.519207920596358
+                                -21.0283411196943,
+                                112.03495687113079,
+                                17.520292907881167
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Fungal Hall A",
+                                "dockNum": 0
+                            }
+                        },
                         "1": {
                             "destination": {
                                 "roomName": "Omega Research",
-                                "dockNum": 2
-                            }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Transport to Magmoor Caverns South",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Storage Depot A": {
@@ -5353,7 +5361,7 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Central Dynamo",
+                                "roomName": "Elite Quarters",
                                 "dockNum": 0
                             }
                         }
@@ -5391,20 +5399,20 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Transport Access",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Elevator Access B",
+                                "roomName": "Security Access A",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Dynamo Access",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": true
                 },
                 "Elevator A": {
@@ -5422,29 +5430,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                13.535200795027547,
-                                194.13409997107007,
-                                -28.880271690204914
+                                13.96198795761667,
+                                193.5331475464243,
+                                -25.525472827362826
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Waste Disposal",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Fungal Hall Access",
-                                "dockNum": 1
+                                "roomName": "Transport Access",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Transport to Magmoor Caverns South",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Elite Control Access": {
                     "pickups": [
@@ -5463,21 +5471,21 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Ore Processing",
-                                "dockNum": 3
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Phazon Processing Center",
+                                "roomName": "Ore Processing",
                                 "dockNum": 2
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Storage Depot B",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Elite Control": {
                     "pickups": [
@@ -5494,9 +5502,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                49.0755702438001,
-                                101.68045894279362,
-                                -27.127461051984
+                                3.3864596376542693,
+                                144.45780653968887,
+                                -66.91412655470711
                             ],
                             "jumboScan": true
                         }
@@ -5504,24 +5512,24 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Waste Disposal",
+                                "roomName": "Maintenance Tunnel",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Quarantine Access B",
+                                "roomName": "Research Access",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Ventilation Shaft",
-                                "dockNum": 1
+                                "roomName": "Elevator B",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Maintenance Tunnel": {
@@ -5539,9 +5547,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -47.46054626554839,
-                                114.92174940852658,
-                                -71.5676280126944
+                                -22.550699091724603,
+                                73.84486340076218,
+                                -61.51266835630054
                             ],
                             "jumboScan": true
                         }
@@ -5549,19 +5557,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Metroid Quarantine A",
-                                "dockNum": 1
+                                "roomName": "Elite Control",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Mine Security Station",
-                                "dockNum": 1
+                                "roomName": "Central Dynamo",
+                                "dockNum": 2
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Ventilation Shaft": {
                     "pickups": [
@@ -5582,13 +5590,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Quarry",
-                                "dockNum": 2
+                                "roomName": "Ore Processing",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Elite Control",
+                                "roomName": "Fungal Hall B",
                                 "dockNum": 2
                             }
                         }
@@ -5615,19 +5623,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Fungal Hall Access",
-                                "dockNum": 0
+                                "roomName": "Phazon Mining Tunnel",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Storage Depot B",
+                                "roomName": "Missile Station Mines",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Elite Control Access",
+                                "roomName": "Quarantine Access A",
                                 "dockNum": 0
                             }
                         }
@@ -5650,9 +5658,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -13.343138107042538,
-                                -38.99897470374964,
-                                -32.26512547074824
+                                59.12569118471686,
+                                -26.111089614156818,
+                                -38.52915741536581
                             ],
                             "jumboScan": true
                         }
@@ -5660,25 +5668,25 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Quarry Access",
-                                "dockNum": 1
+                                "roomName": "Map Station Mines",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Save Station Mines A",
-                                "dockNum": 0
+                                "roomName": "Security Access B",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Security Access B",
+                                "roomName": "Security Access A",
                                 "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Transport Access": {
                     "pickups": [
@@ -5695,28 +5703,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -115.70129031220846,
-                                177.38821778565813,
-                                -23.325808776041598
+                                -128.09550664528587,
+                                146.21692837770274,
+                                -10.669695654261162
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Elite Research",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
+                                "roomName": "Elevator A",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
                                 "roomName": "Central Dynamo",
-                                "dockNum": 2
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Processing Center Access": {
@@ -5736,15 +5744,15 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Fungal Hall A",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Dynamo Access",
+                                "roomName": "Main Quarry",
+                                "dockNum": 3
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Fungal Hall B",
                                 "dockNum": 0
                             }
                         }
@@ -5767,9 +5775,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                35.28367810413901,
-                                -69.93693273380661,
-                                -70.42385531351168
+                                32.61934746123001,
+                                -56.88658447708753,
+                                -63.07543537165942
                             ],
                             "jumboScan": true
                         }
@@ -5777,13 +5785,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ore Processing",
-                                "dockNum": 1
+                                "roomName": "Omega Research",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Dynamo Access": {
                     "pickups": [
@@ -5800,24 +5808,24 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                72.15774045366354,
-                                -15.025361100683291,
-                                -82.82527728816878
+                                78.55202605694627,
+                                -42.72624545478131,
+                                -72.1343379717944
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Mine Security Station",
-                                "dockNum": 2
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Processing Center Access",
-                                "dockNum": 0
+                                "roomName": "Elite Research",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Ore Processing",
+                                "dockNum": 3
                             }
                         }
                     },
@@ -5839,9 +5847,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -111.63381211993145,
-                                200.1071237197853,
-                                -40.16830926554567
+                                -112.15996146870953,
+                                205.1406859958272,
+                                -14.787920738435496
                             ],
                             "jumboScan": true
                         }
@@ -5849,13 +5857,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Security Access B",
-                                "dockNum": 0
+                                "roomName": "Elevator A",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Elite Quarters": {
                     "pickups": [
@@ -5874,15 +5882,15 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Quarantine Access B",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Elevator Access B",
+                                "roomName": "Storage Depot A",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Elevator Access A",
                                 "dockNum": 1
                             }
                         }
@@ -5907,27 +5915,29 @@
                         }
                     ],
                     "doors": {
-                        "0": {
+                        "2": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
                             "destination": {
-                                "roomName": "Storage Depot A",
-                                "dockNum": 0
+                                "roomName": "Maintenance Tunnel",
+                                "dockNum": 1
                             }
                         },
-                        "2": {
+                        "0": {
                             "destination": {
-                                "roomName": "Transport Access",
-                                "dockNum": 0
+                                "roomName": "Elite Quarters Access",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Save Station Mines C",
-                                "dockNum": 0
+                                "roomName": "Transport Access",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Elite Quarters Access": {
                     "pickups": [
@@ -5944,9 +5954,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -152.50878038212807,
-                                -86.35144557123635,
-                                -144.42004761291352
+                                -117.61930095797763,
+                                -79.05094147996265,
+                                -131.83141641668587
                             ],
                             "jumboScan": true
                         }
@@ -5954,19 +5964,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Quarry",
-                                "dockNum": 3
+                                "roomName": "Quarry Access",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Quarantine Access A",
+                                "roomName": "Central Dynamo",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Quarantine Access A": {
                     "pickups": [
@@ -5983,24 +5993,24 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                149.98321207184367,
-                                132.94478438812178,
-                                -93.50646316693152
+                                138.52408218172212,
+                                98.0721019932307,
+                                -92.51416292685451
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Metroid Quarantine B",
+                                "roomName": "Phazon Processing Center",
                                 "dockNum": 2
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Elite Quarters Access",
-                                "dockNum": 1
+                                "roomName": "Metroid Quarantine B",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -6022,23 +6032,25 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                173.31173905699046,
-                                -34.51359161745313,
-                                -94.15837429072295
+                                168.48149113316742,
+                                -24.984840049718184,
+                                -90.7962831192855
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
                         "0": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
                             "destination": {
-                                "roomName": "Fungal Hall A",
-                                "dockNum": 1
+                                "roomName": "Main Quarry",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Metroid Quarantine B": {
                     "pickups": [
@@ -6058,6 +6070,14 @@
                     ],
                     "doors": {
                         "2": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
+                            "destination": {
+                                "roomName": "Elevator Access B",
+                                "dockNum": 0
+                            }
+                        },
+                        "0": {
                             "destination": {
                                 "roomName": "Quarantine Access A",
                                 "dockNum": 1
@@ -6065,19 +6085,13 @@
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Phazon Mining Tunnel",
-                                "dockNum": 1
-                            }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Security Access A",
+                                "roomName": "Fungal Hall Access",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Metroid Quarantine A": {
                     "pickups": [
@@ -6098,18 +6112,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Research Access",
+                                "roomName": "Phazon Mining Tunnel",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Maintenance Tunnel",
+                                "roomName": "Quarantine Access B",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Quarantine Access B": {
@@ -6127,23 +6141,23 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                87.69060757708574,
-                                -54.36632399757542,
-                                -146.78200838378174
+                                87.46807238964999,
+                                -77.0114739377947,
+                                -143.9532833306426
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Elite Quarters",
+                                "roomName": "Metroid Quarantine A",
                                 "dockNum": 1
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Elite Control",
+                                "roomName": "Main Quarry",
                                 "dockNum": 1
                             }
                         }
@@ -6166,17 +6180,19 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -86.23547874118667,
-                                -172.05281731574797,
-                                -149.75621283870439
+                                -82.39323948773321,
+                                -184.85911892860497,
+                                -156.77727253860238
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
                         "0": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
                             "destination": {
-                                "roomName": "Central Dynamo",
+                                "roomName": "Ore Processing",
                                 "dockNum": 1
                             }
                         }
@@ -6199,24 +6215,24 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                156.24794853413835,
-                                334.98895296745184,
-                                -49.18805422300068
+                                181.25115027413355,
+                                336.1391124975185,
+                                -48.765546957633994
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Elite Quarters",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Elite Research",
-                                "dockNum": 0
+                                "roomName": "Metroid Quarantine B",
+                                "dockNum": 2
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Research Access",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -6240,26 +6256,26 @@
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Processing Center Access",
+                                "dockNum": 1
+                            }
+                        },
                         "1": {
                             "destination": {
-                                "roomName": "Quarry Access",
-                                "dockNum": 0
+                                "roomName": "Elevator B",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Elevator Access A",
+                                "roomName": "Ventilation Shaft",
                                 "dockNum": 1
-                            }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Missile Station Mines",
-                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Elevator B": {
@@ -6277,29 +6293,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                154.80151051336884,
-                                392.1002297467837,
-                                -92.16374250775942
+                                167.52890910587647,
+                                393.401813781191,
+                                -83.80263889195622
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Ore Processing",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Elevator Access A",
-                                "dockNum": 0
+                                "roomName": "Elite Control",
+                                "dockNum": 2
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Fungal Hall B",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Missile Station Mines": {
                     "pickups": [
@@ -6316,9 +6332,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                223.61067646053684,
-                                -3.650057421535733,
-                                -131.7478823907289
+                                238.22565958376737,
+                                -0.24160045346067527,
+                                -130.56708025149536
                             ],
                             "jumboScan": true
                         }
@@ -6326,13 +6342,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Fungal Hall B",
-                                "dockNum": 0
+                                "roomName": "Phazon Processing Center",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Phazon Mining Tunnel": {
                     "pickups": [
@@ -6353,19 +6369,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ore Processing",
-                                "dockNum": 2
+                                "roomName": "Metroid Quarantine A",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Metroid Quarantine B",
-                                "dockNum": 1
+                                "roomName": "Phazon Processing Center",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Fungal Hall Access": {
                     "pickups": [
@@ -6386,13 +6402,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phazon Processing Center",
-                                "dockNum": 0
+                                "roomName": "Metroid Quarantine B",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Elevator A",
+                                "roomName": "Elevator Access A",
                                 "dockNum": 0
                             }
                         }
@@ -6415,28 +6431,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                104.83302129118408,
-                                299.24647702480297,
-                                -150.74157048143314
+                                153.63241880214238,
+                                275.9882728151366,
+                                -148.39309588918792
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Save Station Mines B",
+                                "roomName": "Security Access B",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Processing Center Access",
-                                "dockNum": 1
+                                "roomName": "Waste Disposal",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 }
             }
@@ -6468,39 +6484,39 @@
                         }
                     ],
                     "doors": {
-                        "3": {
+                        "0": {
                             "destination": {
-                                "roomName": "Transport Tunnel C",
+                                "roomName": "Main Ventilation Shaft Section C",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport Tunnel A",
+                                "roomName": "Deck Beta Conduit Hall",
+                                "dockNum": 1
+                            }
+                        },
+                        "2": {
+                            "destination": {
+                                "roomName": "Savestation",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "3": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section B",
+                                "roomName": "Temple Lobby",
                                 "dockNum": 1
                             }
                         },
                         "4": {
                             "destination": {
-                                "roomName": "Transport to Magmoor Caverns East",
-                                "dockNum": 0
-                            }
-                        },
-                        "2": {
-                            "destination": {
-                                "roomName": "Arbor Chamber",
+                                "roomName": "Root Tunnel",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Gully": {
                     "pickups": [
@@ -6517,28 +6533,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -447.8792657901144,
-                                385.2885805190461,
-                                4.295954802383996
+                                -421.7865735546734,
+                                408.8223347130361,
+                                -12.594212536396265
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
                                 "roomName": "Reactor Core",
                                 "dockNum": 1
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Deck Beta Transit Hall",
+                                "roomName": "Frigate Crash Site",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Canyon Cavern": {
@@ -6556,29 +6572,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -454.571005005256,
-                                347.43703913161505,
-                                -8.871467993041417
+                                -417.68006854555335,
+                                347.6849167557916,
+                                -13.363235863066512
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Deck Beta Security Hall",
+                                "roomName": "Main Ventilation Shaft Section A",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Reactor Access",
-                                "dockNum": 1
+                                "roomName": "Life Grove",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Temple Hall": {
                     "pickups": [
@@ -6595,29 +6611,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -383.2408436035522,
-                                290.27869422383185,
-                                -10.697027799331343
+                                -382.1147349964924,
+                                289.88068445829174,
+                                -14.539293146270612
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Frigate Crash Site",
+                                "roomName": "Biohazard Containment",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section A",
-                                "dockNum": 0
+                                "roomName": "Reactor Access",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Alcove": {
                     "pickups": [
@@ -6638,8 +6654,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Overgrown Cavern",
-                                "dockNum": 1
+                                "roomName": "Great Tree Hall",
+                                "dockNum": 3
                             }
                         }
                     },
@@ -6661,29 +6677,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -285.37752291046996,
-                                459.2795628543003,
-                                -41.1016389824355
+                                -282.803196690868,
+                                452.4407420671997,
+                                -26.17766428065871
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Transport to Chozo Ruins East",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Connection Elevator to Deck Beta",
+                                "roomName": "Great Tree Hall",
+                                "dockNum": 2
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Overgrown Cavern",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Tallon Canyon": {
                     "pickups": [
@@ -6700,9 +6716,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -475.8911279831551,
-                                320.6612423155447,
-                                14.71516175971265
+                                -532.6555165306229,
+                                336.1018952411673,
+                                4.332191217590626
                             ],
                             "jumboScan": true
                         }
@@ -6710,30 +6726,30 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hydro Access Tunnel",
-                                "dockNum": 1
-                            }
-                        },
-                        "3": {
-                            "destination": {
-                                "roomName": "Transport to Phazon Mines East",
+                                "roomName": "Transport to Chozo Ruins East",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Temple Security Station",
-                                "dockNum": 1
+                                "roomName": "Transport to Magmoor Caverns East",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Life Grove Tunnel",
+                                "roomName": "Transport Tunnel D",
+                                "dockNum": 0
+                            }
+                        },
+                        "3": {
+                            "destination": {
+                                "roomName": "Transport to Chozo Ruins South",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Temple Security Station": {
@@ -6751,28 +6767,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -367.8611660461831,
-                                221.2622704044742,
-                                -4.027065095552864
+                                -390.29592928125066,
+                                236.60645588361493,
+                                -4.564501555112228
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Tallon Canyon",
+                                "roomName": "Transport Tunnel E",
                                 "dockNum": 1
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Deck Beta Conduit Hall",
+                                "roomName": "Biotech Research Area 1",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Frigate Crash Site": {
@@ -6792,27 +6808,27 @@
                         }
                     ],
                     "doors": {
-                        "2": {
-                            "destination": {
-                                "roomName": "Transport Tunnel C",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Temple Hall",
-                                "dockNum": 1
+                                "roomName": "Transport Tunnel A",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Root Tunnel",
+                                "roomName": "Gully",
+                                "dockNum": 1
+                            }
+                        },
+                        "2": {
+                            "destination": {
+                                "roomName": "Deck Beta Transit Hall",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Transport Tunnel A": {
                     "pickups": [
@@ -6829,9 +6845,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -527.8507343389713,
-                                451.17868696635014,
-                                -15.605422413352668
+                                -527.29119103754,
+                                445.9853716506316,
+                                -22.349150726356545
                             ],
                             "jumboScan": true
                         }
@@ -6839,19 +6855,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Landing Site",
-                                "dockNum": 1
+                                "roomName": "Frigate Crash Site",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Cargo Freight Lift to Deck Gamma",
-                                "dockNum": 1
+                                "roomName": "Transport Tunnel C",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Root Tunnel": {
                     "pickups": [
@@ -6868,9 +6884,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -565.8942567696854,
-                                340.128330605222,
-                                -14.918489564331061
+                                -574.7355575460542,
+                                335.36294130030575,
+                                -1.9018609896619552
                             ],
                             "jumboScan": true
                         }
@@ -6878,19 +6894,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Frigate Crash Site",
-                                "dockNum": 1
+                                "roomName": "Landing Site",
+                                "dockNum": 4
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Biotech Research Area 1",
-                                "dockNum": 1
+                                "roomName": "Reactor Access",
+                                "dockNum": 2
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Temple Lobby": {
                     "pickups": [
@@ -6907,9 +6923,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -367.4279868769376,
-                                121.08228128969556,
-                                -9.72572749319333
+                                -366.6220095517776,
+                                117.9889027404306,
+                                -8.993737784277519
                             ],
                             "jumboScan": true
                         }
@@ -6917,8 +6933,8 @@
                     "doors": {
                         "1": {
                             "destination": {
-                                "roomName": "Reactor Access",
-                                "dockNum": 2
+                                "roomName": "Landing Site",
+                                "dockNum": 3
                             }
                         }
                     },
@@ -6940,9 +6956,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -70.98330683823662,
-                                484.5317479183285,
-                                -40.423403387863075
+                                -63.54481498730331,
+                                468.9474206138821,
+                                -39.6614431849722
                             ],
                             "jumboScan": true
                         }
@@ -6950,18 +6966,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Root Cave",
-                                "dockNum": 2
+                                "roomName": "Biotech Research Area 1",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Great Tree Hall",
-                                "dockNum": 2
+                                "roomName": "Transport to Chozo Ruins West",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": true
                 },
                 "Overgrown Cavern": {
@@ -6981,15 +6997,15 @@
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Alcove",
+                                "roomName": "Root Cave",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Transport Tunnel D",
+                                "roomName": "Waterfall Cavern",
                                 "dockNum": 1
                             }
                         }
@@ -7012,9 +7028,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -515.846283555174,
-                                491.03374603123115,
-                                8.58766611035498
+                                -528.3949220174854,
+                                491.8483446000761,
+                                2.6773947965113365
                             ],
                             "jumboScan": true
                         }
@@ -7022,12 +7038,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Great Tree Hall",
-                                "dockNum": 0
+                                "roomName": "Frigate Access Tunnel",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Root Cave": {
@@ -7047,26 +7063,26 @@
                         }
                     ],
                     "doors": {
-                        "2": {
-                            "destination": {
-                                "roomName": "Frigate Access Tunnel",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Transport Tunnel D",
+                                "roomName": "Overgrown Cavern",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Deck Beta Transit Hall",
+                                "roomName": "Reactor Access",
                                 "dockNum": 0
+                            }
+                        },
+                        "2": {
+                            "destination": {
+                                "roomName": "Connection Elevator to Deck Beta",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Artifact Temple": {
@@ -7085,9 +7101,8 @@
                             "showIcon": true
                         }
                     ],
-                    "doors": {},
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Main Ventilation Shaft Section C": {
                     "pickups": [
@@ -7104,9 +7119,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                18.72680209931605,
-                                520.8821573581947,
-                                -39.7395605063004
+                                17.38420682594744,
+                                528.6106555236943,
+                                -66.40194337245552
                             ],
                             "jumboScan": true
                         }
@@ -7114,8 +7129,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Great Tree Hall",
-                                "dockNum": 1
+                                "roomName": "Landing Site",
+                                "dockNum": 0
                             }
                         },
                         "1": {
@@ -7125,7 +7140,7 @@
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Transport Tunnel C": {
@@ -7143,9 +7158,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -118.76871552942656,
-                                666.1030131221847,
-                                11.287052360457075
+                                -75.99244142971257,
+                                672.2883642024074,
+                                57.46917584682577
                             ],
                             "jumboScan": true
                         }
@@ -7153,18 +7168,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Landing Site",
-                                "dockNum": 3
+                                "roomName": "Transport Tunnel A",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Frigate Crash Site",
-                                "dockNum": 2
+                                "roomName": "Transport Tunnel E",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Transport Tunnel B": {
@@ -7186,19 +7201,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Great Tree Hall",
-                                "dockNum": 4
+                                "roomName": "Life Grove Tunnel",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport Tunnel E",
-                                "dockNum": 0
+                                "roomName": "Great Tree Hall",
+                                "dockNum": 4
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Arbor Chamber": {
                     "pickups": [
@@ -7219,8 +7234,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Landing Site",
-                                "dockNum": 2
+                                "roomName": "Main Ventilation Shaft Section B",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -7242,29 +7257,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                38.23204925481751,
-                                487.49029524273794,
-                                -21.6184781731881
+                                36.53192309883824,
+                                487.6041747829402,
+                                -18.916281581326466
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Landing Site",
+                                "roomName": "Reactor Core",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Great Tree Hall",
-                                "dockNum": 3
+                                "roomName": "Arbor Chamber",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Transport to Chozo Ruins East": {
                     "pickups": [
@@ -7281,9 +7296,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -43.18926927108558,
-                                653.641081919581,
-                                37.995961885649734
+                                -49.81996703066376,
+                                655.8595897333308,
+                                9.299086355006665
                             ],
                             "jumboScan": true
                         }
@@ -7291,13 +7306,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Waterfall Cavern",
-                                "dockNum": 1
+                                "roomName": "Tallon Canyon",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Transport to Magmoor Caverns East": {
                     "pickups": [
@@ -7314,9 +7329,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -713.2489364182811,
-                                215.93987989280072,
-                                -54.145138809479064
+                                -699.6183974811194,
+                                209.35140704352617,
+                                -48.48168146059531
                             ],
                             "jumboScan": true
                         }
@@ -7324,8 +7339,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Landing Site",
-                                "dockNum": 4
+                                "roomName": "Tallon Canyon",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -7347,29 +7362,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                87.45675992818262,
-                                428.8049207295398,
-                                -71.20713337329714
+                                40.598899427096605,
+                                427.239222193784,
+                                -61.11802688316934
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Biohazard Containment",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Temple Hall",
+                                "roomName": "Canyon Cavern",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Great Tree Hall",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Reactor Core": {
                     "pickups": [
@@ -7386,29 +7401,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                96.92096962293158,
-                                335.7129194306276,
-                                -81.4272831258571
+                                79.4563610545459,
+                                387.84293462086197,
+                                -83.7729018689096
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Main Ventilation Shaft Section B",
+                                "dockNum": 0
+                            }
+                        },
                         "1": {
                             "destination": {
                                 "roomName": "Gully",
-                                "dockNum": 1
-                            }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Savestation",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Reactor Access": {
                     "pickups": [
@@ -7425,9 +7440,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                8.543768824700116,
-                                367.3765804146018,
-                                -105.37979090637623
+                                1.2094869637429948,
+                                365.18212892373066,
+                                -108.07819334930915
                             ],
                             "jumboScan": true
                         }
@@ -7435,25 +7450,25 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Life Grove",
-                                "dockNum": 0
+                                "roomName": "Root Cave",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Canyon Cavern",
-                                "dockNum": 0
+                                "roomName": "Temple Hall",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Temple Lobby",
+                                "roomName": "Root Tunnel",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Cargo Freight Lift to Deck Gamma": {
                     "pickups": [
@@ -7472,15 +7487,15 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Transport Tunnel A",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Transport Tunnel E",
+                                "roomName": "Life Grove Tunnel",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Hydro Access Tunnel",
                                 "dockNum": 1
                             }
                         }
@@ -7503,9 +7518,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                0.5438735958982344,
-                                389.9339848700746,
-                                -114.78001138235834
+                                1.805355951037141,
+                                389.67590451502116,
+                                -115.14291546631601
                             ],
                             "jumboScan": true
                         }
@@ -7513,12 +7528,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Reactor Core",
-                                "dockNum": 0
+                                "roomName": "Landing Site",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Deck Beta Transit Hall": {
@@ -7536,9 +7551,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -135.56240546020226,
-                                302.63087426822324,
-                                -53.80629308434841
+                                -135.09859866689754,
+                                310.6886434287903,
+                                -54.54265398141802
                             ],
                             "jumboScan": true
                         }
@@ -7546,13 +7561,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Root Cave",
-                                "dockNum": 1
+                                "roomName": "Frigate Crash Site",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Gully",
+                                "roomName": "Deck Beta Security Hall",
                                 "dockNum": 0
                             }
                         }
@@ -7579,14 +7594,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Great Tree Chamber",
+                                "roomName": "Temple Hall",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section A",
-                                "dockNum": 1
+                                "roomName": "Great Tree Chamber",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -7608,9 +7623,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -104.14634188827564,
-                                268.2552206105396,
-                                -64.77596358859425
+                                -91.67399185690512,
+                                272.1311206070864,
+                                -66.55870863211854
                             ],
                             "jumboScan": true
                         }
@@ -7618,18 +7633,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Canyon Cavern",
+                                "roomName": "Deck Beta Transit Hall",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Life Grove Tunnel",
+                                "roomName": "Great Tree Hall",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Biotech Research Area 1": {
@@ -7647,9 +7662,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -52.249676879805904,
-                                238.53940747777597,
-                                -18.951372696806644
+                                -68.84193943204635,
+                                200.74924336486566,
+                                -49.35126208360903
                             ],
                             "jumboScan": true
                         }
@@ -7657,19 +7672,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hydro Access Tunnel",
-                                "dockNum": 0
+                                "roomName": "Temple Security Station",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Root Tunnel",
-                                "dockNum": 1
+                                "roomName": "Frigate Access Tunnel",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Deck Beta Conduit Hall": {
                     "pickups": [
@@ -7686,9 +7701,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -83.15789928156003,
-                                184.70160004811788,
-                                -59.73440474277147
+                                -57.9264561479407,
+                                182.0451577989144,
+                                -65.31674441054025
                             ],
                             "jumboScan": true
                         }
@@ -7696,18 +7711,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Temple Security Station",
+                                "roomName": "Transport to Phazon Mines East",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Chozo Ruins South",
-                                "dockNum": 0
+                                "roomName": "Landing Site",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Connection Elevator to Deck Beta": {
@@ -7725,29 +7740,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -111.24825452836808,
-                                170.5518372396837,
-                                -32.45406536464085
+                                -112.73379295142044,
+                                160.4337010786291,
+                                -46.81988040662775
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Waterfall Cavern",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
                                 "roomName": "Main Ventilation Shaft Section C",
                                 "dockNum": 1
                             }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Root Cave",
+                                "dockNum": 2
+                            }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Hydro Access Tunnel": {
                     "pickups": [
@@ -7766,21 +7781,21 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Tallon Canyon",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Biotech Research Area 1",
-                                "dockNum": 0
+                                "roomName": "Transport Tunnel D",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Cargo Freight Lift to Deck Gamma",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Great Tree Hall": {
                     "pickups": [
@@ -7797,9 +7812,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -16.82102233507547,
-                                121.61828563665408,
-                                3.1183870753371963
+                                -16.044048020194094,
+                                136.82726519708643,
+                                -47.203808341509706
                             ],
                             "jumboScan": true
                         }
@@ -7807,36 +7822,36 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Chozo Ruins West",
-                                "dockNum": 0
+                                "roomName": "Main Ventilation Shaft Section A",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section C",
+                                "roomName": "Deck Beta Security Hall",
+                                "dockNum": 1
+                            }
+                        },
+                        "2": {
+                            "destination": {
+                                "roomName": "Waterfall Cavern",
                                 "dockNum": 0
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section B",
+                                "roomName": "Alcove",
                                 "dockNum": 0
-                            }
-                        },
-                        "2": {
-                            "destination": {
-                                "roomName": "Frigate Access Tunnel",
-                                "dockNum": 1
                             }
                         },
                         "4": {
                             "destination": {
                                 "roomName": "Transport Tunnel B",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": true
                 },
                 "Great Tree Chamber": {
@@ -7859,12 +7874,12 @@
                         "0": {
                             "destination": {
                                 "roomName": "Biohazard Containment",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Transport Tunnel D": {
                     "pickups": [
@@ -7881,23 +7896,23 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                14.8561993865546,
-                                216.15296329755816,
-                                -6.555933021306464
+                                -2.5307919146189306,
+                                187.3042184935637,
+                                -7.780833289973731
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Overgrown Cavern",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Root Cave",
+                                "roomName": "Tallon Canyon",
+                                "dockNum": 2
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Hydro Access Tunnel",
                                 "dockNum": 0
                             }
                         }
@@ -7922,21 +7937,21 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Deck Beta Security Hall",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Tallon Canyon",
-                                "dockNum": 2
+                                "roomName": "Cargo Freight Lift to Deck Gamma",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Transport Tunnel B",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Transport Tunnel E": {
                     "pickups": [
@@ -7953,29 +7968,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                17.471561964837672,
-                                57.639891650825845,
-                                -54.15721091320716
+                                6.105001090558875,
+                                97.60485967910462,
+                                -48.051447812705426
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Cargo Freight Lift to Deck Gamma",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Transport Tunnel B",
+                                "roomName": "Transport Tunnel C",
                                 "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Temple Security Station",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Transport to Chozo Ruins South": {
                     "pickups": [
@@ -7992,9 +8007,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                44.99163790808709,
-                                215.0585587572079,
-                                -8.949915591185949
+                                34.144863802367496,
+                                232.0980056070624,
+                                19.110796100518783
                             ],
                             "jumboScan": true
                         }
@@ -8002,12 +8017,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Deck Beta Conduit Hall",
-                                "dockNum": 1
+                                "roomName": "Tallon Canyon",
+                                "dockNum": 3
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Life Grove": {
@@ -8042,13 +8057,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Reactor Access",
-                                "dockNum": 0
+                                "roomName": "Canyon Cavern",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Transport to Phazon Mines East": {
                     "pickups": [
@@ -8065,9 +8080,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -17.508142665809785,
-                                39.543847284820714,
-                                -71.31926195015716
+                                -15.924163012953194,
+                                31.706316723190245,
+                                -50.770363898737
                             ],
                             "jumboScan": true
                         }
@@ -8075,13 +8090,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Tallon Canyon",
-                                "dockNum": 3
+                                "roomName": "Deck Beta Conduit Hall",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 }
             }
         },
@@ -8108,9 +8123,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                92.2071156573538,
-                                -142.04309965813383,
-                                21.227143368677005
+                                94.55870321500802,
+                                -157.44844780004442,
+                                4.026519755817361
                             ],
                             "jumboScan": true
                         }
@@ -8118,12 +8133,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Gathering Hall",
-                                "dockNum": 3
+                                "roomName": "Ruined Gallery",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Ruins Entrance": {
@@ -8141,9 +8156,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                120.59552178011938,
-                                -108.24481935735157,
-                                24.476102320886266
+                                79.45884412382908,
+                                -82.76632619469136,
+                                7.588807460493076
                             ],
                             "jumboScan": true
                         }
@@ -8152,18 +8167,18 @@
                         "0": {
                             "destination": {
                                 "roomName": "Sun Tower",
-                                "dockNum": 1
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Crossway",
-                                "dockNum": 1
+                                "roomName": "Watery Hall",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Main Plaza": {
                     "pickups": [
@@ -8223,38 +8238,38 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "East Atrium",
+                                "roomName": "Dynamo Access",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Reflecting Pool Access",
                                 "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
+                                "roomName": "Elder Hall Access",
+                                "dockNum": 1
+                            }
+                        },
+                        "3": {
+                            "destination": {
                                 "roomName": "Burn Dome Access",
+                                "dockNum": 0
+                            }
+                        },
+                        "4": {
+                            "destination": {
+                                "roomName": "Crossway Access South",
                                 "dockNum": 0
                             }
                         },
                         "5": {
                             "destination": {
-                                "roomName": "Watery Hall Access",
+                                "roomName": "Elder Chamber",
                                 "dockNum": 0
-                            }
-                        },
-                        "3": {
-                            "destination": {
-                                "roomName": "Sunchamber Access",
-                                "dockNum": 1
-                            }
-                        },
-                        "4": {
-                            "destination": {
-                                "roomName": "Reflecting Pool Access",
-                                "dockNum": 0
-                            }
-                        },
-                        "1": {
-                            "destination": {
-                                "roomName": "Crossway Access South",
-                                "dockNum": 1
                             }
                         }
                     },
@@ -8276,9 +8291,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                191.50550355052002,
-                                -5.445803474098728,
-                                16.55611579349202
+                                154.60532455443774,
+                                -30.28613631014877,
+                                22.19226148765558
                             ],
                             "jumboScan": true
                         }
@@ -8286,14 +8301,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hall of the Elders",
-                                "dockNum": 3
+                                "roomName": "Magma Pool",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Map Station",
-                                "dockNum": 0
+                                "roomName": "Ruined Nursery",
+                                "dockNum": 2
                             }
                         }
                     },
@@ -8315,28 +8330,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                52.83367859819005,
-                                -12.289985646379606,
-                                6.436211352073586
+                                -3.834205639439169,
+                                0.4917994004419697,
+                                7.550867343399727
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Ruined Gallery",
+                                "roomName": "Save Station 2",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "East Furnace Access",
+                                "roomName": "Totem Access",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Nursery Access": {
@@ -8354,9 +8369,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                44.66009604028942,
-                                67.50166293384328,
-                                8.953909713209786
+                                42.166357454581906,
+                                68.04992076134167,
+                                9.884687841466693
                             ],
                             "jumboScan": true
                         }
@@ -8364,14 +8379,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Fountain",
+                                "roomName": "Ruined Gallery",
                                 "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Energy Core Access",
-                                "dockNum": 1
+                                "roomName": "Reflecting Pool",
+                                "dockNum": 3
                             }
                         }
                     },
@@ -8393,9 +8408,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                178.5905560174629,
-                                96.20407398293963,
-                                32.0329918975433
+                                185.19086821144228,
+                                97.19269961435198,
+                                24.934676484503306
                             ],
                             "jumboScan": true
                         }
@@ -8403,18 +8418,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Furnace",
-                                "dockNum": 1
+                                "roomName": "Training Chamber Access",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "North Atrium",
+                                "roomName": "Tower of Light",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Piston Tunnel": {
@@ -8432,9 +8447,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                123.02808509146689,
-                                -89.9736224279994,
-                                24.470723349670024
+                                126.73328987810453,
+                                -93.1903032329063,
+                                27.029911769142174
                             ],
                             "jumboScan": true
                         }
@@ -8442,19 +8457,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Vault Access",
+                                "roomName": "Tower of Light Access",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Sunchamber Lobby",
-                                "dockNum": 0
+                                "roomName": "Sunchamber Access",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Ruined Fountain": {
                     "pickups": [
@@ -8473,26 +8488,26 @@
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Tower of Light Access",
+                                "dockNum": 1
+                            }
+                        },
                         "1": {
                             "destination": {
-                                "roomName": "Training Chamber Access",
-                                "dockNum": 0
+                                "roomName": "Crossway Access South",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Nursery Access",
-                                "dockNum": 0
-                            }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Elder Hall Access",
-                                "dockNum": 0
+                                "roomName": "Transport Access North",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Ruined Shrine": {
@@ -8540,8 +8555,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Dynamo",
-                                "dockNum": 0
+                                "roomName": "Arboretum Access",
+                                "dockNum": 1
                             }
                         },
                         "1": {
@@ -8552,7 +8567,7 @@
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Eyon Tunnel": {
                     "pickups": [
@@ -8569,9 +8584,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                17.712127653256506,
-                                98.47026980969638,
-                                11.010201802650156
+                                -6.227591734564584,
+                                114.49595192815909,
+                                10.14117382741335
                             ],
                             "jumboScan": true
                         }
@@ -8579,18 +8594,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Gathering Hall",
-                                "dockNum": 1
+                                "roomName": "Transport to Magmoor Caverns North",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Reflecting Pool",
+                                "roomName": "Hall of the Elders",
                                 "dockNum": 3
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Vault": {
@@ -8610,15 +8625,15 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Ruined Gallery",
-                                "dockNum": 2
-                            }
-                        },
                         "0": {
                             "destination": {
                                 "roomName": "Gathering Hall Access",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "East Atrium",
                                 "dockNum": 0
                             }
                         }
@@ -8643,21 +8658,21 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Sunchamber Lobby",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Save Station 3",
-                                "dockNum": 1
+                                "roomName": "Transport Access South",
+                                "dockNum": 0
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Elder Hall Access",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Arboretum Access": {
                     "pickups": [
@@ -8674,24 +8689,24 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                283.8766901532618,
-                                -67.48897895126555,
-                                50.05266397836566
+                                278.0161190555556,
+                                -66.35461275591132,
+                                48.41534238138808
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Watery Hall",
+                                "roomName": "Transport to Tallon Overworld East",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "West Furnace Access",
-                                "dockNum": 1
+                                "roomName": "Ruined Shrine",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -8713,29 +8728,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                220.10066081671215,
-                                -130.03686661422483,
-                                18.81374507448868
+                                192.68148867901147,
+                                -106.8163829431698,
+                                25.924274677571297
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Hall of the Elders",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Tower Chamber",
-                                "dockNum": 0
+                                "roomName": "Watery Hall",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Training Chamber Access",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Tower of Light Access": {
                     "pickups": [
@@ -8752,23 +8767,23 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -103.72357118933898,
-                                8.715983714086013,
-                                24.66764402309164
+                                -105.16344309539284,
+                                22.325068267797548,
+                                22.322691960548475
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Burn Dome",
+                                "roomName": "Piston Tunnel",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Reflecting Pool",
+                                "roomName": "Ruined Fountain",
                                 "dockNum": 0
                             }
                         }
@@ -8793,21 +8808,21 @@
                         }
                     ],
                     "doors": {
-                        "2": {
+                        "0": {
                             "destination": {
-                                "roomName": "Transport to Tallon Overworld South",
+                                "roomName": "Save Station 3",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Energy Core Access",
-                                "dockNum": 0
+                                "roomName": "Burn Dome Access",
+                                "dockNum": 1
                             }
                         },
-                        "0": {
+                        "2": {
                             "destination": {
-                                "roomName": "Gathering Hall Access",
+                                "roomName": "Ruined Fountain Access",
                                 "dockNum": 1
                             }
                         }
@@ -8830,28 +8845,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                170.39641387840132,
-                                236.2975363372443,
-                                28.46523000040189
+                                168.94203280846452,
+                                234.34367004809087,
+                                28.995976363875947
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Tower of Light",
+                                "roomName": "Furnace",
                                 "dockNum": 1
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Piston Tunnel",
-                                "dockNum": 0
+                                "roomName": "Gathering Hall",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Training Chamber Access": {
@@ -8873,14 +8888,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Fountain",
-                                "dockNum": 1
+                                "roomName": "Plaza Access",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Arboretum",
-                                "dockNum": 2
+                                "roomName": "Meditation Fountain",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -8902,9 +8917,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                335.6366775050605,
-                                -124.90660462756821,
-                                61.596087928543795
+                                328.01671110653325,
+                                -118.47757218478425,
+                                65.53647473685808
                             ],
                             "jumboScan": true
                         }
@@ -8912,25 +8927,25 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport Access North",
+                                "roomName": "Totem Access",
                                 "dockNum": 0
-                            }
-                        },
-                        "2": {
-                            "destination": {
-                                "roomName": "Training Chamber Access",
-                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Totem Access",
+                                "roomName": "Energy Core Access",
                                 "dockNum": 1
+                            }
+                        },
+                        "2": {
+                            "destination": {
+                                "roomName": "Map Station",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Magma Pool": {
                     "pickups": [
@@ -8951,13 +8966,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport Access North",
-                                "dockNum": 1
+                                "roomName": "Dynamo Access",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Save Station 2",
+                                "roomName": "Ruined Fountain Access",
                                 "dockNum": 0
                             }
                         }
@@ -8984,13 +8999,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Tallon Overworld East",
-                                "dockNum": 0
+                                "roomName": "Sun Tower Access",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Vault Access",
+                                "roomName": "Plaza Access",
                                 "dockNum": 1
                             }
                         }
@@ -9013,9 +9028,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -62.48493358778093,
-                                116.23351595810617,
-                                20.607815651013308
+                                -70.10291729506274,
+                                117.7400326172834,
+                                24.22551354502987
                             ],
                             "jumboScan": true
                         }
@@ -9023,12 +9038,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Crossway",
-                                "dockNum": 0
+                                "roomName": "Hall of the Elders",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "North Atrium": {
@@ -9046,29 +9061,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -12.707030458987383,
-                                183.24760616553328,
-                                19.588715248118014
+                                -40.28409791709122,
+                                164.56979160987714,
+                                19.610467295001882
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Plaza Access",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
                                 "roomName": "Transport to Magmoor Caverns North",
                                 "dockNum": 1
                             }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Crossway",
+                                "dockNum": 0
+                            }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Transport to Magmoor Caverns North": {
                     "pickups": [
@@ -9085,20 +9100,14 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                195.24791010701801,
-                                350.8681204676779,
-                                18.330923924837723
+                                170.99434774005195,
+                                346.65996008585466,
+                                18.057073845324236
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "2": {
-                            "destination": {
-                                "roomName": "Watery Hall",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
                                 "roomName": "Ruined Shrine",
@@ -9110,10 +9119,16 @@
                                 "roomName": "North Atrium",
                                 "dockNum": 0
                             }
+                        },
+                        "2": {
+                            "destination": {
+                                "roomName": "Eyon Tunnel",
+                                "dockNum": 0
+                            }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Sunchamber Lobby": {
                     "pickups": [
@@ -9130,29 +9145,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                294.37054837798615,
-                                -27.548796656202676,
-                                58.72007588800403
+                                285.980354046578,
+                                -18.30942679457848,
+                                62.903115239918975
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Training Chamber",
+                                "roomName": "Sun Tower",
                                 "dockNum": 1
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Piston Tunnel",
-                                "dockNum": 1
+                                "roomName": "Energy Core",
+                                "dockNum": 2
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Gathering Hall Access": {
                     "pickups": [
@@ -9169,28 +9184,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                387.74084175131435,
-                                -111.48187304835831,
-                                27.793716732880966
+                                377.2436099742518,
+                                -110.63010799727523,
+                                30.626908744556943
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Ruined Nursery",
-                                "dockNum": 0
+                                "roomName": "Hive Totem",
+                                "dockNum": 1
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
                                 "roomName": "Vault",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Tower Chamber": {
@@ -9212,8 +9227,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Meditation Fountain",
-                                "dockNum": 0
+                                "roomName": "Hall of the Elders",
+                                "dockNum": 2
                             }
                         }
                     },
@@ -9250,27 +9265,27 @@
                         }
                     ],
                     "doors": {
-                        "2": {
+                        "0": {
                             "destination": {
-                                "roomName": "Vault",
-                                "dockNum": 1
+                                "roomName": "Transport to Tallon Overworld North",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Crossway Access South",
-                                "dockNum": 0
+                                "roomName": "West Furnace Access",
+                                "dockNum": 1
                             }
                         },
-                        "0": {
+                        "2": {
                             "destination": {
-                                "roomName": "Ruined Shrine Access",
-                                "dockNum": 1
+                                "roomName": "Nursery Access",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Sun Tower": {
                     "pickups": [
@@ -9287,29 +9302,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                256.9351854869147,
-                                355.7850159286708,
-                                59.528429790146
+                                224.09979199397802,
+                                354.630253306601,
+                                22.400912636665897
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
                                 "roomName": "Ruins Entrance",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "West Furnace Access",
+                                "roomName": "Sunchamber Lobby",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Transport Access North": {
                     "pickups": [
@@ -9328,21 +9343,21 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Magma Pool",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Arboretum",
-                                "dockNum": 0
+                                "roomName": "Gathering Hall",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Ruined Fountain",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Sunchamber Access": {
                     "pickups": [
@@ -9359,9 +9374,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                289.8277604510112,
-                                67.11547382250518,
-                                72.6054408932216
+                                279.35051258215634,
+                                59.274492351504776,
+                                74.15396010916
                             ],
                             "jumboScan": true
                         }
@@ -9369,13 +9384,13 @@
                     "doors": {
                         "1": {
                             "destination": {
-                                "roomName": "Main Plaza",
-                                "dockNum": 3
+                                "roomName": "Piston Tunnel",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Gathering Hall": {
                     "pickups": [
@@ -9394,33 +9409,35 @@
                         }
                     ],
                     "doors": {
-                        "0": {
+                        "2": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
                             "destination": {
-                                "roomName": "Burn Dome Access",
+                                "roomName": "Vault Access",
                                 "dockNum": 1
                             }
                         },
-                        "3": {
+                        "0": {
                             "destination": {
-                                "roomName": "Transport to Tallon Overworld North",
+                                "roomName": "Dynamo",
                                 "dockNum": 0
-                            }
-                        },
-                        "2": {
-                            "destination": {
-                                "roomName": "Reflecting Pool",
-                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Eyon Tunnel",
+                                "roomName": "Transport Access North",
                                 "dockNum": 0
+                            }
+                        },
+                        "3": {
+                            "destination": {
+                                "roomName": "East Furnace Access",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Totem Access": {
                     "pickups": [
@@ -9437,9 +9454,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -7.530543881457996,
-                                260.455608293554,
-                                4.659863270735148
+                                -11.491554356449209,
+                                275.0020534513868,
+                                4.876720130446746
                             ],
                             "jumboScan": true
                         }
@@ -9447,18 +9464,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Furnace",
-                                "dockNum": 2
+                                "roomName": "Arboretum",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Arboretum",
+                                "roomName": "Ruined Shrine Access",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Map Station": {
@@ -9476,9 +9493,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -22.049580752907687,
-                                201.75218243097459,
-                                12.668258672465814
+                                -25.19326728768206,
+                                205.96081705647663,
+                                11.158047566822004
                             ],
                             "jumboScan": true
                         }
@@ -9486,13 +9503,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Fountain Access",
-                                "dockNum": 1
+                                "roomName": "Arboretum",
+                                "dockNum": 2
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Sun Tower Access": {
                     "pickups": [
@@ -9509,9 +9526,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                309.081351660013,
-                                295.5402670939002,
-                                70.13216901588733
+                                312.0537822792944,
+                                251.20519180439263,
+                                82.50874951531041
                             ],
                             "jumboScan": true
                         }
@@ -9519,13 +9536,13 @@
                     "doors": {
                         "1": {
                             "destination": {
-                                "roomName": "Antechamber",
+                                "roomName": "Tower of Light",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Hive Totem": {
                     "pickups": [
@@ -9546,18 +9563,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Reflecting Pool",
+                                "roomName": "Crossway Access West",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Reflecting Pool Access",
-                                "dockNum": 1
+                                "roomName": "Gathering Hall Access",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Sunchamber": {
@@ -9589,7 +9606,6 @@
                             "showIcon": true
                         }
                     ],
-                    "doors": {},
                     "superheated": false,
                     "submerge": false
                 },
@@ -9612,19 +9628,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Plaza",
-                                "dockNum": 5
+                                "roomName": "Transport to Tallon Overworld South",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Energy Core",
-                                "dockNum": 1
+                                "roomName": "Furnace",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Save Station 2": {
                     "pickups": [
@@ -9641,9 +9657,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                414.3938127175983,
-                                -161.26698508345203,
-                                29.212891334537986
+                                410.9220181655086,
+                                -167.89530088295396,
+                                27.333891261862284
                             ],
                             "jumboScan": true
                         }
@@ -9651,8 +9667,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Magma Pool",
-                                "dockNum": 1
+                                "roomName": "Ruined Shrine Access",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -9674,28 +9690,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                443.8436282076965,
-                                -106.4256385127892,
-                                45.818924453368865
+                                458.7739691909022,
+                                -131.16546559937214,
+                                46.53063561238432
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Main Plaza",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Hall of the Elders",
+                                "roomName": "Vault",
                                 "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Hall of the Elders",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Watery Hall": {
@@ -9728,21 +9744,21 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Transport to Magmoor Caverns North",
-                                "dockNum": 2
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Arboretum Access",
+                                "roomName": "Ruins Entrance",
                                 "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Meditation Fountain",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Energy Core Access": {
                     "pickups": [
@@ -9759,9 +9775,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                503.63423125101156,
-                                -153.79895412769514,
-                                46.38572906191533
+                                496.0192441263094,
+                                -157.57389114518298,
+                                42.591329822886536
                             ],
                             "jumboScan": true
                         }
@@ -9769,13 +9785,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Nursery",
+                                "roomName": "Reflecting Pool",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Nursery Access",
+                                "roomName": "Arboretum",
                                 "dockNum": 1
                             }
                         }
@@ -9798,9 +9814,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                451.1396262946327,
-                                -45.463940852599805,
-                                29.431292285453154
+                                463.2926991084262,
+                                -44.264901284078576,
+                                29.60621762721412
                             ],
                             "jumboScan": true
                         }
@@ -9808,14 +9824,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hall of the Elders",
-                                "dockNum": 2
+                                "roomName": "Magma Pool",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Crossway",
-                                "dockNum": 2
+                                "roomName": "Main Plaza",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -9837,30 +9853,30 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                555.7711324076108,
-                                -188.05151635927135,
-                                56.507409887950246
+                                534.4196973506229,
+                                -127.69653444321138,
+                                32.291722130963905
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "destination": {
+                                "roomName": "Reflecting Pool",
+                                "dockNum": 2
+                            }
+                        },
                         "1": {
                             "destination": {
-                                "roomName": "Watery Hall Access",
+                                "roomName": "Transport Access South",
                                 "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Transport Access South",
-                                "dockNum": 0
-                            }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Crossway Access West",
-                                "dockNum": 0
+                                "roomName": "Sunchamber Lobby",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -9899,12 +9915,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Shrine",
+                                "roomName": "Gathering Hall",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Burn Dome Access": {
@@ -9922,9 +9938,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                569.7210199841753,
-                                -64.21082061186425,
-                                36.3920874109502
+                                569.1671278668023,
+                                -82.73784321752953,
+                                34.629153032532145
                             ],
                             "jumboScan": true
                         }
@@ -9933,13 +9949,13 @@
                         "0": {
                             "destination": {
                                 "roomName": "Main Plaza",
-                                "dockNum": 2
+                                "dockNum": 3
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Gathering Hall",
-                                "dockNum": 0
+                                "roomName": "Ruined Nursery",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -9961,9 +9977,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                605.9770182824809,
-                                -176.24267918757175,
-                                47.96146646139366
+                                596.3339685062141,
+                                -170.3179101016732,
+                                48.31268842554153
                             ],
                             "jumboScan": true
                         }
@@ -9971,14 +9987,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Sun Tower",
-                                "dockNum": 0
+                                "roomName": "Hall of the Elders",
+                                "dockNum": 4
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Arboretum Access",
-                                "dockNum": 0
+                                "roomName": "Ruined Gallery",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -10017,12 +10033,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Tower of Light Access",
-                                "dockNum": 1
+                                "roomName": "Reflecting Pool",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Furnace": {
@@ -10055,26 +10071,26 @@
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Plaza Access",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Elder Hall Access",
+                                "roomName": "Watery Hall Access",
                                 "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Vault Access",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Totem Access",
-                                "dockNum": 0
+                                "roomName": "Save Station 3",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "East Furnace Access": {
@@ -10092,9 +10108,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                729.1407068210679,
-                                -175.61902740288056,
-                                53.0481096925267
+                                748.4909626751479,
+                                -174.75128209081853,
+                                52.680263465120824
                             ],
                             "jumboScan": true
                         }
@@ -10102,18 +10118,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport Access South",
+                                "roomName": "Crossway",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Ruined Shrine Access",
-                                "dockNum": 0
+                                "roomName": "Gathering Hall",
+                                "dockNum": 3
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": true
                 },
                 "Crossway Access West": {
@@ -10131,9 +10147,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                709.7914634666135,
-                                -84.30899490563502,
-                                52.13413775650654
+                                728.6188051349302,
+                                -91.04907359307094,
+                                54.61965867304775
                             ],
                             "jumboScan": true
                         }
@@ -10141,19 +10157,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Energy Core",
+                                "roomName": "Reflecting Pool Access",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Save Station 3",
+                                "roomName": "Hive Totem",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Hall of the Elders": {
                     "pickups": [
@@ -10172,39 +10188,39 @@
                         }
                     ],
                     "doors": {
-                        "3": {
+                        "0": {
                             "destination": {
-                                "roomName": "Ruined Fountain Access",
-                                "dockNum": 0
-                            }
-                        },
-                        "4": {
-                            "destination": {
-                                "roomName": "Elder Chamber",
-                                "dockNum": 0
+                                "roomName": "East Atrium",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "East Atrium",
+                                "roomName": "Save Station 1",
                                 "dockNum": 0
-                            }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Meditation Fountain",
-                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Dynamo Access",
+                                "roomName": "Tower Chamber",
+                                "dockNum": 0
+                            }
+                        },
+                        "3": {
+                            "destination": {
+                                "roomName": "Eyon Tunnel",
+                                "dockNum": 1
+                            }
+                        },
+                        "4": {
+                            "destination": {
+                                "roomName": "West Furnace Access",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Crossway": {
                     "pickups": [
@@ -10223,26 +10239,26 @@
                         }
                     ],
                     "doors": {
-                        "2": {
+                        "0": {
                             "destination": {
-                                "roomName": "Dynamo Access",
+                                "roomName": "North Atrium",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Ruins Entrance",
-                                "dockNum": 1
+                                "roomName": "East Furnace Access",
+                                "dockNum": 0
                             }
                         },
-                        "0": {
+                        "2": {
                             "destination": {
-                                "roomName": "Save Station 1",
+                                "roomName": "Antechamber",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Reflecting Pool Access": {
@@ -10260,9 +10276,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                779.551260675177,
-                                -242.3855704842724,
-                                71.11837383596904
+                                781.5312267550325,
+                                -231.4647183835993,
+                                73.74176595820248
                             ],
                             "jumboScan": true
                         }
@@ -10270,19 +10286,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Plaza",
-                                "dockNum": 4
+                                "roomName": "Crossway Access West",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Hive Totem",
+                                "roomName": "Main Plaza",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Elder Hall Access": {
                     "pickups": [
@@ -10299,29 +10315,29 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                802.983329940437,
-                                -111.2557920445893,
-                                59.935036791393344
+                                804.9585057996447,
+                                -130.5823823637895,
+                                62.56309506062281
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Furnace",
-                                "dockNum": 0
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Fountain",
-                                "dockNum": 0
+                                "roomName": "Training Chamber",
+                                "dockNum": 1
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Main Plaza",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Crossway Access South": {
                     "pickups": [
@@ -10338,28 +10354,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                764.3776346721705,
-                                -120.10996033722706,
-                                61.45085898167553
+                                779.6915906389643,
+                                -110.71131246514922,
+                                57.7664700582795
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
-                            "destination": {
-                                "roomName": "Main Plaza",
-                                "dockNum": 1
-                            }
-                        },
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Gallery",
+                                "roomName": "Main Plaza",
+                                "dockNum": 4
+                            }
+                        },
+                        "1": {
+                            "destination": {
+                                "roomName": "Ruined Fountain",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Elder Chamber": {
@@ -10381,12 +10397,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hall of the Elders",
-                                "dockNum": 4
+                                "roomName": "Main Plaza",
+                                "dockNum": 5
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Reflecting Pool": {
@@ -10404,41 +10420,43 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                777.7825795045698,
-                                -325.87103269366384,
-                                84.18813594009387
+                                767.5725052557242,
+                                -275.5730452797271,
+                                89.95607460835693
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
+                        "0": {
+                            "shieldType": "Blue",
+                            "blastShieldType": "Empty",
+                            "destination": {
+                                "roomName": "Burn Dome",
+                                "dockNum": 0
+                            }
+                        },
                         "1": {
                             "destination": {
-                                "roomName": "Hive Totem",
+                                "roomName": "Energy Core Access",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Gathering Hall",
-                                "dockNum": 2
+                                "roomName": "Energy Core",
+                                "dockNum": 0
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Eyon Tunnel",
+                                "roomName": "Nursery Access",
                                 "dockNum": 1
-                            }
-                        },
-                        "0": {
-                            "destination": {
-                                "roomName": "Tower of Light Access",
-                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Save Station 3": {
                     "pickups": [
@@ -10455,28 +10473,28 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                700.1414846296267,
-                                -301.5837245978575,
-                                91.93387853837608
+                                694.5815604724133,
+                                -302.05083092282655,
+                                92.23893810387479
                             ],
                             "jumboScan": true
                         }
                     ],
                     "doors": {
-                        "1": {
+                        "0": {
                             "destination": {
-                                "roomName": "Training Chamber",
+                                "roomName": "Ruined Nursery",
                                 "dockNum": 0
                             }
                         },
-                        "0": {
+                        "1": {
                             "destination": {
-                                "roomName": "Crossway Access West",
-                                "dockNum": 1
+                                "roomName": "Furnace",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Transport Access South": {
@@ -10494,9 +10512,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                771.8425145236563,
-                                -375.85924992467926,
-                                89.36283663050712
+                                775.0355053861198,
+                                -349.4995283267271,
+                                88.57371102302567
                             ],
                             "jumboScan": true
                         }
@@ -10504,19 +10522,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Energy Core",
-                                "dockNum": 2
+                                "roomName": "Training Chamber",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "East Furnace Access",
-                                "dockNum": 0
+                                "roomName": "Energy Core",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Antechamber": {
                     "pickups": [
@@ -10537,13 +10555,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Sun Tower Access",
-                                "dockNum": 1
+                                "roomName": "Crossway",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Transport to Tallon Overworld East": {
                     "pickups": [
@@ -10560,9 +10578,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                662.4121308019446,
-                                -300.96038432620657,
-                                100.55076899026875
+                                663.2992491078766,
+                                -284.11228126352717,
+                                98.43104987703221
                             ],
                             "jumboScan": true
                         }
@@ -10570,7 +10588,7 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Tower of Light",
+                                "roomName": "Arboretum Access",
                                 "dockNum": 0
                             }
                         }
@@ -10593,9 +10611,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                762.6478578479991,
-                                -415.73358265851095,
-                                65.54349326706438
+                                778.3175465950617,
+                                -394.5989025444047,
+                                95.37645194835639
                             ],
                             "jumboScan": true
                         }
@@ -10603,8 +10621,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Nursery",
-                                "dockNum": 2
+                                "roomName": "Watery Hall Access",
+                                "dockNum": 0
                             }
                         }
                     },

--- a/test/test_files/randomprime_expected_data_one_way_door.json
+++ b/test/test_files/randomprime_expected_data_one_way_door.json
@@ -34,23 +34,23 @@
         "forceFusion": false
     },
     "gameConfig": {
-        "resultsString": "5.2.0.dev65 | Seed Hash - Geemer Shriekbat Fission (AAAAAAAA)",
+        "resultsString": "5.5.0.dev206-dirty | Seed Hash - Geemer Shriekbat Fission (AAAAAAAA)",
         "bossSizes": {
-            "parasiteQueen": 0.44977572662984067,
-            "incineratorDrone": 0.5455729671029474,
-            "adultSheegoth": 0.7089159456686496,
-            "thardus": 1.6623366020623678,
-            "elitePirate1": 2.2878011900309114,
-            "elitePirate2": 0.30400815014892685,
-            "elitePirate3": 0.9231433057954543,
-            "phazonElite": 0.6409823670291537,
-            "omegaPirate": 0.36457831494081505,
-            "Ridley": 0.7414786873418531,
-            "exo": 0.22667724053748933,
-            "essence": 0.14812015272534665,
-            "flaahgra": 2.0275229604319627,
-            "platedBeetle": 0.42416872030226377,
-            "cloakedDrone": 0.6282245815635213
+            "parasiteQueen": 2.577947291387651,
+            "incineratorDrone": 0.3654781630609554,
+            "adultSheegoth": 0.16374431648586274,
+            "thardus": 0.1379740060479601,
+            "elitePirate1": 0.22364738838740073,
+            "elitePirate2": 1.2847752291815655,
+            "elitePirate3": 1.6178804112283933,
+            "phazonElite": 1.2701436794762417,
+            "omegaPirate": 1.9587497320616927,
+            "Ridley": 1.2554676675907293,
+            "exo": 0.28768009389183324,
+            "essence": 2.1550466602224114,
+            "flaahgra": 1.1638233275418013,
+            "platedBeetle": 0.6078574072113649,
+            "cloakedDrone": 0.17844210621533785
         },
         "noDoors": true,
         "shufflePickupPosition": true,
@@ -64,13 +64,13 @@
             "eyeWaitRandomTime": 0.0,
             "eyeStayUpRandomTime": 0.0,
             "resetContraptionRandomTime": 0.0,
-            "eyeWaitInitialMinimumTime": 9.01467716377498,
-            "eyeWaitMinimumTime": 19.89072804664436,
-            "eyeStayUpMinimumTime": 8.805241503030308,
-            "resetContraptionMinimumTime": 3.1936051608647444
+            "eyeWaitInitialMinimumTime": 9.521643635693477,
+            "eyeWaitMinimumTime": 19.09744823053323,
+            "eyeStayUpMinimumTime": 8.567683349518132,
+            "resetContraptionMinimumTime": 3.8219802922271624
         },
         "mazeSeeds": [
-            1886683009
+            1904818819
         ],
         "nonvariaHeatDamage": true,
         "staggeredSuitDamage": false,
@@ -123,7 +123,7 @@
             "gameNameFull": "Metroid Prime: Randomizer - AAAAAAAA",
             "description": "Seed Hash: Geemer Shriekbat Fission"
         },
-        "mainMenuMessage": "Randovania v5.2.0.dev65\nGeemer Shriekbat Fission",
+        "mainMenuMessage": "Randovania v5.5.0.dev206-dirty\nGeemer Shriekbat Fission",
         "creditsString": "&push;&font=C29C51F1;&main-color=#89D6FF;Major Item Locations&pop;\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Charge Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ice Ruins East\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wave Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Arbor Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Ruined Fountain\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Plasma Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Central Dynamo\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Missile Launcher&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Alcove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Grapple Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Ruined Gallery\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Combat Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Landing Site\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Thermal Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Ventilation Shaft\n\n&push;&font=C29C51F1;&main-color=#33ffd6;X-Ray Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Furnace\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Space Jump Boots&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Hall of the Elders\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Boost Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Main Plaza\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Spider Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Watery Hall\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Power Bomb&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Transport Access North\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Varia Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Main Plaza\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Gravity Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Fungal Hall B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Phazon Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Burn Dome\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Super Missile&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Warrior Shrine\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wavebuster&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Phendrana Canyon\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Spreader&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Life Grove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Flamethrower&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ice Ruins East\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Chozo&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Triclops Pit\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Elder&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Storage Cavern\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Lifegiver&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Chapel of the Elders\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Nature&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Phendrana Shorelines\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Strength&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Magma Pool\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Sun&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Lava Lake\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Truth&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ice Ruins West\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Warrior&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Elder Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Wild&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ruined Courtyard",
         "artifactHints": {
             "Artifact of World": "&push;&main-color=#c300ff;Artifact of World&pop; has no need to be located.",
@@ -196,8 +196,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Crater Tunnel B",
-                                "dockNum": 1
+                                "roomName": "Phazon Core",
+                                "dockNum": 2
                             }
                         }
                     },
@@ -219,9 +219,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                0.5090973243703019,
-                                -24.623797919581804,
-                                6.719368964448277
+                                -16.85561956764163,
+                                12.937598088357639,
+                                10.323165438737187
                             ],
                             "jumboScan": true
                         }
@@ -229,18 +229,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Crater Missile Station",
-                                "dockNum": 0
+                                "roomName": "Phazon Infusion Chamber",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Crater Tunnel B",
+                                "roomName": "Crater Missile Station",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Phazon Core": {
@@ -258,9 +258,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                57.93534022906182,
-                                -91.85260321047228,
-                                54.53476046095002
+                                -10.318852912639883,
+                                -73.80955444495477,
+                                77.29420089357681
                             ],
                             "jumboScan": true
                         }
@@ -274,14 +274,14 @@
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Phazon Infusion Chamber",
-                                "dockNum": 1
+                                "roomName": "Crater Tunnel B",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Crater Entry Point",
-                                "dockNum": 0
+                                "roomName": "Crater Tunnel B",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -303,9 +303,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -85.46181598417313,
-                                -122.21192573787484,
-                                38.76963903089778
+                                -70.59832652481127,
+                                -137.25324875139032,
+                                38.90212632312668
                             ],
                             "jumboScan": true
                         }
@@ -314,7 +314,7 @@
                         "0": {
                             "destination": {
                                 "roomName": "Crater Tunnel A",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         }
                     },
@@ -336,9 +336,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                56.31811571868124,
-                                -180.94138305598315,
-                                58.36444245652732
+                                34.064695772880576,
+                                -188.3851759481238,
+                                47.83817247865456
                             ],
                             "jumboScan": true
                         }
@@ -347,13 +347,13 @@
                         "0": {
                             "destination": {
                                 "roomName": "Crater Tunnel A",
-                                "dockNum": 1
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Crater Tunnel A",
-                                "dockNum": 0
+                                "roomName": "Crater Tunnel B",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -375,9 +375,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                63.90493434619051,
-                                -255.38394913465194,
-                                81.49478347076118
+                                52.13353653546185,
+                                -255.52616957264115,
+                                98.09451652270246
                             ],
                             "jumboScan": true
                         }
@@ -386,12 +386,12 @@
                         "1": {
                             "destination": {
                                 "roomName": "Phazon Core",
-                                "dockNum": 2
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Subchamber One": {
                     "pickups": [
@@ -408,14 +408,13 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                48.553048338899934,
-                                -340.54572091602097,
-                                21.33615102362266
+                                -9.679415794388412,
+                                -365.92070272333143,
+                                58.774086718777795
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
                     "superheated": false,
                     "submerge": false
                 },
@@ -434,16 +433,15 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -6.206614260426491,
-                                -357.7258743919699,
-                                -18.114936755616828
+                                -7.400373966121151,
+                                -360.37092013198526,
+                                -7.449266565317949
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Subchamber Three": {
                     "pickups": [
@@ -460,16 +458,15 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -20.31700166499852,
-                                -285.842763690015,
-                                -81.97429969641395
+                                -8.908079706049755,
+                                -220.8153476146357,
+                                -82.38033799736701
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Subchamber Four": {
                     "pickups": [
@@ -486,15 +483,14 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -20.86257577835163,
-                                -237.56781512002527,
-                                -102.93822498139427
+                                24.297614031977687,
+                                -210.39222151912446,
+                                -109.53428334271022
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Subchamber Five": {
@@ -512,14 +508,13 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                27.550550404387632,
-                                -286.67041435674264,
-                                -209.68380968700856
+                                36.79011645524219,
+                                -299.1430841063964,
+                                -161.86573344822335
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
                     "superheated": false,
                     "submerge": false
                 },
@@ -538,16 +533,15 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                74.72396709391498,
-                                -326.4305509814678,
-                                -356.7751072400591
+                                23.060356188226926,
+                                -307.99576061456514,
+                                -285.4204467097148
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 }
             }
         },
@@ -572,9 +566,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -52.244737179696024,
-                                55.37915294691722,
-                                8.72498292290576
+                                -51.55892996007088,
+                                28.97332869419167,
+                                11.314991387857653
                             ],
                             "jumboScan": true
                         }
@@ -582,12 +576,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Quarantine Access",
-                                "dockNum": 0
+                                "roomName": "Lake Tunnel",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Shoreline Entrance": {
@@ -605,9 +599,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -27.144070360656716,
-                                -66.56027038992775,
-                                10.331101675364089
+                                -21.560462112611706,
+                                -66.73396850358122,
+                                8.538110235799518
                             ],
                             "jumboScan": true
                         }
@@ -615,19 +609,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "West Tower",
-                                "dockNum": 0
+                                "roomName": "East Tower",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Observatory",
-                                "dockNum": 2
+                                "roomName": "Temple Entryway",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Phendrana Shorelines": {
                     "pickups": [
@@ -661,43 +655,43 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Research Core Access",
+                                "roomName": "Aether Lab Entryway",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Hunter Cave Access",
-                                "dockNum": 1
+                                "roomName": "Storage Cave",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Specimen Storage",
-                                "dockNum": 1
+                                "roomName": "Save Station C",
+                                "dockNum": 0
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Upper Edge Tunnel",
+                                "roomName": "Hunter Cave Access",
                                 "dockNum": 0
                             }
                         },
                         "4": {
                             "destination": {
-                                "roomName": "Lower Edge Tunnel",
-                                "dockNum": 0
+                                "roomName": "Quarantine Access",
+                                "dockNum": 1
                             }
                         },
                         "5": {
                             "destination": {
-                                "roomName": "Hydra Lab Entryway",
-                                "dockNum": 0
+                                "roomName": "Pike Access",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Temple Entryway": {
                     "pickups": [
@@ -714,9 +708,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -153.13235052803685,
-                                -127.27203997709067,
-                                11.820205311154577
+                                -128.0739756479403,
+                                -111.8170722155429,
+                                13.873810052470503
                             ],
                             "jumboScan": true
                         }
@@ -724,19 +718,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Frozen Pike",
+                                "roomName": "Transport to Magmoor Caverns South",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Phendrana's Edge",
-                                "dockNum": 2
+                                "roomName": "Gravity Chamber",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Save Station B": {
                     "pickups": [
@@ -753,9 +747,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -58.4198706008772,
-                                -216.5311116358355,
-                                9.741756221123243
+                                -75.09412203825232,
+                                -227.07534258976196,
+                                9.824204530648611
                             ],
                             "jumboScan": true
                         }
@@ -763,12 +757,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Research Lab Hydra",
+                                "roomName": "Shoreline Entrance",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": true
                 },
                 "Ruins Entryway": {
@@ -786,9 +780,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -58.677429898647105,
-                                -218.77078471892324,
-                                46.881703864288205
+                                -30.79288875847938,
+                                -223.05686855155437,
+                                45.800404521880495
                             ],
                             "jumboScan": true
                         }
@@ -796,19 +790,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ice Ruins Access",
-                                "dockNum": 1
+                                "roomName": "Hunter Cave",
+                                "dockNum": 3
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Hunter Cave",
-                                "dockNum": 2
+                                "roomName": "Chozo Ice Temple",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Plaza Walkway": {
                     "pickups": [
@@ -825,9 +819,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                70.27803500821491,
-                                -238.42813774482227,
-                                25.088083304125348
+                                55.64924583710295,
+                                -234.0496164793845,
+                                28.904634014390073
                             ],
                             "jumboScan": true
                         }
@@ -835,14 +829,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Quarantine Cave",
-                                "dockNum": 2
+                                "roomName": "Frozen Pike",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Research Core",
-                                "dockNum": 1
+                                "roomName": "Chapel Tunnel",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -864,9 +858,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                71.83246328740671,
-                                -173.74482692835977,
-                                12.92370563246099
+                                35.14829659140412,
+                                -167.32293839753322,
+                                12.75747252498374
                             ],
                             "jumboScan": true
                         }
@@ -874,19 +868,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Frost Cave",
-                                "dockNum": 2
+                                "roomName": "Hydra Lab Entryway",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Ruined Courtyard",
-                                "dockNum": 0
+                                "roomName": "Frozen Pike",
+                                "dockNum": 3
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Chozo Ice Temple": {
                     "pickups": [
@@ -907,19 +901,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Magmoor Caverns South",
+                                "roomName": "Frost Cave Access",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Save Station D",
-                                "dockNum": 0
+                                "roomName": "North Quarantine Tunnel",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Ice Ruins West": {
                     "pickups": [
@@ -940,8 +934,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Frost Cave Access",
-                                "dockNum": 1
+                                "roomName": "Research Core Access",
+                                "dockNum": 0
                             }
                         },
                         "1": {
@@ -952,8 +946,8 @@
                         },
                         "2": {
                             "destination": {
-                                "roomName": "East Tower",
-                                "dockNum": 1
+                                "roomName": "Quarantine Access",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -992,18 +986,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Chapel Tunnel",
+                                "roomName": "Courtyard Entryway",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Shoreline Entrance",
+                                "roomName": "Chamber Access",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Chapel Tunnel": {
@@ -1021,9 +1015,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -314.5689197003111,
-                                -175.06841453582075,
-                                46.53292538748387
+                                -298.5899987909937,
+                                -174.07007631585978,
+                                33.83183480291527
                             ],
                             "jumboScan": true
                         }
@@ -1037,12 +1031,12 @@
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Ice Ruins West",
-                                "dockNum": 2
+                                "roomName": "Phendrana's Edge",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Courtyard Entryway": {
@@ -1060,9 +1054,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -11.608813304741673,
-                                -368.3343622452261,
-                                33.86137252384043
+                                -14.467348293127419,
+                                -377.2943684247258,
+                                31.521899835888842
                             ],
                             "jumboScan": true
                         }
@@ -1070,19 +1064,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phendrana Shorelines",
-                                "dockNum": 4
+                                "roomName": "Frost Cave",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Research Lab Aether",
+                                "roomName": "Research Lab Hydra",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Canyon Entryway": {
                     "pickups": [
@@ -1099,9 +1093,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -144.75195400609445,
-                                -325.03602117180316,
-                                18.275181588813194
+                                -93.32373229431802,
+                                -324.6996615260536,
+                                14.492110780700243
                             ],
                             "jumboScan": true
                         }
@@ -1109,18 +1103,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Courtyard Entryway",
-                                "dockNum": 0
+                                "roomName": "Observatory",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Frozen Pike",
-                                "dockNum": 3
+                                "roomName": "Phendrana Shorelines",
+                                "dockNum": 4
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Chapel of the Elders": {
@@ -1142,12 +1136,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruins Entryway",
+                                "roomName": "Specimen Storage",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Ruined Courtyard": {
@@ -1169,25 +1163,25 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Chapel Tunnel",
-                                "dockNum": 1
+                                "roomName": "Lower Edge Tunnel",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Shoreline Entrance",
-                                "dockNum": 0
+                                "roomName": "Ice Ruins Access",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Upper Edge Tunnel",
-                                "dockNum": 1
+                                "roomName": "Lake Tunnel",
+                                "dockNum": 0
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "West Tower",
+                                "roomName": "Frost Cave Access",
                                 "dockNum": 1
                             }
                         }
@@ -1214,8 +1208,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Security Cave",
-                                "dockNum": 0
+                                "roomName": "Ruins Entryway",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -1237,9 +1231,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -68.97234511012508,
-                                -459.21580139878193,
-                                71.26930212525146
+                                -81.8989940797045,
+                                -455.1928874162677,
+                                71.12221384645501
                             ],
                             "jumboScan": true
                         }
@@ -1247,13 +1241,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Frozen Pike",
-                                "dockNum": 1
+                                "roomName": "Phendrana Canyon",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Specimen Storage": {
                     "pickups": [
@@ -1270,9 +1264,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -6.50466060221995,
-                                -552.6496812439638,
-                                67.45218766634308
+                                -20.54477162322842,
+                                -521.2656653689778,
+                                59.55292803754043
                             ],
                             "jumboScan": true
                         }
@@ -1280,19 +1274,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hunter Cave",
-                                "dockNum": 3
+                                "roomName": "Ice Ruins West",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Phendrana's Edge",
-                                "dockNum": 0
+                                "roomName": "Hunter Cave",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Quarantine Access": {
                     "pickups": [
@@ -1309,9 +1303,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                80.10326787188896,
-                                -468.4711610677132,
-                                72.49751441110142
+                                87.8111451915156,
+                                -466.11941272415913,
+                                69.1244865812912
                             ],
                             "jumboScan": true
                         }
@@ -1319,14 +1313,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Plaza Walkway",
+                                "roomName": "Frozen Pike",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Gravity Chamber",
-                                "dockNum": 1
+                                "roomName": "Observatory Access",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -1348,9 +1342,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                10.213779988865852,
-                                -595.0227183976663,
-                                84.13820062617273
+                                5.127967994424431,
+                                -599.8125014271504,
+                                77.39984228543122
                             ],
                             "jumboScan": true
                         }
@@ -1358,19 +1352,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "North Quarantine Tunnel",
-                                "dockNum": 1
+                                "roomName": "Shoreline Entrance",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Canyon Entryway",
-                                "dockNum": 1
+                                "roomName": "Security Cave",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Save Station A",
+                                "roomName": "Plaza Walkway",
                                 "dockNum": 0
                             }
                         }
@@ -1393,9 +1387,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -6.333323035797022,
-                                -677.3480892153873,
-                                -12.486428013049872
+                                -14.302652749496026,
+                                -705.9480649554018,
+                                49.8818076744313
                             ],
                             "jumboScan": true
                         }
@@ -1403,14 +1397,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Research Lab Hydra",
-                                "dockNum": 0
+                                "roomName": "Chapel Tunnel",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Frozen Pike",
-                                "dockNum": 2
+                                "roomName": "Research Lab Aether",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -1432,9 +1426,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -53.8282853834282,
-                                -662.8508944751733,
-                                69.55231189839127
+                                -57.913055438448666,
+                                -643.6984209501893,
+                                69.21404266286336
                             ],
                             "jumboScan": true
                         }
@@ -1442,8 +1436,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hunter Cave Access",
-                                "dockNum": 0
+                                "roomName": "Quarantine Cave",
+                                "dockNum": 2
                             }
                         }
                     },
@@ -1465,9 +1459,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -21.71037182093924,
-                                -725.647014684324,
-                                76.7345339281302
+                                -22.44758326176647,
+                                -688.8391081885331,
+                                75.90209990352562
                             ],
                             "jumboScan": true
                         }
@@ -1475,18 +1469,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "South Quarantine Tunnel",
-                                "dockNum": 0
+                                "roomName": "Research Lab Aether",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Ruined Courtyard",
-                                "dockNum": 2
+                                "roomName": "Research Core Access",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Quarantine Cave": {
@@ -1508,25 +1502,25 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Map Station",
+                                "roomName": "Save Station D",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Observatory Access",
-                                "dockNum": 0
+                                "roomName": "Hunter Cave Access",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Aether Lab Entryway",
-                                "dockNum": 1
+                                "roomName": "Chamber Access",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Research Lab Hydra": {
                     "pickups": [
@@ -1547,13 +1541,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Lake Tunnel",
-                                "dockNum": 1
+                                "roomName": "South Quarantine Tunnel",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Frost Cave Access",
+                                "roomName": "West Tower",
                                 "dockNum": 0
                             }
                         }
@@ -1576,9 +1570,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                171.82593698472152,
-                                -722.3841544147771,
-                                -9.313101730972729
+                                189.74573536769861,
+                                -805.7061862534,
+                                67.86107964685198
                             ],
                             "jumboScan": true
                         }
@@ -1586,19 +1580,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Chapel of the Elders",
-                                "dockNum": 0
+                                "roomName": "Frozen Pike",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Chozo Ice Temple",
-                                "dockNum": 1
+                                "roomName": "Hunter Cave",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Quarantine Monitor": {
                     "pickups": [
@@ -1619,12 +1613,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ice Ruins West",
-                                "dockNum": 1
+                                "roomName": "Research Lab Hydra",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Observatory Access": {
@@ -1642,9 +1636,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -54.965000199887186,
-                                -785.9626557697579,
-                                104.75093698737072
+                                -63.76393942980904,
+                                -820.7077573395983,
+                                105.76409468614361
                             ],
                             "jumboScan": true
                         }
@@ -1652,13 +1646,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "West Tower Entrance",
-                                "dockNum": 0
+                                "roomName": "Ruined Courtyard",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Phendrana Canyon",
+                                "roomName": "Map Station",
                                 "dockNum": 0
                             }
                         }
@@ -1681,9 +1675,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                164.58171363035456,
-                                -848.2449078136515,
-                                95.54846270402975
+                                194.27241745930667,
+                                -871.8251913003613,
+                                75.5377628787183
                             ],
                             "jumboScan": true
                         }
@@ -1691,19 +1685,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "West Tower Entrance",
+                                "roomName": "Ice Ruins West",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Lower Edge Tunnel",
-                                "dockNum": 1
+                                "roomName": "Chapel of the Elders",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Observatory": {
                     "pickups": [
@@ -1724,24 +1718,24 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport Access",
+                                "roomName": "Save Station A",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "North Quarantine Tunnel",
+                                "roomName": "Transport Access",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Lake Tunnel",
+                                "roomName": "North Quarantine Tunnel",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Transport Access": {
@@ -1769,12 +1763,12 @@
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Control Tower",
+                                "roomName": "West Tower Entrance",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "West Tower Entrance": {
@@ -1792,9 +1786,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -62.67918729694892,
-                                -815.1227547931385,
-                                127.01082381904082
+                                -51.47870928601226,
+                                -842.4341675700713,
+                                129.71087273587244
                             ],
                             "jumboScan": true
                         }
@@ -1802,14 +1796,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Research Entrance",
-                                "dockNum": 1
+                                "roomName": "Control Tower",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Phendrana's Edge",
-                                "dockNum": 3
+                                "roomName": "Research Core",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -1831,9 +1825,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -79.64636025448739,
-                                -971.2071393284906,
-                                127.53387876630443
+                                -75.09724298066358,
+                                -950.6983417217704,
+                                134.21463349595652
                             ],
                             "jumboScan": true
                         }
@@ -1841,8 +1835,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ice Ruins East",
-                                "dockNum": 1
+                                "roomName": "Ruined Courtyard",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -1864,9 +1858,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                160.57546116120972,
-                                -1008.1941557167121,
-                                76.38528023486235
+                                192.8085399784735,
+                                -969.1101840646901,
+                                76.44586481838134
                             ],
                             "jumboScan": true
                         }
@@ -1874,26 +1868,26 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Magmoor Caverns West",
-                                "dockNum": 0
+                                "roomName": "Canyon Entryway",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Save Station C",
-                                "dockNum": 0
+                                "roomName": "West Tower Entrance",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Save Station B",
-                                "dockNum": 0
+                                "roomName": "Transport to Magmoor Caverns South",
+                                "dockNum": 1
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Quarantine Monitor",
-                                "dockNum": 0
+                                "roomName": "Temple Entryway",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -1915,9 +1909,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -59.28065121666961,
-                                -796.4440787513871,
-                                130.51138383762984
+                                -58.93428787667688,
+                                -769.7395560839593,
+                                159.57562747429265
                             ],
                             "jumboScan": true
                         }
@@ -1931,13 +1925,13 @@
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Temple Entryway",
-                                "dockNum": 1
+                                "roomName": "Hunter Cave",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Pike Access": {
                     "pickups": [
@@ -1954,9 +1948,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                108.22707235106733,
-                                -986.5174491064975,
-                                60.0866132240825
+                                132.8145514655434,
+                                -997.87700130094,
+                                50.70545830994419
                             ],
                             "jumboScan": true
                         }
@@ -1964,18 +1958,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phendrana Shorelines",
-                                "dockNum": 5
+                                "roomName": "Research Entrance",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Canyon Entryway",
+                                "roomName": "Phendrana's Edge",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Frost Cave Access": {
@@ -1993,9 +1987,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                195.3212510696729,
-                                -1149.117012593377,
-                                67.37416843024994
+                                161.21064404739408,
+                                -1162.2460937622582,
+                                52.735109453998874
                             ],
                             "jumboScan": true
                         }
@@ -2003,19 +1997,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phendrana's Edge",
-                                "dockNum": 1
+                                "roomName": "Gravity Chamber",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Hunter Cave",
-                                "dockNum": 0
+                                "roomName": "Ice Ruins East",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Hunter Cave Access": {
                     "pickups": [
@@ -2032,9 +2026,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                213.79988936549148,
-                                -1149.4819373547693,
-                                20.499493400123203
+                                194.62812437407428,
+                                -1156.5461930906504,
+                                28.947266919803234
                             ],
                             "jumboScan": true
                         }
@@ -2042,14 +2036,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Pike Access",
-                                "dockNum": 0
+                                "roomName": "West Tower",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Observatory",
-                                "dockNum": 1
+                                "roomName": "Transport to Magmoor Caverns West",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -2075,18 +2069,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Storage Cave",
+                                "roomName": "Canyon Entryway",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Chamber Access",
+                                "roomName": "Upper Edge Tunnel",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Research Core": {
@@ -2108,19 +2102,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Chamber Access",
+                                "roomName": "Upper Edge Tunnel",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport Access",
-                                "dockNum": 1
+                                "roomName": "Aether Lab Entryway",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Frost Cave": {
                     "pickups": [
@@ -2141,25 +2135,25 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruins Entryway",
+                                "roomName": "Save Station B",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Courtyard Entryway",
-                                "dockNum": 1
+                                "roomName": "Pike Access",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Plaza Walkway",
-                                "dockNum": 1
+                                "roomName": "Quarantine Monitor",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Hunter Cave": {
                     "pickups": [
@@ -2176,9 +2170,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                253.95175139371753,
-                                -1240.6545359034412,
-                                -2.7862682807154986
+                                257.52562479335313,
+                                -1249.3391015365692,
+                                25.977183783470444
                             ],
                             "jumboScan": true
                         }
@@ -2186,30 +2180,30 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ice Ruins Access",
-                                "dockNum": 0
+                                "roomName": "Transport Access",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Observatory Access",
-                                "dockNum": 1
+                                "roomName": "Ice Ruins Access",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Hydra Lab Entryway",
+                                "roomName": "Courtyard Entryway",
                                 "dockNum": 1
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "East Tower",
-                                "dockNum": 0
+                                "roomName": "Plaza Walkway",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "East Tower": {
@@ -2227,9 +2221,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                40.082423168564354,
-                                -800.3455932170823,
-                                152.411111159955
+                                20.10892074196399,
+                                -794.1097640494588,
+                                151.69774602547778
                             ],
                             "jumboScan": true
                         }
@@ -2237,14 +2231,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ice Ruins East",
-                                "dockNum": 0
+                                "roomName": "Observatory",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Ruined Courtyard",
-                                "dockNum": 3
+                                "roomName": "Ice Ruins East",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -2266,9 +2260,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                39.80694561780989,
-                                -928.1739696900629,
-                                101.07466715225159
+                                43.93181655754268,
+                                -932.0051532742034,
+                                100.19293390745307
                             ],
                             "jumboScan": true
                         }
@@ -2276,19 +2270,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Courtyard",
-                                "dockNum": 1
+                                "roomName": "Phendrana Shorelines",
+                                "dockNum": 5
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Gravity Chamber",
+                                "roomName": "Quarantine Cave",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Save Station C": {
                     "pickups": [
@@ -2305,9 +2299,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                71.5198968086003,
-                                -1226.366204921744,
-                                64.80229293216678
+                                44.774775403738985,
+                                -1228.9163289098808,
+                                62.5115105244014
                             ],
                             "jumboScan": true
                         }
@@ -2315,12 +2309,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phendrana Shorelines",
-                                "dockNum": 0
+                                "roomName": "Phendrana's Edge",
+                                "dockNum": 3
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Upper Edge Tunnel": {
@@ -2338,9 +2332,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                137.7786994928302,
-                                -1306.919157059261,
-                                42.099501213967
+                                135.90542542553334,
+                                -1313.8107423980875,
+                                48.61031481728889
                             ],
                             "jumboScan": true
                         }
@@ -2348,14 +2342,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Research Lab Aether",
+                                "roomName": "Phendrana Shorelines",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Control Tower",
-                                "dockNum": 1
+                                "roomName": "Ruined Courtyard",
+                                "dockNum": 3
                             }
                         }
                     },
@@ -2377,9 +2371,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                194.11487360694468,
-                                -1297.8930251541187,
-                                18.526225490848276
+                                179.22336198568385,
+                                -1306.359709298816,
+                                11.233952756434489
                             ],
                             "jumboScan": true
                         }
@@ -2387,13 +2381,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ice Ruins West",
-                                "dockNum": 0
+                                "roomName": "Phendrana Shorelines",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Research Core",
+                                "roomName": "Specimen Storage",
                                 "dockNum": 0
                             }
                         }
@@ -2416,9 +2410,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                286.5336036196803,
-                                -1193.960108202984,
-                                26.261724186323256
+                                304.05064820265386,
+                                -1217.7962788191342,
+                                27.72539730134111
                             ],
                             "jumboScan": true
                         }
@@ -2426,14 +2420,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phendrana Shorelines",
-                                "dockNum": 2
+                                "roomName": "Ruined Courtyard",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Frost Cave",
-                                "dockNum": 0
+                                "roomName": "Phendrana's Edge",
+                                "dockNum": 2
                             }
                         }
                     },
@@ -2455,9 +2449,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                289.9621521892457,
-                                -1226.5901479564595,
-                                8.53321148965274
+                                325.2146721149412,
+                                -1228.8181146815707,
+                                13.123271716989336
                             ],
                             "jumboScan": true
                         }
@@ -2465,18 +2459,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phendrana Shorelines",
-                                "dockNum": 1
+                                "roomName": "Ruins Entryway",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Research Entrance",
-                                "dockNum": 2
+                                "roomName": "Phendrana Shorelines",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Aether Lab Entryway": {
@@ -2494,9 +2488,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                38.52115849584967,
-                                -813.7689302036868,
-                                130.38501092369404
+                                39.189295424859,
+                                -815.1073432856456,
+                                130.3093964980674
                             ],
                             "jumboScan": true
                         }
@@ -2504,19 +2498,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phendrana Shorelines",
-                                "dockNum": 3
+                                "roomName": "Frost Cave",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Chozo Ice Temple",
-                                "dockNum": 0
+                                "roomName": "Control Tower",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Research Lab Aether": {
                     "pickups": [
@@ -2550,19 +2544,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Specimen Storage",
-                                "dockNum": 0
+                                "roomName": "Lower Edge Tunnel",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Pike Access",
+                                "roomName": "Observatory Access",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Phendrana's Edge": {
                     "pickups": [
@@ -2579,9 +2573,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                179.62044636104469,
-                                -1375.9207319034856,
-                                46.20776008660954
+                                141.64304990679898,
+                                -1378.0016928857497,
+                                75.27299645349613
                             ],
                             "jumboScan": true
                         }
@@ -2589,31 +2583,31 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Aether Lab Entryway",
-                                "dockNum": 0
+                                "roomName": "Hydra Lab Entryway",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Magmoor Caverns South",
-                                "dockNum": 1
+                                "roomName": "East Tower",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Research Core Access",
-                                "dockNum": 0
+                                "roomName": "Chozo Ice Temple",
+                                "dockNum": 1
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Quarantine Access",
-                                "dockNum": 1
+                                "roomName": "Chozo Ice Temple",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Gravity Chamber": {
                     "pickups": [
@@ -2647,19 +2641,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Temple Entryway",
+                                "roomName": "Chozo Ice Temple",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Courtyard Entryway",
+                                "roomName": "Chozo Ice Temple",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Storage Cave": {
                     "pickups": [
@@ -2680,13 +2674,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hunter Cave",
-                                "dockNum": 1
+                                "roomName": "Ice Ruins West",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Security Cave": {
                     "pickups": [
@@ -2707,13 +2701,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Frost Cave",
-                                "dockNum": 1
+                                "roomName": "Phendrana Shorelines",
+                                "dockNum": 3
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 }
             }
         },
@@ -2737,14 +2731,13 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -20.04602132823615,
-                                224.09621441899571,
-                                39.14345602750485
+                                -63.843634090848525,
+                                222.2410255845275,
+                                16.384511872925223
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
                     "superheated": false,
                     "submerge": true
                 },
@@ -2763,9 +2756,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                19.77577871760946,
-                                62.35321849772693,
-                                5.875754171091754
+                                25.26742944803008,
+                                59.40636867462952,
+                                5.672679808753825
                             ],
                             "jumboScan": true
                         }
@@ -2773,8 +2766,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Biotech Research Area 1",
-                                "dockNum": 0
+                                "roomName": "Biotech Research Area 2",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -2796,9 +2789,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                24.63133044385122,
-                                3.173326685487548,
-                                5.302833855135074
+                                25.254613056776705,
+                                1.8886511481180603,
+                                8.710474266287576
                             ],
                             "jumboScan": true
                         }
@@ -2806,19 +2799,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Deck Beta Transit Hall",
-                                "dockNum": 0
+                                "roomName": "Main Ventilation Shaft Section E",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Biohazard Containment",
-                                "dockNum": 0
+                                "roomName": "Connection Elevator to Deck Beta",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Deck Alpha Mech Shaft": {
                     "pickups": [
@@ -2835,16 +2828,15 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -3.1181434010132802,
-                                49.230752807024274,
-                                6.835358244634307
+                                -3.7117491051817026,
+                                58.07294542715077,
+                                7.2349037420200695
                             ],
                             "jumboScan": true
                         }
                     ],
-                    "doors": {},
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Emergency Evacuation Area": {
                     "pickups": [
@@ -2861,9 +2853,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                17.882456786150723,
-                                -22.513539127995173,
-                                15.246375890972217
+                                11.420455570850354,
+                                -44.512755051054796,
+                                14.431768593514871
                             ],
                             "jumboScan": true
                         }
@@ -2871,19 +2863,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section B",
+                                "roomName": "Air Lock",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section F",
-                                "dockNum": 0
+                                "roomName": "Connection Elevator to Deck Beta (2)",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Connection Elevator to Deck Alpha": {
                     "pickups": [
@@ -2900,9 +2892,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                34.850845909180926,
-                                65.68198077335026,
-                                -11.716288052747935
+                                -0.10937530733090206,
+                                64.9534745246305,
+                                -44.4597109178969
                             ],
                             "jumboScan": true
                         }
@@ -2910,8 +2902,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Deck Alpha Umbilical Hall",
-                                "dockNum": 1
+                                "roomName": "Deck Alpha Access Hall",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -2933,9 +2925,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                16.262209131556475,
-                                -92.83163030163517,
-                                4.7614592272314304
+                                13.827022075396775,
+                                -78.31695276030676,
+                                -0.20135013845826355
                             ],
                             "jumboScan": true
                         }
@@ -2943,14 +2935,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Cargo Freight Lift to Deck Gamma",
+                                "roomName": "Deck Beta Conduit Hall",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Biotech Research Area 2",
-                                "dockNum": 0
+                                "roomName": "Biohazard Containment",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -2972,9 +2964,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                77.47139124605803,
-                                81.5760614469277,
-                                77.79151019738251
+                                134.92083191796632,
+                                74.77964696117382,
+                                -7.050634257181137
                             ],
                             "jumboScan": true
                         }
@@ -2988,13 +2980,13 @@
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section E",
-                                "dockNum": 1
+                                "roomName": "Reactor Core Entrance",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Map Facility": {
                     "pickups": [
@@ -3011,9 +3003,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                0.6927910931755932,
-                                -117.46881962029187,
-                                7.7728093331972525
+                                -23.72424442881634,
+                                -126.0514305313467,
+                                6.967649632528503
                             ],
                             "jumboScan": true
                         }
@@ -3021,19 +3013,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Reactor Core",
-                                "dockNum": 1
+                                "roomName": "Cargo Freight Lift to Deck Gamma",
+                                "dockNum": 3
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Deck Beta Conduit Hall",
+                                "roomName": "Main Ventilation Shaft Section A",
                                 "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Main Ventilation Shaft Section F": {
                     "pickups": [
@@ -3050,9 +3042,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                191.9489125983775,
-                                3.7515907757042815,
-                                -56.536852197833454
+                                184.79255189045548,
+                                -2.7533112555480823,
+                                -53.89116467732522
                             ],
                             "jumboScan": true
                         }
@@ -3060,14 +3052,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Map Facility",
-                                "dockNum": 1
+                                "roomName": "Biohazard Containment",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Connection Elevator to Deck Beta (2)",
-                                "dockNum": 1
+                                "roomName": "Main Ventilation Shaft Section B",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -3089,9 +3081,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                4.448983645941647,
-                                -140.3939424241445,
-                                -9.06037771383695
+                                6.974108245618484,
+                                -150.78318211580753,
+                                -8.344357938007725
                             ],
                             "jumboScan": true
                         }
@@ -3099,19 +3091,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Deck Alpha Umbilical Hall",
+                                "roomName": "Main Ventilation Shaft Section D",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section B",
-                                "dockNum": 1
+                                "roomName": "Main Ventilation Shaft Section E",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Main Ventilation Shaft Section E": {
                     "pickups": [
@@ -3128,9 +3120,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                207.9667837172617,
-                                -21.054723118042315,
-                                -53.583169590913414
+                                237.52155253752443,
+                                -19.53345734039304,
+                                -55.376643975087994
                             ],
                             "jumboScan": true
                         }
@@ -3138,19 +3130,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Deck Beta Conduit Hall",
+                                "roomName": "Deck Gamma Monitor Hall",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Deck Gamma Monitor Hall",
+                                "roomName": "Deck Beta Conduit Hall",
                                 "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Deck Beta Conduit Hall": {
                     "pickups": [
@@ -3167,9 +3159,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                18.98125428438673,
-                                -168.50407575727297,
-                                -35.520564463780445
+                                13.461859628137436,
+                                -170.07905086864935,
+                                -33.738537857953105
                             ],
                             "jumboScan": true
                         }
@@ -3177,18 +3169,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Emergency Evacuation Area",
+                                "roomName": "Biotech Research Area 2",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Reactor Core Entrance",
+                                "roomName": "Deck Beta Transit Hall",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": true
                 },
                 "Main Ventilation Shaft Section D": {
@@ -3206,9 +3198,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                247.98492691121533,
-                                -92.04009772924371,
-                                -57.83300721082516
+                                237.55802229996155,
+                                -52.62924436860345,
+                                -59.9634526871892
                             ],
                             "jumboScan": true
                         }
@@ -3216,19 +3208,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Reactor Core",
-                                "dockNum": 0
+                                "roomName": "Reactor Core Entrance",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Deck Beta Security Hall",
+                                "roomName": "Biotech Research Area 1",
                                 "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Biotech Research Area 1": {
                     "pickups": [
@@ -3245,9 +3237,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                58.014383688791526,
-                                -196.44918382864682,
-                                6.409472211969806
+                                82.56918268456147,
+                                -178.24891695751768,
+                                -34.39879991134315
                             ],
                             "jumboScan": true
                         }
@@ -3255,24 +3247,24 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section C",
-                                "dockNum": 1
+                                "roomName": "Main Ventilation Shaft Section F",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section E",
-                                "dockNum": 0
+                                "roomName": "Subventilation Shaft Section A",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Connection Elevator to Deck Alpha",
+                                "roomName": "Main Ventilation Shaft Section C",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Main Ventilation Shaft Section C": {
@@ -3290,9 +3282,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                308.33906988726176,
-                                -105.19793591808593,
-                                -44.36432948454757
+                                314.67277531663564,
+                                -134.3297605719137,
+                                -44.145488811829395
                             ],
                             "jumboScan": true
                         }
@@ -3300,19 +3292,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Subventilation Shaft Section B",
-                                "dockNum": 1
+                                "roomName": "Connection Elevator to Deck Beta (2)",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Reactor Core Entrance",
-                                "dockNum": 0
+                                "roomName": "Reactor Core",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Deck Beta Security Hall": {
                     "pickups": [
@@ -3329,9 +3321,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                106.14346645734746,
-                                -143.43396257301546,
-                                -31.76438681237547
+                                99.96965583216672,
+                                -163.89728460935999,
+                                -31.869897307224385
                             ],
                             "jumboScan": true
                         }
@@ -3340,13 +3332,13 @@
                         "0": {
                             "destination": {
                                 "roomName": "Deck Beta Transit Hall",
-                                "dockNum": 1
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Map Facility",
-                                "dockNum": 0
+                                "roomName": "Subventilation Shaft Section B",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -3368,9 +3360,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                89.46920060351788,
-                                -246.0127426263901,
-                                -66.50206370156697
+                                100.17100068019711,
+                                -246.2194416532461,
+                                -59.77020948290985
                             ],
                             "jumboScan": true
                         }
@@ -3378,18 +3370,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Biotech Research Area 2",
+                                "roomName": "Deck Beta Security Hall",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Deck Alpha Access Hall",
-                                "dockNum": 0
+                                "roomName": "Main Ventilation Shaft Section F",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Subventilation Shaft Section A": {
@@ -3407,9 +3399,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                118.5632648095762,
-                                -197.23849929648463,
-                                -36.81082325429962
+                                115.50158774441647,
+                                -202.22333909753326,
+                                -41.18699424667567
                             ],
                             "jumboScan": true
                         }
@@ -3417,13 +3409,13 @@
                     "doors": {
                         "1": {
                             "destination": {
-                                "roomName": "Biotech Research Area 1",
-                                "dockNum": 2
+                                "roomName": "Main Ventilation Shaft Section D",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Main Ventilation Shaft Section B": {
                     "pickups": [
@@ -3440,9 +3432,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                284.26244244903666,
-                                -133.96306675169959,
-                                -63.387945883014375
+                                253.89560499364265,
+                                -135.52739452277785,
+                                -58.149105787345164
                             ],
                             "jumboScan": true
                         }
@@ -3450,19 +3442,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Biohazard Containment",
-                                "dockNum": 1
+                                "roomName": "Cargo Freight Lift to Deck Gamma",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Connection Elevator to Deck Beta (2)",
-                                "dockNum": 0
+                                "roomName": "Biotech Research Area 1",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Biohazard Containment": {
                     "pickups": [
@@ -3479,9 +3471,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                125.90623834616781,
-                                -94.53333880725887,
-                                -31.75953069961559
+                                98.88816137974736,
+                                -105.13839150517978,
+                                -14.348830088287276
                             ],
                             "jumboScan": true
                         }
@@ -3489,19 +3481,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Deck Gamma Monitor Hall",
-                                "dockNum": 0
+                                "roomName": "Main Ventilation Shaft Section C",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section D",
-                                "dockNum": 0
+                                "roomName": "Deck Gamma Monitor Hall",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Deck Gamma Monitor Hall": {
                     "pickups": [
@@ -3518,9 +3510,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                126.34676557210804,
-                                -277.5535932825769,
-                                -88.05673950716061
+                                134.40867187655536,
+                                -295.1452679523455,
+                                -85.39740618712504
                             ],
                             "jumboScan": true
                         }
@@ -3528,19 +3520,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section A",
-                                "dockNum": 1
+                                "roomName": "Deck Beta Security Hall",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Deck Beta Security Hall",
+                                "roomName": "Map Facility",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Subventilation Shaft Section B": {
                     "pickups": [
@@ -3557,9 +3549,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                163.05512117183454,
-                                -204.14859868336953,
-                                -60.03360998744673
+                                163.13016551158566,
+                                -193.94962079923147,
+                                -76.1484725441784
                             ],
                             "jumboScan": true
                         }
@@ -3567,12 +3559,12 @@
                     "doors": {
                         "1": {
                             "destination": {
-                                "roomName": "Biotech Research Area 1",
-                                "dockNum": 1
+                                "roomName": "Emergency Evacuation Area",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Main Ventilation Shaft Section A": {
@@ -3590,9 +3582,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                207.9189610691529,
-                                -183.126095112398,
-                                -78.01704842800957
+                                221.79243938938177,
+                                -177.47870911273526,
+                                -67.19068126133375
                             ],
                             "jumboScan": true
                         }
@@ -3600,12 +3592,12 @@
                     "doors": {
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section D",
-                                "dockNum": 1
+                                "roomName": "Biotech Research Area 1",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": true
                 },
                 "Deck Beta Transit Hall": {
@@ -3623,9 +3615,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                165.75319953722814,
-                                -116.37728028162617,
-                                -18.155001460479433
+                                143.27623078280843,
+                                -119.96728943552726,
+                                -17.621394313931514
                             ],
                             "jumboScan": true
                         }
@@ -3633,18 +3625,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Emergency Evacuation Area",
-                                "dockNum": 1
+                                "roomName": "Deck Alpha Umbilical Hall",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section F",
+                                "roomName": "Map Facility",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Reactor Core": {
@@ -3662,9 +3654,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                198.57450311994054,
-                                -358.88237429642413,
-                                -68.0268609083289
+                                152.4825285126885,
+                                -358.13059215757755,
+                                -57.16067203721792
                             ],
                             "jumboScan": true
                         }
@@ -3672,19 +3664,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Air Lock",
-                                "dockNum": 0
+                                "roomName": "Deck Alpha Umbilical Hall",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Connection Elevator to Deck Beta",
+                                "roomName": "Main Ventilation Shaft Section B",
                                 "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Cargo Freight Lift to Deck Gamma": {
                     "pickups": [
@@ -3701,9 +3693,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                193.23516901762406,
-                                -215.05209167085738,
-                                -24.512599570427255
+                                183.5824553559667,
+                                -219.9460369009794,
+                                -72.8428827437311
                             ],
                             "jumboScan": true
                         }
@@ -3711,8 +3703,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Subventilation Shaft Section A",
-                                "dockNum": 1
+                                "roomName": "Connection Elevator to Deck Alpha",
+                                "dockNum": 0
                             }
                         },
                         "3": {
@@ -3740,9 +3732,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                187.31814794357624,
-                                -261.3492439864848,
-                                -73.3573657054261
+                                180.17148072624101,
+                                -248.85514351231484,
+                                -86.55587511638933
                             ],
                             "jumboScan": true
                         }
@@ -3750,13 +3742,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Biotech Research Area 2",
+                                "roomName": "Emergency Evacuation Area",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Deck Gamma Monitor Hall",
+                                "roomName": "Reactor Core",
                                 "dockNum": 1
                             }
                         }
@@ -3790,9 +3782,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -119.54228783533937,
-                                319.101101083459,
-                                78.29040540468407
+                                -117.91549587807425,
+                                311.0183661709289,
+                                83.95266472277272
                             ],
                             "jumboScan": true
                         }
@@ -3800,8 +3792,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport Tunnel C",
-                                "dockNum": 1
+                                "roomName": "Warrior Shrine",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -3823,9 +3815,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -128.54521167439813,
-                                181.09245717260833,
-                                39.46381284088704
+                                -114.5154505097031,
+                                266.4104901560596,
+                                16.01361200340995
                             ],
                             "jumboScan": true
                         }
@@ -3833,20 +3825,20 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Plasma Processing",
+                                "roomName": "Transport Tunnel B",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Monitor Tunnel",
-                                "dockNum": 0
+                                "roomName": "North Core Tunnel",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
                                 "roomName": "Fiery Shores",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         }
                     },
@@ -3868,9 +3860,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -78.85651349578295,
-                                99.44702094271769,
-                                16.008732803559734
+                                -73.90818158672593,
+                                105.65981584063556,
+                                4.698543607492221
                             ],
                             "jumboScan": true
                         }
@@ -3878,18 +3870,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Monitor Station",
-                                "dockNum": 3
+                                "roomName": "Geothermal Core",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Chozo Ruins North",
+                                "roomName": "Save Station Magmoor A",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Save Station Magmoor A": {
@@ -3907,9 +3899,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -90.78852610916216,
-                                219.5156224686094,
-                                8.424769491629709
+                                -115.8744060489512,
+                                239.41314065239231,
+                                22.852277252842658
                             ],
                             "jumboScan": true
                         }
@@ -3917,13 +3909,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Lake Tunnel",
+                                "roomName": "Geothermal Core",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Lava Lake": {
                     "pickups": [
@@ -3944,19 +3936,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Monitor Tunnel",
-                                "dockNum": 1
+                                "roomName": "Transport Tunnel C",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
                                 "roomName": "Transport Tunnel A",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Pit Tunnel": {
                     "pickups": [
@@ -3973,9 +3965,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                48.56804719598535,
-                                -45.317476951398525,
-                                27.216822381732687
+                                76.95279239204416,
+                                -43.22426864891721,
+                                10.366406963605925
                             ],
                             "jumboScan": true
                         }
@@ -3983,19 +3975,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "South Core Tunnel",
+                                "roomName": "Lake Tunnel",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Phendrana Drifts North",
+                                "roomName": "Save Station Magmoor B",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Triclops Pit": {
                     "pickups": [
@@ -4016,20 +4008,20 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Burning Trail",
+                                "roomName": "Warrior Shrine",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "North Core Tunnel",
-                                "dockNum": 0
+                                "roomName": "Burning Trail",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Workstation Tunnel",
-                                "dockNum": 1
+                                "roomName": "Plasma Processing",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -4051,9 +4043,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                208.81075569899036,
-                                -142.68812434280179,
-                                31.919688097980156
+                                206.8155022412352,
+                                -173.20670427494727,
+                                29.683271069614655
                             ],
                             "jumboScan": true
                         }
@@ -4061,19 +4053,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Magmoor Workstation",
+                                "roomName": "Lava Lake",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Phazon Mines West",
+                                "roomName": "Storage Cavern",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Storage Cavern": {
                     "pickups": [
@@ -4094,8 +4086,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Magmoor Workstation",
-                                "dockNum": 1
+                                "roomName": "Monitor Station",
+                                "dockNum": 2
                             }
                         }
                     },
@@ -4117,9 +4109,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                202.42263530075823,
-                                -238.0257093093981,
-                                58.66905081841165
+                                173.4700100584335,
+                                -225.7192767533334,
+                                50.069150702371616
                             ],
                             "jumboScan": true
                         }
@@ -4127,8 +4119,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "North Core Tunnel",
-                                "dockNum": 1
+                                "roomName": "Lake Tunnel",
+                                "dockNum": 0
                             }
                         },
                         "1": {
@@ -4139,18 +4131,18 @@
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Storage Cavern",
+                                "roomName": "North Core Tunnel",
                                 "dockNum": 0
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Transport Tunnel C",
-                                "dockNum": 0
+                                "roomName": "South Core Tunnel",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Transport Tunnel A": {
@@ -4173,18 +4165,18 @@
                         "0": {
                             "destination": {
                                 "roomName": "Triclops Pit",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Tallon Overworld West",
+                                "roomName": "Magmoor Workstation",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Warrior Shrine": {
                     "pickups": [
@@ -4205,14 +4197,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Lava Lake",
+                                "roomName": "Transport to Phendrana Drifts South",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Phendrana Drifts South",
-                                "dockNum": 1
+                                "roomName": "Burning Trail",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -4238,14 +4230,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Twin Fires Tunnel",
-                                "dockNum": 1
+                                "roomName": "Triclops Pit",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Triclops Pit",
-                                "dockNum": 1
+                                "roomName": "Transport Tunnel A",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -4267,9 +4259,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                76.87586207758568,
-                                -261.56336140153576,
-                                59.52326141066406
+                                77.08356725117142,
+                                -262.2109591017304,
+                                40.819182293732624
                             ],
                             "jumboScan": true
                         }
@@ -4277,8 +4269,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Tallon Overworld West",
-                                "dockNum": 1
+                                "roomName": "Triclops Pit",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -4317,19 +4309,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport Tunnel A",
+                                "roomName": "Transport to Tallon Overworld West",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Pit Tunnel",
+                                "roomName": "Twin Fires",
                                 "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Twin Fires Tunnel",
+                                "roomName": "Transport to Chozo Ruins North",
                                 "dockNum": 0
                             }
                         }
@@ -4352,9 +4344,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                346.5449532883505,
-                                -470.2810561822839,
-                                33.01256700572961
+                                361.22944276626487,
+                                -498.7846779978332,
+                                45.73977409966683
                             ],
                             "jumboScan": true
                         }
@@ -4362,14 +4354,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Geothermal Core",
-                                "dockNum": 0
+                                "roomName": "Magmoor Workstation",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Burning Trail",
-                                "dockNum": 0
+                                "roomName": "Transport to Phendrana Drifts South",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -4391,9 +4383,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                349.1455691403838,
-                                -549.3793904123144,
-                                36.70374411732307
+                                347.8458788859655,
+                                -555.5230321009376,
+                                45.5890100162229
                             ],
                             "jumboScan": true
                         }
@@ -4401,14 +4393,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Triclops Pit",
-                                "dockNum": 2
+                                "roomName": "Pit Tunnel",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Fiery Shores",
-                                "dockNum": 2
+                                "roomName": "Transport to Phazon Mines West",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -4430,9 +4422,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                319.2941436179108,
-                                -627.3125593989221,
-                                39.62658408953081
+                                345.3790630638145,
+                                -580.0048947158839,
+                                33.015400248976334
                             ],
                             "jumboScan": true
                         }
@@ -4440,8 +4432,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Burning Trail",
-                                "dockNum": 2
+                                "roomName": "Fiery Shores",
+                                "dockNum": 0
                             }
                         },
                         "1": {
@@ -4469,9 +4461,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                290.6666833624875,
-                                -752.7034256172315,
-                                50.56655900240492
+                                308.0804429841253,
+                                -683.0073683453032,
+                                33.85749952913493
                             ],
                             "jumboScan": true
                         }
@@ -4480,13 +4472,13 @@
                         "0": {
                             "destination": {
                                 "roomName": "Shore Tunnel",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Fiery Shores",
-                                "dockNum": 1
+                                "roomName": "Workstation Tunnel",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -4508,9 +4500,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                275.8064178683361,
-                                -814.8968810834439,
-                                42.612863097488976
+                                284.531251407748,
+                                -826.8899924174326,
+                                45.71315638511351
                             ],
                             "jumboScan": true
                         }
@@ -4518,14 +4510,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Warrior Shrine",
-                                "dockNum": 0
+                                "roomName": "Magmoor Workstation",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Shore Tunnel",
-                                "dockNum": 1
+                                "roomName": "Twin Fires Tunnel",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -4547,9 +4539,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                428.1644141971865,
-                                -869.3196514570087,
-                                42.6731538780938
+                                424.6705465186797,
+                                -817.054841166256,
+                                77.30792098580162
                             ],
                             "jumboScan": true
                         }
@@ -4557,25 +4549,25 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Workstation Tunnel",
+                                "roomName": "Monitor Tunnel",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Save Station Magmoor A",
-                                "dockNum": 0
+                                "roomName": "Transport Tunnel C",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Lake Tunnel",
-                                "dockNum": 0
+                                "roomName": "Workstation Tunnel",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Plasma Processing": {
                     "pickups": [
@@ -4596,7 +4588,7 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Warrior Shrine",
+                                "roomName": "Monitor Tunnel",
                                 "dockNum": 1
                             }
                         }
@@ -4619,9 +4611,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                478.034393954282,
-                                -915.2929840922908,
-                                47.65880615181062
+                                471.7482746525942,
+                                -920.7396294968268,
+                                51.569812269599325
                             ],
                             "jumboScan": true
                         }
@@ -4629,14 +4621,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Monitor Station",
-                                "dockNum": 1
+                                "roomName": "Transport to Tallon Overworld West",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport Tunnel B",
-                                "dockNum": 0
+                                "roomName": "Lava Lake",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -4662,20 +4654,20 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Save Station Magmoor B",
+                                "roomName": "South Core Tunnel",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Lake Tunnel",
+                                "roomName": "South Core Tunnel",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Transport Tunnel B",
-                                "dockNum": 1
+                                "roomName": "South Core Tunnel",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -4697,9 +4689,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                464.8273068983411,
-                                -1118.8950985850827,
-                                55.432580347158336
+                                465.72460891832935,
+                                -1064.5736392725428,
+                                49.15048653295195
                             ],
                             "jumboScan": true
                         }
@@ -4708,17 +4700,17 @@
                         "0": {
                             "destination": {
                                 "roomName": "Monitor Station",
-                                "dockNum": 2
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Twin Fires",
-                                "dockNum": 1
+                                "roomName": "Shore Tunnel",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Transport Tunnel C": {
@@ -4736,9 +4728,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                363.99222493610597,
-                                -988.4793594105502,
-                                48.803321582622104
+                                357.7368042509348,
+                                -983.6939414877553,
+                                50.13345369762341
                             ],
                             "jumboScan": true
                         }
@@ -4746,19 +4738,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Geothermal Core",
-                                "dockNum": 1
+                                "roomName": "Monitor Station",
+                                "dockNum": 3
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "South Core Tunnel",
-                                "dockNum": 0
+                                "roomName": "Burning Trail",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Transport to Phazon Mines West": {
                     "pickups": [
@@ -4775,9 +4767,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                486.3710662148865,
-                                -1175.405913103737,
-                                58.36504740334955
+                                506.56097767272684,
+                                -1182.0404558369862,
+                                51.61126687402063
                             ],
                             "jumboScan": true
                         }
@@ -4785,7 +4777,7 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Phendrana Drifts South",
+                                "roomName": "Twin Fires",
                                 "dockNum": 0
                             }
                         }
@@ -4808,9 +4800,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                326.3831022919284,
-                                -955.0249819332253,
-                                66.86449631209263
+                                317.47021818835657,
+                                -960.1483747600411,
+                                69.4686841129187
                             ],
                             "jumboScan": true
                         }
@@ -4818,18 +4810,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Twin Fires",
+                                "roomName": "Transport to Phendrana Drifts North",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "South Core Tunnel",
-                                "dockNum": 0
+                                "roomName": "Twin Fires Tunnel",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Save Station Magmoor B": {
@@ -4847,9 +4839,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                284.932645342864,
-                                -961.6804800773735,
-                                45.5090150072285
+                                298.4517100900763,
+                                -961.8544860994238,
+                                45.081702681598536
                             ],
                             "jumboScan": true
                         }
@@ -4888,9 +4880,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                274.3423991359065,
-                                114.97807507314587,
-                                55.71756477226863
+                                271.50447223325756,
+                                113.97398865661529,
+                                27.626261025722027
                             ],
                             "jumboScan": true
                         }
@@ -4898,8 +4890,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Storage Depot B",
-                                "dockNum": 0
+                                "roomName": "Elite Control",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -4921,9 +4913,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                210.5424147503455,
-                                100.51764269081936,
-                                27.82606753688395
+                                220.50990035689617,
+                                74.8403507254054,
+                                41.19933099981442
                             ],
                             "jumboScan": true
                         }
@@ -4931,18 +4923,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Metroid Quarantine B",
-                                "dockNum": 1
+                                "roomName": "Fungal Hall Access",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Omega Research",
-                                "dockNum": 2
+                                "roomName": "Maintenance Tunnel",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Main Quarry": {
@@ -4964,31 +4956,31 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Research Access",
-                                "dockNum": 1
+                                "roomName": "Transport to Magmoor Caverns South",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Phazon Mining Tunnel",
+                                "roomName": "Elite Control Access",
                                 "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Ventilation Shaft",
+                                "roomName": "Dynamo Access",
                                 "dockNum": 1
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Security Access B",
-                                "dockNum": 1
+                                "roomName": "Elevator Access A",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Waste Disposal": {
                     "pickups": [
@@ -5005,9 +4997,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                100.13316526889281,
-                                127.62368190654445,
-                                55.27353835711138
+                                100.56918206019651,
+                                126.00882622163536,
+                                53.33903918890951
                             ],
                             "jumboScan": true
                         }
@@ -5015,19 +5007,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Save Station Mines C",
-                                "dockNum": 0
+                                "roomName": "Mine Security Station",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Quarantine Access B",
-                                "dockNum": 0
+                                "roomName": "Metroid Quarantine B",
+                                "dockNum": 2
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Save Station Mines A": {
                     "pickups": [
@@ -5044,9 +5036,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                135.94383561865436,
-                                -17.73960199586488,
-                                17.501301552770354
+                                141.141045037475,
+                                -2.5691643977560332,
+                                17.965126264701738
                             ],
                             "jumboScan": true
                         }
@@ -5054,13 +5046,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elite Research",
-                                "dockNum": 0
+                                "roomName": "Phazon Processing Center",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Security Access A": {
                     "pickups": [
@@ -5081,13 +5073,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Omega Research",
-                                "dockNum": 1
+                                "roomName": "Metroid Quarantine A",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Metroid Quarantine B",
+                                "roomName": "Waste Disposal",
                                 "dockNum": 0
                             }
                         }
@@ -5110,9 +5102,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                81.7687000274424,
-                                183.834630416377,
-                                55.898805701463544
+                                109.3084731031395,
+                                176.49952529123834,
+                                53.31631150362868
                             ],
                             "jumboScan": true
                         }
@@ -5120,31 +5112,31 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Save Station Mines A",
+                                "roomName": "Security Access A",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Fungal Hall Access",
-                                "dockNum": 1
+                                "roomName": "Elevator Access B",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Transport Access",
-                                "dockNum": 1
+                                "roomName": "Quarry Access",
+                                "dockNum": 0
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Elite Quarters Access",
-                                "dockNum": 1
+                                "roomName": "Quarantine Access A",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Mine Security Station": {
                     "pickups": [
@@ -5161,9 +5153,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                16.911444353377824,
-                                -4.687627865161975,
-                                15.186295167407959
+                                -20.98544323269368,
+                                -3.6820630173879465,
+                                1.1771418187048894
                             ],
                             "jumboScan": true
                         }
@@ -5171,19 +5163,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elevator B",
+                                "roomName": "Storage Depot B",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport Access",
-                                "dockNum": 0
+                                "roomName": "Quarry Access",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Map Station Mines",
+                                "roomName": "Missile Station Mines",
                                 "dockNum": 0
                             }
                         }
@@ -5206,9 +5198,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                37.402139294477095,
-                                156.59934580034997,
-                                50.15222225050201
+                                33.04041728406031,
+                                158.19808802761807,
+                                53.219865948573776
                             ],
                             "jumboScan": true
                         }
@@ -5216,19 +5208,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elite Control",
-                                "dockNum": 2
+                                "roomName": "Main Quarry",
+                                "dockNum": 3
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Metroid Quarantine B",
-                                "dockNum": 2
+                                "roomName": "Elevator A",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Storage Depot B": {
                     "pickups": [
@@ -5250,7 +5242,7 @@
                         "0": {
                             "destination": {
                                 "roomName": "Main Quarry",
-                                "dockNum": 2
+                                "dockNum": 0
                             }
                         }
                     },
@@ -5272,9 +5264,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                46.683422646245276,
-                                191.58783607465605,
-                                60.91102295472218
+                                60.34999981526833,
+                                176.9342122713988,
+                                43.87448517349569
                             ],
                             "jumboScan": true
                         }
@@ -5282,14 +5274,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elite Quarters",
+                                "roomName": "Elite Research",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Elite Control",
-                                "dockNum": 0
+                                "roomName": "Elite Quarters",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -5311,9 +5303,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -29.247590039919608,
-                                78.77104039488549,
-                                8.207978412853107
+                                -6.698662310876305,
+                                68.42170879613266,
+                                23.62089160475658
                             ],
                             "jumboScan": true
                         }
@@ -5321,18 +5313,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elevator A",
-                                "dockNum": 0
+                                "roomName": "Main Quarry",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Fungal Hall A",
-                                "dockNum": 1
+                                "roomName": "Central Dynamo",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Storage Depot A": {
@@ -5354,12 +5346,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phazon Processing Center",
-                                "dockNum": 1
+                                "roomName": "Omega Research",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": true
                 },
                 "Elite Research": {
@@ -5394,14 +5386,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Quarantine Access B",
+                                "roomName": "Processing Center Access",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Processing Center Access",
-                                "dockNum": 1
+                                "roomName": "Dynamo Access",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -5423,9 +5415,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                33.59204048921499,
-                                204.223700349354,
-                                -18.337427489711473
+                                16.272261059875632,
+                                192.24508511714308,
+                                -5.297551851124624
                             ],
                             "jumboScan": true
                         }
@@ -5433,18 +5425,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Waste Disposal",
-                                "dockNum": 0
+                                "roomName": "Fungal Hall Access",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Fungal Hall Access",
-                                "dockNum": 0
+                                "roomName": "Elite Quarters Access",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Elite Control Access": {
@@ -5466,14 +5458,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Quarry",
+                                "roomName": "Phazon Processing Center",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
                                 "roomName": "Metroid Quarantine A",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         }
                     },
@@ -5495,9 +5487,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                22.56526922148525,
-                                94.29359124518493,
-                                -22.396109217644543
+                                21.418292158763823,
+                                108.04690008867816,
+                                -27.013674400600117
                             ],
                             "jumboScan": true
                         }
@@ -5505,19 +5497,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Waste Disposal",
+                                "roomName": "Quarantine Access B",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Elite Quarters Access",
+                                "roomName": "Research Access",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Transport to Magmoor Caverns South",
+                                "roomName": "Save Station Mines B",
                                 "dockNum": 0
                             }
                         }
@@ -5540,9 +5532,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -13.874727958436196,
-                                81.90692357509715,
-                                -70.15877545818579
+                                -48.72288557003932,
+                                116.35017228549879,
+                                -71.73091752536544
                             ],
                             "jumboScan": true
                         }
@@ -5550,14 +5542,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Central Dynamo",
-                                "dockNum": 0
+                                "roomName": "Main Quarry",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Fungal Hall B",
-                                "dockNum": 1
+                                "roomName": "Elevator A",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -5584,18 +5576,18 @@
                         "0": {
                             "destination": {
                                 "roomName": "Ore Processing",
-                                "dockNum": 2
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Elevator A",
+                                "roomName": "Mine Security Station",
                                 "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Phazon Processing Center": {
                     "pickups": [
@@ -5616,20 +5608,20 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elevator Access B",
+                                "roomName": "Security Access B",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Quarry Access",
+                                "roomName": "Ventilation Shaft",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Elevator Access A",
-                                "dockNum": 0
+                                "roomName": "Security Access A",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -5651,9 +5643,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                10.21848082650012,
-                                12.997482939253047,
-                                -39.71672907989842
+                                50.19489394592593,
+                                -16.281327929185046,
+                                -70.58490923631862
                             ],
                             "jumboScan": true
                         }
@@ -5661,14 +5653,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elite Control Access",
-                                "dockNum": 1
+                                "roomName": "Processing Center Access",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
                                 "roomName": "Maintenance Tunnel",
-                                "dockNum": 1
+                                "dockNum": 0
                             }
                         },
                         "2": {
@@ -5679,7 +5671,7 @@
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Transport Access": {
                     "pickups": [
@@ -5696,9 +5688,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -127.13760372527807,
-                                156.9889083514437,
-                                -8.740780421174478
+                                -126.75420101646733,
+                                175.74454278221185,
+                                -20.573184475823286
                             ],
                             "jumboScan": true
                         }
@@ -5706,19 +5698,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Fungal Hall B",
+                                "roomName": "Elite Control",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Fungal Hall A",
-                                "dockNum": 0
+                                "roomName": "Ore Processing",
+                                "dockNum": 3
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Processing Center Access": {
                     "pickups": [
@@ -5740,18 +5732,18 @@
                         "0": {
                             "destination": {
                                 "roomName": "Ore Processing",
-                                "dockNum": 1
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Omega Research",
-                                "dockNum": 0
+                                "roomName": "Central Dynamo",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Map Station Mines": {
                     "pickups": [
@@ -5768,9 +5760,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                23.89648746594995,
-                                -72.6519505204504,
-                                -46.58871936241985
+                                33.47298037278857,
+                                -55.691859513143015,
+                                -46.03492612678798
                             ],
                             "jumboScan": true
                         }
@@ -5778,13 +5770,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phazon Processing Center",
-                                "dockNum": 2
+                                "roomName": "Elite Quarters",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Dynamo Access": {
                     "pickups": [
@@ -5801,9 +5793,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                80.47968394329209,
-                                -37.78256674982261,
-                                -83.47201805268931
+                                117.6570068378594,
+                                -40.55167034165328,
+                                -85.3322189799308
                             ],
                             "jumboScan": true
                         }
@@ -5811,19 +5803,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elite Research",
+                                "roomName": "Fungal Hall A",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Mine Security Station",
+                                "roomName": "Elite Control",
                                 "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Transport to Magmoor Caverns South": {
                     "pickups": [
@@ -5840,9 +5832,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -112.70148520892542,
-                                198.73862412363044,
-                                7.830713688519822
+                                -132.66669436975354,
+                                203.80739251857824,
+                                -38.20886453111603
                             ],
                             "jumboScan": true
                         }
@@ -5850,8 +5842,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Quarantine Access A",
-                                "dockNum": 1
+                                "roomName": "Ore Processing",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -5877,14 +5869,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Quarry Access",
-                                "dockNum": 1
+                                "roomName": "Storage Depot A",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Dynamo Access",
-                                "dockNum": 0
+                                "roomName": "Transport Access",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -5910,19 +5902,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elevator Access A",
-                                "dockNum": 1
+                                "roomName": "Save Station Mines C",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Processing Center Access",
+                                "roomName": "Elite Quarters Access",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Missile Station Mines",
+                                "roomName": "Elite Control Access",
                                 "dockNum": 0
                             }
                         }
@@ -5945,9 +5937,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -148.65613150549837,
-                                -68.79231372096451,
-                                -135.24881054849328
+                                -118.26168226817431,
+                                -67.61523351519698,
+                                -147.3122389515176
                             ],
                             "jumboScan": true
                         }
@@ -5955,19 +5947,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Central Dynamo",
+                                "roomName": "Omega Research",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Fungal Hall B",
-                                "dockNum": 2
+                                "roomName": "Waste Disposal",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Quarantine Access A": {
                     "pickups": [
@@ -5984,9 +5976,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                167.42068837308423,
-                                126.81446107257,
-                                -78.68283894981487
+                                165.48003514065545,
+                                102.95523465881654,
+                                -81.25197693576166
                             ],
                             "jumboScan": true
                         }
@@ -5994,14 +5986,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phazon Mining Tunnel",
+                                "roomName": "Fungal Hall B",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Research Access",
-                                "dockNum": 0
+                                "roomName": "Ventilation Shaft",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -6023,9 +6015,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                180.22789245417903,
-                                -26.49488291795793,
-                                -91.31301893341919
+                                169.47794401745824,
+                                -35.2438091259168,
+                                -90.52224816551532
                             ],
                             "jumboScan": true
                         }
@@ -6033,12 +6025,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Metroid Quarantine A",
+                                "roomName": "Elite Research",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Metroid Quarantine B": {
@@ -6060,24 +6052,24 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elevator B",
-                                "dockNum": 1
+                                "roomName": "Phazon Mining Tunnel",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Save Station Mines B",
-                                "dockNum": 0
+                                "roomName": "Elevator B",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Maintenance Tunnel",
-                                "dockNum": 0
+                                "roomName": "Quarantine Access A",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Metroid Quarantine A": {
@@ -6099,19 +6091,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ventilation Shaft",
-                                "dockNum": 0
+                                "roomName": "Phazon Mining Tunnel",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Security Access A",
-                                "dockNum": 0
+                                "roomName": "Security Access B",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Quarantine Access B": {
                     "pickups": [
@@ -6128,9 +6120,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                93.94055778373502,
-                                -50.28102063040695,
-                                -146.41316595838876
+                                106.40902098092249,
+                                -67.36279040774046,
+                                -146.99147984730288
                             ],
                             "jumboScan": true
                         }
@@ -6138,18 +6130,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ore Processing",
-                                "dockNum": 3
+                                "roomName": "Central Dynamo",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Elite Control",
-                                "dockNum": 1
+                                "roomName": "Omega Research",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Save Station Mines C": {
@@ -6167,9 +6159,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -68.25503398025177,
-                                -175.99278039654592,
-                                -144.0245391250119
+                                -70.17835117672394,
+                                -170.9459287700455,
+                                -151.6940253857683
                             ],
                             "jumboScan": true
                         }
@@ -6177,13 +6169,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Quarry",
-                                "dockNum": 3
+                                "roomName": "Fungal Hall A",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Elevator Access B": {
                     "pickups": [
@@ -6200,9 +6192,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                187.24023989698776,
-                                333.0465359324371,
-                                -51.1696578691154
+                                169.92800533222695,
+                                331.48380339391116,
+                                -81.57371563030443
                             ],
                             "jumboScan": true
                         }
@@ -6210,18 +6202,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elite Quarters",
-                                "dockNum": 1
+                                "roomName": "Metroid Quarantine B",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Central Dynamo",
-                                "dockNum": 2
+                                "roomName": "Phazon Processing Center",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": true
                 },
                 "Fungal Hall B": {
@@ -6243,25 +6235,25 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Tallon Overworld South",
+                                "roomName": "Map Station Mines",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Security Access A",
-                                "dockNum": 1
+                                "roomName": "Transport Access",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Security Access B",
-                                "dockNum": 0
+                                "roomName": "Research Access",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Elevator B": {
                     "pickups": [
@@ -6278,9 +6270,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                170.53612887002473,
-                                405.3902953964015,
-                                -94.57796484469671
+                                171.96855273589665,
+                                406.18091846454826,
+                                -92.46223686951974
                             ],
                             "jumboScan": true
                         }
@@ -6288,18 +6280,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ore Processing",
-                                "dockNum": 0
+                                "roomName": "Fungal Hall B",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Dynamo Access",
-                                "dockNum": 1
+                                "roomName": "Save Station Mines A",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Missile Station Mines": {
@@ -6317,9 +6309,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                238.41320283444608,
-                                15.460499500475446,
-                                -141.19654558818908
+                                206.0448271621656,
+                                12.36843572061045,
+                                -142.24580721668298
                             ],
                             "jumboScan": true
                         }
@@ -6327,12 +6319,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Quarry",
-                                "dockNum": 0
+                                "roomName": "Metroid Quarantine B",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Phazon Mining Tunnel": {
@@ -6354,13 +6346,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Phazon Processing Center",
+                                "roomName": "Elevator B",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Mine Security Station",
+                                "roomName": "Quarantine Access B",
                                 "dockNum": 0
                             }
                         }
@@ -6387,14 +6379,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Quarantine Access A",
-                                "dockNum": 0
+                                "roomName": "Fungal Hall B",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Elite Control Access",
-                                "dockNum": 0
+                                "roomName": "Elevator Access A",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -6416,9 +6408,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                154.10316250743494,
-                                293.8167341449175,
-                                -155.13850288932485
+                                118.95784244278325,
+                                207.43417068503322,
+                                -150.70426750042267
                             ],
                             "jumboScan": true
                         }
@@ -6426,13 +6418,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Storage Depot A",
+                                "roomName": "Transport to Tallon Overworld South",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Elevator B",
+                                "roomName": "Mine Security Station",
                                 "dockNum": 0
                             }
                         }
@@ -6471,32 +6463,32 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Temple Lobby",
-                                "dockNum": 1
+                                "roomName": "Arbor Chamber",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Deck Beta Conduit Hall",
+                                "roomName": "Main Ventilation Shaft Section C",
                                 "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Transport to Magmoor Caverns East",
+                                "roomName": "Transport Tunnel C",
                                 "dockNum": 0
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Savestation",
-                                "dockNum": 0
+                                "roomName": "Deck Beta Security Hall",
+                                "dockNum": 1
                             }
                         },
                         "4": {
                             "destination": {
-                                "roomName": "Deck Beta Transit Hall",
-                                "dockNum": 1
+                                "roomName": "Savestation",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -6518,9 +6510,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -434.9253172016451,
-                                383.91800753351123,
-                                3.5613378465411856
+                                -456.6191406611688,
+                                402.0117587344575,
+                                4.453451455863366
                             ],
                             "jumboScan": true
                         }
@@ -6528,18 +6520,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Temple Hall",
-                                "dockNum": 0
+                                "roomName": "Biotech Research Area 1",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Great Tree Hall",
-                                "dockNum": 3
+                                "roomName": "Hydro Access Tunnel",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Canyon Cavern": {
@@ -6557,9 +6549,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -447.13735715975247,
-                                336.01581207027397,
-                                -21.553506151515528
+                                -417.2163538544762,
+                                374.6960673175164,
+                                -9.978168222208687
                             ],
                             "jumboScan": true
                         }
@@ -6567,19 +6559,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Connection Elevator to Deck Beta",
-                                "dockNum": 1
+                                "roomName": "Biotech Research Area 1",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Great Tree Chamber",
+                                "roomName": "Reactor Access",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Temple Hall": {
                     "pickups": [
@@ -6596,9 +6588,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -382.3095410048726,
-                                290.3379320521832,
-                                -15.248770438751297
+                                -383.27598124314795,
+                                271.2762408609678,
+                                -12.357268568621667
                             ],
                             "jumboScan": true
                         }
@@ -6606,18 +6598,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Tallon Canyon",
+                                "roomName": "Connection Elevator to Deck Beta",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Canyon Cavern",
-                                "dockNum": 1
+                                "roomName": "Transport to Phazon Mines East",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Alcove": {
@@ -6639,13 +6631,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Life Grove Tunnel",
-                                "dockNum": 1
+                                "roomName": "Frigate Crash Site",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Waterfall Cavern": {
                     "pickups": [
@@ -6662,9 +6654,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -277.00039876496396,
-                                417.79287845879105,
-                                -28.923997363104437
+                                -262.6715086798832,
+                                428.06102653888826,
+                                -32.443498559352456
                             ],
                             "jumboScan": true
                         }
@@ -6672,14 +6664,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport Tunnel B",
+                                "roomName": "Main Ventilation Shaft Section A",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Deck Beta Conduit Hall",
-                                "dockNum": 0
+                                "roomName": "Reactor Access",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -6701,9 +6693,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -477.8745532933544,
-                                380.7067835751812,
-                                26.813052960773746
+                                -544.7007720433162,
+                                381.15413366438446,
+                                3.151184691385673
                             ],
                             "jumboScan": true
                         }
@@ -6711,30 +6703,30 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport Tunnel D",
+                                "roomName": "Frigate Access Tunnel",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section C",
+                                "roomName": "Deck Beta Security Hall",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Transport to Phazon Mines East",
+                                "roomName": "Great Tree Chamber",
                                 "dockNum": 0
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Waterfall Cavern",
-                                "dockNum": 0
+                                "roomName": "Main Ventilation Shaft Section B",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Temple Security Station": {
@@ -6752,9 +6744,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -393.9281715061148,
-                                173.0143017490451,
-                                -6.889062054142306
+                                -394.25315375910475,
+                                217.48687887841044,
+                                -2.637143430213186
                             ],
                             "jumboScan": true
                         }
@@ -6762,13 +6754,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Cargo Freight Lift to Deck Gamma",
-                                "dockNum": 0
+                                "roomName": "Great Tree Hall",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Root Tunnel",
+                                "roomName": "Cargo Freight Lift to Deck Gamma",
                                 "dockNum": 1
                             }
                         }
@@ -6796,18 +6788,18 @@
                         "0": {
                             "destination": {
                                 "roomName": "Gully",
-                                "dockNum": 1
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section C",
-                                "dockNum": 1
+                                "roomName": "Canyon Cavern",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Canyon Cavern",
+                                "roomName": "Transport to Magmoor Caverns East",
                                 "dockNum": 0
                             }
                         }
@@ -6830,9 +6822,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -532.5967740901139,
-                                417.33004116161925,
-                                -17.413367254125482
+                                -530.066589541215,
+                                449.57734168869956,
+                                -21.724744995645594
                             ],
                             "jumboScan": true
                         }
@@ -6840,14 +6832,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Landing Site",
-                                "dockNum": 3
+                                "roomName": "Root Cave",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Biohazard Containment",
-                                "dockNum": 0
+                                "roomName": "Landing Site",
+                                "dockNum": 3
                             }
                         }
                     },
@@ -6869,9 +6861,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -605.789066533653,
-                                337.4527447016792,
-                                -4.302139013282808
+                                -616.9229575817819,
+                                332.6870934601104,
+                                -4.574686343412367
                             ],
                             "jumboScan": true
                         }
@@ -6879,19 +6871,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Gully",
+                                "roomName": "Reactor Core",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport Tunnel A",
-                                "dockNum": 1
+                                "roomName": "Biohazard Containment",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Temple Lobby": {
                     "pickups": [
@@ -6908,9 +6900,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -378.795902781023,
-                                150.0572679270685,
-                                -10.050756772805794
+                                -368.0014032474325,
+                                116.55317011267982,
+                                -9.013338892010086
                             ],
                             "jumboScan": true
                         }
@@ -6918,8 +6910,8 @@
                     "doors": {
                         "1": {
                             "destination": {
-                                "roomName": "Transport Tunnel D",
-                                "dockNum": 1
+                                "roomName": "Tallon Canyon",
+                                "dockNum": 2
                             }
                         }
                     },
@@ -6941,9 +6933,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -45.574974117240686,
-                                468.92191839282134,
-                                -39.235257353752594
+                                -38.00628523495034,
+                                482.2754632970207,
+                                -43.315302961360885
                             ],
                             "jumboScan": true
                         }
@@ -6951,19 +6943,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport Tunnel A",
+                                "roomName": "Landing Site",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Great Tree Hall",
-                                "dockNum": 4
+                                "roomName": "Root Cave",
+                                "dockNum": 2
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Overgrown Cavern": {
                     "pickups": [
@@ -6984,18 +6976,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport Tunnel E",
-                                "dockNum": 1
+                                "roomName": "Great Tree Hall",
+                                "dockNum": 3
                             }
                         },
                         "1": {
                             "destination": {
                                 "roomName": "Temple Security Station",
-                                "dockNum": 1
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Transport to Chozo Ruins West": {
@@ -7013,9 +7005,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -517.082098012113,
-                                475.8575352144481,
-                                13.613088152038124
+                                -518.8973021818215,
+                                467.71023292018583,
+                                9.284142890275177
                             ],
                             "jumboScan": true
                         }
@@ -7023,13 +7015,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Overgrown Cavern",
+                                "roomName": "Great Tree Hall",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Root Cave": {
                     "pickups": [
@@ -7050,20 +7042,20 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Frigate Access Tunnel",
-                                "dockNum": 1
+                                "roomName": "Deck Beta Conduit Hall",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section A",
-                                "dockNum": 1
+                                "roomName": "Transport to Chozo Ruins West",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Temple Security Station",
-                                "dockNum": 0
+                                "roomName": "Transport Tunnel E",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -7086,8 +7078,7 @@
                             "showIcon": true
                         }
                     ],
-                    "doors": {},
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Main Ventilation Shaft Section C": {
@@ -7105,9 +7096,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -16.43232130752398,
-                                526.563786206234,
-                                -42.15139223760332
+                                -10.946239669449117,
+                                488.20038285280026,
+                                -51.656724741048606
                             ],
                             "jumboScan": true
                         }
@@ -7115,19 +7106,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Root Cave",
+                                "roomName": "Frigate Crash Site",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Landing Site",
-                                "dockNum": 2
+                                "roomName": "Biohazard Containment",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Transport Tunnel C": {
                     "pickups": [
@@ -7144,9 +7135,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -130.9004573174843,
-                                591.9694058804148,
-                                83.22457272074759
+                                -80.86039846947342,
+                                669.7371941485226,
+                                51.699665029035664
                             ],
                             "jumboScan": true
                         }
@@ -7154,18 +7145,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Frigate Crash Site",
+                                "roomName": "Life Grove Tunnel",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Alcove",
-                                "dockNum": 0
+                                "roomName": "Waterfall Cavern",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Transport Tunnel B": {
@@ -7187,14 +7178,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Frigate Crash Site",
-                                "dockNum": 1
+                                "roomName": "Reactor Access",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Great Tree Hall",
-                                "dockNum": 0
+                                "roomName": "Temple Security Station",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -7220,13 +7211,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport Tunnel E",
-                                "dockNum": 0
+                                "roomName": "Transport Tunnel B",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Main Ventilation Shaft Section B": {
                     "pickups": [
@@ -7243,9 +7234,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                27.339777391799185,
-                                488.38569333380656,
-                                -24.954492237674394
+                                38.91785874971944,
+                                458.3967358623705,
+                                -21.32722425341767
                             ],
                             "jumboScan": true
                         }
@@ -7253,14 +7244,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Connection Elevator to Deck Beta",
-                                "dockNum": 0
+                                "roomName": "Life Grove Tunnel",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Temple Hall",
-                                "dockNum": 1
+                                "roomName": "Transport Tunnel A",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -7282,9 +7273,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -28.753002838885056,
-                                664.4407428931136,
-                                27.65732088940669
+                                -41.08978705370485,
+                                669.8047254105473,
+                                24.428384373649273
                             ],
                             "jumboScan": true
                         }
@@ -7292,7 +7283,7 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section B",
+                                "roomName": "Deck Beta Conduit Hall",
                                 "dockNum": 1
                             }
                         }
@@ -7315,9 +7306,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -691.2941808359417,
-                                200.83029207229248,
-                                -74.71527703872069
+                                -691.171144382053,
+                                206.96616217943796,
+                                -75.7154762413313
                             ],
                             "jumboScan": true
                         }
@@ -7325,8 +7316,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section B",
-                                "dockNum": 0
+                                "roomName": "Overgrown Cavern",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -7348,9 +7339,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                47.303207438743776,
-                                405.2553119744269,
-                                -72.45979126240123
+                                88.27437741992367,
+                                421.3381480265895,
+                                -64.15904423667753
                             ],
                             "jumboScan": true
                         }
@@ -7358,19 +7349,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Deck Beta Security Hall",
+                                "roomName": "Transport Tunnel E",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
                                 "roomName": "Transport Tunnel B",
-                                "dockNum": 1
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Reactor Core": {
                     "pickups": [
@@ -7387,9 +7378,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                36.67645743772371,
-                                349.17637793195024,
-                                -136.08218451201236
+                                58.250021802159885,
+                                332.97066691023304,
+                                -107.4437930772452
                             ],
                             "jumboScan": true
                         }
@@ -7397,19 +7388,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Chozo Ruins West",
+                                "roomName": "Main Ventilation Shaft Section C",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Arbor Chamber",
+                                "roomName": "Transport to Chozo Ruins East",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Reactor Access": {
                     "pickups": [
@@ -7426,9 +7417,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                10.92203795702272,
-                                355.48209319343044,
-                                -102.85851818170538
+                                13.872687555972426,
+                                371.19655770020006,
+                                -112.6319490683524
                             ],
                             "jumboScan": true
                         }
@@ -7436,20 +7427,20 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Biohazard Containment",
-                                "dockNum": 1
+                                "roomName": "Root Tunnel",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Main Ventilation Shaft Section A",
+                                "roomName": "Connection Elevator to Deck Beta",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
                                 "roomName": "Tallon Canyon",
-                                "dockNum": 0
+                                "dockNum": 3
                             }
                         }
                     },
@@ -7475,18 +7466,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Chozo Ruins East",
+                                "roomName": "Transport to Chozo Ruins South",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport Tunnel C",
+                                "roomName": "Hydro Access Tunnel",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Savestation": {
@@ -7504,9 +7495,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                7.45776924123559,
-                                387.48497167564335,
-                                -107.59505196608914
+                                1.6273083862944446,
+                                382.6011251996101,
+                                -104.82014994245655
                             ],
                             "jumboScan": true
                         }
@@ -7514,13 +7505,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Cargo Freight Lift to Deck Gamma",
-                                "dockNum": 1
+                                "roomName": "Great Tree Hall",
+                                "dockNum": 4
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Deck Beta Transit Hall": {
                     "pickups": [
@@ -7537,9 +7528,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -130.7248532525802,
-                                298.463642625308,
-                                -52.73187476758616
+                                -131.79211455381562,
+                                302.6465600576295,
+                                -56.03506195127824
                             ],
                             "jumboScan": true
                         }
@@ -7547,19 +7538,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Reactor Access",
-                                "dockNum": 2
+                                "roomName": "Landing Site",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Root Cave",
-                                "dockNum": 0
+                                "roomName": "Frigate Crash Site",
+                                "dockNum": 2
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Biohazard Containment": {
                     "pickups": [
@@ -7581,17 +7572,17 @@
                         "0": {
                             "destination": {
                                 "roomName": "Waterfall Cavern",
-                                "dockNum": 1
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Overgrown Cavern",
+                                "roomName": "Temple Lobby",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Deck Beta Security Hall": {
@@ -7609,9 +7600,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -89.2427557230716,
-                                255.72378873419544,
-                                -70.95499217077031
+                                -96.09539542655583,
+                                255.10397094708523,
+                                -69.06803765943577
                             ],
                             "jumboScan": true
                         }
@@ -7619,14 +7610,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Landing Site",
-                                "dockNum": 4
+                                "roomName": "Cargo Freight Lift to Deck Gamma",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Reactor Core",
-                                "dockNum": 1
+                                "roomName": "Life Grove",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -7648,9 +7639,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -41.50640002389708,
-                                203.89013837720242,
-                                -63.349586413530076
+                                -39.20086364924887,
+                                228.7014596913667,
+                                -67.01903826748648
                             ],
                             "jumboScan": true
                         }
@@ -7658,18 +7649,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Frigate Access Tunnel",
-                                "dockNum": 0
+                                "roomName": "Temple Hall",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Hydro Access Tunnel",
+                                "roomName": "Transport Tunnel D",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Deck Beta Conduit Hall": {
@@ -7687,9 +7678,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -83.77835300563416,
-                                185.0850911962621,
-                                -58.18240103770514
+                                -56.96956713378118,
+                                183.2992805785526,
+                                -58.71799716842075
                             ],
                             "jumboScan": true
                         }
@@ -7697,19 +7688,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Great Tree Hall",
-                                "dockNum": 2
+                                "roomName": "Landing Site",
+                                "dockNum": 4
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Root Cave",
-                                "dockNum": 2
+                                "roomName": "Reactor Core",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Connection Elevator to Deck Beta": {
                     "pickups": [
@@ -7726,9 +7717,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -112.37458197884119,
-                                172.61434626861,
-                                -47.23038072177698
+                                -112.6060540152306,
+                                156.51077897574007,
+                                -43.6479330603929
                             ],
                             "jumboScan": true
                         }
@@ -7736,14 +7727,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Tallon Canyon",
-                                "dockNum": 2
+                                "roomName": "Main Ventilation Shaft Section A",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport Tunnel C",
-                                "dockNum": 0
+                                "roomName": "Deck Beta Transit Hall",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -7769,13 +7760,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Reactor Core",
-                                "dockNum": 0
+                                "roomName": "Frigate Access Tunnel",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Life Grove",
+                                "roomName": "Temple Hall",
                                 "dockNum": 0
                             }
                         }
@@ -7798,9 +7789,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                38.51443605572856,
-                                138.9385253526874,
-                                -46.670358288128114
+                                -15.501846773916498,
+                                123.20651386232271,
+                                26.64786623183214
                             ],
                             "jumboScan": true
                         }
@@ -7808,37 +7799,37 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Root Tunnel",
-                                "dockNum": 0
+                                "roomName": "Gully",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Deck Beta Transit Hall",
+                                "roomName": "Main Ventilation Shaft Section B",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Reactor Access",
+                                "roomName": "Transport Tunnel A",
                                 "dockNum": 1
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Transport to Chozo Ruins South",
-                                "dockNum": 0
+                                "roomName": "Canyon Cavern",
+                                "dockNum": 1
                             }
                         },
                         "4": {
                             "destination": {
-                                "roomName": "Deck Beta Security Hall",
+                                "roomName": "Transport Tunnel C",
                                 "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Great Tree Chamber": {
                     "pickups": [
@@ -7859,7 +7850,7 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Biotech Research Area 1",
+                                "roomName": "Root Cave",
                                 "dockNum": 0
                             }
                         }
@@ -7882,9 +7873,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                14.022590936871506,
-                                191.6476649116706,
-                                -6.209067799194093
+                                6.721215870451641,
+                                189.34602613963042,
+                                -7.14633252189453
                             ],
                             "jumboScan": true
                         }
@@ -7893,13 +7884,13 @@
                         "0": {
                             "destination": {
                                 "roomName": "Landing Site",
-                                "dockNum": 0
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Frigate Crash Site",
-                                "dockNum": 2
+                                "roomName": "Tallon Canyon",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -7925,13 +7916,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Tallon Canyon",
-                                "dockNum": 3
+                                "roomName": "Root Tunnel",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Reactor Access",
+                                "roomName": "Overgrown Cavern",
                                 "dockNum": 0
                             }
                         }
@@ -7954,9 +7945,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -2.361728501788244,
-                                47.49451599896163,
-                                -45.942128622439
+                                20.395060033947225,
+                                91.21309820369899,
+                                -57.3218481537202
                             ],
                             "jumboScan": true
                         }
@@ -7964,19 +7955,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Landing Site",
-                                "dockNum": 1
+                                "roomName": "Tallon Canyon",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Life Grove Tunnel",
+                                "roomName": "Deck Beta Transit Hall",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Transport to Chozo Ruins South": {
                     "pickups": [
@@ -7993,9 +7984,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                32.723727362390086,
-                                220.80342686913124,
-                                -7.252000604148396
+                                34.253014830985435,
+                                238.2897139936149,
+                                13.533203792824153
                             ],
                             "jumboScan": true
                         }
@@ -8003,12 +7994,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hydro Access Tunnel",
+                                "roomName": "Great Tree Hall",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Life Grove": {
@@ -8043,7 +8034,7 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Gully",
+                                "roomName": "Alcove",
                                 "dockNum": 0
                             }
                         }
@@ -8066,9 +8057,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -17.824036276916466,
-                                16.934187138522674,
-                                -48.34629927643015
+                                -38.02759661502495,
+                                22.299625499310345,
+                                -73.78684466904656
                             ],
                             "jumboScan": true
                         }
@@ -8076,13 +8067,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Great Tree Hall",
+                                "roomName": "Transport Tunnel D",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 }
             }
         },
@@ -8109,9 +8100,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                91.52764865944404,
-                                -158.53965695311913,
-                                22.94986982537612
+                                93.88559980671289,
+                                -162.94294013773592,
+                                29.516051599282306
                             ],
                             "jumboScan": true
                         }
@@ -8119,12 +8110,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Save Station 2",
+                                "roomName": "Gathering Hall Access",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Ruins Entrance": {
@@ -8142,9 +8133,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                87.7132561644951,
-                                -117.47042223035575,
-                                24.65220717944578
+                                119.00551847386282,
+                                -71.61068717418661,
+                                14.925619679561674
                             ],
                             "jumboScan": true
                         }
@@ -8152,19 +8143,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Meditation Fountain",
+                                "roomName": "West Furnace Access",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Tallon Overworld East",
-                                "dockNum": 0
+                                "roomName": "Sunchamber Lobby",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Main Plaza": {
                     "pickups": [
@@ -8224,43 +8215,43 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Sunchamber Lobby",
-                                "dockNum": 0
+                                "roomName": "Eyon Tunnel",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "East Furnace Access",
-                                "dockNum": 1
+                                "roomName": "Map Station",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Burn Dome Access",
+                                "roomName": "North Atrium",
                                 "dockNum": 1
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Dynamo Access",
+                                "roomName": "Sun Tower Access",
                                 "dockNum": 1
                             }
                         },
                         "4": {
                             "destination": {
-                                "roomName": "East Atrium",
-                                "dockNum": 0
+                                "roomName": "Elder Hall Access",
+                                "dockNum": 1
                             }
                         },
                         "5": {
                             "destination": {
-                                "roomName": "Watery Hall Access",
-                                "dockNum": 0
+                                "roomName": "Dynamo Access",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Ruined Fountain Access": {
                     "pickups": [
@@ -8277,9 +8268,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                147.81433270103622,
-                                -20.75011136698154,
-                                23.971183170944876
+                                190.8495444782783,
+                                -27.47506032799729,
+                                27.045128156500038
                             ],
                             "jumboScan": true
                         }
@@ -8287,18 +8278,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Furnace",
-                                "dockNum": 2
+                                "roomName": "Hall of the Elders",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Ruined Nursery",
-                                "dockNum": 2
+                                "roomName": "Reflecting Pool",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Ruined Shrine Access": {
@@ -8316,9 +8307,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                39.58727897409895,
-                                -0.24796837862552223,
-                                6.380421056690122
+                                54.21256701579273,
+                                -2.4424092276413063,
+                                2.01803098703327
                             ],
                             "jumboScan": true
                         }
@@ -8326,13 +8317,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Magma Pool",
-                                "dockNum": 1
+                                "roomName": "Hall of the Elders",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Dynamo",
+                                "roomName": "Crossway",
                                 "dockNum": 0
                             }
                         }
@@ -8355,9 +8346,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                62.31831942344945,
-                                69.69637567424402,
-                                5.86450828051902
+                                64.21920125757492,
+                                73.39498780127927,
+                                8.509580819632792
                             ],
                             "jumboScan": true
                         }
@@ -8365,19 +8356,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Energy Core",
-                                "dockNum": 0
+                                "roomName": "Crossway",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Sunchamber Lobby",
-                                "dockNum": 1
+                                "roomName": "Sun Tower",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Plaza Access": {
                     "pickups": [
@@ -8394,9 +8385,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                184.00739433152805,
-                                93.24093659739273,
-                                32.47732531002337
+                                182.81818706745537,
+                                117.93349826644328,
+                                33.469490083060705
                             ],
                             "jumboScan": true
                         }
@@ -8405,17 +8396,17 @@
                         "0": {
                             "destination": {
                                 "roomName": "Reflecting Pool",
-                                "dockNum": 3
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Arboretum",
-                                "dockNum": 2
+                                "roomName": "Energy Core",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Piston Tunnel": {
@@ -8433,9 +8424,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                122.2440270379804,
-                                -87.3370151282109,
-                                29.950903474849383
+                                122.20764611341994,
+                                -96.62623049422432,
+                                28.047953795596193
                             ],
                             "jumboScan": true
                         }
@@ -8443,19 +8434,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Plaza Access",
-                                "dockNum": 0
+                                "roomName": "Ruined Shrine Access",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Crossway Access South",
-                                "dockNum": 0
+                                "roomName": "Save Station 3",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Ruined Fountain": {
                     "pickups": [
@@ -8476,24 +8467,24 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "West Furnace Access",
+                                "roomName": "Burn Dome Access",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Training Chamber Access",
-                                "dockNum": 1
+                                "roomName": "Vault",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Dynamo Access",
-                                "dockNum": 0
+                                "roomName": "Vault Access",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Ruined Shrine": {
@@ -8541,14 +8532,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Training Chamber Access",
-                                "dockNum": 0
+                                "roomName": "Piston Tunnel",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Piston Tunnel",
-                                "dockNum": 1
+                                "roomName": "Save Station 3",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -8570,9 +8561,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                11.774255667760968,
-                                115.67938443924709,
-                                8.134254569990018
+                                -8.210425771100205,
+                                105.71349410476464,
+                                4.541833113185222
                             ],
                             "jumboScan": true
                         }
@@ -8580,18 +8571,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Plaza",
-                                "dockNum": 3
+                                "roomName": "Gathering Hall",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Watery Hall",
-                                "dockNum": 0
+                                "roomName": "Ruined Fountain",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Vault": {
@@ -8613,19 +8604,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Fountain",
-                                "dockNum": 1
+                                "roomName": "Ruined Shrine",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Magmoor Caverns North",
-                                "dockNum": 0
+                                "roomName": "Ruined Nursery",
+                                "dockNum": 2
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Training Chamber": {
                     "pickups": [
@@ -8646,13 +8637,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Magmoor Caverns North",
-                                "dockNum": 1
+                                "roomName": "Vault Access",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Save Station 3",
+                                "roomName": "Transport to Tallon Overworld South",
                                 "dockNum": 0
                             }
                         }
@@ -8675,9 +8666,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                285.4773272890953,
-                                -65.51246745292737,
-                                46.697232588481825
+                                256.37460405375225,
+                                -109.39418722649265,
+                                61.13067316358398
                             ],
                             "jumboScan": true
                         }
@@ -8686,18 +8677,18 @@
                         "0": {
                             "destination": {
                                 "roomName": "Crossway",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Burn Dome",
+                                "roomName": "Tower of Light",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Meditation Fountain": {
                     "pickups": [
@@ -8714,9 +8705,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                219.34877509665426,
-                                -122.05865343733878,
-                                27.02278675126508
+                                222.41058096723702,
+                                -132.66316295222686,
+                                27.72814310163777
                             ],
                             "jumboScan": true
                         }
@@ -8730,8 +8721,8 @@
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Arboretum Access",
-                                "dockNum": 0
+                                "roomName": "Gathering Hall Access",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -8753,9 +8744,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -130.2427493039896,
-                                21.341242029971344,
-                                24.654946728847165
+                                -133.75936130325618,
+                                2.239736429236811,
+                                24.977315524922954
                             ],
                             "jumboScan": true
                         }
@@ -8763,19 +8754,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Plaza",
-                                "dockNum": 5
+                                "roomName": "Hall of the Elders",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Gathering Hall",
+                                "roomName": "Training Chamber",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": true
+                    "superheated": true,
+                    "submerge": false
                 },
                 "Ruined Nursery": {
                     "pickups": [
@@ -8796,24 +8787,24 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Crossway Access West",
+                                "roomName": "Transport to Magmoor Caverns North",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Ruined Shrine Access",
+                                "roomName": "Arboretum Access",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
                                 "roomName": "Burn Dome Access",
-                                "dockNum": 0
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Vault Access": {
@@ -8831,9 +8822,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                169.39576956607746,
-                                241.34899379657602,
-                                24.20877330837167
+                                173.5062051858044,
+                                299.95742545445364,
+                                21.11261676810183
                             ],
                             "jumboScan": true
                         }
@@ -8841,13 +8832,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Plaza",
+                                "roomName": "Gathering Hall",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Furnace",
+                                "roomName": "Crossway Access West",
                                 "dockNum": 0
                             }
                         }
@@ -8874,14 +8865,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Plaza",
-                                "dockNum": 2
+                                "roomName": "Arboretum Access",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Tower of Light",
-                                "dockNum": 0
+                                "roomName": "Energy Core",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -8903,9 +8894,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                325.30866847476295,
-                                -72.45062964810394,
-                                43.51626818342606
+                                335.57805005445204,
+                                -65.42020638903065,
+                                15.445019200746557
                             ],
                             "jumboScan": true
                         }
@@ -8913,20 +8904,20 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Totem Access",
-                                "dockNum": 1
+                                "roomName": "Transport Access South",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Vault Access",
-                                "dockNum": 1
+                                "roomName": "Nursery Access",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Map Station",
-                                "dockNum": 0
+                                "roomName": "Crossway Access West",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -8952,19 +8943,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Reflecting Pool Access",
+                                "roomName": "Tower Chamber",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport to Tallon Overworld North",
-                                "dockNum": 0
+                                "roomName": "Reflecting Pool",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Tower of Light": {
                     "pickups": [
@@ -8985,19 +8976,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Shrine Access",
+                                "roomName": "Transport Access North",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Elder Chamber",
+                                "roomName": "Transport to Magmoor Caverns North",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Save Station 1": {
                     "pickups": [
@@ -9014,9 +9005,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -68.30677379215435,
-                                112.60343950986379,
-                                16.299630721254548
+                                -63.93949770092685,
+                                115.57418301474746,
+                                22.369973375419143
                             ],
                             "jumboScan": true
                         }
@@ -9024,13 +9015,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Shrine",
-                                "dockNum": 0
+                                "roomName": "Tower of Light Access",
+                                "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "North Atrium": {
                     "pickups": [
@@ -9047,9 +9038,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -40.13182627859184,
-                                186.13633627536217,
-                                12.414725815890701
+                                -10.908864733318346,
+                                165.75269762230448,
+                                17.863222460242955
                             ],
                             "jumboScan": true
                         }
@@ -9057,14 +9048,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hall of the Elders",
+                                "roomName": "Furnace",
                                 "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Gathering Hall",
-                                "dockNum": 1
+                                "roomName": "Hall of the Elders",
+                                "dockNum": 3
                             }
                         }
                     },
@@ -9086,9 +9077,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                193.83405571614915,
-                                334.5645813118809,
-                                13.529891035494042
+                                193.77806458427526,
+                                330.2890738764326,
+                                20.96167236750645
                             ],
                             "jumboScan": true
                         }
@@ -9096,25 +9087,25 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Crossway",
-                                "dockNum": 2
+                                "roomName": "East Atrium",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Gathering Hall Access",
-                                "dockNum": 0
+                                "roomName": "Magma Pool",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Tower Chamber",
+                                "roomName": "Elder Chamber",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Sunchamber Lobby": {
                     "pickups": [
@@ -9131,9 +9122,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                296.14129411697394,
-                                -18.41835629087317,
-                                66.10648264379388
+                                292.90872001706606,
+                                -18.76837881385481,
+                                58.58010991447345
                             ],
                             "jumboScan": true
                         }
@@ -9141,13 +9132,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Sun Tower",
+                                "roomName": "Ruined Nursery",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Crossway",
+                                "roomName": "Watery Hall",
                                 "dockNum": 1
                             }
                         }
@@ -9170,9 +9161,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                388.5336806398326,
-                                -101.17809829722935,
-                                28.074646254347925
+                                366.37437377331446,
+                                -108.47274188821255,
+                                18.068728288953267
                             ],
                             "jumboScan": true
                         }
@@ -9180,18 +9171,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Main Plaza",
+                                "roomName": "Vault",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Hive Totem",
-                                "dockNum": 1
+                                "roomName": "Ruins Entrance",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Tower Chamber": {
@@ -9213,13 +9204,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Save Station 3",
-                                "dockNum": 1
+                                "roomName": "Reflecting Pool",
+                                "dockNum": 3
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Ruined Gallery": {
                     "pickups": [
@@ -9253,19 +9244,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Magmoor Caverns North",
-                                "dockNum": 2
+                                "roomName": "Transport Access South",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "East Furnace Access",
+                                "roomName": "Save Station 2",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Sun Tower Access",
+                                "roomName": "Ruins Entrance",
                                 "dockNum": 1
                             }
                         }
@@ -9288,9 +9279,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                255.46130867222857,
-                                336.0943438529773,
-                                66.7929835478185
+                                252.8468105262315,
+                                331.88353613852183,
+                                74.5335568443846
                             ],
                             "jumboScan": true
                         }
@@ -9298,19 +9289,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Elder Hall Access",
-                                "dockNum": 1
+                                "roomName": "Totem Access",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport Access North",
-                                "dockNum": 1
+                                "roomName": "Crossway Access South",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Transport Access North": {
                     "pickups": [
@@ -9331,14 +9322,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Arboretum",
-                                "dockNum": 0
+                                "roomName": "Gathering Hall",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Training Chamber",
-                                "dockNum": 1
+                                "roomName": "Furnace",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -9360,9 +9351,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                289.87485502046076,
-                                27.203409003217686,
-                                71.69927036896824
+                                281.5552476565997,
+                                28.612293156714316,
+                                72.37806165115757
                             ],
                             "jumboScan": true
                         }
@@ -9370,13 +9361,13 @@
                     "doors": {
                         "1": {
                             "destination": {
-                                "roomName": "Hall of the Elders",
-                                "dockNum": 4
+                                "roomName": "Hive Totem",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Gathering Hall": {
                     "pickups": [
@@ -9397,30 +9388,30 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Reflecting Pool",
+                                "roomName": "North Atrium",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Energy Core Access",
-                                "dockNum": 1
+                                "roomName": "Save Station 1",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Meditation Fountain",
-                                "dockNum": 0
+                                "roomName": "Sunchamber Access",
+                                "dockNum": 1
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Sunchamber Access",
-                                "dockNum": 1
+                                "roomName": "East Furnace Access",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": true
                 },
                 "Totem Access": {
@@ -9438,9 +9429,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                27.979045723424207,
-                                282.3363955961814,
-                                4.663874159765765
+                                -9.182667729661032,
+                                261.0936604475907,
+                                0.6914163518096532
                             ],
                             "jumboScan": true
                         }
@@ -9448,18 +9439,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Gathering Hall",
-                                "dockNum": 2
+                                "roomName": "Training Chamber",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Ruined Fountain",
-                                "dockNum": 2
+                                "roomName": "Dynamo Access",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Map Station": {
@@ -9477,9 +9468,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                -26.213804123875136,
-                                207.24838799682476,
-                                14.004115915768399
+                                -22.87723483421132,
+                                203.0067297278131,
+                                11.223637389369765
                             ],
                             "jumboScan": true
                         }
@@ -9487,13 +9478,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hall of the Elders",
+                                "roomName": "Ruined Fountain",
                                 "dockNum": 1
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Sun Tower Access": {
                     "pickups": [
@@ -9510,9 +9501,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                301.54999629109653,
-                                313.64507690324604,
-                                81.07659727057295
+                                280.56010378132135,
+                                252.07600886947031,
+                                73.71104823589604
                             ],
                             "jumboScan": true
                         }
@@ -9520,8 +9511,8 @@
                     "doors": {
                         "1": {
                             "destination": {
-                                "roomName": "Nursery Access",
-                                "dockNum": 1
+                                "roomName": "Elder Hall Access",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -9547,18 +9538,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Eyon Tunnel",
-                                "dockNum": 1
+                                "roomName": "Transport to Magmoor Caverns North",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Arboretum Access",
+                                "roomName": "East Furnace Access",
                                 "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Sunchamber": {
@@ -9590,9 +9581,8 @@
                             "showIcon": true
                         }
                     ],
-                    "doors": {},
                     "superheated": true,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Watery Hall Access": {
                     "pickups": [
@@ -9613,18 +9603,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Furnace",
-                                "dockNum": 1
+                                "roomName": "Ruined Shrine Access",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport Access North",
-                                "dockNum": 0
+                                "roomName": "Main Plaza",
+                                "dockNum": 2
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Save Station 2": {
@@ -9642,9 +9632,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                415.37997056980043,
-                                -162.91753287114977,
-                                30.54038101139856
+                                415.08679186727767,
+                                -159.63864321127375,
+                                28.046819873903125
                             ],
                             "jumboScan": true
                         }
@@ -9652,13 +9642,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Energy Core",
-                                "dockNum": 2
+                                "roomName": "Plaza Access",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "East Atrium": {
                     "pickups": [
@@ -9675,9 +9665,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                460.08064698119233,
-                                -106.46406393398478,
-                                48.97160688291327
+                                455.237478245504,
+                                -106.59635391541988,
+                                47.86947579414278
                             ],
                             "jumboScan": true
                         }
@@ -9685,19 +9675,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruins Entrance",
-                                "dockNum": 0
+                                "roomName": "Nursery Access",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Watery Hall",
-                                "dockNum": 1
+                                "roomName": "Watery Hall Access",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": true
+                    "superheated": false,
+                    "submerge": false
                 },
                 "Watery Hall": {
                     "pickups": [
@@ -9731,19 +9721,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Nursery Access",
-                                "dockNum": 0
+                                "roomName": "Reflecting Pool Access",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Transport Access South",
+                                "roomName": "Training Chamber Access",
                                 "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Energy Core Access": {
                     "pickups": [
@@ -9760,9 +9750,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                503.6107022633444,
-                                -160.18491378047065,
-                                45.87613320777749
+                                500.65489251853074,
+                                -142.65636738084203,
+                                45.662901896960975
                             ],
                             "jumboScan": true
                         }
@@ -9770,19 +9760,19 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Tower of Light",
+                                "roomName": "Hive Totem",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Ruined Nursery",
-                                "dockNum": 0
+                                "roomName": "Main Plaza",
+                                "dockNum": 5
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Dynamo Access": {
                     "pickups": [
@@ -9799,9 +9789,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                459.5436859345424,
-                                -35.43254844801409,
-                                30.118572736735956
+                                462.51153303829756,
+                                -15.835359665850739,
+                                26.345987214924865
                             ],
                             "jumboScan": true
                         }
@@ -9809,18 +9799,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Hall of the Elders",
-                                "dockNum": 0
+                                "roomName": "Ruined Gallery",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Ruined Gallery",
-                                "dockNum": 1
+                                "roomName": "Burn Dome",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Energy Core": {
@@ -9838,9 +9828,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                563.6742708033094,
-                                -118.47353652816878,
-                                55.13774172345697
+                                528.4570107834099,
+                                -116.69537820791379,
+                                50.181090761923386
                             ],
                             "jumboScan": true
                         }
@@ -9848,25 +9838,25 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Crossway Access South",
-                                "dockNum": 1
+                                "roomName": "East Atrium",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Vault",
-                                "dockNum": 0
+                                "roomName": "Totem Access",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Reflecting Pool",
-                                "dockNum": 1
+                                "roomName": "Transport Access North",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
-                    "submerge": false
+                    "superheated": false,
+                    "submerge": true
                 },
                 "Dynamo": {
                     "pickups": [
@@ -9900,8 +9890,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Gathering Hall",
-                                "dockNum": 3
+                                "roomName": "Ruined Nursery",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -9923,9 +9913,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                568.1632318037105,
-                                -76.16320785995313,
-                                34.051389962783134
+                                574.1001146777384,
+                                -86.13162451006231,
+                                34.81446723084672
                             ],
                             "jumboScan": true
                         }
@@ -9933,18 +9923,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Sun Tower",
+                                "roomName": "Main Plaza",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Training Chamber",
-                                "dockNum": 0
+                                "roomName": "Gathering Hall",
+                                "dockNum": 3
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "West Furnace Access": {
@@ -9962,9 +9952,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                580.2539310244539,
-                                -186.88023647471795,
-                                45.599505593070276
+                                606.9442967524571,
+                                -176.37433447018472,
+                                47.53929326426378
                             ],
                             "jumboScan": true
                         }
@@ -9972,14 +9962,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Nursery",
+                                "roomName": "Energy Core Access",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Tower of Light Access",
-                                "dockNum": 1
+                                "roomName": "Ruined Fountain",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -10018,12 +10008,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Vault Access",
+                                "roomName": "Plaza Access",
                                 "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Furnace": {
@@ -10058,20 +10048,20 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Reflecting Pool Access",
-                                "dockNum": 1
+                                "roomName": "Tower of Light Access",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "East Atrium",
-                                "dockNum": 1
+                                "roomName": "Reflecting Pool Access",
+                                "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "North Atrium",
-                                "dockNum": 1
+                                "roomName": "Dynamo",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -10093,9 +10083,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                750.361957568703,
-                                -189.4843721489541,
-                                52.61586321239778
+                                732.9074229980755,
+                                -192.67606116790836,
+                                52.64003095624199
                             ],
                             "jumboScan": true
                         }
@@ -10103,14 +10093,14 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Magma Pool",
-                                "dockNum": 0
+                                "roomName": "Arboretum",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Piston Tunnel",
-                                "dockNum": 0
+                                "roomName": "Main Plaza",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -10132,9 +10122,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                701.5383251217586,
-                                -115.35166816903725,
-                                56.32946927434808
+                                699.5921189087937,
+                                -124.55612517712078,
+                                56.16056147968773
                             ],
                             "jumboScan": true
                         }
@@ -10142,18 +10132,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Gallery",
-                                "dockNum": 2
+                                "roomName": "Main Plaza",
+                                "dockNum": 3
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Reflecting Pool",
-                                "dockNum": 2
+                                "roomName": "Hall of the Elders",
+                                "dockNum": 4
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": false
                 },
                 "Hall of the Elders": {
@@ -10175,31 +10165,31 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Watery Hall Access",
-                                "dockNum": 1
+                                "roomName": "Meditation Fountain",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Tower of Light Access",
+                                "roomName": "Eyon Tunnel",
                                 "dockNum": 0
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Energy Core Access",
+                                "roomName": "Antechamber",
                                 "dockNum": 0
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Antechamber",
+                                "roomName": "West Furnace Access",
                                 "dockNum": 0
                             }
                         },
                         "4": {
                             "destination": {
-                                "roomName": "Ruined Fountain Access",
+                                "roomName": "Energy Core Access",
                                 "dockNum": 0
                             }
                         }
@@ -10226,20 +10216,20 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Totem Access",
+                                "roomName": "Transport to Tallon Overworld East",
                                 "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "North Atrium",
-                                "dockNum": 0
+                                "roomName": "Meditation Fountain",
+                                "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Transport Access South",
-                                "dockNum": 1
+                                "roomName": "Sunchamber Lobby",
+                                "dockNum": 0
                             }
                         }
                     },
@@ -10261,9 +10251,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                774.4396840792682,
-                                -237.6060430919385,
-                                74.14926776469018
+                                773.8071806614439,
+                                -238.24076118725108,
+                                71.28846837582616
                             ],
                             "jumboScan": true
                         }
@@ -10271,18 +10261,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Gallery",
-                                "dockNum": 0
+                                "roomName": "Energy Core",
+                                "dockNum": 2
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Energy Core",
-                                "dockNum": 1
+                                "roomName": "Ruined Gallery",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Elder Hall Access": {
@@ -10300,9 +10290,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                817.2452649621081,
-                                -131.61785561855694,
-                                62.59169827875376
+                                818.5881968060545,
+                                -135.77238580192483,
+                                62.96566812147558
                             ],
                             "jumboScan": true
                         }
@@ -10310,8 +10300,8 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruins Entrance",
-                                "dockNum": 1
+                                "roomName": "Watery Hall",
+                                "dockNum": 0
                             }
                         },
                         "1": {
@@ -10321,8 +10311,8 @@
                             }
                         }
                     },
-                    "superheated": false,
-                    "submerge": false
+                    "superheated": true,
+                    "submerge": true
                 },
                 "Crossway Access South": {
                     "pickups": [
@@ -10339,9 +10329,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                775.2878980346973,
-                                -108.59293542064827,
-                                54.57846255511274
+                                784.2937393983588,
+                                -112.15531771715125,
+                                58.77119324599143
                             ],
                             "jumboScan": true
                         }
@@ -10349,13 +10339,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Transport to Tallon Overworld South",
-                                "dockNum": 0
+                                "roomName": "Ruined Shrine",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Eyon Tunnel",
+                                "roomName": "Arboretum",
                                 "dockNum": 0
                             }
                         }
@@ -10382,13 +10372,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Shrine",
-                                "dockNum": 1
+                                "roomName": "Magma Pool",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 },
                 "Reflecting Pool": {
                     "pickups": [
@@ -10405,9 +10395,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                787.1081797306706,
-                                -296.91647892120665,
-                                87.30790304318164
+                                765.1454115554463,
+                                -270.27747767845676,
+                                81.3727725117762
                             ],
                             "jumboScan": true
                         }
@@ -10415,26 +10405,26 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Vault",
+                                "roomName": "Watery Hall Access",
                                 "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Ruined Fountain Access",
+                                "roomName": "Sun Tower",
                                 "dockNum": 1
                             }
                         },
                         "2": {
                             "destination": {
-                                "roomName": "Hive Totem",
-                                "dockNum": 0
+                                "roomName": "Ruined Gallery",
+                                "dockNum": 2
                             }
                         },
                         "3": {
                             "destination": {
-                                "roomName": "Save Station 1",
-                                "dockNum": 0
+                                "roomName": "Training Chamber Access",
+                                "dockNum": 1
                             }
                         }
                     },
@@ -10456,9 +10446,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                707.644362117611,
-                                -302.29691567494467,
-                                92.79190237056477
+                                729.0472922237495,
+                                -289.1024296233735,
+                                93.24614195635883
                             ],
                             "jumboScan": true
                         }
@@ -10466,18 +10456,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Crossway Access West",
-                                "dockNum": 0
+                                "roomName": "Furnace",
+                                "dockNum": 1
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Plaza Access",
-                                "dockNum": 1
+                                "roomName": "Ruined Fountain Access",
+                                "dockNum": 0
                             }
                         }
                     },
-                    "superheated": true,
+                    "superheated": false,
                     "submerge": true
                 },
                 "Transport Access South": {
@@ -10495,9 +10485,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                781.0437883657347,
-                                -352.1000767540685,
-                                84.0347842961398
+                                773.5553035776018,
+                                -349.5520077021601,
+                                84.41256783739047
                             ],
                             "jumboScan": true
                         }
@@ -10505,18 +10495,18 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "West Furnace Access",
-                                "dockNum": 1
+                                "roomName": "Piston Tunnel",
+                                "dockNum": 0
                             }
                         },
                         "1": {
                             "destination": {
-                                "roomName": "Elder Hall Access",
-                                "dockNum": 0
+                                "roomName": "Tower of Light",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Antechamber": {
@@ -10538,13 +10528,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Gathering Hall Access",
+                                "roomName": "Crossway Access South",
                                 "dockNum": 1
                             }
                         }
                     },
                     "superheated": true,
-                    "submerge": true
+                    "submerge": false
                 },
                 "Transport to Tallon Overworld East": {
                     "pickups": [
@@ -10561,9 +10551,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                667.0291389570086,
-                                -298.1366755184243,
-                                72.30601638191905
+                                665.4535891468003,
+                                -279.31124193677954,
+                                99.02548234811778
                             ],
                             "jumboScan": true
                         }
@@ -10571,12 +10561,12 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Fountain",
-                                "dockNum": 0
+                                "roomName": "Ruined Fountain Access",
+                                "dockNum": 1
                             }
                         }
                     },
-                    "superheated": false,
+                    "superheated": true,
                     "submerge": false
                 },
                 "Transport to Tallon Overworld South": {
@@ -10594,9 +10584,9 @@
                             "respawn": false,
                             "showIcon": true,
                             "position": [
-                                761.25855228441,
-                                -401.2108071359134,
-                                83.0336036156421
+                                760.6898991287129,
+                                -390.99875969472816,
+                                95.71129691755917
                             ],
                             "jumboScan": true
                         }
@@ -10604,13 +10594,13 @@
                     "doors": {
                         "0": {
                             "destination": {
-                                "roomName": "Ruined Shrine Access",
-                                "dockNum": 1
+                                "roomName": "Transport to Tallon Overworld North",
+                                "dockNum": 0
                             }
                         }
                     },
                     "superheated": false,
-                    "submerge": false
+                    "submerge": true
                 }
             }
         }


### PR DESCRIPTION
This has the side effect of re-randomizing chaos setting seeds generated on older versions. That was never guaranteed to begin with, however.

Also, the prime patch data factory now deletes empty fields, as randomprime guarantees that empty fields and non-populated fields are the same behavior.