### PR TITLE
Fix dark agon temple logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Optimize Solver by choosing actions in a smarter order. Prefer actions of types that are likely to progress th. Postpone dangerous actions. This should make the solver able to validate seeds where it previously timed out. Solving should in general be faster in general.
 - Fixed: Solver bug that made it unable to detect dangerous actions, which could result in some possible seeds being considered impossible.
 
+### Metroid Prime 2: Echoes
+
+#### Logic Database
+
+- Added: Shoot Super Missile template
+
+##### Agon Wastes
+
+- Change: Removed SJ and Bomb Jump (beginner) requirements from Amorbis fight
+- Change: Add combat requirements to Amorbis fight
+- Change: Amorbis to Dark Suit now trivial
+
 ### Metroid Dread
 
 #### Logic Database

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### Agon Wastes
 
-- Change: Removed SJ and Bomb Jump (beginner) requirements from Amorbis fight
-- Change: Add combat requirements to Amorbis fight
-- Change: Amorbis to Dark Suit now trivial
+- Added: Proper combat requirements for the Amorbis fight.
+- Removed: Incorrect and improper connections to and from the Amorbis fight.
 
 ### Metroid Dread
 

--- a/randovania/games/prime2/json_data/Agon Wastes.json
+++ b/randovania/games/prime2/json_data/Agon Wastes.json
@@ -14551,98 +14551,7 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Activate Safe Zone"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "damage",
-                                                        "name": "DarkWorld1",
-                                                        "amount": 50,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "DarkWorld1",
-                                                                    "amount": 30,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Damage",
-                                                                    "amount": 20,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Combat",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Damage",
-                                                                    "amount": 10,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "damage",
-                                                                    "name": "DarkWorld1",
-                                                                    "amount": 20,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }
@@ -15382,26 +15291,137 @@
                                         }
                                     },
                                     {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "damage",
+                                            "name": "DarkWorld1",
+                                            "amount": 50,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Activate Safe Zone"
+                                    },
+                                    {
                                         "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "SpaceJump",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Charge",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "DarkWorld1",
+                                                                    "amount": 100,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Light",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "LightAmmo",
+                                                                                            "amount": 60,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Shoot Supers"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "BombJump",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 30,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "DarkWorld1",
+                                                                    "amount": 10,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]

--- a/randovania/games/prime2/json_data/Agon Wastes.json
+++ b/randovania/games/prime2/json_data/Agon Wastes.json
@@ -15300,8 +15300,25 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Activate Safe Zone"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "DarkWorld1",
+                                                        "amount": 30,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Activate Safe Zone"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "or",
@@ -15316,17 +15333,8 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "Charge",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
                                                                     "type": "damage",
-                                                                    "name": "DarkWorld1",
+                                                                    "name": "Damage",
                                                                     "amount": 100,
                                                                     "negate": false
                                                                 }
@@ -15337,10 +15345,23 @@
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
+                                                                            "type": "template",
+                                                                            "data": "Shoot Supers"
+                                                                        },
+                                                                        {
                                                                             "type": "and",
                                                                             "data": {
                                                                                 "comment": null,
                                                                                 "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Charge",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
                                                                                     {
                                                                                         "type": "resource",
                                                                                         "data": {
@@ -15361,10 +15382,6 @@
                                                                                     }
                                                                                 ]
                                                                             }
-                                                                        },
-                                                                        {
-                                                                            "type": "template",
-                                                                            "data": "Shoot Supers"
                                                                         }
                                                                     ]
                                                                 }

--- a/randovania/games/prime2/json_data/Agon Wastes.txt
+++ b/randovania/games/prime2/json_data/Agon Wastes.txt
@@ -1835,11 +1835,7 @@ Extra - in_dark_aether: True
   * Layers: default
   * Event Amorbis
   > Pickup (Dark Suit)
-      All of the following:
-          Dark World Damage ≥ 50 or Activate Safe Zone
-          Any of the following:
-              Normal Damage ≥ 20 and Dark World Damage ≥ 30
-              Combat (Intermediate) and Normal Damage ≥ 10 and Dark World Damage ≥ 20
+      Trivial
 
 > Safe Zone (Behind Key Gate); Heals? True
   * Layers: default
@@ -1889,8 +1885,15 @@ Extra - in_dark_aether: True
       Dark Agon Key 1 and Dark Agon Key 2 and Dark Agon Key 3 and Morph Ball Bomb and Morph Ball and Space Jump Boots and Bomb Space Jump (Expert) and Single Room Out of Bounds (Expert) and Slope Jump (Expert) and Standable Terrain (Expert) and Dark World Damage ≥ 175
   > Event - Amorbis
       All of the following:
-          Morph Ball Bomb and Morph Ball
-          Space Jump Boots or Bomb Jump (Beginner)
+          Morph Ball Bomb and Morph Ball and Dark World Damage ≥ 50 and Activate Safe Zone
+          Any of the following:
+              All of the following:
+                  Charge Beam and Dark World Damage ≥ 100
+                  Any of the following:
+                      Shoot Supers
+                      Light Beam and Light Ammo ≥ 60
+              Combat (Beginner) and Normal Damage ≥ 30
+              Combat (Intermediate) and Dark World Damage ≥ 10
 
 ----------------
 Command Center Access

--- a/randovania/games/prime2/json_data/Agon Wastes.txt
+++ b/randovania/games/prime2/json_data/Agon Wastes.txt
@@ -1885,13 +1885,14 @@ Extra - in_dark_aether: True
       Dark Agon Key 1 and Dark Agon Key 2 and Dark Agon Key 3 and Morph Ball Bomb and Morph Ball and Space Jump Boots and Bomb Space Jump (Expert) and Single Room Out of Bounds (Expert) and Slope Jump (Expert) and Standable Terrain (Expert) and Dark World Damage ≥ 175
   > Event - Amorbis
       All of the following:
-          Morph Ball Bomb and Morph Ball and Dark World Damage ≥ 50 and Activate Safe Zone
+          Morph Ball Bomb and Morph Ball and Dark World Damage ≥ 50
+          Dark World Damage ≥ 30 or Activate Safe Zone
           Any of the following:
               All of the following:
-                  Charge Beam and Dark World Damage ≥ 100
+                  Normal Damage ≥ 100
                   Any of the following:
                       Shoot Supers
-                      Light Beam and Light Ammo ≥ 60
+                      Charge Beam and Light Beam and Light Ammo ≥ 60
               Combat (Beginner) and Normal Damage ≥ 30
               Combat (Intermediate) and Dark World Damage ≥ 10
 

--- a/randovania/games/prime2/json_data/header.json
+++ b/randovania/games/prime2/json_data/header.json
@@ -1792,6 +1792,50 @@
                         }
                     ]
                 }
+            },
+            "Shoot Supers": {
+                "type": "and",
+                "data": {
+                    "comment": null,
+                    "items": [
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Charge",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Power",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Missile",
+                                "amount": 5,
+                                "negate": false
+                            }
+                        },
+                        {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Supers",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        }
+                    ]
+                }
             }
         },
         "damage_reductions": [

--- a/randovania/games/prime2/json_data/header.txt
+++ b/randovania/games/prime2/json_data/header.txt
@@ -66,6 +66,9 @@ Templates
                   Morph Ball Bomb or Power Bomb
               Knowledge (Beginner) and Use Screw Attack (Space Jump)
 
+* Shoot Supers:
+      Charge Beam and Missile ≥ 5 and Power Beam and Super Missile
+
 ====================
 Dock Weaknesses
 


### PR DESCRIPTION
Closes #4120  

### Metroid Prime 2: Echoes

#### Logic Database

- Added: Shoot Super Missile template

##### Agon Wastes

- Change: Removed SJ and Bomb Jump (beginner) requirements from Amorbis fight
- Change: Add combat requirements to Amorbis fight
- Change: Amorbis to Dark Suit now trivial