### PR TITLE
Dread: Add missing collision_camera in DB for Burenia

### DIFF
--- a/randovania/games/dread/json_data/Burenia.json
+++ b/randovania/games/dread/json_data/Burenia.json
@@ -5189,7 +5189,8 @@
                         -900.0,
                         -2115.0
                     ]
-                ]
+                ],
+                "asset_id": "collision_camera_010"
             },
             "nodes": {
                 "Dock to Main Hub Tower Middle (Left)": {
@@ -7612,7 +7613,8 @@
                         -900.0,
                         -11800.0
                     ]
-                ]
+                ],
+                "asset_id": "collision_camera_010"
             },
             "nodes": {
                 "Door to Energy Recharge South": {

--- a/randovania/games/dread/json_data/Burenia.txt
+++ b/randovania/games/dread/json_data/Burenia.txt
@@ -890,6 +890,7 @@ Extra - asset_id: collision_camera_009
 Main Hub Tower Top
 Extra - total_boundings: {'x1': -5000.0, 'x2': -900.0, 'y1': -2115.0, 'y2': 3700.0}
 Extra - polygon: [[-900.0, 3700.0], [-5000.0, 3700.0], [-5000.0, -2115.0], [-900.0, -2115.0]]
+Extra - asset_id: collision_camera_010
 > Dock to Main Hub Tower Middle (Left); Heals? False
   * Layers: default
   * Open Passage to Main Hub Tower Middle/Dock to Main Hub Tower Top (Left)
@@ -1261,6 +1262,7 @@ Extra - asset_id: collision_camera_010
 Main Hub Tower Bottom
 Extra - total_boundings: {'x1': -5000.0, 'x2': -900.0, 'y1': -11800.0, 'y2': -7000.0}
 Extra - polygon: [[-900.0, -7000.0], [-5000.0, -7000.0], [-5000.0, -10700.0], [-4700.0, -11200.0], [-4700.0, -11800.0], [-900.0, -11800.0]]
+Extra - asset_id: collision_camera_010
 > Door to Energy Recharge South; Heals? False
   * Layers: default
   * Power Beam Door to Energy Recharge South/Door to Main Hub Tower Bottom


### PR DESCRIPTION
Burenia - Main Hub Tower Top and Main Hub Tower Bottom were the only ones missing it. Checked it with a temporary integrity check.