### PR TITLE
Database Updates for Major/Minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Logic Database
 
-- Fixed: The Artifact of Truth pickup location is now a major location for Major/Minor split.
+- Fixed: The Artifact of Truth pickup is now a major location for Major/Minor split.
 
 ### Metroid Prime 2: Echoes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Selecting an ISO that isn't for Metroid Prime is now explicitly refused when exporting.
 - Fixed: All pickups in the pool are now correctly assigned major or minor.
 
+#### Logic Database
+
+- Fixed: The Artifact of Truth pickup location is now a major location for Major/Minor split.
+
 ### Metroid Prime 2: Echoes
 
 - Added: Selecting an ISO that isn't for Metroid Prime 2 is now explicitly refused when exporting.
+
+#### Logic Database
+
+- Fixed: Energy Tanks are now considered major items in Major/Minor split. 
 
 ### Metroid Dread
 
@@ -44,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Avoid treating Gravity Suit as a dangerous resource, by removing the "No Gravity Suit" constraint from the "Perform WBJ" template.
 - Changed: Going through Artaria Lower Path to Cataris using Damage Boost no longer requires Morph Ball.
 - Removed: Use Cross Bombs to skip the blob submerged in water in Artaria Early Cloak room. The point of this connection is to skip breaking the blob, which is no longer dangerous when you have the Morph Ball.
+- Fixed: Experiment Z-57's pickup is now a major item location in Major/Minor split.
 
 ### Metroid Prime
 

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -2708,7 +2708,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 141,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Z-57 Room": {
                             "type": "and",

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -512,7 +512,7 @@ Extra - asset_id: collision_camera_009
 
 > Pickup (Z-57); Heals? False
   * Layers: default
-  * Pickup 141; Category? Minor
+  * Pickup 141; Category? Major
   * Extra - pickup_type: cutscene
   * Extra - callback_function: OnExperimentDeath_CUSTOM
   * Extra - boss_hint_name: Experiment Z-57

--- a/randovania/games/prime1/json_data/Tallon Overworld.json
+++ b/randovania/games/prime1/json_data/Tallon Overworld.json
@@ -3528,7 +3528,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 63,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Door to Temple Lobby": {
                             "type": "and",

--- a/randovania/games/prime1/json_data/Tallon Overworld.txt
+++ b/randovania/games/prime1/json_data/Tallon Overworld.txt
@@ -609,7 +609,7 @@ Extra - aabb: [-576.05975, -221.71631, -188.35965, -170.50539, 225.37242, 45.510
 
 > Pickup (Artifact of Truth); Heals? False
   * Layers: default
-  * Pickup 63; Category? Minor
+  * Pickup 63; Category? Major
   * Extra - position_required: False
   > Door to Temple Lobby
       Trivial

--- a/randovania/games/prime2/item_database/item-database.json
+++ b/randovania/games/prime2/item_database/item-database.json
@@ -840,7 +840,7 @@
             "must_be_starting": false,
             "probability_offset": 1,
             "probability_multiplier": 2,
-            "preferred_location_category": "minor",
+            "preferred_location_category": "major",
             "extra": {}
         }
     },


### PR DESCRIPTION
- Fixed: The Artifact of Truth pickup is now a major location for Major/Minor split.
- Fixed: Energy Tanks are now considered major items in Echoes' Major/Minor split.
- Fixed: Experiment Z-57's pickup is now a major item location in Major/Minor split.