### PR TITLE
Add "Shuffled (avoid majors)" option to Location Pool settings

### DIFF
--- a/randovania/generator/filler/runner.py
+++ b/randovania/generator/filler/runner.py
@@ -63,6 +63,8 @@ async def run_filler(rng: Random,
         new_game, state = pool.game_generator.bootstrap.logic_bootstrap(config, pool.game,
                                                                         pool.patches)
         major_configuration = config.standard_pickup_configuration
+        all_indices_to_exclude = config.available_locations.excluded_indices.union(
+            config.available_locations.minor_only_indices)
         player_states.append(PlayerState(
             index=index,
             game=new_game,
@@ -72,7 +74,7 @@ async def run_filler(rng: Random,
                 randomization_mode=config.available_locations.randomization_mode,
                 minimum_random_starting_items=major_configuration.minimum_random_starting_pickups,
                 maximum_random_starting_items=major_configuration.maximum_random_starting_pickups,
-                indices_to_exclude=config.available_locations.excluded_indices,
+                indices_to_exclude=all_indices_to_exclude,
                 logical_resource_action=config.logical_resource_action,
                 first_progression_must_be_local=config.first_progression_must_be_local,
                 minimum_available_locations_for_hint_placement=config.minimum_available_locations_for_hint_placement,

--- a/randovania/generator/generator.py
+++ b/randovania/generator/generator.py
@@ -148,9 +148,9 @@ def _distribute_remaining_items(rng: Random,
         rng.shuffle(nodes)
         rng.shuffle(pickups)
 
-        # after shuffling, sort both lists such that locations marked as "no majors" come first and major items come last
-        # this will attempt to prevent majors from being assigned to locations marked as "no majors", but allows for such
-        # assignments to happen if there aren't enough remaining locations
+        # after shuffling, sort both lists such that locations marked as "no majors" come first and major items come
+        # last this will attempt to prevent majors from being assigned to locations marked as "no majors", but allows
+        # for such assignments to happen if there aren't enough remaining locations
         nodes.sort(key=lambda n: 0 if n in avoid_majors_pickup_nodes else 1)
         pickups.sort(
             key=lambda t: 1 if t.pickup.generator_params.preferred_location_category == LocationCategory.MAJOR else 0)

--- a/randovania/gui/preset_settings/location_pool_row_widget.py
+++ b/randovania/gui/preset_settings/location_pool_row_widget.py
@@ -3,6 +3,7 @@ from PySide6.QtWidgets import QWidget
 
 from randovania.game_description.world.pickup_node import PickupNode
 from randovania.gui.generated.widget_location_pool_row_ui import Ui_LocationPoolRowWidget
+from randovania.layout.base.available_locations import LocationPickupMode
 
 
 class LocationPoolRowWidget(QWidget, Ui_LocationPoolRowWidget):
@@ -18,18 +19,28 @@ class LocationPoolRowWidget(QWidget, Ui_LocationPoolRowWidget):
 
         self.radio_shuffled.toggled.connect(self._on_radio_changed)
         self.radio_shuffled_no_progression.toggled.connect(self._on_radio_changed)
+        self.radio_shuffled_no_majors.toggled.connect(self._on_radio_changed)
 
-    def set_can_have_progression(self, progression: bool):
-        if progression:
-            self.radio_shuffled.setChecked(True)
-        else:
+    def set_location_pickup_mode(self, mode: LocationPickupMode):
+        if mode == LocationPickupMode.SHUFFLED_NO_PROGRESSION:
             self.radio_shuffled_no_progression.setChecked(True)
+        elif mode == LocationPickupMode.SHUFFLED_NO_MAJORS:
+            self.radio_shuffled_no_majors.setChecked(True)
+        else:
+            self.radio_shuffled.setChecked(True)
         self.changed.emit(self.node)
+
+    def set_is_major_only_location(self, major_only: bool):
+        self.radio_shuffled_no_majors.setEnabled(not major_only)
 
     def _on_radio_changed(self, checked: bool):
         if checked:
             self.changed.emit(self.node)
 
     @property
-    def can_have_progression(self):
-        return self.radio_shuffled.isChecked()
+    def location_pickup_mode(self) -> LocationPickupMode:
+        if self.radio_shuffled_no_progression.isChecked():
+            return LocationPickupMode.SHUFFLED_NO_PROGRESSION
+        elif self.radio_shuffled_no_majors.isChecked():
+            return LocationPickupMode.SHUFFLED_NO_MAJORS
+        return LocationPickupMode.SHUFFLED

--- a/randovania/gui/preset_settings/location_pool_tab.py
+++ b/randovania/gui/preset_settings/location_pool_tab.py
@@ -125,7 +125,8 @@ class PresetLocationPool(PresetTab, Ui_PresetLocationPool, NodeListHelper):
                 else:
                     row_widget.setEnabled(True)
                     row_widget.set_location_pickup_mode(LocationPickupMode.SHUFFLED)
-                    row_widget.set_is_major_only_location(node.location_category == LocationCategory.MAJOR)
+                    row_widget.set_is_major_only_location(mode == RandomizationMode.MAJOR_MINOR_SPLIT and
+                                                          node.location_category == LocationCategory.MAJOR)
 
     def _on_location_changed(self, node: PickupNode):
         if self._during_batch_update:

--- a/randovania/gui/ui_files/widget_location_pool_row.ui
+++ b/randovania/gui/ui_files/widget_location_pool_row.ui
@@ -88,6 +88,22 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QRadioButton" name="radio_shuffled_no_majors">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>This location is shuffled, but cannot contain a &quot;major&quot; item</string>
+     </property>
+     <property name="text">
+      <string>Shuffled (no majors)</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>

--- a/randovania/gui/ui_files/widget_location_pool_row.ui
+++ b/randovania/gui/ui_files/widget_location_pool_row.ui
@@ -81,7 +81,7 @@
       </sizepolicy>
      </property>
      <property name="toolTip">
-      <string>This location is shuffled, but cannot contain a item required for progression</string>
+      <string>This location is shuffled, but cannot contain an item required for progression</string>
      </property>
      <property name="text">
       <string>Shuffled (no progression)</string>
@@ -97,10 +97,10 @@
       </sizepolicy>
      </property>
      <property name="toolTip">
-      <string>This location is shuffled, but cannot contain a &quot;major&quot; item</string>
+      <string>This location is shuffled, but cannot contain an item required for progression or an item that is considered &quot;major&quot; (except as a last resort)</string>
      </property>
      <property name="text">
-      <string>Shuffled (no majors)</string>
+      <string>Shuffled (avoid majors)</string>
      </property>
     </widget>
    </item>

--- a/test/gui/preset_settings/test_location_pool_row_widget.py
+++ b/test/gui/preset_settings/test_location_pool_row_widget.py
@@ -84,10 +84,14 @@ def test_location_pool_row_disabled_on_major_minor_split(customized_preset, echo
     assert first_non_major.isEnabled()
     assert not first_major.radio_shuffled.isChecked()
 
+    first_major.set_location_pickup_mode(LocationPickupMode.SHUFFLED_NO_MAJORS)
+    assert not first_major.radio_shuffled_no_progression.isChecked()
+
     location_pool_tab._major_minor = True
     location_pool_tab._on_update_randomization_mode()
 
     assert first_major.isEnabled()
     assert not first_major.radio_shuffled_no_majors.isEnabled()
+    assert not first_major.radio_shuffled_no_majors.isChecked()
     assert not first_non_major.isEnabled()
     assert first_major.radio_shuffled.isChecked()

--- a/test/gui/preset_settings/test_location_pool_row_widget.py
+++ b/test/gui/preset_settings/test_location_pool_row_widget.py
@@ -9,6 +9,7 @@ from randovania.game_description.world.pickup_node import PickupNode
 from randovania.gui.preset_settings.location_pool_row_widget import LocationPoolRowWidget
 from randovania.gui.preset_settings.location_pool_tab import PresetLocationPool
 from randovania.interface_common.preset_editor import PresetEditor
+from randovania.layout.base.available_locations import LocationPickupMode
 
 
 @pytest.fixture(name="pickup_node")
@@ -51,7 +52,7 @@ def test_location_pool_row_actions(pickup_node, skip_qtbot):
 
     # Run & Assert
     assert not signal_received
-    widget.set_can_have_progression(True)
+    widget.set_location_pickup_mode(LocationPickupMode.SHUFFLED)
     assert signal_received
     assert widget.radio_shuffled.isChecked()
 
@@ -79,6 +80,7 @@ def test_location_pool_row_disabled_on_major_minor_split(customized_preset, echo
 
     # Run & Assert
     assert first_major.isEnabled()
+    assert first_major.radio_shuffled_no_majors.isEnabled()
     assert first_non_major.isEnabled()
     assert not first_major.radio_shuffled.isChecked()
 
@@ -86,5 +88,6 @@ def test_location_pool_row_disabled_on_major_minor_split(customized_preset, echo
     location_pool_tab._on_update_randomization_mode()
 
     assert first_major.isEnabled()
+    assert not first_major.radio_shuffled_no_majors.isEnabled()
     assert not first_non_major.isEnabled()
     assert first_major.radio_shuffled.isChecked()


### PR DESCRIPTION
This new option for locations in the Location Pool will exclude the location from containing progression items, but it will also try to avoid placing any item marked as "major" in the location unless there are no other options left.