### PR TITLE
Fix some room names

### DIFF
--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -7,6 +7,7 @@ from randovania.exporter.hints.hint_exporter import HintExporter
 from randovania.exporter.patch_data_factory import BasePatchDataFactory
 from randovania.exporter.pickup_exporter import ExportedPickupDetails
 from randovania.game_description.assignment import PickupTarget
+from randovania.game_description.db.area import Area
 from randovania.game_description.resources.item_resource_info import ItemResourceInfo
 from randovania.game_description.resources.pickup_entry import ConditionalResources
 from randovania.game_description.resources.resource_info import ResourceCollection
@@ -307,6 +308,30 @@ class DreadPatchDataFactory(BasePatchDataFactory):
             DreadHintNamer(self.description.all_patches, self.players_config),
         )
 
+    def _static_room_name_fixes(self, scenario_name: str, area: Area):
+        # static fixes for some rooms
+        cc_name = area.extra["asset_id"]
+        area_name = area.name
+        if scenario_name == "s040_aqua":
+            if cc_name == "collision_camera_010":
+                return cc_name, "Burenia Main Hub"
+            if cc_name == "collision_camera_023_B":
+                return "collision_camera_023", area_name
+            
+        if scenario_name == "s050_forest":
+            if cc_name == "collision_camera_024":
+                return cc_name, "Golzuna Tower"
+
+        if scenario_name == "s060_quarantine":
+            if cc_name == "collision_camera_MBL_B":
+                return "collision_camera_MBL", area.name
+
+        if scenario_name == "s070_basesanc":
+            if cc_name == "collision_camera_038_A":
+                return "collision_camera_038", area.name
+            
+        return cc_name, area.name
+
     def _build_area_name_dict(self) -> dict[str, dict[str, str]]:
         # generate a 2D dictionary of (scenario, collision camera) => room name
         all_dict: dict = {}
@@ -315,13 +340,9 @@ class DreadPatchDataFactory(BasePatchDataFactory):
             region_dict: dict = {}
 
             for area in region.areas:
-                region_dict[area.extra["asset_id"]] = area.name
-
+                cc_name, area_name = self._static_room_name_fixes(scenario, area)
+                region_dict[cc_name] = area_name
             all_dict[scenario] = region_dict
-
-        # fix Burenia Main Tower and Golzuna Tower
-        all_dict["s040_aqua"]["collision_camera_010"] = "Burenia Main Hub"
-        all_dict["s050_forest"]["collision_camera_024"] = "Golzuna Tower"
 
         return all_dict
 

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -10656,7 +10656,7 @@
                         200.0
                     ]
                 ],
-                "asset_id": "collision_camera_025_B"
+                "asset_id": "collision_camera_025"
             },
             "nodes": {
                 "Door from Chozo Warrior Arena": {

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -1846,7 +1846,7 @@ Extra - asset_id: collision_camera_024
 Total Recharge Station North
 Extra - total_boundings: {'x1': 6300.0, 'x2': 10100.0, 'y1': 200.0, 'y2': 3400.0}
 Extra - polygon: [[10100.0, 3400.0], [7000.0, 3400.0], [7000.0, 1900.0], [6300.0, 1900.0], [6300.0, 200.0], [10100.0, 200.0]]
-Extra - asset_id: collision_camera_025_B
+Extra - asset_id: collision_camera_025
 > Door from Chozo Warrior Arena; Heals? False
   * Layers: default
   * Access Closed to Chozo Warrior Arena/Door to Total Recharge Station North; Dock Lock Rando incompatible with: Grapple Beam Door

--- a/test/games/dread/exporter/test_dread_patch_data_factory.py
+++ b/test/games/dread/exporter/test_dread_patch_data_factory.py
@@ -246,7 +246,7 @@ def test_create_patch_with_custom_spawn(test_files_dir, mocker, setup_and_teardo
     assert data == expected_data
 
 
-def test_create_patch_with_crazy_settings(test_files_dir, mocker, setup_and_teardown_for_custom_spawn):
+def test_create_patch_with_crazy_settings(test_files_dir, mocker):
     # test for various uncommon or unusual preset settings
     file = test_files_dir.joinpath("log_files", "dread", "crazy_settings.rdvgame")
     description = LayoutDescription.from_file(file)

--- a/test/test_files/patcher_data/dread/crazy_settings.json
+++ b/test/test_files/patcher_data/dread/crazy_settings.json
@@ -4416,7 +4416,7 @@
                     "collision_camera_019": "Early Gravity Speedboost Room 2",
                     "collision_camera_021": "Gravity Suit Tower",
                     "collision_camera_022": "Ammo Recharge South",
-                    "collision_camera_023_B": "Gravity Suit Room",
+                    "collision_camera_023": "Gravity Suit Room",
                     "collision_camera_024": "Gravity Suit Room Access",
                     "collision_camera_025": "Storm Missile Gate Room",
                     "collision_camera_026": "Save Station South Access",
@@ -4462,7 +4462,7 @@
                     "collision_camera_033": "EMMI Zone Exit East Access",
                     "collision_camera_034": "Purple EMMI Arena",
                     "collision_camera_035": "Central Unit",
-                    "collision_camera_038_A": "Central Unit Access",
+                    "collision_camera_038": "Central Unit Access",
                     "collision_camera_040": "Purple EMMI Introduction",
                     "collision_camera_041": "Save Station Southeast"
                 },
@@ -4492,7 +4492,7 @@
                     "collision_camera_022": "Save Station Center",
                     "collision_camera_023": "Chozo Warrior Arena",
                     "collision_camera_024": "Golzuna Tower",
-                    "collision_camera_025_B": "Total Recharge Station North",
+                    "collision_camera_025": "Total Recharge Station North",
                     "collision_camera_026": "Golzuna Arena",
                     "collision_camera_027": "Transport to Ferenia",
                     "collision_camera_028": "Map Station Access Secret",
@@ -4523,7 +4523,7 @@
                     "collision_camera_010": "Horizontal Bomb Maze",
                     "collision_camera_011": "Exterior Bridge",
                     "collision_camera_012": "Save Station",
-                    "collision_camera_MBL_B": "Bottom Morph Launcher"
+                    "collision_camera_MBL": "Bottom Morph Launcher"
                 },
                 "s080_shipyard": {
                     "collision_camera_000": "Transport to Ferenia",

--- a/test/test_files/patcher_data/dread/custom_start.json
+++ b/test/test_files/patcher_data/dread/custom_start.json
@@ -4418,7 +4418,7 @@
                     "collision_camera_019": "Early Gravity Speedboost Room 2",
                     "collision_camera_021": "Gravity Suit Tower",
                     "collision_camera_022": "Ammo Recharge South",
-                    "collision_camera_023_B": "Gravity Suit Room",
+                    "collision_camera_023": "Gravity Suit Room",
                     "collision_camera_024": "Gravity Suit Room Access",
                     "collision_camera_025": "Storm Missile Gate Room",
                     "collision_camera_026": "Save Station South Access",
@@ -4464,7 +4464,7 @@
                     "collision_camera_033": "EMMI Zone Exit East Access",
                     "collision_camera_034": "Purple EMMI Arena",
                     "collision_camera_035": "Central Unit",
-                    "collision_camera_038_A": "Central Unit Access",
+                    "collision_camera_038": "Central Unit Access",
                     "collision_camera_040": "Purple EMMI Introduction",
                     "collision_camera_041": "Save Station Southeast"
                 },
@@ -4494,7 +4494,7 @@
                     "collision_camera_022": "Save Station Center",
                     "collision_camera_023": "Chozo Warrior Arena",
                     "collision_camera_024": "Golzuna Tower",
-                    "collision_camera_025_B": "Total Recharge Station North",
+                    "collision_camera_025": "Total Recharge Station North",
                     "collision_camera_026": "Golzuna Arena",
                     "collision_camera_027": "Transport to Ferenia",
                     "collision_camera_028": "Map Station Access Secret",
@@ -4525,7 +4525,7 @@
                     "collision_camera_010": "Horizontal Bomb Maze",
                     "collision_camera_011": "Exterior Bridge",
                     "collision_camera_012": "Save Station",
-                    "collision_camera_MBL_B": "Bottom Morph Launcher"
+                    "collision_camera_MBL": "Bottom Morph Launcher"
                 },
                 "s080_shipyard": {
                     "collision_camera_000": "Transport to Ferenia",

--- a/test/test_files/patcher_data/dread/dread_dread_multiworld_expected.json
+++ b/test/test_files/patcher_data/dread/dread_dread_multiworld_expected.json
@@ -4347,7 +4347,7 @@
                     "collision_camera_019": "Early Gravity Speedboost Room 2",
                     "collision_camera_021": "Gravity Suit Tower",
                     "collision_camera_022": "Ammo Recharge South",
-                    "collision_camera_023_B": "Gravity Suit Room",
+                    "collision_camera_023": "Gravity Suit Room",
                     "collision_camera_024": "Gravity Suit Room Access",
                     "collision_camera_025": "Storm Missile Gate Room",
                     "collision_camera_026": "Save Station South Access",
@@ -4393,7 +4393,7 @@
                     "collision_camera_033": "EMMI Zone Exit East Access",
                     "collision_camera_034": "Purple EMMI Arena",
                     "collision_camera_035": "Central Unit",
-                    "collision_camera_038_A": "Central Unit Access",
+                    "collision_camera_038": "Central Unit Access",
                     "collision_camera_040": "Purple EMMI Introduction",
                     "collision_camera_041": "Save Station Southeast"
                 },
@@ -4423,7 +4423,7 @@
                     "collision_camera_022": "Save Station Center",
                     "collision_camera_023": "Chozo Warrior Arena",
                     "collision_camera_024": "Golzuna Tower",
-                    "collision_camera_025_B": "Total Recharge Station North",
+                    "collision_camera_025": "Total Recharge Station North",
                     "collision_camera_026": "Golzuna Arena",
                     "collision_camera_027": "Transport to Ferenia",
                     "collision_camera_028": "Map Station Access Secret",
@@ -4454,7 +4454,7 @@
                     "collision_camera_010": "Horizontal Bomb Maze",
                     "collision_camera_011": "Exterior Bridge",
                     "collision_camera_012": "Save Station",
-                    "collision_camera_MBL_B": "Bottom Morph Launcher"
+                    "collision_camera_MBL": "Bottom Morph Launcher"
                 },
                 "s080_shipyard": {
                     "collision_camera_000": "Transport to Ferenia",

--- a/test/test_files/patcher_data/dread/dread_prime1_multiworld_expected.json
+++ b/test/test_files/patcher_data/dread/dread_prime1_multiworld_expected.json
@@ -4488,7 +4488,7 @@
                     "collision_camera_019": "Early Gravity Speedboost Room 2",
                     "collision_camera_021": "Gravity Suit Tower",
                     "collision_camera_022": "Ammo Recharge South",
-                    "collision_camera_023_B": "Gravity Suit Room",
+                    "collision_camera_023": "Gravity Suit Room",
                     "collision_camera_024": "Gravity Suit Room Access",
                     "collision_camera_025": "Storm Missile Gate Room",
                     "collision_camera_026": "Save Station South Access",
@@ -4534,7 +4534,7 @@
                     "collision_camera_033": "EMMI Zone Exit East Access",
                     "collision_camera_034": "Purple EMMI Arena",
                     "collision_camera_035": "Central Unit",
-                    "collision_camera_038_A": "Central Unit Access",
+                    "collision_camera_038": "Central Unit Access",
                     "collision_camera_040": "Purple EMMI Introduction",
                     "collision_camera_041": "Save Station Southeast"
                 },
@@ -4564,7 +4564,7 @@
                     "collision_camera_022": "Save Station Center",
                     "collision_camera_023": "Chozo Warrior Arena",
                     "collision_camera_024": "Golzuna Tower",
-                    "collision_camera_025_B": "Total Recharge Station North",
+                    "collision_camera_025": "Total Recharge Station North",
                     "collision_camera_026": "Golzuna Arena",
                     "collision_camera_027": "Transport to Ferenia",
                     "collision_camera_028": "Map Station Access Secret",
@@ -4595,7 +4595,7 @@
                     "collision_camera_010": "Horizontal Bomb Maze",
                     "collision_camera_011": "Exterior Bridge",
                     "collision_camera_012": "Save Station",
-                    "collision_camera_MBL_B": "Bottom Morph Launcher"
+                    "collision_camera_MBL": "Bottom Morph Launcher"
                 },
                 "s080_shipyard": {
                     "collision_camera_000": "Transport to Ferenia",

--- a/test/test_files/patcher_data/dread/starter_preset.json
+++ b/test/test_files/patcher_data/dread/starter_preset.json
@@ -4394,7 +4394,7 @@
                     "collision_camera_019": "Early Gravity Speedboost Room 2",
                     "collision_camera_021": "Gravity Suit Tower",
                     "collision_camera_022": "Ammo Recharge South",
-                    "collision_camera_023_B": "Gravity Suit Room",
+                    "collision_camera_023": "Gravity Suit Room",
                     "collision_camera_024": "Gravity Suit Room Access",
                     "collision_camera_025": "Storm Missile Gate Room",
                     "collision_camera_026": "Save Station South Access",
@@ -4440,7 +4440,7 @@
                     "collision_camera_033": "EMMI Zone Exit East Access",
                     "collision_camera_034": "Purple EMMI Arena",
                     "collision_camera_035": "Central Unit",
-                    "collision_camera_038_A": "Central Unit Access",
+                    "collision_camera_038": "Central Unit Access",
                     "collision_camera_040": "Purple EMMI Introduction",
                     "collision_camera_041": "Save Station Southeast"
                 },
@@ -4470,7 +4470,7 @@
                     "collision_camera_022": "Save Station Center",
                     "collision_camera_023": "Chozo Warrior Arena",
                     "collision_camera_024": "Golzuna Tower",
-                    "collision_camera_025_B": "Total Recharge Station North",
+                    "collision_camera_025": "Total Recharge Station North",
                     "collision_camera_026": "Golzuna Arena",
                     "collision_camera_027": "Transport to Ferenia",
                     "collision_camera_028": "Map Station Access Secret",
@@ -4501,7 +4501,7 @@
                     "collision_camera_010": "Horizontal Bomb Maze",
                     "collision_camera_011": "Exterior Bridge",
                     "collision_camera_012": "Save Station",
-                    "collision_camera_MBL_B": "Bottom Morph Launcher"
+                    "collision_camera_MBL": "Bottom Morph Launcher"
                 },
                 "s080_shipyard": {
                     "collision_camera_000": "Transport to Ferenia",


### PR DESCRIPTION
Fixes #4316

Fixed the following room names:
Ghavoran:
    - "Total Recharge Station North" by changing from collision_camera_025b to collision_camera_025
Elun:
    - "Bottom Morph Launcher" by applying a static fix for renaming the key for "collision_camera_MBL_B" (which is the name according to dread-editor) to "collision_camera_MBL" (which is used according to the screenshots)
Ferenia:
    - "Central Unit Access" by applying a static fix for renaming the key for "collision_camera_038_A" (which is the name according to dread-editor) to "collision_camera_038" (which is used according to the screenshots)
Burenia:
    - "Gravity Suit Room" by applying a static fix for renaming the key for "collision_camera_023_B" (which is the name according to dread-editor) to "collision_camera_023" (which is used according to the screenshots)

For the last two screenshots of the issue see (also applies to "Total Recharge Station North"): https://github.com/randovania/open-dread-rando/issues/223

Result:
![1](https://github.com/randovania/randovania/assets/117127188/88c652fa-72eb-486c-9cd1-3161e3917448)
![2](https://github.com/randovania/randovania/assets/117127188/f0a2b56e-d96e-4c55-92ff-90ff4885a590)
![3](https://github.com/randovania/randovania/assets/117127188/f9fe62ac-50a7-43d2-bbcf-ddd25f368080)
![4](https://github.com/randovania/randovania/assets/117127188/3b98bba4-ca28-481d-87f2-501c1b3b94b7)
