### PR TITLE
Data editor: View connection to node by single clicking

### DIFF
--- a/randovania/gui/lib/data_editor_canvas.py
+++ b/randovania/gui/lib/data_editor_canvas.py
@@ -263,6 +263,16 @@ class DataEditorCanvas(QtWidgets.QWidget):
 
         return result
 
+    def mouseReleaseEvent(self, event: QtGui.QMouseEvent) -> None:
+        local_pos = QPointF(self.mapFromGlobal(event.globalPos()))
+        local_pos -= self.get_area_canvas_offset()
+
+        nodes_at_mouse = self._nodes_at_position(local_pos)
+        if nodes_at_mouse:
+            if len(nodes_at_mouse) == 1 and nodes_at_mouse[0] != self.highlighted_node:
+                self.SelectConnectionsRequest.emit(nodes_at_mouse[0])
+            return
+
     def mouseDoubleClickEvent(self, event: QtGui.QMouseEvent) -> None:
         local_pos = QPointF(self.mapFromGlobal(event.globalPos()))
         local_pos -= self.get_area_canvas_offset()


### PR DESCRIPTION
Currently, to view the connection from the highlighted node to another node, you either need to:
- select it from the connections dropdown
- right click on the node you want to see the connection to -> "view connections to this node"

As both ways can be tedious in rooms with a decent amount of nodes, it's now also possible to quickly view a connection to a node by single clicking it.