### PR TITLE
Fix Corruption valhalla having wrong door type

### DIFF
--- a/randovania/games/prime3/json_data/GFS Valhalla.json
+++ b/randovania/games/prime3/json_data/GFS Valhalla.json
@@ -704,7 +704,7 @@
                     "default_connection": {
                         "region": "G.F.S. Valhalla",
                         "area": "MedLab Alpha",
-                        "node": "Morph Ball Door to Security Access (2)"
+                        "node": "Door to Security Access"
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
@@ -822,7 +822,7 @@
                     "default_connection": {
                         "region": "G.F.S. Valhalla",
                         "area": "MedLab Alpha",
-                        "node": "Morph Ball Door to Security Access (1)"
+                        "node": "Morph Ball Door to Security Access"
                     },
                     "default_dock_weakness": "Morph Ball Door",
                     "exclude_from_dock_rando": false,
@@ -2543,12 +2543,12 @@
             }
         },
         "MedLab Alpha": {
-            "default_node": "Morph Ball Door to Security Access (2)",
+            "default_node": "Door to Security Access",
             "extra": {
                 "asset_id": 4052690289582601366
             },
             "nodes": {
-                "Morph Ball Door to Security Access (1)": {
+                "Morph Ball Door to Security Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2604,7 +2604,7 @@
                         }
                     }
                 },
-                "Morph Ball Door to Security Access (2)": {
+                "Door to Security Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2620,13 +2620,13 @@
                         "dock_index": 1
                     },
                     "valid_starting_location": true,
-                    "dock_type": "morph_ball",
+                    "dock_type": "door",
                     "default_connection": {
                         "region": "G.F.S. Valhalla",
                         "area": "Security Access",
                         "node": "Door to MedLab Alpha"
                     },
-                    "default_dock_weakness": "Morph Ball Door",
+                    "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -2721,7 +2721,7 @@
                     "pickup_index": 14,
                     "location_category": "minor",
                     "connections": {
-                        "Morph Ball Door to Security Access (2)": {
+                        "Door to Security Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2743,7 +2743,7 @@
                     "pickup_index": 15,
                     "location_category": "minor",
                     "connections": {
-                        "Morph Ball Door to Security Access (1)": {
+                        "Morph Ball Door to Security Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/prime3/json_data/GFS Valhalla.txt
+++ b/randovania/games/prime3/json_data/GFS Valhalla.txt
@@ -117,7 +117,7 @@ Security Access
 Extra - asset_id: 2123213449889105147
 > Door to MedLab Alpha; Heals? False
   * Layers: default
-  * Normal Door to MedLab Alpha/Morph Ball Door to Security Access (2)
+  * Normal Door to MedLab Alpha/Door to Security Access
   * Extra - dock_index: 0
   > Door to Security Station
       Trivial
@@ -140,7 +140,7 @@ Extra - asset_id: 2123213449889105147
 
 > Morph Ball Door to MedLab Alpha; Heals? False
   * Layers: default
-  * Morph Ball Door to MedLab Alpha/Morph Ball Door to Security Access (1)
+  * Morph Ball Door to MedLab Alpha/Morph Ball Door to Security Access
   * Extra - dock_index: 3
   > Door to Security Station
       All of the following:
@@ -350,16 +350,16 @@ Extra - asset_id: 2774000464172079912
 ----------------
 MedLab Alpha
 Extra - asset_id: 4052690289582601366
-> Morph Ball Door to Security Access (1); Heals? False
+> Morph Ball Door to Security Access; Heals? False
   * Layers: default
   * Morph Ball Door to Security Access/Morph Ball Door to MedLab Alpha
   * Extra - dock_index: 0
   > Pickup (Ship Missile Expansion)
       Morph Ball Bomb and Morph Ball
 
-> Morph Ball Door to Security Access (2); Heals? False; Spawn Point; Default Node
+> Door to Security Access; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Morph Ball Door to Security Access/Door to MedLab Alpha
+  * Normal Door to Security Access/Door to MedLab Alpha
   * Extra - dock_index: 1
   > Pickup (Missile Expansion)
       Grapple Lasso and Missile ≥ 3 and Morph Ball
@@ -374,13 +374,13 @@ Extra - asset_id: 4052690289582601366
 > Pickup (Missile Expansion); Heals? False
   * Layers: default
   * Pickup 14; Category? Minor
-  > Morph Ball Door to Security Access (2)
+  > Door to Security Access
       Trivial
 
 > Pickup (Ship Missile Expansion); Heals? False
   * Layers: default
   * Pickup 15; Category? Minor
-  > Morph Ball Door to Security Access (1)
+  > Morph Ball Door to Security Access
       Morph Ball Bomb and Morph Ball
   > Morph Ball Door to Ventilation Shaft
       Morph Ball


### PR DESCRIPTION
Someone accidentally made two morph ball doors instead of one door and one morph ball door