### PR TITLE
AM2R: add fields to doors + slight logic errors

### DIFF
--- a/randovania/games/am2r/json_data/Distribution Center.json
+++ b/randovania/games/am2r/json_data/Distribution Center.json
@@ -268,7 +268,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 132495
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -476,7 +478,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 132468
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -523,7 +527,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 132467
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -594,7 +600,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 132574
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -645,7 +653,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 132575
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -845,7 +855,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 132428
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -911,7 +923,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 132427
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -985,7 +999,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133481
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1025,7 +1041,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133480
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1106,7 +1124,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133499
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1119,7 +1139,15 @@
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
-                    "connections": {}
+                    "connections": {
+                        "Save Station": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 },
                 "Door to Beam Bot Prison": {
                     "node_type": "dock",
@@ -1133,7 +1161,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133498
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1176,7 +1206,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133512
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1244,7 +1276,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133514
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1279,7 +1313,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133513
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1322,7 +1358,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133616
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1388,7 +1426,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133615
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1462,7 +1502,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133682
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1502,7 +1544,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133681
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1545,7 +1589,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133732
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1590,7 +1636,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133731
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1696,7 +1744,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133805
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1741,7 +1791,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133806
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1866,7 +1918,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133836
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1901,7 +1955,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133841
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1990,7 +2046,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133903
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2025,7 +2083,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133904
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2123,7 +2183,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133914
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2158,7 +2220,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133917
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2219,7 +2283,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133911
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2374,7 +2440,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133982
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2418,7 +2486,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 133981
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2684,7 +2754,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134067
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2779,7 +2851,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134068
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2836,7 +2910,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134069
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3197,7 +3273,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134402
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3424,7 +3502,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134401
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3693,7 +3773,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134427
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3758,7 +3840,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134426
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3826,7 +3910,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134480
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3916,7 +4002,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134481
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4031,7 +4119,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134495
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4123,7 +4213,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134570
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4215,7 +4307,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134563
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4621,7 +4715,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134613
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5002,7 +5098,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134644
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5037,7 +5135,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134645
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5080,7 +5180,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134661
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5115,7 +5217,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134662
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5150,7 +5254,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134670
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5205,7 +5311,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134710
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5240,7 +5348,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134711
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5481,7 +5591,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134883
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5516,7 +5628,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134884
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5573,7 +5687,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134899
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5634,7 +5750,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 134898
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5677,7 +5795,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135046
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6070,7 +6190,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135119
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6278,7 +6400,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135156
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6358,7 +6482,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135157
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6446,7 +6572,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135204
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6514,7 +6642,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135205
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6557,7 +6687,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135221
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6627,7 +6759,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135232
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6738,7 +6872,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135253
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6848,7 +6984,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135298
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6973,7 +7111,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135317
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -7069,7 +7209,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135329
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -7151,7 +7293,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135330
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -7541,7 +7685,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135404
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -7722,7 +7868,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135449
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -7762,7 +7910,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135448
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -7933,7 +8083,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135598
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -8442,7 +8594,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135756
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -8658,7 +8812,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135783
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -8759,7 +8915,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135801
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -8847,7 +9005,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 135800
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -9689,7 +9849,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136376
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -9831,7 +9993,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136414
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -9883,7 +10047,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136415
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10047,7 +10213,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136413
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10107,7 +10275,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136488
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10147,7 +10317,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136487
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10195,7 +10367,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136503
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10314,7 +10488,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136516
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10349,7 +10525,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136515
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10392,7 +10570,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136529
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10419,7 +10599,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136531
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10462,7 +10644,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136607
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10502,7 +10686,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136608
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10652,7 +10838,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136637
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10687,7 +10875,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136632
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10831,7 +11021,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136636
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10874,7 +11066,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136678
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10935,7 +11129,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136676
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -10999,7 +11195,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136689
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -11070,7 +11268,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136853
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -11119,7 +11319,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136854
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -11176,7 +11378,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 136869
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/am2r/json_data/Distribution Center.txt
+++ b/randovania/games/am2r/json_data/Distribution Center.txt
@@ -49,6 +49,7 @@ Extra - map_name: rm_a5h04
 > Door to Facility Storage Tower West; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Tower West/Door to Distribution Center Exterior West
+  * Extra - instance_id: 132495
   > Dock to Distribution Center Exterior West Access
       Trivial
   > Door to Blade Bot Patrol Room
@@ -72,6 +73,7 @@ Extra - map_name: rm_a5h04
 > Door to Blade Bot Patrol Room; Heals? False
   * Layers: default
   * Normal Door to Blade Bot Patrol Room/Door to Distribution Center Exterior West
+  * Extra - instance_id: 132468
   > Door to Facility Storage Tower West
       Trivial
   > Door to Pipe Hub Access
@@ -80,6 +82,7 @@ Extra - map_name: rm_a5h04
 > Door to Pipe Hub Access; Heals? False
   * Layers: default
   * A5 Near Pipe Hub EMP Door to Pipe Hub Access/Door to Distribution Center Exterior West
+  * Extra - instance_id: 132467
   > Door to Blade Bot Patrol Room
       Trivial
 
@@ -96,6 +99,7 @@ Extra - map_name: rm_a5h05
 > Door to Distribution Center Exterior East Access; Heals? False
   * Layers: default
   * Normal Door to Distribution Center Exterior East Access/Door to Distribution Center Exterior East
+  * Extra - instance_id: 132574
   > Door to Facility Storage Spiked Path
       Trivial
   > Pickup (Power Bomb Tank)
@@ -104,6 +108,7 @@ Extra - map_name: rm_a5h05
 > Door to Facility Storage Spiked Path; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Spiked Path/Door to Distribution Center Exterior East
+  * Extra - instance_id: 132575
   > Door to Distribution Center Exterior East Access
       Any of the following:
           All of the following:
@@ -135,6 +140,7 @@ Extra - map_name: rm_a5c01
 > Door to Beam Bot Prison; Heals? False
   * Layers: default
   * Normal Door to Beam Bot Prison/Door to Blade Bot Patrol Room
+  * Extra - instance_id: 132428
   > Door to Distribution Center Exterior West
       Any of the following:
           Tunnel Climb
@@ -143,6 +149,7 @@ Extra - map_name: rm_a5c01
 > Door to Distribution Center Exterior West; Heals? False
   * Layers: default
   * Normal Door to Distribution Center Exterior West/Door to Blade Bot Patrol Room
+  * Extra - instance_id: 132427
   > Door to Beam Bot Prison
       Any of the following:
           Tunnel Climb
@@ -154,12 +161,14 @@ Extra - map_name: rm_a5c02
 > Door to Energy Distribution Entrance Save Station; Heals? False
   * Layers: default
   * Normal Door to Energy Distribution Entrance Save Station/Door to Beam Bot Prison
+  * Extra - instance_id: 133481
   > Door to Blade Bot Patrol Room
       Space Jump Wall
 
 > Door to Blade Bot Patrol Room; Heals? False
   * Layers: default
   * Normal Door to Blade Bot Patrol Room/Door to Beam Bot Prison
+  * Extra - instance_id: 133480
   > Door to Energy Distribution Entrance Save Station
       Space Jump Wall
 
@@ -177,10 +186,14 @@ Extra - map_name: rm_a5c03
 > Door to Energy Distribution Tower West; Heals? False
   * Layers: default
   * Normal Door to Energy Distribution Tower West/Door to Energy Distribution Entrance Save Station
+  * Extra - instance_id: 133499
+  > Save Station
+      Trivial
 
 > Door to Beam Bot Prison; Heals? False
   * Layers: default
   * Normal Door to Beam Bot Prison/Door to Energy Distribution Entrance Save Station
+  * Extra - instance_id: 133498
   > Save Station
       Trivial
 
@@ -190,6 +203,7 @@ Extra - map_name: rm_a5c04
 > Door to Energy Distribution Entrance Save Station; Heals? False
   * Layers: default
   * Normal Door to Energy Distribution Entrance Save Station/Door to Energy Distribution Tower West
+  * Extra - instance_id: 133512
   > Door to Meat Boy Room
       Any of the following:
           Hijump With Power Grip Wall
@@ -200,12 +214,14 @@ Extra - map_name: rm_a5c04
 > Door to Meat Boy Room; Heals? False
   * Layers: default
   * Normal Door to Meat Boy Room/Door to Energy Distribution Tower West
+  * Extra - instance_id: 133514
   > Door to Energy Distribution Entrance Save Station
       Trivial
 
 > Door to Energy Distribution Tower East; Heals? False
   * Layers: default
   * A5 Near Save EMP Door to Energy Distribution Tower East/Door to Energy Distribution Tower West
+  * Extra - instance_id: 133513
   > Door to Energy Distribution Entrance Save Station
       Trivial
 
@@ -215,6 +231,7 @@ Extra - map_name: rm_a5c05
 > Door to Energy Distribution Activation Shaft; Heals? False
   * Layers: default
   * Normal Door to Energy Distribution Activation Shaft/Door to Meat Boy Room
+  * Extra - instance_id: 133616
   > Door to Energy Distribution Tower West
       All of the following:
           Can Use Any Bombs
@@ -223,6 +240,7 @@ Extra - map_name: rm_a5c05
 > Door to Energy Distribution Tower West; Heals? False
   * Layers: default
   * Normal Door to Energy Distribution Tower West/Door to Meat Boy Room
+  * Extra - instance_id: 133615
   > Door to Energy Distribution Activation Shaft
       All of the following:
           Can Use Any Bombs
@@ -234,12 +252,14 @@ Extra - map_name: rm_a5c06
 > Door to Meat Boy Room; Heals? False
   * Layers: default
   * Normal Door to Meat Boy Room/Door to Energy Distribution Activation Shaft
+  * Extra - instance_id: 133682
   > Door to Energy Distribution Activation
       Space Jump Wall
 
 > Door to Energy Distribution Activation; Heals? False
   * Layers: default
   * Normal Door to Energy Distribution Activation/Door to Energy Distribution Activation Shaft
+  * Extra - instance_id: 133681
   > Door to Meat Boy Room
       Trivial
 
@@ -249,12 +269,14 @@ Extra - map_name: rm_a5c07
 > Door to Energy Distribution Activation Shaft; Heals? False
   * Layers: default
   * A5 Activation Tower Door to Energy Distribution Activation Shaft/Door to Energy Distribution Activation
+  * Extra - instance_id: 133732
   > Event - EMP Activation Statue
       Morph Ball
 
 > Door to Energy Distribution Emergency Exit; Heals? False
   * Layers: default
   * A5 Activation Tower Door to Energy Distribution Emergency Exit/Door to Energy Distribution Activation
+  * Extra - instance_id: 133731
   > Event - EMP Activation Statue
       Trivial
 
@@ -274,12 +296,14 @@ Extra - map_name: rm_a5c08
 > Door to Energy Distribution Activation; Heals? False
   * Layers: default
   * Normal Door to Energy Distribution Activation/Door to Energy Distribution Emergency Exit
+  * Extra - instance_id: 133805
   > Door to EMP Ball Introduction
       Speed Booster
 
 > Door to EMP Ball Introduction; Heals? False
   * Layers: default
   * Normal Door to EMP Ball Introduction/Door to Energy Distribution Emergency Exit
+  * Extra - instance_id: 133806
   > Pickup (Super Missile Tank)
       Screw Attack
 
@@ -298,12 +322,14 @@ Extra - map_name: rm_a5c09
 > Door to Energy Distribution Robot Home; Heals? False
   * Layers: default
   * A5 Near Activation Tower EMP Door to Energy Distribution Robot Home/Door to EMP Ball Introduction
+  * Extra - instance_id: 133836
   > Event - EMPPuzzle
       Trivial
 
 > Door to Energy Distribution Emergency Exit; Heals? False
   * Layers: default
   * Normal Door to Energy Distribution Emergency Exit/Door to EMP Ball Introduction
+  * Extra - instance_id: 133841
   > Event - EMPPuzzle
       Can Use Any Bombs
 
@@ -321,12 +347,14 @@ Extra - map_name: rm_a5c10
 > Door to Energy Distribution Tower East; Heals? False
   * Layers: default
   * A5 Robots Showcase EMP Door to Energy Distribution Tower East/Door to Energy Distribution Robot Home
+  * Extra - instance_id: 133903
   > Event - EMPPuzzle
       Trivial
 
 > Door to EMP Ball Introduction; Heals? False
   * Layers: default
   * Normal Door to EMP Ball Introduction/Door to Energy Distribution Robot Home
+  * Extra - instance_id: 133904
   > Event - EMPPuzzle
       Missiles ≥ 2 or Super Missiles or Can Use Bombs
 
@@ -344,12 +372,14 @@ Extra - map_name: rm_a5c11
 > Door to Energy Distribution Tower West; Heals? False
   * Layers: default
   * A5 Near Save EMP Door to Energy Distribution Tower West/Door to Energy Distribution Tower East
+  * Extra - instance_id: 133914
   > Door to Energy Distribution Zeta Nest
       Trivial
 
 > Door to Energy Distribution Robot Home; Heals? False
   * Layers: default
   * Normal Door to Energy Distribution Robot Home/Door to Energy Distribution Tower East
+  * Extra - instance_id: 133917
   > Event - EMP Puzzle
       Any of the following:
           Can Use Bombs
@@ -358,6 +388,7 @@ Extra - map_name: rm_a5c11
 > Door to Energy Distribution Zeta Nest; Heals? False
   * Layers: default
   * A5 Near Save EMP Door to Energy Distribution Zeta Nest/Door to Energy Distribution Tower East
+  * Extra - instance_id: 133911
   > Door to Energy Distribution Tower West
       Trivial
 
@@ -384,12 +415,14 @@ Extra - map_name: rm_a5c12
 > Door to Distribution Facility Tower West; Heals? False
   * Layers: default
   * Normal Door to Distribution Facility Tower West/Door to Energy Distribution Zeta Nest
+  * Extra - instance_id: 133982
   > Middle
       Can Use Any Bombs and Power Grip Wall
 
 > Door to Energy Distribution Tower East; Heals? False
   * Layers: default
   * A5 Near Save EMP Door to Energy Distribution Tower East/Door to Energy Distribution Zeta Nest
+  * Extra - instance_id: 133981
   > Middle
       Can Use Any Bombs and Power Grip Wall
 
@@ -426,6 +459,7 @@ Extra - map_name: rm_a5c13
 > Door to Energy Distribution Zeta Nest; Heals? False
   * Layers: default
   * Normal Door to Energy Distribution Zeta Nest/Door to Distribution Facility Tower West
+  * Extra - instance_id: 134067
   > Pipe to Distribution Facility Tower East (Bottom)
       Morph Ball
   > Near Middle Pipe
@@ -438,6 +472,7 @@ Extra - map_name: rm_a5c13
 > Door to Distribution Facility Connecting Path; Heals? False
   * Layers: default
   * Normal Door to Distribution Facility Connecting Path/Door to Distribution Facility Tower West
+  * Extra - instance_id: 134068
   > Near Middle Pipe
       Screw Attack
   > Pillar
@@ -446,6 +481,7 @@ Extra - map_name: rm_a5c13
 > Door to Pipe Hub; Heals? False
   * Layers: default
   * Normal Door to Pipe Hub/Door to Distribution Facility Tower West
+  * Extra - instance_id: 134069
   > Pillar
       Screw Attack
 
@@ -495,6 +531,7 @@ Extra - map_name: rm_a5c14
 > Door to Distribution Facility Tower West; Heals? False; Default Node
   * Layers: default
   * Normal Door to Distribution Facility Tower West/Door to Pipe Hub
+  * Extra - instance_id: 134402
   > Door to Pipe Hub Access
       Trivial
   > Pipe to Gravity Area Moto Room Pipe
@@ -519,6 +556,7 @@ Extra - map_name: rm_a5c14
 > Door to Pipe Hub Access; Heals? False
   * Layers: default
   * Normal Door to Pipe Hub Access/Door to Pipe Hub
+  * Extra - instance_id: 134401
   > Door to Distribution Facility Tower West
       Trivial
 
@@ -562,6 +600,7 @@ Extra - map_name: rm_a5c15
 > Door to Pipe Hub; Heals? False
   * Layers: default
   * Normal Door to Pipe Hub/Door to Pipe Hub Access
+  * Extra - instance_id: 134427
   > Door to Distribution Center Exterior West
       Trivial
   > Event - NearLeftOutsideEMP
@@ -570,6 +609,7 @@ Extra - map_name: rm_a5c15
 > Door to Distribution Center Exterior West; Heals? False
   * Layers: default
   * A5 Near Pipe Hub EMP Door to Distribution Center Exterior West/Door to Pipe Hub Access
+  * Extra - instance_id: 134426
   > Door to Pipe Hub
       Trivial
 
@@ -585,6 +625,7 @@ Extra - map_name: rm_a5c16
 > Door to Distribution Facility Tower West; Heals? False
   * Layers: default
   * Normal Door to Distribution Facility Tower West/Door to Distribution Facility Connecting Path
+  * Extra - instance_id: 134480
   > Door to Distribution Facility Tower East
       All of the following:
           Power Grip Wall
@@ -597,6 +638,7 @@ Extra - map_name: rm_a5c16
 > Door to Distribution Facility Tower East; Heals? False
   * Layers: default
   * Normal Door to Distribution Facility Tower East/Door to Distribution Facility Connecting Path
+  * Extra - instance_id: 134481
   > Door to Distribution Facility Tower West
       All of the following:
           Movement (Advanced) or Power Grip Wall
@@ -612,6 +654,7 @@ Extra - map_name: rm_a5c17
 > Door to Distribution Facility Connecting Path; Heals? False
   * Layers: default
   * Normal Door to Distribution Facility Connecting Path/Door to Distribution Facility Tower East
+  * Extra - instance_id: 134495
   > Door to Distribution Facility Save Station
       Power Grip or Space Jump or Morph Glide (Intermediate) or Movement (Advanced) or Walljump (Advanced) or Can Use Spider Ball
   > Pipe to Meboid Blockade Interior
@@ -620,6 +663,7 @@ Extra - map_name: rm_a5c17
 > Door to Distribution Facility Save Station; Heals? False
   * Layers: default
   * Missile Door to Distribution Facility Save Station/Door to Distribution Facility Tower East
+  * Extra - instance_id: 134570
   > Door to Distribution Facility Connecting Path
       Power Grip or Space Jump or Morph Glide (Intermediate) or Movement (Advanced) or Walljump (Advanced) or Can Use Spider Ball
   > Pipe to Meboid Blockade Interior
@@ -628,6 +672,7 @@ Extra - map_name: rm_a5c17
 > Door to Alpha Squad Nest; Heals? False
   * Layers: default
   * Normal Door to Alpha Squad Nest/Door to Distribution Facility Tower East
+  * Extra - instance_id: 134563
   > Pipe to Distribution Facility Tower West (Top)
       Screw Attack
   > Pipe to Meboid Blockade Interior
@@ -678,6 +723,7 @@ Extra - map_name: rm_a5c18
 > Door to Distribution Facility Tower East; Heals? False
   * Layers: default
   * Normal Door to Distribution Facility Tower East/Door to Alpha Squad Nest
+  * Extra - instance_id: 134613
   > Bottom
       Trivial
 
@@ -746,12 +792,14 @@ Extra - map_name: rm_a5c19
 > Door to Distribution Facility Tower East; Heals? False
   * Layers: default
   * Normal Door to Distribution Facility Tower East/Door to Distribution Facility Save Station
+  * Extra - instance_id: 134644
   > Save Station
       Trivial
 
 > Door to Distribution Facility Intersection; Heals? False
   * Layers: default
   * Normal Door to Distribution Facility Intersection/Door to Distribution Facility Save Station
+  * Extra - instance_id: 134645
   > Save Station
       Trivial
 
@@ -761,18 +809,21 @@ Extra - map_name: rm_a5c20
 > Door to Distribution Facility Save Station; Heals? False
   * Layers: default
   * Normal Door to Distribution Facility Save Station/Door to Distribution Facility Intersection
+  * Extra - instance_id: 134661
   > Door to Distribution Center Exterior East Access
       Trivial
 
 > Door to Bullet Hell Room Access; Heals? False
   * Layers: default
   * Normal Door to Bullet Hell Room Access/Door to Distribution Facility Intersection
+  * Extra - instance_id: 134662
   > Door to Distribution Center Exterior East Access
       Trivial
 
 > Door to Distribution Center Exterior East Access; Heals? False
   * Layers: default
   * A5 Near Right Side EMP Door to Distribution Center Exterior East Access/Door to Distribution Facility Intersection
+  * Extra - instance_id: 134670
   > Door to Distribution Facility Save Station
       Space Jump Wall
   > Door to Bullet Hell Room Access
@@ -784,12 +835,14 @@ Extra - map_name: rm_a5c21
 > Door to Distribution Facility Intersection; Heals? False
   * Layers: default
   * Normal Door to Distribution Facility Intersection/Door to Bullet Hell Room Access
+  * Extra - instance_id: 134710
   > Door to Bullet Hell Room
       Trivial
 
 > Door to Bullet Hell Room; Heals? False
   * Layers: default
   * A5 Near Screw EMP Door to Bullet Hell Room/Door to Bullet Hell Room Access
+  * Extra - instance_id: 134711
   > Door to Distribution Facility Intersection
       Any of the following:
           Space Jump or Enabled Septogg Helpers or Can Use Spider Ball
@@ -819,12 +872,14 @@ Extra - map_name: rm_a5c22
 > Door to Bullet Hell Room Access; Heals? False
   * Layers: default
   * Normal Door to Bullet Hell Room Access/Door to Bullet Hell Room
+  * Extra - instance_id: 134883
   > Door to Screw Attack Chamber Access
       Trivial
 
 > Door to Screw Attack Chamber Access; Heals? False
   * Layers: default
   * Normal Door to Screw Attack Chamber Access/Door to Bullet Hell Room
+  * Extra - instance_id: 134884
   > Door to Bullet Hell Room Access
       Power Bombs and Space Jump Wall
 
@@ -834,6 +889,7 @@ Extra - map_name: rm_a5c23
 > Door to Bullet Hell Room; Heals? False
   * Layers: default
   * Normal Door to Bullet Hell Room/Door to Screw Attack Chamber Access
+  * Extra - instance_id: 134899
   > Door to Screw Attack Chamber
       Any of the following:
           Space Jump Wall
@@ -842,6 +898,7 @@ Extra - map_name: rm_a5c23
 > Door to Screw Attack Chamber; Heals? False
   * Layers: default
   * Missile Door to Screw Attack Chamber/Door to Screw Attack Chamber Access
+  * Extra - instance_id: 134898
   > Door to Bullet Hell Room
       Trivial
 
@@ -851,6 +908,7 @@ Extra - map_name: rm_a5c24
 > Door to Screw Attack Chamber Access; Heals? False
   * Layers: default
   * Normal Door to Screw Attack Chamber Access/Door to Screw Attack Chamber
+  * Extra - instance_id: 135046
   > Pickup (Screw Attack)
       Trivial
 
@@ -911,6 +969,7 @@ Extra - map_name: rm_a5c26
 > Door to Waterblob Habitat; Heals? False
   * Layers: default
   * Normal Door to Waterblob Habitat/Door to Moheek Hangout
+  * Extra - instance_id: 135119
   > Pipe to Meboid Blockade Interior
       Any of the following:
           Power Grip or Walljump (Beginner)
@@ -936,6 +995,7 @@ Extra - map_name: rm_a5c27
 > Door to Facility Storage Save Station; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Save Station/Door to Waterblob Habitat
+  * Extra - instance_id: 135156
   > Door to Moheek Hangout
       Any of the following:
           Ice Beam or Damage Boost (Intermediate)
@@ -944,6 +1004,7 @@ Extra - map_name: rm_a5c27
 > Door to Moheek Hangout; Heals? False
   * Layers: default
   * Normal Door to Moheek Hangout/Door to Waterblob Habitat
+  * Extra - instance_id: 135157
   > Door to Facility Storage Save Station
       Any of the following:
           Ice Beam or Damage Boost (Intermediate)
@@ -955,6 +1016,7 @@ Extra - map_name: rm_a5c28
 > Door to Facility Storage Intersection East; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Intersection East/Door to Facility Storage Save Station
+  * Extra - instance_id: 135204
   > Save Station
       Trivial
 
@@ -969,6 +1031,7 @@ Extra - map_name: rm_a5c28
 > Door to Waterblob Habitat; Heals? False
   * Layers: default
   * Normal Door to Waterblob Habitat/Door to Facility Storage Save Station
+  * Extra - instance_id: 135205
   > Save Station
       Trivial
 
@@ -978,6 +1041,7 @@ Extra - map_name: rm_a5c29
 > Door to Facility Storage Save Station; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Save Station/Door to Facility Storage Intersection East
+  * Extra - instance_id: 135221
   > Door to Dual Gamma Nest
       Trivial
 
@@ -990,6 +1054,7 @@ Extra - map_name: rm_a5c29
 > Door to Dual Gamma Nest; Heals? False
   * Layers: default
   * Normal Door to Dual Gamma Nest/Door to Facility Storage Intersection East
+  * Extra - instance_id: 135232
   > Door to Facility Storage Save Station
       Any of the following:
           Power Grip or Walljump (Beginner)
@@ -1006,6 +1071,7 @@ Extra - map_name: rm_a5c30
 > Door to Facility Storage Intersection East; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Intersection East/Door to Dual Gamma Nest
+  * Extra - instance_id: 135253
   > Event - Left Gamma
       Defeat Gamma
   > Event - Right Gamma
@@ -1029,6 +1095,7 @@ Extra - map_name: rm_a5c31
 > Door to Ice Beam Chamber; Heals? False
   * Layers: default
   * Missile Door to Ice Beam Chamber/Door to Ice Beam Chamber Access
+  * Extra - instance_id: 135298
   > Pipe to Serris Arena Pipe
       All of the following:
           Morph Ball and Destroy Ice Barrier
@@ -1048,6 +1115,7 @@ Extra - map_name: rm_a5c32
 > Door to Ice Beam Chamber Access; Heals? False
   * Layers: default
   * Normal Door to Ice Beam Chamber Access/Door to Ice Beam Chamber
+  * Extra - instance_id: 135317
   > Pickup (Ice Beam)
       Trivial
 
@@ -1070,6 +1138,7 @@ Extra - map_name: rm_a5c33
 > Door to Distribution Center Exterior East; Heals? False
   * Layers: default
   * Normal Door to Distribution Center Exterior East/Door to Distribution Center Exterior East Access
+  * Extra - instance_id: 135329
   > Door to Distribution Facility Intersection
       Can Use Any Bombs
   > Event - NearRightOutsideEMP
@@ -1080,6 +1149,7 @@ Extra - map_name: rm_a5c33
 > Door to Distribution Facility Intersection; Heals? False
   * Layers: default
   * A5 Near Right Side EMP Door to Distribution Facility Intersection/Door to Distribution Center Exterior East Access
+  * Extra - instance_id: 135330
   > Door to Distribution Center Exterior East
       Can Use Any Bombs
 
@@ -1131,6 +1201,7 @@ Extra - map_name: rm_a5b02
 > Door to Serris Arena; Heals? False
   * Layers: default
   * Missile Door to Serris Arena/Door to Serris Arena Access
+  * Extra - instance_id: 135404
   > Dock to Spiky Spider Trial
       Trivial
   > Dock to Facility Storage Clogged Pipe North
@@ -1159,12 +1230,14 @@ Extra - map_name: rm_a5b03a
 > Door to Serris Arena Access; Heals? False
   * Layers: default
   * Serris Door to Serris Arena Access/Door to Serris Arena
+  * Extra - instance_id: 135449
   > Door to Serris Arena Pipe
       Power Grip Wall
 
 > Door to Serris Arena Pipe; Heals? False
   * Layers: default
   * Serris Door to Serris Arena Pipe/Door to Serris Arena
+  * Extra - instance_id: 135448
   > Door to Serris Arena Access
       Power Grip Wall
   > Event - Serris
@@ -1192,6 +1265,7 @@ Extra - map_name: rm_a5b03
 > Door to Serris Arena; Heals? False; Default Node
   * Layers: default
   * Normal Door to Serris Arena/Door to Serris Arena Pipe
+  * Extra - instance_id: 135598
   > Pipe to Ice Beam Chamber Access
       Morph Ball
 
@@ -1273,6 +1347,7 @@ Extra - map_name: rm_a5b07
 > Door to Facility Storage Tower Route South; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Tower Route South/Door to Facility Storage Tower East
+  * Extra - instance_id: 135756
   > Dock to Facility Storage Clogged Pipe South
       Any of the following:
           Power Grip or Walljump (Beginner)
@@ -1303,6 +1378,7 @@ Extra - map_name: rm_a5b08
 > Door to Facility Storage Spiked Path; Heals? False; Default Node
   * Layers: default
   * Normal Door to Facility Storage Spiked Path/Door to Facility Storage Spiked Path Pipe
+  * Extra - instance_id: 135783
   > Pipe to Gravity Area Blockade Pipe
       Morph Ball
 
@@ -1320,6 +1396,7 @@ Extra - map_name: rm_a5b09
 > Door to Distribution Center Exterior East; Heals? False
   * Layers: default
   * Normal Door to Distribution Center Exterior East/Door to Facility Storage Spiked Path
+  * Extra - instance_id: 135801
   > Door to Facility Storage Spiked Path Pipe
       Any of the following:
           Gravity Suit and Space Jump
@@ -1328,6 +1405,7 @@ Extra - map_name: rm_a5b09
 > Door to Facility Storage Spiked Path Pipe; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Spiked Path Pipe/Door to Facility Storage Spiked Path
+  * Extra - instance_id: 135800
   > Door to Distribution Center Exterior East
       Any of the following:
           Gravity Suit and Space Jump
@@ -1434,6 +1512,7 @@ Extra - map_name: rm_a5b20
 > Door to Facility Storage Tower West; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Tower West/Door to Facility Storage Tower Route North
+  * Extra - instance_id: 136376
   > Dock to Facility Storage Tower East
       All of the following:
           Gravity Suit and Speed Booster
@@ -1454,6 +1533,7 @@ Extra - map_name: rm_a5b21
 > Door to Facility Storage Tower Route North; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Tower Route North/Door to Facility Storage Tower West
+  * Extra - instance_id: 136414
   > Door to Facility Storage Tower Route South
       Trivial
   > Door to Distribution Center Exterior West
@@ -1462,6 +1542,7 @@ Extra - map_name: rm_a5b21
 > Door to Facility Storage Tower Route South; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Tower Route South/Door to Facility Storage Tower West
+  * Extra - instance_id: 136415
   > Door to Facility Storage Tower Route North
       Any of the following:
           Power Grip or Walljump (Beginner)
@@ -1480,6 +1561,7 @@ Extra - map_name: rm_a5b21
 > Door to Distribution Center Exterior West; Heals? False
   * Layers: default
   * Normal Door to Distribution Center Exterior West/Door to Facility Storage Tower West
+  * Extra - instance_id: 136413
   > Door to Facility Storage Tower Route North
       Gravity Suit
   > Door to Facility Storage Tower Route South
@@ -1491,12 +1573,14 @@ Extra - map_name: rm_a5b22
 > Door to Facility Storage Tower East; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Tower East/Door to Facility Storage Tower Route South
+  * Extra - instance_id: 136488
   > Door to Facility Storage Tower West
       Destroy Ice Barrier
 
 > Door to Facility Storage Tower West; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Tower West/Door to Facility Storage Tower Route South
+  * Extra - instance_id: 136487
   > Door to Facility Storage Tower East
       Destroy Ice Barrier
 
@@ -1506,6 +1590,7 @@ Extra - map_name: rm_a5a01
 > Door to Gravity Area Moto Room; Heals? False
   * Layers: default
   * Normal Door to Gravity Area Moto Room/Door to Gravity Area Moto Room Pipe
+  * Extra - instance_id: 136503
   > Pipe to Pipe Hub
       All of the following:
           Morph Ball
@@ -1523,12 +1608,14 @@ Extra - map_name: rm_a5a02
 > Door to Gravity Area One-Way Route; Heals? False
   * Layers: default
   * Normal Door to Gravity Area One-Way Route/Door to Gravity Area Moto Room
+  * Extra - instance_id: 136516
   > Door to Gravity Area Moto Room Pipe
       Trivial
 
 > Door to Gravity Area Moto Room Pipe; Heals? False
   * Layers: default
   * Normal Door to Gravity Area Moto Room Pipe/Door to Gravity Area Moto Room
+  * Extra - instance_id: 136515
   > Door to Gravity Area One-Way Route
       Trivial
 
@@ -1538,10 +1625,12 @@ Extra - map_name: rm_a5a03
 > Door to Gravity Area Corridor; Heals? False
   * Layers: default
   * Normal Door to Gravity Area Corridor/Door to Gravity Area One-Way Route
+  * Extra - instance_id: 136529
 
 > Door to Gravity Area Moto Room; Heals? False
   * Layers: default
   * Normal Door to Gravity Area Moto Room/Door to Gravity Area One-Way Route
+  * Extra - instance_id: 136531
   > Door to Gravity Area Corridor
       Trivial
 
@@ -1551,12 +1640,14 @@ Extra - map_name: rm_a5a04
 > Door to Gravity Area One-Way Route; Heals? False
   * Layers: default
   * Normal Door to Gravity Area One-Way Route/Door to Gravity Area Corridor
+  * Extra - instance_id: 136607
   > Middle
       Power Grip Wall
 
 > Door to Gravity Area Shaft; Heals? False
   * Layers: default
   * Normal Door to Gravity Area Shaft/Door to Gravity Area Corridor
+  * Extra - instance_id: 136608
   > Middle
       Power Grip Wall
 
@@ -1584,12 +1675,14 @@ Extra - map_name: rm_a5a05
 > Door to Gravity Area Corridor; Heals? False
   * Layers: default
   * Normal Door to Gravity Area Corridor/Door to Gravity Area Shaft
+  * Extra - instance_id: 136637
   > Door to Gravity Chamber Access
       Trivial
 
 > Door to Gravity Chamber Access; Heals? False
   * Layers: default
   * Missile Door to Gravity Chamber Access/Door to Gravity Area Shaft
+  * Extra - instance_id: 136632
   > Door to Gravity Area Corridor
       No Varia Suit and Walljump (Intermediate) and Enabled Septogg Helpers
   > Door to Gravity Area Blockade
@@ -1601,6 +1694,7 @@ Extra - map_name: rm_a5a05
 > Door to Gravity Area Blockade; Heals? False
   * Layers: default
   * Normal Door to Gravity Area Blockade/Door to Gravity Area Shaft
+  * Extra - instance_id: 136636
   > Door to Gravity Area Corridor
       Trivial
 
@@ -1610,6 +1704,7 @@ Extra - map_name: rm_a5a06
 > Door to Gravity Chamber; Heals? False
   * Layers: default
   * Normal Door to Gravity Chamber/Door to Gravity Chamber Access
+  * Extra - instance_id: 136678
   > Door to Gravity Area Shaft
       Any of the following:
           Can Use Power Bombs
@@ -1618,6 +1713,7 @@ Extra - map_name: rm_a5a06
 > Door to Gravity Area Shaft; Heals? False
   * Layers: default
   * Normal Door to Gravity Area Shaft/Door to Gravity Chamber Access
+  * Extra - instance_id: 136676
   > Door to Gravity Chamber
       Any of the following:
           Can Use Power Bombs
@@ -1629,6 +1725,7 @@ Extra - map_name: rm_a5a07
 > Door to Gravity Chamber Access; Heals? False
   * Layers: default
   * Normal Door to Gravity Chamber Access/Door to Gravity Chamber
+  * Extra - instance_id: 136689
   > Pickup (Gravity Suit)
       Trivial
 
@@ -1645,12 +1742,14 @@ Extra - map_name: rm_a5a08
 > Door to Gravity Area Shaft; Heals? False
   * Layers: default
   * Normal Door to Gravity Area Shaft/Door to Gravity Area Blockade
+  * Extra - instance_id: 136853
   > Door to Gravity Area Blockade Pipe
       Gravity Suit and Space Jump Wall
 
 > Door to Gravity Area Blockade Pipe; Heals? False
   * Layers: default
   * Normal Door to Gravity Area Blockade Pipe/Door to Gravity Area Blockade
+  * Extra - instance_id: 136854
   > Door to Gravity Area Shaft
       Gravity Suit and Space Jump Wall
 
@@ -1660,6 +1759,7 @@ Extra - map_name: rm_a5a09
 > Door to Gravity Area Blockade; Heals? False; Default Node
   * Layers: default
   * Normal Door to Gravity Area Blockade/Door to Gravity Area Blockade Pipe
+  * Extra - instance_id: 136869
   > Pipe to Facility Storage Spiked Path Pipe
       Morph Ball
 

--- a/randovania/games/am2r/json_data/GFS Thoth.json
+++ b/randovania/games/am2r/json_data/GFS Thoth.json
@@ -118,7 +118,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149522
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -222,7 +224,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149406
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -541,7 +545,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149560
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -576,7 +582,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149559
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -619,7 +627,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149600
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -654,7 +664,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149598
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -696,7 +708,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149597
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -738,7 +752,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149599
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -781,7 +797,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 400001
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -816,7 +834,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 400000
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -859,7 +879,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149696
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -894,7 +916,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149708
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -937,7 +961,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149718
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -972,7 +998,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149758
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1081,7 +1109,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149807
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1116,7 +1146,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149808
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1159,7 +1191,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149828
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1360,7 +1394,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149853
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1448,7 +1484,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149890
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1483,7 +1521,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 149889
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/am2r/json_data/GFS Thoth.txt
+++ b/randovania/games/am2r/json_data/GFS Thoth.txt
@@ -19,6 +19,7 @@ Extra - map_name: rm_a8h01
 > Door to Thoth East Entrance; Heals? False
   * Layers: default
   * Normal Door to Thoth East Entrance/Door to GFS Thoth Exterior
+  * Extra - instance_id: 149522
   > Pickup (Power Bomb Tank)
       Any of the following:
           Hijump Wall
@@ -35,6 +36,7 @@ Extra - map_name: rm_a8h01
 > Door to Thoth West Entrance; Heals? False
   * Layers: default
   * Normal Door to Thoth West Entrance/Door to GFS Thoth Exterior
+  * Extra - instance_id: 149406
   > Dock to Elevator Shaft
       Trivial
 
@@ -98,12 +100,14 @@ Extra - map_name: rm_a8a01
 > Door to GFS Thoth Exterior; Heals? False
   * Layers: default
   * Normal Door to GFS Thoth Exterior/Door to Thoth East Entrance
+  * Extra - instance_id: 149560
   > Door to Thoth East Lift
       Trivial
 
 > Door to Thoth East Lift; Heals? False
   * Layers: default
   * Normal Door to Thoth East Lift/Door to Thoth East Entrance
+  * Extra - instance_id: 149559
   > Door to GFS Thoth Exterior
       Trivial
 
@@ -113,12 +117,14 @@ Extra - map_name: rm_a8a02
 > Door to Thoth East Entrance; Heals? False
   * Layers: default
   * Normal Door to Thoth East Entrance/Door to Thoth East Lift
+  * Extra - instance_id: 149600
   > Door to Thoth Bridge
       Trivial
 
 > Door to Thoth Bridge; Heals? False
   * Layers: default
   * Normal Door to Thoth Bridge/Door to Thoth East Lift
+  * Extra - instance_id: 149598
   > Door to Thoth East Entrance
       Trivial
   > Door to Thoth Research
@@ -127,6 +133,7 @@ Extra - map_name: rm_a8a02
 > Door to Thoth Research; Heals? False
   * Layers: default
   * Normal Door to Thoth Research/Door to Thoth East Lift
+  * Extra - instance_id: 149597
   > Door to Thoth Bridge
       Trivial
   > Door to Thoth Cockpit
@@ -135,6 +142,7 @@ Extra - map_name: rm_a8a02
 > Door to Thoth Cockpit; Heals? False
   * Layers: default
   * Normal Door to Thoth Cockpit/Door to Thoth East Lift
+  * Extra - instance_id: 149599
   > Door to Thoth Research
       Trivial
 
@@ -144,12 +152,14 @@ Extra - map_name: rm_a8a03
 > Door to Thoth East Lift; Heals? False
   * Layers: default
   * Normal Door to Thoth East Lift/Door to Thoth Bridge
+  * Extra - instance_id: 400001
   > Door to Thoth Storage
       Trivial
 
 > Door to Thoth Storage; Heals? False
   * Layers: default
   * Normal Door to Thoth Storage/Door to Thoth Bridge
+  * Extra - instance_id: 400000
   > Door to Thoth East Lift
       Trivial
 
@@ -159,12 +169,14 @@ Extra - map_name: rm_a8a06
 > Door to Thoth Storage; Heals? False
   * Layers: default
   * Normal Door to Thoth Storage/Door to Thoth West Entrance
+  * Extra - instance_id: 149696
   > Door to GFS Thoth Exterior
       Trivial
 
 > Door to GFS Thoth Exterior; Heals? False
   * Layers: default
   * Normal Door to GFS Thoth Exterior/Door to Thoth West Entrance
+  * Extra - instance_id: 149708
   > Door to Thoth Storage
       Trivial
 
@@ -174,6 +186,7 @@ Extra - map_name: rm_a8a07
 > Door to Thoth East Lift; Heals? False
   * Layers: default
   * Normal Door to Thoth East Lift/Door to Thoth Cockpit
+  * Extra - instance_id: 149718
 
 ----------------
 Thoth Research
@@ -181,6 +194,7 @@ Extra - map_name: rm_a8a08
 > Door to Thoth East Lift; Heals? False
   * Layers: default
   * Normal Door to Thoth East Lift/Door to Thoth Research
+  * Extra - instance_id: 149758
   > Tunnel to Thoth West Lift
       All of the following:
           Can Use Any Bombs
@@ -198,12 +212,14 @@ Extra - map_name: rm_a8a10
 > Door to Thoth West Entrance; Heals? False
   * Layers: default
   * Normal Door to Thoth West Entrance/Door to Thoth Storage
+  * Extra - instance_id: 149807
   > Door to Thoth Bridge
       Trivial
 
 > Door to Thoth Bridge; Heals? False
   * Layers: default
   * Normal Door to Thoth Bridge/Door to Thoth Storage
+  * Extra - instance_id: 149808
   > Door to Thoth West Entrance
       Trivial
 
@@ -213,6 +229,7 @@ Extra - map_name: rm_a8a11
 > Door to Thoth West Lift; Heals? False
   * Layers: default
   * Normal Door to Thoth West Lift/Door to Genesis Arena
+  * Extra - instance_id: 149828
   > Pickup (Energy Tank)
       Trivial
 
@@ -241,6 +258,7 @@ Extra - map_name: rm_a8a12
 > Door to Thoth West Lift; Heals? False
   * Layers: default
   * Normal Door to Thoth West Lift/Door to Thoth Save Station Access
+  * Extra - instance_id: 149853
   > Tunnel to Thoth Save Station
       Can Use Any Bombs
 
@@ -256,12 +274,14 @@ Extra - map_name: rm_a8a13
 > Door to Genesis Arena; Heals? False
   * Layers: default
   * Normal Door to Genesis Arena/Door to Thoth West Lift
+  * Extra - instance_id: 149890
   > Door to Thoth Save Station Access
       Trivial
 
 > Door to Thoth Save Station Access; Heals? False
   * Layers: default
   * Normal Door to Thoth Save Station Access/Door to Thoth West Lift
+  * Extra - instance_id: 149889
   > Door to Genesis Arena
       Trivial
   > Tunnel to Thoth Research

--- a/randovania/games/am2r/json_data/Genetics Laboratory.json
+++ b/randovania/games/am2r/json_data/Genetics Laboratory.json
@@ -1020,7 +1020,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146501
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1096,7 +1098,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146514
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1131,7 +1135,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146513
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1174,7 +1180,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146532
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1209,7 +1217,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146531
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1244,7 +1254,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146535
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1364,7 +1376,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146563
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1518,7 +1532,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146602
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1558,7 +1574,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146601
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1606,7 +1624,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146836
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1830,7 +1850,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146900
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1839,7 +1861,7 @@
                         "node": "Door to Laboratory Foyer"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -1946,7 +1968,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146934
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1955,7 +1979,7 @@
                         "node": "Door to Laboratory Small Shaft East"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -1986,7 +2010,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146935
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1995,7 +2021,7 @@
                         "node": "Door to Laboratory Small Shaft East"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2066,7 +2092,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146959
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2075,7 +2103,7 @@
                         "node": "Door to Laboratory Corridor"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2101,7 +2129,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 146956
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2110,7 +2140,7 @@
                         "node": "Door to Laboratory Corridor"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2144,7 +2174,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 147000
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2153,7 +2185,7 @@
                         "node": "Door to Laboratory Long Shaft"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2300,7 +2332,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 147001
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2309,7 +2343,7 @@
                         "node": "Door to Laboratory Long Shaft"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2409,7 +2443,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 147042
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2418,7 +2454,7 @@
                         "node": "Door to Laboratory Spiked Hall"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -2544,7 +2580,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 147043
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2553,7 +2591,7 @@
                         "node": "Door to Laboratory Spiked Hall"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -3126,7 +3164,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 147081
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3135,7 +3175,7 @@
                         "node": "Door to Laboratory Arena"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -3166,7 +3206,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 147287
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3175,7 +3217,7 @@
                         "node": "Door to Laboratory Arena"
                     },
                     "default_dock_weakness": "Normal Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -3393,7 +3435,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 147404
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3428,7 +3472,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 147405
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3476,7 +3522,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 147656
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/am2r/json_data/Genetics Laboratory.txt
+++ b/randovania/games/am2r/json_data/Genetics Laboratory.txt
@@ -166,6 +166,7 @@ Extra - map_name: rm_a7b01A
 > Door to Laboratory Save Station; Heals? False
   * Layers: default
   * Normal Door to Laboratory Save Station/Door to Laboratory Save Station Access
+  * Extra - instance_id: 146501
   > Dock to Waterfalls Exterior
       Trivial
 
@@ -183,12 +184,14 @@ Extra - map_name: rm_a7b02A
 > Door to Laboratory Entrance; Heals? False
   * Layers: default
   * Normal Door to Laboratory Entrance/Door to Laboratory Save Station
+  * Extra - instance_id: 146514
   > Save Station
       Trivial
 
 > Door to Laboratory Save Station Access; Heals? False
   * Layers: default
   * Normal Door to Laboratory Save Station Access/Door to Laboratory Save Station
+  * Extra - instance_id: 146513
   > Save Station
       Trivial
 
@@ -198,18 +201,21 @@ Extra - map_name: rm_a7b03A
 > Door to Destroyed Chozo Memorial; Heals? False
   * Layers: default
   * Normal Door to Destroyed Chozo Memorial/Door to Laboratory Entrance
+  * Extra - instance_id: 146532
   > Door to Laboratory Pipe
       Trivial
 
 > Door to Laboratory Save Station; Heals? False
   * Layers: default
   * Normal Door to Laboratory Save Station/Door to Laboratory Entrance
+  * Extra - instance_id: 146531
   > Door to Laboratory Pipe
       Trivial
 
 > Door to Laboratory Pipe; Heals? False
   * Layers: default
   * Normal Door to Laboratory Pipe/Door to Laboratory Entrance
+  * Extra - instance_id: 146535
   > Door to Destroyed Chozo Memorial
       Any of the following:
           Hi-Jump Boots or Space Jump or Can Use Spider Ball
@@ -226,6 +232,7 @@ Extra - map_name: rm_a7b03B
 > Door to Laboratory Entrance; Heals? False; Default Node
   * Layers: default
   * Normal Door to Laboratory Entrance/Door to Laboratory Pipe
+  * Extra - instance_id: 146563
   > Pipe to Hydro Station
       After Area 6 - Nest Left Bottom Omega and After Area 6 - Nest Left Top Omega and After Area 6 - Nest Right Omega
 
@@ -247,12 +254,14 @@ Extra - map_name: rm_a7b04A
 > Door to Laboratory Entrance; Heals? False
   * Layers: default
   * Normal Door to Laboratory Entrance/Door to Destroyed Chozo Memorial
+  * Extra - instance_id: 146602
   > Door to Hatchling Room Underside
       Can Use Any Bombs
 
 > Door to Hatchling Room Underside; Heals? False
   * Layers: default
   * Normal Door to Hatchling Room Underside/Door to Destroyed Chozo Memorial
+  * Extra - instance_id: 146601
   > Door to Laboratory Entrance
       Can Use Any Bombs
 
@@ -262,6 +271,7 @@ Extra - map_name: rm_a7b04
 > Door to Destroyed Chozo Memorial; Heals? False
   * Layers: default
   * Normal Door to Destroyed Chozo Memorial/Door to Hatchling Room Underside
+  * Extra - instance_id: 146836
   > Tunnel to Laboratory Foyer
       All of the following:
           Hijump Tunnel Climb
@@ -292,7 +302,8 @@ Extra - map_name: rm_a7b05
 
 > Door to Laboratory Small Shaft East; Heals? False
   * Layers: default
-  * Normal Door to Laboratory Small Shaft East/Door to Laboratory Foyer
+  * Normal Door to Laboratory Small Shaft East/Door to Laboratory Foyer; Excluded from Dock Lock Rando
+  * Extra - instance_id: 146900
   > Bottom
       Trivial
 
@@ -316,13 +327,15 @@ Laboratory Small Shaft East
 Extra - map_name: rm_a7b06
 > Door to Laboratory Foyer; Heals? False
   * Layers: default
-  * Normal Door to Laboratory Foyer/Door to Laboratory Small Shaft East
+  * Normal Door to Laboratory Foyer/Door to Laboratory Small Shaft East; Excluded from Dock Lock Rando
+  * Extra - instance_id: 146934
   > Door to Laboratory Corridor
       Power Grip Wall
 
 > Door to Laboratory Corridor; Heals? False
   * Layers: default
-  * Normal Door to Laboratory Corridor/Door to Laboratory Small Shaft East
+  * Normal Door to Laboratory Corridor/Door to Laboratory Small Shaft East; Excluded from Dock Lock Rando
+  * Extra - instance_id: 146935
   > Door to Laboratory Foyer
       Trivial
   > Event - Larva
@@ -339,13 +352,15 @@ Laboratory Corridor
 Extra - map_name: rm_a7b06A
 > Door to Laboratory Small Shaft East; Heals? False
   * Layers: default
-  * Normal Door to Laboratory Small Shaft East/Door to Laboratory Corridor
+  * Normal Door to Laboratory Small Shaft East/Door to Laboratory Corridor; Excluded from Dock Lock Rando
+  * Extra - instance_id: 146959
   > Door to Laboratory Long Shaft
       Trivial
 
 > Door to Laboratory Long Shaft; Heals? False
   * Layers: default
-  * Normal Door to Laboratory Long Shaft/Door to Laboratory Corridor
+  * Normal Door to Laboratory Long Shaft/Door to Laboratory Corridor; Excluded from Dock Lock Rando
+  * Extra - instance_id: 146956
   > Door to Laboratory Small Shaft East
       Trivial
 
@@ -354,7 +369,8 @@ Laboratory Long Shaft
 Extra - map_name: rm_a7b07
 > Door to Laboratory Corridor; Heals? False
   * Layers: default
-  * Normal Door to Laboratory Corridor/Door to Laboratory Long Shaft
+  * Normal Door to Laboratory Corridor/Door to Laboratory Long Shaft; Excluded from Dock Lock Rando
+  * Extra - instance_id: 147000
   > Door to Laboratory Spiked Hall
       Any of the following:
           Space Jump or Walljump (Advanced) or Can Use Spider Ball
@@ -366,7 +382,8 @@ Extra - map_name: rm_a7b07
 
 > Door to Laboratory Spiked Hall; Heals? False
   * Layers: default
-  * Normal Door to Laboratory Spiked Hall/Door to Laboratory Long Shaft
+  * Normal Door to Laboratory Spiked Hall/Door to Laboratory Long Shaft; Excluded from Dock Lock Rando
+  * Extra - instance_id: 147001
   > Door to Laboratory Corridor
       Trivial
   > Event - Top Larva
@@ -391,7 +408,8 @@ Laboratory Spiked Hall
 Extra - map_name: rm_a7b08
 > Door to Laboratory Arena; Heals? False
   * Layers: default
-  * Normal Door to Laboratory Arena/Door to Laboratory Spiked Hall
+  * Normal Door to Laboratory Arena/Door to Laboratory Spiked Hall; Excluded from Dock Lock Rando
+  * Extra - instance_id: 147042
   > Middle Platform
       Any of the following:
           Space Jump or Damage Boost (Intermediate) or Can Use Spider Ball
@@ -405,7 +423,8 @@ Extra - map_name: rm_a7b08
 
 > Door to Laboratory Long Shaft; Heals? False
   * Layers: default
-  * Normal Door to Laboratory Long Shaft/Door to Laboratory Spiked Hall
+  * Normal Door to Laboratory Long Shaft/Door to Laboratory Spiked Hall; Excluded from Dock Lock Rando
+  * Extra - instance_id: 147043
   > Middle Platform
       Any of the following:
           Space Jump or Damage Boost (Intermediate) or Can Use Spider Ball
@@ -471,13 +490,15 @@ Laboratory Arena
 Extra - map_name: rm_a7b08A
 > Door to Laboratory Spiked Hall; Heals? False
   * Layers: default
-  * Normal Door to Laboratory Spiked Hall/Door to Laboratory Arena
+  * Normal Door to Laboratory Spiked Hall/Door to Laboratory Arena; Excluded from Dock Lock Rando
+  * Extra - instance_id: 147081
   > Door to Laboratory Small Shaft West
       Can Use Any Bombs
 
 > Door to Laboratory Small Shaft West; Heals? False
   * Layers: default
-  * Normal Door to Laboratory Small Shaft West/Door to Laboratory Arena
+  * Normal Door to Laboratory Small Shaft West/Door to Laboratory Arena; Excluded from Dock Lock Rando
+  * Extra - instance_id: 147287
   > Door to Laboratory Spiked Hall
       All of the following:
           Space Jump Wall
@@ -514,12 +535,14 @@ Extra - map_name: rm_a7b09
 > Door to Laboratory Arena; Heals? False
   * Layers: default
   * Normal Door to Laboratory Arena/Door to Laboratory Small Shaft West
+  * Extra - instance_id: 147404
   > Door to Queen Arena Access
       Trivial
 
 > Door to Queen Arena Access; Heals? False
   * Layers: default
   * Normal Door to Queen Arena Access/Door to Laboratory Small Shaft West
+  * Extra - instance_id: 147405
   > Door to Laboratory Arena
       Power Grip Wall
 
@@ -529,6 +552,7 @@ Extra - map_name: rm_a7b10
 > Door to Laboratory Small Shaft West; Heals? False
   * Layers: default
   * Normal Door to Laboratory Small Shaft West/Door to Queen Arena Access
+  * Extra - instance_id: 147656
   > Dock to Queen Arena
       Any of the following:
           Space Jump or Damage Boost (Intermediate)

--- a/randovania/games/am2r/json_data/Golden Temple.json
+++ b/randovania/games/am2r/json_data/Golden Temple.json
@@ -1165,7 +1165,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 108039
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1372,7 +1374,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 108040
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2813,6 +2817,10 @@
                                                                     "amount": 7,
                                                                     "negate": false
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Power Bombs"
                                                             }
                                                         ]
                                                     }
@@ -2905,7 +2913,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 108232
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2988,7 +2998,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 108256
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3092,7 +3104,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 108287
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3443,7 +3457,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 108382
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3486,7 +3502,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 108438
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3885,7 +3903,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 108557
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4095,7 +4115,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 108539
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5119,7 +5141,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 108658
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5259,7 +5283,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 108723
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5431,7 +5457,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 109096
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/am2r/json_data/Golden Temple.txt
+++ b/randovania/games/am2r/json_data/Golden Temple.txt
@@ -169,6 +169,7 @@ Extra - map_name: rm_a1h05
 > Door to Inner Temple Save Station; Heals? False
   * Layers: default
   * Normal Door to Inner Temple Save Station/Door to Golden Temple Exterior
+  * Extra - instance_id: 108039
   > Door to Inner Temple East Hall
       ZipFromDestroyable
   > Middle
@@ -196,6 +197,7 @@ Extra - map_name: rm_a1h05
 > Door to Inner Temple East Hall; Heals? False
   * Layers: default
   * Normal Door to Inner Temple East Hall/Door to Golden Temple Exterior
+  * Extra - instance_id: 108040
   > Dock to Outer Temple Save Station
       Trivial
   > Door to Inner Temple Save Station
@@ -386,7 +388,7 @@ Extra - map_name: rm_a1h09
                   Charged Bomb Jump (Beginner) and Can Use Charged Bomb Jump
           All of the following:
               # PB and then damage boost
-              Damage Boost (Advanced) and Normal Damage ≥ 7
+              Damage Boost (Advanced) and Normal Damage ≥ 7 and Can Use Power Bombs
               Any of the following:
                   Hi-Jump Boots or Mid-Air Morph (Advanced) or Walljump (Beginner) or Can Use Spider Ball
                   Charged Bomb Jump (Intermediate) and Can Use Charged Bomb Jump
@@ -394,6 +396,7 @@ Extra - map_name: rm_a1h09
 > Door to Storage Cavern; Heals? False
   * Layers: default
   * Power Bomb Door to Storage Cavern/Door to Torture Room
+  * Extra - instance_id: 108232
   > Dock to Guardian Arena
       Can Use Any Bombs
   > Pickup (Missile Tank)
@@ -412,6 +415,7 @@ Extra - map_name: rm_a1h10
 > Door to Torture Room; Heals? False
   * Layers: default
   * Normal Door to Torture Room/Door to Storage Cavern
+  * Extra - instance_id: 108256
   > Pickup (Power Bomb Tank)
       Trivial
 
@@ -436,6 +440,7 @@ Extra - map_name: rm_a1a01
 > Door to Golden Temple Exterior; Heals? False
   * Layers: default
   * Normal Door to Golden Temple Exterior/Door to Inner Temple Save Station
+  * Extra - instance_id: 108287
   > Save Station
       Trivial
 
@@ -494,6 +499,7 @@ Extra - map_name: rm_a1a03
 > Door to Bomb Chamber; Heals? False
   * Layers: default
   * Missile Door to Bomb Chamber/Door to Bomb Chamber Access
+  * Extra - instance_id: 108382
   > Dock to Inner Temple West Hall
       Trivial
 
@@ -503,6 +509,7 @@ Extra - map_name: rm_a1a04
 > Door to Bomb Chamber Access; Heals? False
   * Layers: default
   * Normal Door to Bomb Chamber Access/Door to Bomb Chamber
+  * Extra - instance_id: 108438
   > Pickup (Bombs)
       Trivial
   > Pickup (Missile Tank)
@@ -578,6 +585,7 @@ Extra - map_name: rm_a1a06
 > Door to Golden Temple Exterior; Heals? False
   * Layers: default
   * Normal Door to Golden Temple Exterior/Door to Inner Temple East Hall
+  * Extra - instance_id: 108557
   > Middle
       Trivial
 
@@ -614,6 +622,7 @@ Extra - map_name: rm_a1a06
 > Door to Parkour Course; Heals? False
   * Layers: default
   * Golden Temple EMP Activated Door to Parkour Course/Door to Inner Temple East Hall
+  * Extra - instance_id: 108539
   > Middle
       Can Use Any Bombs
 
@@ -786,6 +795,7 @@ Extra - map_name: rm_a1a09
 > Door to Charge Beam Chamber; Heals? False
   * Layers: default
   * Missile Door to Charge Beam Chamber/Door to Charge Beam Chamber Access
+  * Extra - instance_id: 108658
   > Dock to Inner Temple East Hall
       All of the following:
           Morph Ball
@@ -802,6 +812,7 @@ Extra - map_name: rm_a1a10
 > Door to Charge Beam Chamber Access; Heals? False
   * Layers: default
   * Normal Door to Charge Beam Chamber Access/Door to Charge Beam Chamber
+  * Extra - instance_id: 108723
   > Pickup (Charge Beam)
       Trivial
 
@@ -835,6 +846,7 @@ Extra - map_name: rm_a1a12
 > Door to Inner Temple East Hall; Heals? False
   * Layers: default
   * Normal Door to Inner Temple East Hall/Door to Parkour Course
+  * Extra - instance_id: 109096
   > Pickup (Super Missile Tank)
       All of the following:
           Screw Attack and Speed Booster and Super Missiles and Shinesparking Tricks (Advanced) and Can Use Any Bombs and Can Use Spring Ball

--- a/randovania/games/am2r/json_data/Hydro Station.json
+++ b/randovania/games/am2r/json_data/Hydro Station.json
@@ -633,7 +633,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 110043
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -642,7 +644,7 @@
                         "node": "Door to Hydro Station Exterior"
                     },
                     "default_dock_weakness": "Water Turbine Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -1910,7 +1912,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 110421
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1996,7 +2000,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 110437
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2366,7 +2372,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 110608
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2784,7 +2792,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 110748
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2869,7 +2879,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 400002
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3687,7 +3699,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 110894
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3758,7 +3772,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 111055
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4350,7 +4366,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 111244
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4442,7 +4460,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 111277
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6193,7 +6213,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 111778
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6286,15 +6308,32 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Bombs"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Missile Launcher",
+                                                        "amount": 20,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Missiles",
-                                            "amount": 20,
+                                            "type": "events",
+                                            "name": "EMP",
+                                            "amount": 1,
                                             "negate": false
                                         }
                                     }
@@ -7144,17 +7183,29 @@
                             }
                         },
                         "Event - Alpha": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Go Through Vines"
+                                        "data": "Defeat Alpha"
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Hijump With Power Grip Wall"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Go Through Vines"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Hijump With Power Grip Wall"
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -7687,7 +7738,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 113636
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -7706,15 +7759,6 @@
                             "data": {
                                 "comment": null,
                                 "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Super Missiles",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
                                     {
                                         "type": "and",
                                         "data": {

--- a/randovania/games/am2r/json_data/Hydro Station.txt
+++ b/randovania/games/am2r/json_data/Hydro Station.txt
@@ -93,7 +93,8 @@ Extra - map_name: rm_a2h02
 
 > Door to Water Turbine Station; Heals? False
   * Layers: default
-  * Water Turbine Door to Water Turbine Station/Door to Hydro Station Exterior
+  * Water Turbine Door to Water Turbine Station/Door to Hydro Station Exterior; Excluded from Dock Lock Rando
+  * Extra - instance_id: 110043
   > Dock to Inner Save Station
       Trivial
 
@@ -293,6 +294,7 @@ Extra - map_name: rm_a2a03
 > Door to Arachnus Arena; Heals? False
   * Layers: default
   * Missile Door to Arachnus Arena/Door to Arachnus Save Station
+  * Extra - instance_id: 110421
   > Save Station
       All of the following:
           Power Grip Wall
@@ -306,6 +308,7 @@ Extra - map_name: rm_a2a04
 > Door to Arachnus Save Station; Heals? False
   * Layers: default
   * Normal Door to Arachnus Save Station/Door to Arachnus Arena
+  * Extra - instance_id: 110437
   > Event - Arachnus
       All of the following:
           Any of the following:
@@ -373,6 +376,7 @@ Extra - map_name: rm_a2a06
 > Door to Varia Chamber; Heals? False
   * Layers: default
   * Missile Door to Varia Chamber/Door to Varia Chamber Access
+  * Extra - instance_id: 110608
   > Dock to Autrack Corridor Left Water Pipe
       Tunnel Climb
   > Top tunnel
@@ -433,6 +437,7 @@ Extra - map_name: rm_a2a07
 > Door to Varia Chamber Access; Heals? False
   * Layers: default
   * Normal Door to Varia Chamber Access/Door to Varia Chamber
+  * Extra - instance_id: 110748
   > Pickup (Varia Suit)
       Can Use Any Bombs
 
@@ -449,6 +454,7 @@ Extra - map_name: rm_a2a08
 > Door to Hydro Station Exterior; Heals? False
   * Layers: default
   * Normal Door to Hydro Station Exterior/Door to Water Turbine Station
+  * Extra - instance_id: 400002
   > Event - A2WaterLowered
       Trivial
 
@@ -569,6 +575,7 @@ Extra - map_name: rm_a2a10
 > Door to Wave Beam Chamber Access; Heals? False
   * Layers: default
   * Normal Door to Wave Beam Chamber Access/Door to Wave Beam Chamber
+  * Extra - instance_id: 110894
   > Pickup (Wave Beam)
       Trivial
 
@@ -585,6 +592,7 @@ Extra - map_name: rm_a2a11
 > Door to Wave Beam Chamber; Heals? False
   * Layers: default
   * Missile Door to Wave Beam Chamber/Door to Wave Beam Chamber Access
+  * Extra - instance_id: 111055
   > Left Wallfire
       Can Use Any Bombs
 
@@ -679,6 +687,7 @@ Extra - map_name: rm_a2a13
 > Door to Hi-Jump Chamber; Heals? False
   * Layers: default
   * Missile Door to Hi-Jump Chamber/Door to Hi-Jump Chamber Access
+  * Extra - instance_id: 111244
   > Dock to Lower Hydro Station Hub
       Enabled Septogg Helpers or Hijump Wall
 
@@ -694,6 +703,7 @@ Extra - map_name: rm_a2a14
 > Door to Hi-Jump Chamber Access; Heals? False
   * Layers: default
   * Normal Door to Hi-Jump Chamber Access/Door to Hi-Jump Chamber
+  * Extra - instance_id: 111277
   > Tunnel to Hydro Station Basement
       Can Use Any Bombs and Tunnel Climb
   > Pickup (Hi-Jump Boots)
@@ -941,6 +951,7 @@ Extra - map_name: rm_a2c01
 > Door to Speedboosting Challenge; Heals? False
   * Layers: default
   * Hydro Station EMP Activated Door to Speedboosting Challenge/Door to Breeding Grounds Access
+  * Extra - instance_id: 111778
   > Dock to Hydro Station Exterior (Bottom)
       Trivial
 
@@ -957,7 +968,7 @@ Extra - map_name: rm_a2c01
   > Dock to Hydro Station Exterior (Bottom)
       Trivial
   > Event - A2EMP
-      Missiles ≥ 20 or Can Use Bombs
+      Missile Launcher ≥ 20 or After EMP Activated or Can Use Bombs
 
 ----------------
 Breeding Grounds Save Station
@@ -1097,7 +1108,9 @@ Extra - map_name: rm_a2c06
   > Dock to Breeding Grounds Overgrown Alley
       Speed Booster and Shinesparking Tricks (Beginner) and Go Through Vines
   > Event - Alpha
-      Go Through Vines or Hijump With Power Grip Wall
+      All of the following:
+          Defeat Alpha
+          Go Through Vines or Hijump With Power Grip Wall
 
 > Dock to Breeding Grounds Overgrown Alley; Heals? False
   * Layers: default
@@ -1195,8 +1208,9 @@ Extra - map_name: rm_a2c10
 > Door to Breeding Grounds Access; Heals? False
   * Layers: default
   * Normal Door to Breeding Grounds Access/Door to Speedboosting Challenge
+  * Extra - instance_id: 113636
   > Pickup (Super Missile Tank)
-      Speed Booster and Super Missiles and Shinesparking Tricks (Intermediate)
+      Speed Booster and Shinesparking Tricks (Intermediate)
 
 > Pickup (Super Missile Tank); Heals? False
   * Layers: default

--- a/randovania/games/am2r/json_data/Industrial Complex.json
+++ b/randovania/games/am2r/json_data/Industrial Complex.json
@@ -1124,7 +1124,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 114250
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1237,7 +1239,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 114721
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1806,7 +1810,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 115126
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1984,7 +1990,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 115149
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2176,7 +2184,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 115233
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2247,7 +2257,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 115254
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2593,7 +2605,7 @@
                     "valid_starting_location": true,
                     "connections": {
                         "In Sand": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -3036,7 +3048,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 116035
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3217,7 +3231,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 116073
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -3823,7 +3839,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 116700
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4005,7 +4023,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 116779
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/am2r/json_data/Industrial Complex.txt
+++ b/randovania/games/am2r/json_data/Industrial Complex.txt
@@ -175,6 +175,7 @@ Extra - map_name: rm_a3h04
 > Door to Torizo Arena; Heals? False
   * Layers: default
   * Missile Door to Torizo Arena/Door to Industrial Complex Exterior
+  * Extra - instance_id: 114250
   > Dock to Upper Factory Save Station
       Any of the following:
           Space Jump or Enabled Septogg Helpers
@@ -190,6 +191,7 @@ Extra - map_name: rm_a3h04
 > Door to Exterior Puzzle Cavern; Heals? False
   * Layers: default
   * Super Missile Door to Exterior Puzzle Cavern/Door to Industrial Complex Exterior
+  * Extra - instance_id: 114721
   > Dock to Upper Factory Save Station
       Trivial
 
@@ -280,6 +282,7 @@ Extra - map_name: rm_a3h07
 > Door to Industrial Complex Exterior; Heals? False
   * Layers: default
   * Normal Door to Industrial Complex Exterior/Door to Exterior Puzzle Cavern
+  * Extra - instance_id: 115126
   > Pickup (Power Bomb Tank)
       Speed Booster and Shinesparking Tricks (Intermediate) and Disabled Entrance Rando and Can Use Power Bombs
 
@@ -308,6 +311,7 @@ Extra - map_name: rm_a3h08
 > Door to Storage Cavern; Heals? False
   * Layers: default
   * Industrial Complex EMP Activated Door to Storage Cavern/Door to EMP Sentry Cavern
+  * Extra - instance_id: 115149
   > Bottom
       Trivial
 
@@ -345,6 +349,7 @@ Extra - map_name: rm_a3h09
 > Door to EMP Sentry Cavern; Heals? False
   * Layers: default
   * Normal Door to EMP Sentry Cavern/Door to Storage Cavern
+  * Extra - instance_id: 115233
   > Pickup (Power Bomb Tank)
       Trivial
 
@@ -361,6 +366,7 @@ Extra - map_name: rm_a3a01
 > Door to Industrial Complex Exterior; Heals? False
   * Layers: default
   * Normal Door to Industrial Complex Exterior/Door to Torizo Arena
+  * Extra - instance_id: 115254
   > Pickup (Space Jump)
       Trivial
 
@@ -415,7 +421,7 @@ Extra - map_name: rm_a3a02
   * Layers: default
   * Extra - save_room: 10
   > In Sand
-      Any of the following:
+      All of the following:
           Any of the following:
               # Get into tunnel
               Tunnel Climb
@@ -486,6 +492,7 @@ Extra - map_name: rm_a3a04
 > Door to Spazer Beam; Heals? False
   * Layers: default
   * Missile Door to Spazer Beam/Door to Spazer Beam Chamber Access
+  * Extra - instance_id: 116035
   > Dock to Upper Factory Intersection
       All of the following:
           # Speedboost
@@ -514,6 +521,7 @@ Extra - map_name: rm_a3a05
 > Door to Spazer Beam Chamber Access; Heals? False
   * Layers: default
   * Normal Door to Spazer Beam Chamber Access/Door to Spazer Beam
+  * Extra - instance_id: 116073
   > Pickup (Spazer Beam)
       Trivial
 
@@ -616,6 +624,7 @@ Extra - map_name: rm_a3a09
 > Door to Speed Booster Chamber; Heals? False
   * Layers: default
   * Missile Door to Speed Booster Chamber/Door to Speed Booster Chamber Access
+  * Extra - instance_id: 116700
   > Dock to Upper Factory Autoad Fork
       Any of the following:
           Speed Booster
@@ -641,6 +650,7 @@ Extra - map_name: rm_a3a10
 > Door to Speed Booster Chamber Access; Heals? False
   * Layers: default
   * Normal Door to Speed Booster Chamber Access/Door to Speed Booster Chamber
+  * Extra - instance_id: 116779
   > Pickup (Speed Booster)
       Power Grip Wall
 

--- a/randovania/games/am2r/json_data/Main Caves.json
+++ b/randovania/games/am2r/json_data/Main Caves.json
@@ -1111,7 +1111,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 101612
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1187,7 +1189,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 101657
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/am2r/json_data/Main Caves.txt
+++ b/randovania/games/am2r/json_data/Main Caves.txt
@@ -184,6 +184,7 @@ Extra - map_name: rm_a0h04b
 > Door to Surface Pond Save Station; Heals? False
   * Layers: default
   * Missile Door to Surface Pond Save Station/Door to Surface Pond
+  * Extra - instance_id: 101612
   > Dock to Surface Pond Access
       Trivial
 
@@ -201,6 +202,7 @@ Extra - map_name: rm_a0h04c
 > Door to Surface Pond; Heals? False
   * Layers: default
   * Normal Door to Surface Pond/Door to Surface Pond Save Station
+  * Extra - instance_id: 101657
   > Save Station
       Trivial
 

--- a/randovania/games/am2r/json_data/The Tower.json
+++ b/randovania/games/am2r/json_data/The Tower.json
@@ -20,7 +20,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 125465
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -1151,7 +1153,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 125529
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2083,7 +2087,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 126190
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2173,7 +2179,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 125934
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -2237,7 +2245,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 125935
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4545,7 +4555,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 127649
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4606,7 +4618,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 127650
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4727,7 +4741,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 127719
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4762,7 +4778,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 127720
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4805,7 +4823,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 127809
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4845,7 +4865,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 127810
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4888,7 +4910,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 127890
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -4923,7 +4947,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 127838
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5074,7 +5100,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 127943
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5109,7 +5137,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 128037
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5296,7 +5326,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 128065
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5331,7 +5363,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 128064
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5556,7 +5590,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 128421
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5591,7 +5627,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 128420
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -5744,7 +5782,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 128525
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6157,7 +6197,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 128625
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6250,7 +6292,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 128607
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6393,7 +6437,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 128664
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {
@@ -6741,6 +6787,10 @@
                                     {
                                         "type": "template",
                                         "data": "Can Use Any Bombs"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Defeat Zeta"
                                     }
                                 ]
                             }
@@ -7334,7 +7384,9 @@
                     "layers": [
                         "default"
                     ],
-                    "extra": {},
+                    "extra": {
+                        "instance_id": 129395
+                    },
                     "valid_starting_location": false,
                     "dock_type": "door",
                     "default_connection": {

--- a/randovania/games/am2r/json_data/The Tower.txt
+++ b/randovania/games/am2r/json_data/The Tower.txt
@@ -4,6 +4,7 @@ Extra - map_name: rm_a4h01
 > Door to Inner Save Station East Access; Heals? False
   * Layers: default
   * Normal Door to Inner Save Station East Access/Door to Tower Exterior South East
+  * Extra - instance_id: 125465
   > Dock to Tower Right Exterior Access
       Trivial
   > Dock to Tower Exterior North East
@@ -139,6 +140,7 @@ Extra - map_name: rm_a4h02
 > Door to Plasma Beam Chamber Access; Heals? False
   * Layers: default
   * Tower Activated Door to Plasma Beam Chamber Access/Door to Tower Exterior North East
+  * Extra - instance_id: 125529
   > Dock to Tower Exterior South East
       Trivial
   > Tunnel to Inner Zeta Nest Access
@@ -271,6 +273,7 @@ Extra - map_name: rm_a4h04
 > Door to Power Plant Entrance; Heals? False
   * Layers: default
   * Normal Door to Power Plant Entrance/Door to Tower Exterior West
+  * Extra - instance_id: 126190
   > Dock to Exterior Zeta Nest West Access
       Power Grip Wall
   > Dock to Tower Exterior North
@@ -283,6 +286,7 @@ Extra - map_name: rm_a4h04
 > Door to Tower Activation Station; Heals? False
   * Layers: default
   * Power Bomb Door to Tower Activation Station/Door to Tower Exterior West
+  * Extra - instance_id: 125934
   > Dock to Exterior Zeta Nest West Access
       Movement (Beginner)
   > Tunnel to Plasma Beam Chamber
@@ -293,6 +297,7 @@ Extra - map_name: rm_a4h04
 > Door to Inner Save Station West Access; Heals? False
   * Layers: default
   * Normal Door to Inner Save Station West Access/Door to Tower Exterior West
+  * Extra - instance_id: 125935
   > Dock to Exterior Zeta Nest West Access
       Movement (Intermediate)
   > Door to Power Plant Entrance
@@ -598,6 +603,7 @@ Extra - map_name: rm_a4a01
 > Door to Tower Exterior South East; Heals? False
   * Layers: default
   * Normal Door to Tower Exterior South East/Door to Inner Save Station East Access
+  * Extra - instance_id: 127649
   > Door to Inner Save Station
       Space Jump Wall
   > Dock to Inner Tower Pipe
@@ -606,6 +612,7 @@ Extra - map_name: rm_a4a01
 > Door to Inner Save Station; Heals? False
   * Layers: default
   * Normal Door to Inner Save Station/Door to Inner Save Station East Access
+  * Extra - instance_id: 127650
   > Door to Tower Exterior South East
       Trivial
 
@@ -629,12 +636,14 @@ Extra - map_name: rm_a4a02
 > Door to Inner Save Station East Access; Heals? False
   * Layers: default
   * Normal Door to Inner Save Station East Access/Door to Inner Save Station
+  * Extra - instance_id: 127719
   > Save Station
       Trivial
 
 > Door to Inner Save Station West Access; Heals? False
   * Layers: default
   * Normal Door to Inner Save Station West Access/Door to Inner Save Station
+  * Extra - instance_id: 127720
   > Save Station
       Trivial
 
@@ -644,12 +653,14 @@ Extra - map_name: rm_a4a03
 > Door to Tower Exterior West; Heals? False
   * Layers: default
   * Normal Door to Tower Exterior West/Door to Inner Save Station West Access
+  * Extra - instance_id: 127809
   > Door to Inner Save Station
       Space Jump Wall
 
 > Door to Inner Save Station; Heals? False
   * Layers: default
   * Normal Door to Inner Save Station/Door to Inner Save Station West Access
+  * Extra - instance_id: 127810
   > Door to Tower Exterior West
       Trivial
 
@@ -659,12 +670,14 @@ Extra - map_name: rm_a4a04
 > Door to Gunzoo Shaft; Heals? False
   * Layers: default
   * Tower Activated Door to Gunzoo Shaft/Door to Tower Activation Station
+  * Extra - instance_id: 127890
   > Ground
       Trivial
 
 > Door to Tower Exterior West; Heals? False
   * Layers: default
   * After Tester Door to Tower Exterior West/Door to Tower Activation Station
+  * Extra - instance_id: 127838
   > Ground
       Trivial
 
@@ -695,12 +708,14 @@ Extra - map_name: rm_a4a05
 > Door to Tester Arena Access North; Heals? False
   * Layers: default
   * After Tester Door to Tester Arena Access North/Door to Tester Arena
+  * Extra - instance_id: 127943
   > Door to Tester Arena Access South
       Trivial
 
 > Door to Tester Arena Access South; Heals? False
   * Layers: default
   * After Tester Door to Tester Arena Access South/Door to Tester Arena
+  * Extra - instance_id: 128037
   > Event - Tester
       All of the following:
           Any of the following:
@@ -728,12 +743,14 @@ Extra - map_name: rm_a4a06
 > Door to Gunzoo Shaft; Heals? False
   * Layers: default
   * Tower Activated Door to Gunzoo Shaft/Door to Tester Arena Access South
+  * Extra - instance_id: 128065
   > Top Platform
       Trivial
 
 > Door to Tester Arena; Heals? False
   * Layers: default
   * Tower Activated Door to Tester Arena/Door to Tester Arena Access South
+  * Extra - instance_id: 128064
   > Bottom
       Trivial
 
@@ -772,12 +789,14 @@ Extra - map_name: rm_a4a07
 > Door to Tester Arena Access South; Heals? False
   * Layers: default
   * Normal Door to Tester Arena Access South/Door to Gunzoo Shaft
+  * Extra - instance_id: 128421
   > Door to Tower Activation Station
       Trivial
 
 > Door to Tower Activation Station; Heals? False
   * Layers: default
   * Normal Door to Tower Activation Station/Door to Gunzoo Shaft
+  * Extra - instance_id: 128420
   > Door to Tester Arena Access South
       Any of the following:
           Space Jump Wall
@@ -799,6 +818,7 @@ Extra - map_name: rm_a4a08
 > Door to Tester Arena; Heals? False
   * Layers: default
   * Tower Activated Door to Tester Arena/Door to Tester Arena Access North
+  * Extra - instance_id: 128525
   > Middle
       Trivial
 
@@ -859,6 +879,7 @@ Extra - map_name: rm_a4a09
 > Door to Tower Exterior North East; Heals? False
   * Layers: default
   * Tower Activated Door to Tower Exterior North East/Door to Plasma Beam Chamber Access
+  * Extra - instance_id: 128625
   > Door to Plasma Beam Chamber
       Trivial
 
@@ -874,6 +895,7 @@ Extra - map_name: rm_a4a09
 > Door to Plasma Beam Chamber; Heals? False
   * Layers: default
   * Tower Activated Door to Plasma Beam Chamber/Door to Plasma Beam Chamber Access
+  * Extra - instance_id: 128607
   > Door to Tower Exterior North East
       Trivial
   > Middle in Tunnel
@@ -897,6 +919,7 @@ Extra - map_name: rm_a4a10
 > Door to Plasma Beam Chamber Access; Heals? False
   * Layers: default
   * Normal Door to Plasma Beam Chamber Access/Door to Plasma Beam Chamber
+  * Extra - instance_id: 128664
   > Pickup (Plasma Beam)
       Trivial
 
@@ -946,7 +969,7 @@ Extra - map_name: rm_a4a12
   * Layers: default
   * Open Passage to Inner Zeta Nest Access/Dock to Inner Zeta Nest
   > Event - Zeta
-      Can Use Any Bombs
+      Can Use Any Bombs and Defeat Zeta
 
 > Event - Zeta; Heals? False
   * Layers: default
@@ -1028,6 +1051,7 @@ Extra - map_name: rm_a4b01
 > Door to Tower Exterior West; Heals? False
   * Layers: default
   * Normal Door to Tower Exterior West/Door to Power Plant Entrance
+  * Extra - instance_id: 129395
   > Dock to Power Plant Destroyed Shaft
       Low Mid-Air Morph Tunnel Climb
 


### PR DESCRIPTION
This adds extra fields to doors for future use in the door lock rando and fixes some slight logic errors.
The logic errors have been gone through with @DruidVorse
Specifically what they fix are:
**Golden Temple**
- Add a missing PB check for a potential way to get up torture room

**Hydro Station**
- Add a missing "after emp activated" event in order to reach the a2 emp event in breeding grounds entrance
- Add a missing "defeat alpha" template in order to reach the alpha node in breeding grounds alpha nest west
- Remove Super Missile requirement in Speedboosting challenge

**Distribution Center**
- Going in upper factory save station from the save to the sand now requires all requirements instead of any

**Tower**
- Going from the dock node in Inner Zeta nest to the zeta event, now requires "Defeat Zeta"

**Distribution Center**
- In Energy Distribution Entrance Save Station add a missing trivial from one dock to save

(Yes, the logic PRs should've been in a different PR, but I am bad with branches, noticed it too late, and didn't wanna go through the effort of splitting it up...)