### PR TITLE
AM2R: Fix some room name typos

### DIFF
--- a/randovania/games/am2r/json_data/Distribution Center.json
+++ b/randovania/games/am2r/json_data/Distribution Center.json
@@ -843,7 +843,7 @@
                 "map_name": "rm_a5c01"
             },
             "nodes": {
-                "Door to Beam Bot Prison": {
+                "Door to Robomine Prison": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -862,7 +862,7 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Distribution Center",
-                        "area": "Beam Bot Prison",
+                        "area": "Robomine Prison",
                         "node": "Door to Blade Bot Patrol Room"
                     },
                     "default_dock_weakness": "Normal Door",
@@ -939,7 +939,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Beam Bot Prison": {
+                        "Door to Robomine Prison": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -981,7 +981,7 @@
                 }
             }
         },
-        "Beam Bot Prison": {
+        "Robomine Prison": {
             "default_node": null,
             "extra": {
                 "map_name": "rm_a5c02"
@@ -1007,7 +1007,7 @@
                     "default_connection": {
                         "region": "Distribution Center",
                         "area": "Energy Distribution Entrance Save Station",
-                        "node": "Door to Beam Bot Prison"
+                        "node": "Door to Robomine Prison"
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
@@ -1049,7 +1049,7 @@
                     "default_connection": {
                         "region": "Distribution Center",
                         "area": "Blade Bot Patrol Room",
-                        "node": "Door to Beam Bot Prison"
+                        "node": "Door to Robomine Prison"
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
@@ -1103,7 +1103,7 @@
                                 "items": []
                             }
                         },
-                        "Door to Beam Bot Prison": {
+                        "Door to Robomine Prison": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1149,7 +1149,7 @@
                         }
                     }
                 },
-                "Door to Beam Bot Prison": {
+                "Door to Robomine Prison": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1168,7 +1168,7 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Distribution Center",
-                        "area": "Beam Bot Prison",
+                        "area": "Robomine Prison",
                         "node": "Door to Energy Distribution Entrance Save Station"
                     },
                     "default_dock_weakness": "Normal Door",

--- a/randovania/games/am2r/json_data/Distribution Center.txt
+++ b/randovania/games/am2r/json_data/Distribution Center.txt
@@ -137,9 +137,9 @@ Extra - map_name: rm_a5h05
 ----------------
 Blade Bot Patrol Room
 Extra - map_name: rm_a5c01
-> Door to Beam Bot Prison; Heals? False
+> Door to Robomine Prison; Heals? False
   * Layers: default
-  * Normal Door to Beam Bot Prison/Door to Blade Bot Patrol Room
+  * Normal Door to Robomine Prison/Door to Blade Bot Patrol Room
   * Extra - instance_id: 132428
   > Door to Distribution Center Exterior West
       Any of the following:
@@ -150,24 +150,24 @@ Extra - map_name: rm_a5c01
   * Layers: default
   * Normal Door to Distribution Center Exterior West/Door to Blade Bot Patrol Room
   * Extra - instance_id: 132427
-  > Door to Beam Bot Prison
+  > Door to Robomine Prison
       Any of the following:
           Tunnel Climb
           Morph Ball and Mid-Air Morph (Beginner)
 
 ----------------
-Beam Bot Prison
+Robomine Prison
 Extra - map_name: rm_a5c02
 > Door to Energy Distribution Entrance Save Station; Heals? False
   * Layers: default
-  * Normal Door to Energy Distribution Entrance Save Station/Door to Beam Bot Prison
+  * Normal Door to Energy Distribution Entrance Save Station/Door to Robomine Prison
   * Extra - instance_id: 133481
   > Door to Blade Bot Patrol Room
       Space Jump Wall
 
 > Door to Blade Bot Patrol Room; Heals? False
   * Layers: default
-  * Normal Door to Blade Bot Patrol Room/Door to Beam Bot Prison
+  * Normal Door to Blade Bot Patrol Room/Door to Robomine Prison
   * Extra - instance_id: 133480
   > Door to Energy Distribution Entrance Save Station
       Space Jump Wall
@@ -180,7 +180,7 @@ Extra - map_name: rm_a5c03
   * Extra - save_room: 17
   > Door to Energy Distribution Tower West
       Trivial
-  > Door to Beam Bot Prison
+  > Door to Robomine Prison
       Trivial
 
 > Door to Energy Distribution Tower West; Heals? False
@@ -190,9 +190,9 @@ Extra - map_name: rm_a5c03
   > Save Station
       Trivial
 
-> Door to Beam Bot Prison; Heals? False
+> Door to Robomine Prison; Heals? False
   * Layers: default
-  * Normal Door to Beam Bot Prison/Door to Energy Distribution Entrance Save Station
+  * Normal Door to Robomine Prison/Door to Energy Distribution Entrance Save Station
   * Extra - instance_id: 133498
   > Save Station
       Trivial

--- a/randovania/games/am2r/json_data/Golden Temple.json
+++ b/randovania/games/am2r/json_data/Golden Temple.json
@@ -5737,7 +5737,7 @@
                 "map_name": "rm_a1b02"
             },
             "nodes": {
-                "Dock to Breeding Ground South East": {
+                "Dock to Breeding Grounds South East": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5754,7 +5754,7 @@
                     "dock_type": "other",
                     "default_connection": {
                         "region": "Golden Temple",
-                        "area": "Breeding Ground South East",
+                        "area": "Breeding Grounds South East",
                         "node": "Dock to Breeding Grounds Hub"
                     },
                     "default_dock_weakness": "Open Passage",
@@ -5763,14 +5763,14 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Breeding Ground North West": {
+                        "Dock to Breeding Grounds North West": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Dock to Breeding Ground South West": {
+                        "Dock to Breeding Grounds South West": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5805,7 +5805,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Breeding Ground North West": {
+                        "Dock to Breeding Grounds North West": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5814,7 +5814,7 @@
                         }
                     }
                 },
-                "Dock to Breeding Ground North West": {
+                "Dock to Breeding Grounds North West": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5831,7 +5831,7 @@
                     "dock_type": "other",
                     "default_connection": {
                         "region": "Golden Temple",
-                        "area": "Breeding Ground North West",
+                        "area": "Breeding Grounds North West",
                         "node": "Dock to Breeding Grounds Hub"
                     },
                     "default_dock_weakness": "Open Passage",
@@ -5840,7 +5840,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Breeding Ground South East": {
+                        "Dock to Breeding Grounds South East": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5856,7 +5856,7 @@
                         }
                     }
                 },
-                "Dock to Breeding Ground South West": {
+                "Dock to Breeding Grounds South West": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5873,7 +5873,7 @@
                     "dock_type": "other",
                     "default_connection": {
                         "region": "Golden Temple",
-                        "area": "Breeding Ground South West",
+                        "area": "Breeding Grounds South West",
                         "node": "Dock to Breeding Grounds Hub"
                     },
                     "default_dock_weakness": "Open Passage",
@@ -5882,7 +5882,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Breeding Ground South East": {
+                        "Dock to Breeding Grounds South East": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5893,7 +5893,7 @@
                 }
             }
         },
-        "Breeding Ground North West": {
+        "Breeding Grounds North West": {
             "default_node": null,
             "extra": {
                 "map_name": "rm_a1b03"
@@ -5917,7 +5917,7 @@
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds Hub",
-                        "node": "Dock to Breeding Ground North West"
+                        "node": "Dock to Breeding Grounds North West"
                     },
                     "default_dock_weakness": "Open Passage",
                     "exclude_from_dock_rando": false,
@@ -5966,7 +5966,7 @@
                 }
             }
         },
-        "Breeding Ground South East": {
+        "Breeding Grounds South East": {
             "default_node": null,
             "extra": {
                 "map_name": "rm_a1b04"
@@ -5990,7 +5990,7 @@
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds Hub",
-                        "node": "Dock to Breeding Ground South East"
+                        "node": "Dock to Breeding Grounds South East"
                     },
                     "default_dock_weakness": "Open Passage",
                     "exclude_from_dock_rando": false,
@@ -6039,7 +6039,7 @@
                 }
             }
         },
-        "Breeding Ground South West": {
+        "Breeding Grounds South West": {
             "default_node": null,
             "extra": {
                 "map_name": "rm_a1b05"
@@ -6063,7 +6063,7 @@
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds Hub",
-                        "node": "Dock to Breeding Ground South West"
+                        "node": "Dock to Breeding Grounds South West"
                     },
                     "default_dock_weakness": "Open Passage",
                     "exclude_from_dock_rando": false,

--- a/randovania/games/am2r/json_data/Golden Temple.txt
+++ b/randovania/games/am2r/json_data/Golden Temple.txt
@@ -886,40 +886,40 @@ Extra - map_name: rm_a1b01
 ----------------
 Breeding Grounds Hub
 Extra - map_name: rm_a1b02
-> Dock to Breeding Ground South East; Heals? False
+> Dock to Breeding Grounds South East; Heals? False
   * Layers: default
-  * Open Passage to Breeding Ground South East/Dock to Breeding Grounds Hub
-  > Dock to Breeding Ground North West
+  * Open Passage to Breeding Grounds South East/Dock to Breeding Grounds Hub
+  > Dock to Breeding Grounds North West
       Trivial
-  > Dock to Breeding Ground South West
+  > Dock to Breeding Grounds South West
       Trivial
 
 > Dock to Breeding Grounds Entrance; Heals? False
   * Layers: default
   * Open Passage to Breeding Grounds Entrance/Dock to Breeding Grounds Hub
-  > Dock to Breeding Ground North West
+  > Dock to Breeding Grounds North West
       Trivial
 
-> Dock to Breeding Ground North West; Heals? False
+> Dock to Breeding Grounds North West; Heals? False
   * Layers: default
-  * Open Passage to Breeding Ground North West/Dock to Breeding Grounds Hub
-  > Dock to Breeding Ground South East
+  * Open Passage to Breeding Grounds North West/Dock to Breeding Grounds Hub
+  > Dock to Breeding Grounds South East
       Trivial
   > Dock to Breeding Grounds Entrance
       Trivial
 
-> Dock to Breeding Ground South West; Heals? False
+> Dock to Breeding Grounds South West; Heals? False
   * Layers: default
-  * Open Passage to Breeding Ground South West/Dock to Breeding Grounds Hub
-  > Dock to Breeding Ground South East
+  * Open Passage to Breeding Grounds South West/Dock to Breeding Grounds Hub
+  > Dock to Breeding Grounds South East
       Trivial
 
 ----------------
-Breeding Ground North West
+Breeding Grounds North West
 Extra - map_name: rm_a1b03
 > Dock to Breeding Grounds Hub; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds Hub/Dock to Breeding Ground North West
+  * Open Passage to Breeding Grounds Hub/Dock to Breeding Grounds North West
   > Event - Alpha
       Defeat Alpha
 
@@ -930,11 +930,11 @@ Extra - map_name: rm_a1b03
       Trivial
 
 ----------------
-Breeding Ground South East
+Breeding Grounds South East
 Extra - map_name: rm_a1b04
 > Dock to Breeding Grounds Hub; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds Hub/Dock to Breeding Ground South East
+  * Open Passage to Breeding Grounds Hub/Dock to Breeding Grounds South East
   > Event - Alpha
       Defeat Alpha
 
@@ -945,11 +945,11 @@ Extra - map_name: rm_a1b04
       Trivial
 
 ----------------
-Breeding Ground South West
+Breeding Grounds South West
 Extra - map_name: rm_a1b05
 > Dock to Breeding Grounds Hub; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds Hub/Dock to Breeding Ground South West
+  * Open Passage to Breeding Grounds Hub/Dock to Breeding Grounds South West
   > Event - Alpha
       Defeat Alpha
 


### PR DESCRIPTION
Some rooms were named `Breeding Ground` instead of `Breeding Ground*s*`. 
Also the `Beam Bot Prison` is now named `Robomine Prison`, because that's the actual name of the enemies.