### PR TITLE
Enable word wrap for dread goal ui

### DIFF
--- a/randovania/gui/ui_files/preset_dread_goal.ui
+++ b/randovania/gui/ui_files/preset_dread_goal.ui
@@ -96,6 +96,9 @@
          <property name="text">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The following options limit where Metroid DNA will be placed. There can only be as many DNA shuffled as there are preferred locations enabled. Each option adds 6 locations, up to a total of 12.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
Makes UI not resize awkwardly now when switching to the goal tab
