### PR TITLE
AM2R: When going down from thoth, have access to the lift event

### DIFF
--- a/randovania/games/am2r/json_data/Main Caves.json
+++ b/randovania/games/am2r/json_data/Main Caves.json
@@ -7237,21 +7237,11 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Research Site": {
+                        "Event - ThothPBEntrance": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "ThothPBEntrance",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }

--- a/randovania/games/am2r/json_data/Main Caves.txt
+++ b/randovania/games/am2r/json_data/Main Caves.txt
@@ -1077,8 +1077,8 @@ Extra - map_name: rm_a0h13
 > Dock to Elevator Shaft; Heals? False
   * Layers: default
   * Open Passage to Elevator Shaft/Dock to Research Site Access
-  > Dock to Research Site
-      After Thoth Power Bomb Entrance
+  > Event - ThothPBEntrance
+      Trivial
 
 > Event - ThothPBEntrance; Heals? False
   * Layers: default


### PR DESCRIPTION
In vanilla AM2R, when you go down from the Thoth elevator, you need to reset the game, as you're blocked by the power bombs.
Since the patcher will clear the event if you come from above, I adjusted the DB accordingly.