### PR TITLE
AM2R: Fix A2/A3 EMP logic errors

### DIFF
--- a/randovania/games/am2r/json_data/Hydro Station.json
+++ b/randovania/games/am2r/json_data/Hydro Station.json
@@ -6303,7 +6303,7 @@
                             }
                         },
                         "Event - A2EMP": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [

--- a/randovania/games/am2r/json_data/Hydro Station.txt
+++ b/randovania/games/am2r/json_data/Hydro Station.txt
@@ -968,7 +968,9 @@ Extra - map_name: rm_a2c01
   > Dock to Hydro Station Exterior (Bottom)
       Trivial
   > Event - A2EMP
-      Missile Launcher ≥ 20 or After EMP Activated or Can Use Bombs
+      All of the following:
+          After EMP Activated
+          Missile Launcher ≥ 20 or Can Use Bombs
 
 ----------------
 Breeding Grounds Save Station

--- a/randovania/games/am2r/json_data/Industrial Complex.json
+++ b/randovania/games/am2r/json_data/Industrial Complex.json
@@ -2126,11 +2126,37 @@
                                         "data": "Can Use Power Bombs"
                                     },
                                     {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Missiles",
+                                                        "amount": 5,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Super Missiles",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Missiles",
-                                            "amount": 10,
+                                            "type": "events",
+                                            "name": "EMP",
+                                            "amount": 1,
                                             "negate": false
                                         }
                                     }

--- a/randovania/games/am2r/json_data/Industrial Complex.txt
+++ b/randovania/games/am2r/json_data/Industrial Complex.txt
@@ -335,7 +335,9 @@ Extra - map_name: rm_a3h08
   > Dock to Outer Caverns Save Station
       Can Use Any Bombs
   > Event - A3EMP
-      Missiles ≥ 10 and Can Use Power Bombs
+      All of the following:
+          After EMP Activated and Can Use Power Bombs
+          Missiles ≥ 5 or Super Missiles ≥ 2
 
 > Event - A3EMP; Heals? False
   * Layers: default


### PR DESCRIPTION
Fixes an accidental OR in A2, and missing EMP+Super conditions for A3.
Noticed during a testing session.