### PR TITLE
Remove the Back button, always reply with new message

### DIFF
--- a/test/server/discord/test_database_command.py
+++ b/test/server/discord/test_database_command.py
@@ -69,9 +69,10 @@ async def test_on_database_world_selected():
     await item.callback(ctx)
 
     # Assert
-    ctx.edit_original_response.assert_awaited_once_with(
+    ctx.response.send_message.assert_awaited_once_with(
         embed=ANY,
         view=view,
+        ephemeral=True,
     )
 
 


### PR DESCRIPTION
There's a bug in the bot currently that it seems to randomly fail to work. I can reproduce it easily by:
1. Starting the bot
2. Run `/database-inspect` with a game
3. Select one section of regions
4. Press back
5. Repeat 3 and 4 until it fails

The error messages comes as if we're sending too much data, but adding prints to the libraries tells we don't. But since that request is a PATCH one, I'm wondering if we're hiting a _lifetime_ total message or something?

This PR dodges the issue by just never editing the message anymore.