### PR TITLE
Add "Open Session Window" action / Allow joining without password 

### DIFF
--- a/randovania/game_connection/game_connection.py
+++ b/randovania/game_connection/game_connection.py
@@ -15,6 +15,7 @@ from randovania.game_description.db.region import Region
 from randovania.game_description.resources.item_resource_info import Inventory
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.interface_common.options import Options
+from randovania.interface_common.world_database import WorldDatabase
 from randovania.lib.infinite_timer import InfiniteTimer
 from randovania.network_common.game_connection_status import GameConnectionStatus
 
@@ -38,13 +39,14 @@ class GameConnection(QObject):
     connected_states: dict[RemoteConnector, ConnectedGameState]
     _dt: float = 2.5
 
-    def __init__(self, options: Options):
+    def __init__(self, options: Options, world_database: WorldDatabase):
         super().__init__()
         self.logger = logging.getLogger(type(self).__name__)
         self._options = options
         self.connection_builders = []
         self.remote_connectors = {}
         self.connected_states = {}
+        self.world_database = world_database
 
         for builder_param in options.connector_builders:
             self.add_connection_builder(builder_param.create_builder())

--- a/randovania/gui/lib/multiplayer_session_api.py
+++ b/randovania/gui/lib/multiplayer_session_api.py
@@ -77,25 +77,26 @@ def handle_network_errors(fn: typing.Callable[typing.Concatenate[MultiplayerSess
 
 
 class MultiplayerSessionApi(QtCore.QObject):
+    # FIXME: All these signals are unused
     MetaUpdated = QtCore.Signal(MultiplayerSessionEntry)
     ActionsUpdated = QtCore.Signal(MultiplayerSessionActions)
     AuditLogUpdated = QtCore.Signal(MultiplayerSessionAuditLog)
 
-    current_entry: MultiplayerSessionEntry
+    current_session_id: int
     widget_root: QtWidgets.QWidget | None
 
-    def __init__(self, network_client: QtNetworkClient, entry: MultiplayerSessionEntry):
+    def __init__(self, network_client: QtNetworkClient, session_id: int):
         super().__init__()
         self.widget_root = None
         self.network_client = network_client
-        self.current_entry = entry
+        self.current_session_id = session_id
 
     async def session_admin_global(self, action: admin_actions.SessionAdminGlobalAction, arg):
         try:
             self.widget_root.setEnabled(False)
             return await self.network_client.server_call(
                 "multiplayer_admin_session",
-                (self.current_entry.id, action.value, arg))
+                (self.current_session_id, action.value, arg))
         finally:
             self.widget_root.setEnabled(True)
 
@@ -104,7 +105,7 @@ class MultiplayerSessionApi(QtCore.QObject):
             self.widget_root.setEnabled(False)
             return await self.network_client.server_call(
                 "multiplayer_admin_player",
-                (self.current_entry.id, user_id, action.value, arg)
+                (self.current_session_id, user_id, action.value, arg)
             )
         finally:
             self.widget_root.setEnabled(True)
@@ -175,5 +176,5 @@ class MultiplayerSessionApi(QtCore.QObject):
     async def request_session_update(self):
         await self.network_client.server_call(
             "multiplayer_request_session_update",
-            self.current_entry.id
+            self.current_session_id
         )

--- a/randovania/gui/lib/window_manager.py
+++ b/randovania/gui/lib/window_manager.py
@@ -11,7 +11,8 @@ if typing.TYPE_CHECKING:
     from randovania.layout.layout_description import LayoutDescription
     from randovania.layout.preset import Preset
     from randovania.layout.base.trick_level_configuration import TrickLevelConfiguration
-
+    from randovania.gui.lib.qt_network_client import QtNetworkClient
+    from randovania.interface_common.options import Options
 
 class WindowManager(QtWidgets.QMainWindow):
     tracked_windows: list[CloseEventWidget]
@@ -54,6 +55,12 @@ class WindowManager(QtWidgets.QMainWindow):
 
         window.CloseEvent.connect(remove_window)
         self.tracked_windows.append(window)
+
+    async def ensure_multiplayer_session_window(self, network_client: QtNetworkClient,
+                                                session_id: int, options: Options
+                                                ):
+        raise NotImplementedError()
+        
 
 
 def get_global_window_manager() -> WindowManager:

--- a/randovania/gui/main_online_interaction.py
+++ b/randovania/gui/main_online_interaction.py
@@ -9,36 +9,12 @@ from randovania.gui.generated.main_window_ui import Ui_MainWindow
 from randovania.gui.lib import async_dialog, wait_dialog
 from randovania.gui.lib.qt_network_client import handle_network_errors, QtNetworkClient
 from randovania.gui.lib.window_manager import WindowManager
-from randovania.gui.multiplayer_session_window import MultiplayerSessionWindow
 from randovania.interface_common.options import Options
 from randovania.interface_common.preset_manager import PresetManager
-from randovania.network_client.network_client import ConnectionState
-
-
-async def ensure_logged_in(parent: QtWidgets.QWidget | None, network_client: QtNetworkClient):
-    if network_client.connection_state == ConnectionState.Connected:
-        return True
-
-    if network_client.connection_state.is_disconnected:
-        try:
-            await wait_dialog.cancellable_wait(
-                parent,
-                network_client.connect_to_server(),
-                "Connecting",
-                "Connecting to server...",
-            )
-        except asyncio.CancelledError:
-            return False
-
-    if network_client.current_user is None:
-        await async_dialog.execute_dialog(LoginPromptDialog(network_client))
-
-    return network_client.current_user is not None
 
 
 class OnlineInteractions(QtWidgets.QWidget):
     network_client: QtNetworkClient
-    game_session_window: MultiplayerSessionWindow | None = None
     _login_window: QtWidgets.QDialog | None = None
 
     def __init__(self, window_manager: WindowManager, preset_manager: PresetManager, network_client: QtNetworkClient,
@@ -58,30 +34,10 @@ class OnlineInteractions(QtWidgets.QWidget):
         # Menu Bar
         main_window.action_login_window.triggered.connect(self._action_login_window)
 
-    async def _game_session_active(self) -> bool:
-        if self.game_session_window is None or self.game_session_window.has_closed:
-            return False
-        else:
-            await async_dialog.message_box(
-                self,
-                QtWidgets.QMessageBox.Critical,
-                "Game Session in progress",
-                "There's already a game session window open. Please close it first.",
-                QtWidgets.QMessageBox.Ok
-            )
-            self.game_session_window.activateWindow()
-            return True
-
-    async def _ensure_logged_in(self) -> bool:
-        return await ensure_logged_in(self, self.network_client)
-
     @asyncSlot()
     @handle_network_errors
     async def _browse_for_session(self):
-        if await self._game_session_active():
-            return
-
-        if not await self._ensure_logged_in():
+        if not await self.network_client.ensure_logged_in(self):
             return
 
         network_client = self.network_client
@@ -101,12 +57,9 @@ class OnlineInteractions(QtWidgets.QWidget):
             return
 
         if await async_dialog.execute_dialog(browser) == QtWidgets.QDialog.DialogCode.Accepted:
-            self.game_session_window = await MultiplayerSessionWindow.create_and_update(
-                network_client, browser.joined_session,
-                self.window_manager, self.options,
+            await self.window_manager.ensure_multiplayer_session_window(
+                network_client, browser.joined_session.id, self.options
             )
-            if self.game_session_window is not None:
-                self.game_session_window.show()
 
     @asyncSlot()
     @handle_network_errors
@@ -123,10 +76,7 @@ class OnlineInteractions(QtWidgets.QWidget):
     @asyncSlot()
     @handle_network_errors
     async def _host_game_session(self):
-        if await self._game_session_active():
-            return
-
-        if not await self._ensure_logged_in():
+        if not await self.network_client.ensure_logged_in(self):
             return
 
         dialog = QtWidgets.QInputDialog(self)
@@ -137,11 +87,8 @@ class OnlineInteractions(QtWidgets.QWidget):
             return
 
         new_session = await self.network_client.create_new_session(dialog.textValue())
-        self.game_session_window = await MultiplayerSessionWindow.create_and_update(
+        await self.window_manager.ensure_multiplayer_session_window(
             self.network_client,
-            new_session,
-            self.window_manager,
+            new_session.id,
             self.options,
         )
-        if self.game_session_window is not None:
-            self.game_session_window.show()

--- a/randovania/gui/main_window.py
+++ b/randovania/gui/main_window.py
@@ -22,6 +22,7 @@ from randovania.gui.generated.main_window_ui import Ui_MainWindow
 from randovania.gui.lib import common_qt_lib, async_dialog, theme
 from randovania.gui.lib.background_task_mixin import BackgroundTaskMixin
 from randovania.gui.lib.common_qt_lib import open_directory_in_explorer
+from randovania.gui.lib.qt_network_client import QtNetworkClient
 from randovania.layout.lib.trick_lib import used_tricks, difficulties_for_trick
 from randovania.gui.lib.window_manager import WindowManager
 from randovania.interface_common import update_checker
@@ -31,6 +32,7 @@ from randovania.layout.base.trick_level import LayoutTrickLevel
 from randovania.layout.layout_description import LayoutDescription
 from randovania.lib import enum_lib, json_lib
 from randovania.resolver import debug
+from randovania.gui.multiplayer_session_window import MultiplayerSessionWindow
 
 if typing.TYPE_CHECKING:
     from randovania.layout.permalink import Permalink
@@ -68,6 +70,7 @@ class MainWindow(WindowManager, BackgroundTaskMixin, Ui_MainWindow):
     changelog_window: QtWidgets.QMainWindow | None = None
     help_window: QtWidgets.QMainWindow | None = None
     game_connection_window: GameConnectionWindow | None = None
+    opened_session_windows: dict[int, MultiplayerSessionWindow]
 
     GameDetailsSignal = Signal(LayoutDescription)
     RequestOpenLayoutSignal = Signal(Path)
@@ -104,6 +107,7 @@ class MainWindow(WindowManager, BackgroundTaskMixin, Ui_MainWindow):
         self._preset_manager = preset_manager
         self.network_client = network_client
         self._play_game_logos = {}
+        self.opened_session_windows = {}
 
         if preview:
             debug.set_level(2)
@@ -449,7 +453,8 @@ class MainWindow(WindowManager, BackgroundTaskMixin, Ui_MainWindow):
     def open_game_connection_window(self):
         from randovania.gui.widgets.game_connection_window import GameConnectionWindow
         if self.game_connection_window is None:
-            self.game_connection_window = GameConnectionWindow(common_qt_lib.get_game_connection())
+            self.game_connection_window = GameConnectionWindow(self, self.network_client,
+                                                               self._options, common_qt_lib.get_game_connection())
 
         self.game_connection_window.show()
         self.game_connection_window.raise_()
@@ -703,3 +708,18 @@ class MainWindow(WindowManager, BackgroundTaskMixin, Ui_MainWindow):
         tab = getattr(self.help_window.centralWidget(), tab_name, None)
         if tab is not None:
             self.help_window.centralWidget().setCurrentWidget(tab)
+
+    async def ensure_multiplayer_session_window(self, network_client: QtNetworkClient,
+                                                session_id: int, options: Options
+                                                ):
+        session_window = self.opened_session_windows.get(session_id, None)
+        if session_window is not None and not session_window.has_closed:
+            session_window.activateWindow()
+            return
+        game_session_window = await MultiplayerSessionWindow.create_and_update(
+            network_client, session_id,
+            self.preset_manager, options,
+        )
+        if game_session_window is not None:
+            self.opened_session_windows[session_id] = game_session_window
+            game_session_window.show()

--- a/randovania/gui/qt.py
+++ b/randovania/gui/qt.py
@@ -73,8 +73,7 @@ async def show_main_window(app: QtWidgets.QApplication, options: Options, is_pre
         from randovania.gui.lib import async_dialog
 
         try:
-            from randovania.gui import main_online_interaction
-            if not await main_online_interaction.ensure_logged_in(None, network_client):
+            if not await network_client.ensure_logged_in(None):
                 await async_dialog.warning(None, "Login required",
                                            "Logging in is required to use dev builds.")
                 return False
@@ -159,7 +158,7 @@ async def show_game_session(app: QtWidgets.QApplication, options, session_id: in
         app.quit()
         return
 
-    new_session = await network_client.join_multiplayer_session(sessions[0], None)
+    new_session = await network_client.join_multiplayer_session(sessions[0].id, None)
     # preset_for = preset_manager.default_preset_for_game
 
     preset_manager = PresetManager(options.presets_path)
@@ -168,7 +167,6 @@ async def show_game_session(app: QtWidgets.QApplication, options, session_id: in
         network_client,
         new_session,
         preset_manager,
-        None,
         options
     )
     app.game_session_window.show()
@@ -279,7 +277,7 @@ async def qt_main(app: QtWidgets.QApplication, args):
 
     logging.info("Creating the global game connection")
     from randovania.game_connection.game_connection import GameConnection
-    app.game_connection = GameConnection(options)
+    app.game_connection = GameConnection(options, app.world_database)
     
     logging.info("Creating the global multiworld client")
     from randovania.gui.multiworld_client import MultiworldClient

--- a/randovania/interface_common/world_database.py
+++ b/randovania/interface_common/world_database.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 from pathlib import Path
 from typing import Iterable, Self
+from PySide6.QtCore import Signal, QObject
 
 from randovania.bitpacking.json_dataclass import JsonDataclass
 from randovania.interface_common.players_configuration import INVALID_UUID
@@ -56,9 +57,11 @@ class WorldData(JsonDataclass):
         )
 
 
-class WorldDatabase:
+class WorldDatabase(QObject):
     _all_data: dict[uuid.UUID, WorldData]
     _persist_path: Path
+
+    WorldDataUpdate = Signal()
 
     def __init__(self, persist_path: Path):
         super().__init__()
@@ -112,6 +115,7 @@ class WorldDatabase:
                 if data != self._all_data.get(uid):
                     self._all_data[uid] = data
                     await self._write_data(uid, data)
+            self.WorldDataUpdate.emit()
 
     def get_locations_to_upload(self, uid: uuid.UUID) -> tuple[int, ...]:
         data = self.get_data_for(uid)

--- a/randovania/network_client/network_client.py
+++ b/randovania/network_client/network_client.py
@@ -437,17 +437,17 @@ class NetworkClient:
         result = await self.server_call("multiplayer_create_session", session_name)
         return self._with_new_session(result)
 
-    async def join_multiplayer_session(self, session: MultiplayerSessionListEntry, password: str | None):
-        result = await self.server_call("multiplayer_join_session", (session.id, password))
+    async def join_multiplayer_session(self, session_id: int, password: str | None):
+        result = await self.server_call("multiplayer_join_session", (session_id, password))
         return self._with_new_session(result)
 
-    async def listen_to_session(self, session: MultiplayerSessionEntry, listen: bool):
-        result = await self.server_call("multiplayer_listen_to_session", (session.id, listen))
+    async def listen_to_session(self, session_id: int, listen: bool):
+        result = await self.server_call("multiplayer_listen_to_session", (session_id, listen))
         sessions = self._sessions_interested_in
         if listen:
-            sessions.add(session.id)
-        elif session.id in sessions:
-            sessions.remove(session.id)
+            sessions.add(session_id)
+        elif session_id in sessions:
+            sessions.remove(session_id)
         return result
 
     async def session_admin_global(self, session: MultiplayerSessionEntry,

--- a/randovania/network_common/multiplayer_session.py
+++ b/randovania/network_common/multiplayer_session.py
@@ -23,6 +23,7 @@ class MultiplayerSessionListEntry(JsonDataclass):
     num_players: int
     creator: str
     creation_date: datetime.datetime
+    is_user_in_session: bool
 
     def __post_init__(self):
         tzinfo = self.creation_date.tzinfo

--- a/randovania/server/database.py
+++ b/randovania/server/database.py
@@ -179,7 +179,14 @@ class MultiplayerSession(BaseModel):
     def creation_datetime(self) -> datetime.datetime:
         return datetime.datetime.fromisoformat(self.creation_date)
 
-    def create_list_entry(self):
+    def is_user_in_session(self, user: User):
+        try:
+            MultiplayerMembership.get_by_ids(user, self.id)
+        except peewee.DoesNotExist:
+            return False
+        return True
+
+    def create_list_entry(self, user: User):
         return MultiplayerSessionListEntry(
             id=self.id,
             name=self.name,
@@ -188,6 +195,7 @@ class MultiplayerSession(BaseModel):
             num_players=len(self.members),
             creator=self.creator.name,
             creation_date=self.creation_datetime,
+            is_user_in_session=self.is_user_in_session(user),
         )
 
     @property

--- a/randovania/server/multiplayer/world_api.py
+++ b/randovania/server/multiplayer/world_api.py
@@ -191,7 +191,7 @@ def sync_one_world(sio: ServerApp, user: User, uid: uuid.UUID, world_request: Se
     if world_request.request_details:
         response = ServerWorldResponse(
             world_name=world.name,
-            session=world.session.create_list_entry(),
+            session=world.session.create_list_entry(user),
         )
 
     # Do this last, as it fails if session is in setup

--- a/randovania/server/user_session.py
+++ b/randovania/server/user_session.py
@@ -32,7 +32,7 @@ def _create_client_side_session_raw(sio: ServerApp, user: User) -> dict:
     return {
         "user": user.as_json,
         "sessions": [
-            membership.session.create_list_entry().as_json
+            membership.session.create_list_entry(user).as_json
             for membership in memberships
         ],
     }

--- a/test/game_connection/test_game_connection.py
+++ b/test/game_connection/test_game_connection.py
@@ -18,7 +18,7 @@ from randovania.games.game import RandovaniaGame
 
 @pytest.fixture(name="connection")
 def _connection(skip_qtbot):
-    return GameConnection(MagicMock())
+    return GameConnection(MagicMock(), MagicMock())
 
 
 async def test_create_builders_on_init(skip_qtbot):
@@ -29,7 +29,7 @@ async def test_create_builders_on_init(skip_qtbot):
     options.connector_builders = [builder_option]
 
     # Run
-    connection = GameConnection(options)
+    connection = GameConnection(options, MagicMock())
 
     # Assert
     assert options.connector_builders == [builder_option]

--- a/test/gui/lib/test_qt_network_client.py
+++ b/test/gui/lib/test_qt_network_client.py
@@ -2,7 +2,6 @@ import asyncio
 import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
-from mock import patch
 from PySide6 import QtWidgets 
 
 import pytest
@@ -112,7 +111,7 @@ async def test_attempt_join(client, mocker, in_session):
     )
 
     # Run
-    result = await client.attempt_join(session)
+    result = await client.attempt_join_with_password_check(session)
     # Assert
     assert result == "A Session"
     if in_session:

--- a/test/gui/test_main_online_interaction.py
+++ b/test/gui/test_main_online_interaction.py
@@ -1,4 +1,3 @@
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -7,16 +6,17 @@ from PySide6.QtWidgets import QDialog
 
 from randovania.gui.main_online_interaction import OnlineInteractions
 from randovania.interface_common.options import Options
-from randovania.network_client.network_client import ConnectionState
+from randovania.gui.lib.qt_network_client import QtNetworkClient
 
 
 @pytest.fixture(name="default_online_interactions")
 def _default_online_interactions(skip_qtbot, preset_manager) -> OnlineInteractions:
     main_window = MagicMock()
     parent = QtWidgets.QWidget()
+    network_client = MagicMock(QtNetworkClient, autospec=True)
     skip_qtbot.add_widget(parent)
 
-    return OnlineInteractions(parent, preset_manager, MagicMock(), main_window, Options(MagicMock()))
+    return OnlineInteractions(parent, preset_manager, network_client, main_window, Options(MagicMock()))
 
 
 @pytest.mark.parametrize("refresh_success", [False, True])
@@ -24,10 +24,9 @@ async def test_browse_for_game_session(skip_qtbot, default_online_interactions, 
     # Setup
     mock_game_session_browser: MagicMock = mocker.patch(
         "randovania.gui.main_online_interaction.OnlineGameListDialog", autospec=True)
-    mock_create_and_update: AsyncMock = mocker.patch(
-        "randovania.gui.main_online_interaction.MultiplayerSessionWindow.create_and_update", new_callable=AsyncMock)
-    mock_create_and_update.return_value = MagicMock()
-    mock_get_game_connection = mocker.patch("randovania.gui.lib.common_qt_lib.get_game_connection", autospec=True)
+    mock_activate_or_create_game_session_window = AsyncMock(return_value=MagicMock())
+    default_online_interactions.window_manager.activate_or_create_game_session_window = mock_activate_or_create_game_session_window
+
     default_online_interactions._ensure_logged_in = AsyncMock(return_value=True)
     message_box = mocker.patch("PySide6.QtWidgets.QMessageBox")
 
@@ -45,25 +44,22 @@ async def test_browse_for_game_session(skip_qtbot, default_online_interactions, 
     message_box.assert_called_once()
     if refresh_success:
         mock_execute_dialog.assert_awaited_once_with(mock_game_session_browser.return_value)
-        mock_create_and_update.assert_awaited_once_with(
+        mock_activate_or_create_game_session_window.assert_awaited_once_with(
             default_online_interactions.network_client,
             mock_game_session_browser.return_value.joined_session,
-            default_online_interactions.window_manager,
             default_online_interactions.options,
         )
-        mock_create_and_update.return_value.show.assert_called_once_with()
     else:
         mock_execute_dialog.assert_not_awaited()
-        mock_create_and_update.assert_not_awaited()
+        mock_activate_or_create_game_session_window.assert_not_awaited()
 
 
 @patch("randovania.gui.lib.async_dialog.execute_dialog", new_callable=AsyncMock)
 async def test_host_game_session(mock_execute_dialog: AsyncMock,
                                  skip_qtbot, default_online_interactions, mocker):
     # Setup
-    mock_create_and_update: AsyncMock = mocker.patch(
-        "randovania.gui.main_online_interaction.MultiplayerSessionWindow.create_and_update", new_callable=AsyncMock)
-    mock_create_and_update.return_value = MagicMock()
+    mock_activate_or_create_game_session_window = AsyncMock(return_value=MagicMock())
+    default_online_interactions.window_manager.activate_or_create_game_session_window = mock_activate_or_create_game_session_window
     default_online_interactions._ensure_logged_in = AsyncMock(return_value=True)
     mock_execute_dialog.return_value = QDialog.Accepted
     default_online_interactions.network_client.create_new_session = AsyncMock()
@@ -74,31 +70,9 @@ async def test_host_game_session(mock_execute_dialog: AsyncMock,
     # Assert
     mock_execute_dialog.assert_awaited_once()
     default_online_interactions.network_client.create_new_session.assert_awaited_once_with("")
-    mock_create_and_update.assert_awaited_once_with(
+    mock_activate_or_create_game_session_window.assert_awaited_once_with(
         default_online_interactions.network_client,
         default_online_interactions.network_client.create_new_session.return_value,
-        default_online_interactions.window_manager,
         default_online_interactions.options,
     )
-    mock_create_and_update.return_value.show.assert_called_once_with()
 
-
-async def test_ensure_logged_in(default_online_interactions, mocker):
-    # Setup
-    mock_message_box = mocker.patch("PySide6.QtWidgets.QMessageBox")
-
-    async def true(): return True
-
-    connect_task = asyncio.create_task(true())
-
-    network_client = default_online_interactions.network_client
-    network_client.connect_to_server.return_value = connect_task
-    network_client.connection_state = ConnectionState.Disconnected
-    network_client.current_user = MagicMock()
-
-    # Run
-    result = await default_online_interactions._ensure_logged_in()
-
-    # Assert
-    mock_message_box.assert_called_once()
-    assert result

--- a/test/gui/test_main_online_interaction.py
+++ b/test/gui/test_main_online_interaction.py
@@ -24,8 +24,8 @@ async def test_browse_for_game_session(skip_qtbot, default_online_interactions, 
     # Setup
     mock_game_session_browser: MagicMock = mocker.patch(
         "randovania.gui.main_online_interaction.OnlineGameListDialog", autospec=True)
-    mock_activate_or_create_game_session_window = AsyncMock(return_value=MagicMock())
-    default_online_interactions.window_manager.activate_or_create_game_session_window = mock_activate_or_create_game_session_window
+    mock_ensure_multiplayer_session_window = AsyncMock(return_value=MagicMock())
+    default_online_interactions.window_manager.ensure_multiplayer_session_window = mock_ensure_multiplayer_session_window
 
     default_online_interactions._ensure_logged_in = AsyncMock(return_value=True)
     message_box = mocker.patch("PySide6.QtWidgets.QMessageBox")
@@ -44,22 +44,22 @@ async def test_browse_for_game_session(skip_qtbot, default_online_interactions, 
     message_box.assert_called_once()
     if refresh_success:
         mock_execute_dialog.assert_awaited_once_with(mock_game_session_browser.return_value)
-        mock_activate_or_create_game_session_window.assert_awaited_once_with(
+        mock_ensure_multiplayer_session_window.assert_awaited_once_with(
             default_online_interactions.network_client,
-            mock_game_session_browser.return_value.joined_session,
+            mock_game_session_browser.return_value.joined_session.id,
             default_online_interactions.options,
         )
     else:
         mock_execute_dialog.assert_not_awaited()
-        mock_activate_or_create_game_session_window.assert_not_awaited()
+        mock_ensure_multiplayer_session_window.assert_not_awaited()
 
 
 @patch("randovania.gui.lib.async_dialog.execute_dialog", new_callable=AsyncMock)
 async def test_host_game_session(mock_execute_dialog: AsyncMock,
                                  skip_qtbot, default_online_interactions, mocker):
     # Setup
-    mock_activate_or_create_game_session_window = AsyncMock(return_value=MagicMock())
-    default_online_interactions.window_manager.activate_or_create_game_session_window = mock_activate_or_create_game_session_window
+    mock_ensure_multiplayer_session_window = AsyncMock(return_value=MagicMock())
+    default_online_interactions.window_manager.ensure_multiplayer_session_window = mock_ensure_multiplayer_session_window
     default_online_interactions._ensure_logged_in = AsyncMock(return_value=True)
     mock_execute_dialog.return_value = QDialog.Accepted
     default_online_interactions.network_client.create_new_session = AsyncMock()
@@ -70,9 +70,9 @@ async def test_host_game_session(mock_execute_dialog: AsyncMock,
     # Assert
     mock_execute_dialog.assert_awaited_once()
     default_online_interactions.network_client.create_new_session.assert_awaited_once_with("")
-    mock_activate_or_create_game_session_window.assert_awaited_once_with(
+    mock_ensure_multiplayer_session_window.assert_awaited_once_with(
         default_online_interactions.network_client,
-        default_online_interactions.network_client.create_new_session.return_value,
+        default_online_interactions.network_client.create_new_session.return_value.id,
         default_online_interactions.options,
     )
 

--- a/test/gui/test_main_window.py
+++ b/test/gui/test_main_window.py
@@ -8,13 +8,16 @@ from PySide6 import QtWidgets
 from PySide6.QtWidgets import QDialog
 
 from randovania.games.game import RandovaniaGame
+from randovania.gui.lib.qt_network_client import QtNetworkClient
 from randovania.gui.main_window import MainWindow
+from randovania.gui.multiplayer_session_window import MultiplayerSessionWindow
 from randovania.gui.widgets.about_widget import AboutWidget
 from randovania.gui.widgets.randovania_help_widget import RandovaniaHelpWidget
 from randovania.interface_common.options import Options
 from randovania.interface_common.preset_manager import PresetManager
 from randovania.layout.generator_parameters import GeneratorParameters
 from randovania.layout.permalink import Permalink
+from randovania.network_common.multiplayer_session import MultiplayerSessionEntry
 
 
 def create_window(options: Options | MagicMock,
@@ -238,3 +241,42 @@ def test_select_game_and_selector_visibility(default_main_window, skip_qtbot):
     default_main_window.main_tab_widget.setCurrentWidget(default_main_window.tab_welcome)
     default_main_window.set_games_selector_visible(True)
     assert default_main_window.main_tab_widget.currentWidget() is default_main_window.tab_welcome
+
+
+async def test_create_game_session_window(default_main_window, mocker):
+    # setup
+    network_client = MagicMock(QtNetworkClient)
+    session_entry = MagicMock(MultiplayerSessionEntry)
+    session_entry.id = 1
+    mock_return = MagicMock(MultiplayerSessionWindow)
+    mocker.patch("randovania.gui.multiplayer_session_window.MultiplayerSessionWindow.create_and_update",
+                                      return_value=mock_return)
+    # run
+    await default_main_window.activate_or_create_game_session_window(network_client, session_entry, MagicMock())
+
+    # assert
+    mock_return.show.assert_called_once()
+    assert default_main_window.opened_session_windows[session_entry.id] == mock_return
+
+
+@pytest.mark.parametrize("has_closed", [False, True])
+async def test_existing_game_session_window(default_main_window, has_closed: bool, mocker):
+    # setup
+    network_client = MagicMock(QtNetworkClient)
+    session_entry = MagicMock(MultiplayerSessionEntry)
+    session_entry.id = 1
+    mock_return = MagicMock(MultiplayerSessionWindow)
+    mock_return.has_closed = has_closed
+    mocker.patch("randovania.gui.multiplayer_session_window.MultiplayerSessionWindow.create_and_update",
+                                      return_value=mock_return)
+    default_main_window.opened_session_windows[session_entry.id] = mock_return
+
+    # run
+    await default_main_window.activate_or_create_game_session_window(network_client, session_entry, MagicMock())
+
+    # assert
+    if has_closed:
+        mock_return.show.assert_called_once()
+    else:
+        mock_return.activateWindow.assert_called_once()
+    assert default_main_window.opened_session_windows[session_entry.id] == mock_return

--- a/test/gui/test_main_window.py
+++ b/test/gui/test_main_window.py
@@ -252,7 +252,7 @@ async def test_create_game_session_window(default_main_window, mocker):
     mocker.patch("randovania.gui.multiplayer_session_window.MultiplayerSessionWindow.create_and_update",
                                       return_value=mock_return)
     # run
-    await default_main_window.activate_or_create_game_session_window(network_client, session_entry, MagicMock())
+    await default_main_window.ensure_multiplayer_session_window(network_client, session_entry.id, MagicMock())
 
     # assert
     mock_return.show.assert_called_once()
@@ -272,7 +272,7 @@ async def test_existing_game_session_window(default_main_window, has_closed: boo
     default_main_window.opened_session_windows[session_entry.id] = mock_return
 
     # run
-    await default_main_window.activate_or_create_game_session_window(network_client, session_entry, MagicMock())
+    await default_main_window.ensure_multiplayer_session_window(network_client, session_entry.id, MagicMock())
 
     # assert
     if has_closed:

--- a/test/gui/test_multiplayer_session_window.py
+++ b/test/gui/test_multiplayer_session_window.py
@@ -77,7 +77,6 @@ async def test_on_session_meta_update(preset_manager, skip_qtbot, sample_session
     game_connection.lock_identifier = None
 
     u1 = uuid.UUID('53308c10-c283-4be5-b5d2-1761c81a871b')
-    u2 = uuid.UUID('4bdb294e-9059-4fdf-9822-3f649023249a')
 
     initial_session = sample_session
     second_session = MultiplayerSessionEntry(
@@ -106,7 +105,7 @@ async def test_on_session_meta_update(preset_manager, skip_qtbot, sample_session
         generation_in_progress=None,
         allowed_games=[RandovaniaGame.METROID_PRIME_ECHOES],
     )
-    window = await MultiplayerSessionWindow.create_and_update(network_client, initial_session,
+    window = await MultiplayerSessionWindow.create_and_update(network_client, initial_session.id,
                                                               MagicMock(), MagicMock())
     skip_qtbot.addWidget(window)
 
@@ -480,7 +479,7 @@ async def test_on_kicked(skip_qtbot, window: MultiplayerSessionWindow, mocker, a
         mock_warning.assert_not_awaited()
         window.close.assert_not_called()
     else:
-        window.network_client.listen_to_session.assert_awaited_once_with(window._session, False)
+        window.network_client.listen_to_session.assert_awaited_once_with(window._session.id, False)
         mock_warning.assert_awaited_once()
         window.close.assert_called_once_with()
 
@@ -566,7 +565,7 @@ async def test_on_close_event(window: MultiplayerSessionWindow, mocker, is_membe
     super_close_event.assert_called_once_with(event)
 
     if is_member:
-        window.network_client.listen_to_session.assert_awaited_once_with(window._session, False)
+        window.network_client.listen_to_session.assert_awaited_once_with(window._session.id, False)
     else:
         window.network_client.listen_to_session.assert_not_awaited()
 

--- a/test/gui/test_multiworld_client.py
+++ b/test/gui/test_multiworld_client.py
@@ -199,6 +199,7 @@ async def test_server_sync(client, mocker: MockerFixture):
         id=567, name="The Session", has_password=False, state=MultiplayerSessionState.IN_PROGRESS,
         num_players=5, creator="Not You", creation_date=datetime.datetime(2019, 1, 3, 2, 50,
                                                                           tzinfo=datetime.timezone.utc),
+        is_user_in_session=False,
     )
 
     request = ServerSyncRequest(worlds=frozendict({

--- a/test/gui/test_online_game_list_window.py
+++ b/test/gui/test_online_game_list_window.py
@@ -1,16 +1,16 @@
 import datetime
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from randovania.gui.dialog.online_game_list_dialog import OnlineGameListDialog
 from randovania.network_common.multiplayer_session import MultiplayerSessionListEntry
 from randovania.network_common.session_state import MultiplayerSessionState
 
 
-async def test_attempt_join():
+async def test_attempt_join(skip_qtbot):
     # Setup
     utc = datetime.timezone.utc
     network_client = MagicMock()
-    network_client.attempt_join = AsyncMock()
+    network_client.attempt_join_with_password_check = AsyncMock()
 
     session_a = MultiplayerSessionListEntry(
         id=1, name="A Game", has_password=True, state=MultiplayerSessionState.FINISHED,
@@ -33,4 +33,4 @@ async def test_attempt_join():
     await dialog._attempt_join()
 
     # Assert
-    network_client.attempt_join.assert_awaited_once_with(session_b)
+    network_client.attempt_join_with_password_check.assert_awaited_once_with(session_b)

--- a/test/gui/test_online_game_list_window.py
+++ b/test/gui/test_online_game_list_window.py
@@ -1,31 +1,26 @@
 import datetime
 from unittest.mock import patch, AsyncMock, MagicMock
 
-from PySide6.QtWidgets import QDialog
-
 from randovania.gui.dialog.online_game_list_dialog import OnlineGameListDialog
 from randovania.network_common.multiplayer_session import MultiplayerSessionListEntry
 from randovania.network_common.session_state import MultiplayerSessionState
 
 
-@patch("randovania.gui.lib.async_dialog.execute_dialog", new_callable=AsyncMock)
-async def test_attempt_join(mock_execute_dialog: AsyncMock,
-                            skip_qtbot):
+async def test_attempt_join():
     # Setup
     utc = datetime.timezone.utc
-    mock_execute_dialog.return_value = QDialog.DialogCode.Accepted
     network_client = MagicMock()
-    network_client.join_multiplayer_session = AsyncMock()
+    network_client.attempt_join = AsyncMock()
 
     session_a = MultiplayerSessionListEntry(
         id=1, name="A Game", has_password=True, state=MultiplayerSessionState.FINISHED,
-        num_players=1, creator="You",
+        num_players=1, creator="You", is_user_in_session=True,
         creation_date=datetime.datetime(year=2015, month=5, day=1, tzinfo=utc),
     )
     session_b = MultiplayerSessionListEntry(
         id=2, name="B Game", has_password=True,
         state=MultiplayerSessionState.IN_PROGRESS,
-        num_players=1, creator="You",
+        num_players=1, creator="You", is_user_in_session=True,
         creation_date=datetime.datetime.now(utc) - datetime.timedelta(days=4),
     )
 
@@ -35,8 +30,7 @@ async def test_attempt_join(mock_execute_dialog: AsyncMock,
     dialog.table_widget.selectRow(0)
 
     # Run
-    await dialog.attempt_join()
+    await dialog._attempt_join()
 
     # Assert
-    mock_execute_dialog.assert_awaited_once()
-    network_client.join_multiplayer_session.assert_awaited_once_with(session_b, "")
+    network_client.attempt_join.assert_awaited_once_with(session_b)

--- a/test/network_client/test_network_client.py
+++ b/test/network_client/test_network_client.py
@@ -160,7 +160,7 @@ async def test_listen_to_session(client: NetworkClient, listen, was_listening):
         client._sessions_interested_in.add(1234)
 
     # Run
-    await client.listen_to_session(session_meta, listen)
+    await client.listen_to_session(session_meta.id, listen)
 
     # Assert
     client.server_call.assert_awaited_once_with(
@@ -308,7 +308,7 @@ async def test_join_multiplayer_session(client: NetworkClient, mocker: pytest_mo
     client.server_call = AsyncMock()
 
     # Run
-    result = await client.join_multiplayer_session(session, "mahSecret")
+    result = await client.join_multiplayer_session(session.id, "mahSecret")
 
     # Assert
     assert result is mock_session_from.return_value

--- a/test/network_common/test_world_sync.py
+++ b/test/network_common/test_world_sync.py
@@ -54,6 +54,7 @@ def test_encode_sync_response():
                     num_players=2,
                     creator="Not You",
                     creation_date=datetime.datetime(2020, 5, 2, 10, 20, tzinfo=datetime.timezone.utc),
+                    is_user_in_session=True,
                 ),
             ),
         }),
@@ -66,6 +67,6 @@ def test_encode_sync_response():
 
     assert encoded == (
         b'\x01&\x8e\x8d38\xccJ\x9b\xb7?A\x9f\xad\xa7H\xb7\x05World\n\x0bOur Session'
-        b'\x01\x01\x04\x07Not You\x80\xa0\xcc\xf1\x8c\xa3\xb78\x01\x97U\xef\xc7'
+        b'\x01\x01\x04\x07Not You\x80\xa0\xcc\xf1\x8c\xa3\xb78\x01\x01\x97U\xef\xc7'
         b'w\xe4G\x11\x8f\x03\xbaq\xc3f\xef\x81"{"error":{"code":6,"detail":null}}'
     )

--- a/test/server/multiplayer/test_session_api.py
+++ b/test/server/multiplayer/test_session_api.py
@@ -31,11 +31,11 @@ def test_list_sessions(clean_database, flask_app, limit):
     # Assert
     expected = [
         {'has_password': False, 'id': 3, 'state': state, 'name': 'Third', 'num_players': 0, 'creator': 'Someone',
-         'creation_date': '2021-01-20T05:02:00+00:00'},
+         'creation_date': '2021-01-20T05:02:00+00:00', 'is_user_in_session': False},
         {'has_password': False, 'id': 2, 'state': state, 'name': 'Other', 'num_players': 0, 'creator': 'Someone',
-         'creation_date': '2020-01-20T05:02:00+00:00'},
+         'creation_date': '2020-01-20T05:02:00+00:00', 'is_user_in_session': False},
         {'has_password': False, 'id': 1, 'state': state, 'name': 'Debug', 'num_players': 0, 'creator': 'Someone',
-         'creation_date': '2020-10-02T10:20:00+00:00'},
+         'creation_date': '2020-10-02T10:20:00+00:00', 'is_user_in_session': False},
     ]
     if limit == 2:
         expected = expected[:2]

--- a/test/server/multiplayer/test_world_api.py
+++ b/test/server/multiplayer/test_world_api.py
@@ -209,7 +209,8 @@ def test_world_sync(flask_app, solo_two_world_session, mocker: MockerFixture, mo
     mock_emit_inventory = mocker.patch("randovania.server.multiplayer.session_common.emit_inventory_update")
 
     sio = MagicMock()
-    sio.get_current_user.return_value = database.User.get_by_id(1234)
+    user = database.User.get_by_id(1234)
+    sio.get_current_user.return_value = user
 
     w1 = database.World.get_by_id(1)
     w2 = database.World.get_by_id(2)
@@ -247,7 +248,7 @@ def test_world_sync(flask_app, solo_two_world_session, mocker: MockerFixture, mo
         worlds=frozendict({
             w1.uuid: ServerWorldResponse(
                 world_name=w1.name,
-                session=session.create_list_entry(),
+                session=session.create_list_entry(user),
             ),
         }),
         errors=frozendict({


### PR DESCRIPTION
1. Adds "Open Session Window" action to game connection window
2. Allow joining without password if user already belongs to the session

Got somehow distracted by 2. because that made the refactor for 1. a little bit easier.

Not really happy with some parts: Moving the whole "which game session windows are open" part to `WindowManager` introduced some cyclic dependencies. Atm I fixed that by importing when used in the functions.

Let's see what codecov says.