### PR TITLE
AM2R: fix extra data of 2 doors

### DIFF
--- a/randovania/games/am2r/json_data/Distribution Center.json
+++ b/randovania/games/am2r/json_data/Distribution Center.json
@@ -856,7 +856,7 @@
                         "default"
                     ],
                     "extra": {
-                        "instance_id": 132428
+                        "instance_id": 133428
                     },
                     "valid_starting_location": false,
                     "dock_type": "door",
@@ -924,7 +924,7 @@
                         "default"
                     ],
                     "extra": {
-                        "instance_id": 132427
+                        "instance_id": 133427
                     },
                     "valid_starting_location": false,
                     "dock_type": "door",

--- a/randovania/games/am2r/json_data/Distribution Center.txt
+++ b/randovania/games/am2r/json_data/Distribution Center.txt
@@ -140,7 +140,7 @@ Extra - map_name: rm_a5c01
 > Door to Robomine Prison; Heals? False
   * Layers: default
   * Normal Door to Robomine Prison/Door to Blade Bot Patrol Room
-  * Extra - instance_id: 132428
+  * Extra - instance_id: 133428
   > Door to Distribution Center Exterior West
       Any of the following:
           Tunnel Climb
@@ -149,7 +149,7 @@ Extra - map_name: rm_a5c01
 > Door to Distribution Center Exterior West; Heals? False
   * Layers: default
   * Normal Door to Distribution Center Exterior West/Door to Blade Bot Patrol Room
-  * Extra - instance_id: 132427
+  * Extra - instance_id: 133427
   > Door to Robomine Prison
       Any of the following:
           Tunnel Climb

--- a/randovania/games/am2r/json_data/header.json
+++ b/randovania/games/am2r/json_data/header.json
@@ -2630,7 +2630,6 @@
                     "unlocked": "Normal Door",
                     "locked": "Locked Door",
                     "change_from": [
-                        "Locked Door",
                         "Missile Door",
                         "Normal Door",
                         "Power Bomb Door",

--- a/randovania/games/am2r/json_data/header.txt
+++ b/randovania/games/am2r/json_data/header.txt
@@ -317,7 +317,6 @@ Dock Weaknesses
       Unlocked: Normal Door
       Locked: Locked Door
       Change from:
-          Locked Door
           Missile Door
           Normal Door
           Power Bomb Door


### PR DESCRIPTION
See title. Instance_id was wrong.
Also remove Locked Door from change_from, as they never appear in vanilla under normal circumstances