### PR TITLE
AM2R: add new beam doors and make tower doors shuffable

### DIFF
--- a/randovania/games/am2r/json_data/Main Caves.json
+++ b/randovania/games/am2r/json_data/Main Caves.json
@@ -4128,6 +4128,75 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Power Grip",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Space Jump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Walljump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Morph Ball",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "MidAirMorph",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/am2r/json_data/Main Caves.txt
+++ b/randovania/games/am2r/json_data/Main Caves.txt
@@ -653,7 +653,13 @@ Extra - map_name: rm_a0h24
   * Layers: default
   * Open Passage to Western Cave Shaft/Dock to Western Cave Entrance
   > Pickup (Missile Tank)
-      Speed Booster and Shinesparking Tricks (Beginner)
+      All of the following:
+          Speed Booster and Shinesparking Tricks (Beginner)
+          Any of the following:
+              Power Grip
+              All of the following:
+                  Morph Ball and Mid-Air Morph (Beginner)
+                  Space Jump or Walljump (Beginner)
   > Middle 
       Space Jump Wall
 

--- a/randovania/games/am2r/json_data/The Nest.json
+++ b/randovania/games/am2r/json_data/The Nest.json
@@ -1451,8 +1451,25 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Power Grip Wall"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Power Grip Wall"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "Omega1",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",
@@ -1483,6 +1500,40 @@
                                                         "type": "tricks",
                                                         "name": "Shinesparking",
                                                         "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Spider Ball"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space Jump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "IBJ over them https://www.youtube.com/watch?v=I7IayKDp2ss",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Bombs"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "IBJ",
+                                                        "amount": 4,
                                                         "negate": false
                                                     }
                                                 }

--- a/randovania/games/am2r/json_data/The Nest.txt
+++ b/randovania/games/am2r/json_data/The Nest.txt
@@ -241,8 +241,15 @@ Extra - map_name: rm_a6a09B
   * Open Passage to Hideout Omega Nest Access/Dock to Hideout Omega Nest
   > Dock to Hideout Storage
       Any of the following:
-          Power Grip Wall
-          Speed Booster and After Area 6 - First Omega and Shinesparking Tricks (Beginner)
+          Space Jump or Can Use Spider Ball
+          All of the following:
+              # IBJ over them https://www.youtube.com/watch?v=I7IayKDp2ss
+              Infinite Bomb Jumping (Expert) and Can Use Bombs
+          All of the following:
+              After Area 6 - First Omega
+              Any of the following:
+                  Power Grip Wall
+                  Speed Booster and Shinesparking Tricks (Beginner)
   > Event - Omega
       Defeat Omega
 

--- a/randovania/games/am2r/json_data/The Tower.json
+++ b/randovania/games/am2r/json_data/The Tower.json
@@ -5110,13 +5110,13 @@
                         "area": "Tester Arena Access North",
                         "node": "Door to Tester Arena"
                     },
-                    "default_dock_weakness": "After Tester Door",
+                    "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Tester Arena Access South": {
+                        "Event - Tester": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5147,7 +5147,7 @@
                         "area": "Tester Arena Access South",
                         "node": "Door to Tester Arena"
                     },
-                    "default_dock_weakness": "After Tester Door",
+                    "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -5302,6 +5302,13 @@
                                         "data": "Space Jump Wall"
                                     }
                                 ]
+                            }
+                        },
+                        "Door to Tester Arena Access South": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -6447,7 +6454,7 @@
                         "area": "Plasma Beam Chamber Access",
                         "node": "Door to Plasma Beam Chamber"
                     },
-                    "default_dock_weakness": "Normal Door",
+                    "default_dock_weakness": "Tower Activated Door",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,

--- a/randovania/games/am2r/json_data/The Tower.json
+++ b/randovania/games/am2r/json_data/The Tower.json
@@ -2051,17 +2051,34 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Walljump",
-                                            "amount": 4,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "template",
                                         "data": "Can Use Spider Ball"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Hi-Jump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -5116,7 +5133,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Tester": {
+                        "Before Tester": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5153,6 +5170,67 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Before Tester": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Tester": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 8.841354723707665,
+                        "y": 496.541889483066,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "TesterDead",
+                    "connections": {
+                        "Door to Tester Arena Access North": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Space Jump Wall"
+                                    }
+                                ]
+                            }
+                        },
+                        "Door to Tester Arena Access South": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Before Tester": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 163.99286987522282,
+                        "y": 498.8235294117647,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "connections": {
                         "Event - Tester": {
                             "type": "and",
                             "data": {
@@ -5161,7 +5239,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "Movements requirements",
+                                            "comment": "Movement requirements",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -5218,9 +5296,9 @@
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Combat",
-                                                        "amount": 2,
+                                                        "type": "items",
+                                                        "name": "Plasma Beam",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
@@ -5236,16 +5314,16 @@
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Plasma Beam",
-                                                        "amount": 1,
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 2,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "4 PBs to destroy the outer shell",
+                                                        "comment": "4 PBs to destroy outer shell",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -5272,43 +5350,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        }
-                    }
-                },
-                "Event - Tester": {
-                    "node_type": "event",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 154.38,
-                        "y": 506.41,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "valid_starting_location": false,
-                    "event_name": "TesterDead",
-                    "connections": {
-                        "Door to Tester Arena Access North": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Space Jump Wall"
-                                    }
-                                ]
-                            }
-                        },
-                        "Door to Tester Arena Access South": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }

--- a/randovania/games/am2r/json_data/The Tower.txt
+++ b/randovania/games/am2r/json_data/The Tower.txt
@@ -707,14 +707,14 @@ Tester Arena
 Extra - map_name: rm_a4a05
 > Door to Tester Arena Access North; Heals? False
   * Layers: default
-  * After Tester Door to Tester Arena Access North/Door to Tester Arena
+  * Normal Door to Tester Arena Access North/Door to Tester Arena
   * Extra - instance_id: 127943
-  > Door to Tester Arena Access South
+  > Event - Tester
       Trivial
 
 > Door to Tester Arena Access South; Heals? False
   * Layers: default
-  * After Tester Door to Tester Arena Access South/Door to Tester Arena
+  * Normal Door to Tester Arena Access South/Door to Tester Arena
   * Extra - instance_id: 128037
   > Event - Tester
       All of the following:
@@ -736,6 +736,8 @@ Extra - map_name: rm_a4a05
   * Event Boss Tester Defeated
   > Door to Tester Arena Access North
       Space Jump Wall
+  > Door to Tester Arena Access South
+      Trivial
 
 ----------------
 Tester Arena Access South
@@ -918,7 +920,7 @@ Extra - map_name: rm_a4a10
 
 > Door to Plasma Beam Chamber Access; Heals? False
   * Layers: default
-  * Normal Door to Plasma Beam Chamber Access/Door to Plasma Beam Chamber
+  * Tower Activated Door to Plasma Beam Chamber Access/Door to Plasma Beam Chamber
   * Extra - instance_id: 128664
   > Pickup (Plasma Beam)
       Trivial

--- a/randovania/games/am2r/json_data/The Tower.txt
+++ b/randovania/games/am2r/json_data/The Tower.txt
@@ -266,7 +266,9 @@ Extra - map_name: rm_a4h04
   > Dock to Gamma Nest West Access
       Mid-Air Morph (Intermediate) and Movement (Intermediate)
   > Dock to Tower Exterior North
-      Space Jump or Walljump (Expert) or Can Use Spider Ball
+      Any of the following:
+          Space Jump or Can Use Spider Ball
+          Hi-Jump Boots and Walljump (Advanced)
   > Door to Tower Activation Station
       Trivial
 
@@ -709,27 +711,15 @@ Extra - map_name: rm_a4a05
   * Layers: default
   * Normal Door to Tester Arena Access North/Door to Tester Arena
   * Extra - instance_id: 127943
-  > Event - Tester
+  > Before Tester
       Trivial
 
 > Door to Tester Arena Access South; Heals? False
   * Layers: default
   * Normal Door to Tester Arena Access South/Door to Tester Arena
   * Extra - instance_id: 128037
-  > Event - Tester
-      All of the following:
-          Any of the following:
-              # Movements requirements
-              Space Jump or Combat (Advanced)
-          Any of the following:
-              # Energy requirements
-              Combat (Advanced) or Normal Damage ≥ 599
-          Any of the following:
-              # Attack requirements
-              Plasma Beam or Spazer Beam or Combat (Intermediate)
-              All of the following:
-                  # 4 PBs to destroy the outer shell
-                  Morph Ball and Power Bombs ≥ 4
+  > Before Tester
+      Trivial
 
 > Event - Tester; Heals? False
   * Layers: default
@@ -738,6 +728,23 @@ Extra - map_name: rm_a4a05
       Space Jump Wall
   > Door to Tester Arena Access South
       Trivial
+
+> Before Tester; Heals? False
+  * Layers: default
+  > Event - Tester
+      All of the following:
+          Any of the following:
+              # Movement requirements
+              Space Jump or Combat (Advanced)
+          Any of the following:
+              # Energy requirements
+              Combat (Advanced) or Normal Damage ≥ 599
+          Any of the following:
+              # Attack requirements
+              Plasma Beam or Spazer Beam or Combat (Intermediate)
+              All of the following:
+                  # 4 PBs to destroy outer shell
+                  Morph Ball and Power Bombs ≥ 4
 
 ----------------
 Tester Arena Access South

--- a/randovania/games/am2r/json_data/header.json
+++ b/randovania/games/am2r/json_data/header.json
@@ -2605,6 +2605,71 @@
                         },
                         "lock": null
                     },
+                    "Charge Beam Door": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Charge Beam",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "lock": null
+                    },
+                    "Wave Beam Door": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Wave Beam",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "lock": null
+                    },
+                    "Spazer Beam Door": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Spazer Beam",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "lock": null
+                    },
+                    "Plasma Beam Door": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Plasma Beam",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "lock": null
+                    },
+                    "Ice Beam Door": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Ice Beam",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "lock": null
+                    },
                     "Locked Door": {
                         "extra": {},
                         "requirement": {
@@ -2636,11 +2701,16 @@
                         "Super Missile Door"
                     ],
                     "change_to": [
+                        "Charge Beam Door",
+                        "Ice Beam Door",
                         "Locked Door",
                         "Missile Door",
                         "Normal Door",
+                        "Plasma Beam Door",
                         "Power Bomb Door",
-                        "Super Missile Door"
+                        "Spazer Beam Door",
+                        "Super Missile Door",
+                        "Wave Beam Door"
                     ]
                 }
             },

--- a/randovania/games/am2r/json_data/header.json
+++ b/randovania/games/am2r/json_data/header.json
@@ -2695,10 +2695,12 @@
                     "unlocked": "Normal Door",
                     "locked": "Locked Door",
                     "change_from": [
+                        "After Tester Door",
                         "Missile Door",
                         "Normal Door",
                         "Power Bomb Door",
-                        "Super Missile Door"
+                        "Super Missile Door",
+                        "Tower Activated Door"
                     ],
                     "change_to": [
                         "Charge Beam Door",

--- a/randovania/games/am2r/json_data/header.json
+++ b/randovania/games/am2r/json_data/header.json
@@ -1731,48 +1731,82 @@
                 }
             },
             "Defeat Alpha": {
-                "type": "or",
+                "type": "and",
                 "data": {
                     "comment": null,
                     "items": [
                         {
-                            "type": "resource",
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "Missiles",
-                                "amount": 7,
-                                "negate": false
-                            }
-                        },
-                        {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Super Missiles",
-                                "amount": 2,
-                                "negate": false
-                            }
-                        },
-                        {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
+                                "comment": "Item requirements",
                                 "items": [
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "Charge Beam",
-                                            "amount": 1,
+                                            "name": "Missiles",
+                                            "amount": 7,
                                             "negate": false
                                         }
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "Knowledge",
+                                            "type": "items",
+                                            "name": "Super Missiles",
                                             "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Charge Beam",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "or",
+                            "data": {
+                                "comment": "Damage requirements",
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Combat",
+                                            "amount": 4,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "damage",
+                                            "name": "Damage",
+                                            "amount": 66,
                                             "negate": false
                                         }
                                     }
@@ -1783,48 +1817,82 @@
                 }
             },
             "Defeat Gamma": {
-                "type": "or",
+                "type": "and",
                 "data": {
                     "comment": null,
                     "items": [
                         {
-                            "type": "resource",
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "Missiles",
-                                "amount": 15,
-                                "negate": false
-                            }
-                        },
-                        {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Super Missiles",
-                                "amount": 3,
-                                "negate": false
-                            }
-                        },
-                        {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
+                                "comment": "Item requirements",
                                 "items": [
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "Charge Beam",
-                                            "amount": 1,
+                                            "name": "Missiles",
+                                            "amount": 15,
                                             "negate": false
                                         }
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
+                                            "type": "items",
+                                            "name": "Super Missiles",
+                                            "amount": 3,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Charge Beam",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "or",
+                            "data": {
+                                "comment": "Energy requirements",
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
                                             "type": "tricks",
-                                            "name": "Knowledge",
-                                            "amount": 2,
+                                            "name": "Combat",
+                                            "amount": 4,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "damage",
+                                            "name": "Damage",
+                                            "amount": 99,
                                             "negate": false
                                         }
                                     }
@@ -1835,48 +1903,125 @@
                 }
             },
             "Defeat Zeta": {
-                "type": "or",
+                "type": "and",
                 "data": {
                     "comment": null,
                     "items": [
                         {
-                            "type": "resource",
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "Missiles",
-                                "amount": 30,
-                                "negate": false
-                            }
-                        },
-                        {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Super Missiles",
-                                "amount": 6,
-                                "negate": false
-                            }
-                        },
-                        {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
+                                "comment": "Item requirements",
                                 "items": [
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "Charge Beam",
-                                            "amount": 1,
+                                            "name": "Missiles",
+                                            "amount": 30,
                                             "negate": false
                                         }
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "Knowledge",
-                                            "amount": 2,
+                                            "type": "items",
+                                            "name": "Super Missiles",
+                                            "amount": 6,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Charge Beam",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "or",
+                            "data": {
+                                "comment": "Energy requirements",
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Morph Ball",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Space Jump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "damage",
+                                            "name": "Damage",
+                                            "amount": 199,
                                             "negate": false
                                         }
                                     }
@@ -1887,39 +2032,21 @@
                 }
             },
             "Defeat Omega": {
-                "type": "or",
+                "type": "and",
                 "data": {
                     "comment": null,
                     "items": [
                         {
-                            "type": "resource",
+                            "type": "or",
                             "data": {
-                                "type": "items",
-                                "name": "Missiles",
-                                "amount": 32,
-                                "negate": false
-                            }
-                        },
-                        {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Super Missiles",
-                                "amount": 7,
-                                "negate": false
-                            }
-                        },
-                        {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
+                                "comment": "Item requirements",
                                 "items": [
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "Knowledge",
-                                            "amount": 2,
+                                            "type": "items",
+                                            "name": "Missiles",
+                                            "amount": 32,
                                             "negate": false
                                         }
                                     },
@@ -1927,30 +2054,13 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "Charge Beam",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "Combat",
-                                            "amount": 2,
+                                            "name": "Super Missile Launcher",
+                                            "amount": 7,
                                             "negate": false
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
@@ -1958,21 +2068,133 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Super Missiles",
-                                                        "amount": 3,
+                                                        "name": "Charge Beam",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Missiles",
-                                                        "amount": 11,
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 2,
                                                         "negate": false
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Backshots",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Missiles",
+                                                                    "amount": 11,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Super Missiles",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "or",
+                            "data": {
+                                "comment": "Energy requirements",
+                                "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Morph Ball",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Space Jump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "damage",
+                                            "name": "Damage",
+                                            "amount": 399,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -2670,6 +2892,45 @@
                         },
                         "lock": null
                     },
+                    "Bomb Door": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Bombs",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "lock": null
+                    },
+                    "Spider Ball Door": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Spider Ball",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "lock": null
+                    },
+                    "Screw Attack Door": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Screw Attack",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "lock": null
+                    },
                     "Locked Door": {
                         "extra": {},
                         "requirement": {
@@ -2703,6 +2964,7 @@
                         "Tower Activated Door"
                     ],
                     "change_to": [
+                        "Bomb Door",
                         "Charge Beam Door",
                         "Ice Beam Door",
                         "Locked Door",
@@ -2710,7 +2972,9 @@
                         "Normal Door",
                         "Plasma Beam Door",
                         "Power Bomb Door",
+                        "Screw Attack Door",
                         "Spazer Beam Door",
+                        "Spider Ball Door",
                         "Super Missile Door",
                         "Wave Beam Door"
                     ]

--- a/randovania/games/am2r/json_data/header.txt
+++ b/randovania/games/am2r/json_data/header.txt
@@ -347,10 +347,12 @@ Dock Weaknesses
       Unlocked: Normal Door
       Locked: Locked Door
       Change from:
+          After Tester Door
           Missile Door
           Normal Door
           Power Bomb Door
           Super Missile Door
+          Tower Activated Door
       Change to:
           Charge Beam Door
           Ice Beam Door

--- a/randovania/games/am2r/json_data/header.txt
+++ b/randovania/games/am2r/json_data/header.txt
@@ -141,27 +141,54 @@ Templates
                   Space Jump or Walljump (Advanced)
 
 * Defeat Alpha:
-      Any of the following:
-          Missiles ≥ 7 or Super Missiles ≥ 2
-          Charge Beam and Knowledge (Intermediate)
+      All of the following:
+          Any of the following:
+              # Item requirements
+              Missiles ≥ 7 or Super Missiles ≥ 2
+              Charge Beam and Knowledge (Intermediate)
+          Any of the following:
+              # Damage requirements
+              Combat (Expert) or Normal Damage ≥ 66
 
 * Defeat Gamma:
-      Any of the following:
-          Missiles ≥ 15 or Super Missiles ≥ 3
-          Charge Beam and Knowledge (Intermediate)
+      All of the following:
+          Any of the following:
+              # Item requirements
+              Missiles ≥ 15 or Super Missiles ≥ 3
+              Charge Beam and Knowledge (Intermediate)
+          Any of the following:
+              # Energy requirements
+              Combat (Expert) or Normal Damage ≥ 99
 
 * Defeat Zeta:
-      Any of the following:
-          Missiles ≥ 30 or Super Missiles ≥ 6
-          Charge Beam and Knowledge (Intermediate)
+      All of the following:
+          Any of the following:
+              # Item requirements
+              Missiles ≥ 30 or Super Missiles ≥ 6
+              Charge Beam and Knowledge (Intermediate)
+          Any of the following:
+              # Energy requirements
+              Normal Damage ≥ 199
+              All of the following:
+                  Combat (Advanced)
+                  Morph Ball or Space Jump or Walljump (Advanced)
 
 * Defeat Omega:
-      Any of the following:
-          Missiles ≥ 32 or Super Missiles ≥ 7
-          Charge Beam and Knowledge (Intermediate)
-          All of the following:
-              Combat (Intermediate)
-              Missiles ≥ 11 or Super Missiles ≥ 3
+      All of the following:
+          Any of the following:
+              # Item requirements
+              Missiles ≥ 32 or Super Missile Launcher ≥ 7
+              Charge Beam and Knowledge (Intermediate)
+              All of the following:
+                  # Backshots
+                  Combat (Intermediate)
+                  Missiles ≥ 11 or Super Missiles ≥ 3
+          Any of the following:
+              # Energy requirements
+              Normal Damage ≥ 399
+              All of the following:
+                  Combat (Advanced)
+                  Morph Ball or Space Jump or Walljump (Advanced)
 
 * Go Through Vines:
       Gravity Suit or Damage Boost (Beginner)
@@ -337,6 +364,24 @@ Dock Weaknesses
       No lock
 
 
+  * Bomb Door
+      Open:
+          Bombs
+      No lock
+
+
+  * Spider Ball Door
+      Open:
+          Spider Ball
+      No lock
+
+
+  * Screw Attack Door
+      Open:
+          Screw Attack
+      No lock
+
+
   * Locked Door
       Open:
           Impossible
@@ -354,6 +399,7 @@ Dock Weaknesses
           Super Missile Door
           Tower Activated Door
       Change to:
+          Bomb Door
           Charge Beam Door
           Ice Beam Door
           Locked Door
@@ -361,7 +407,9 @@ Dock Weaknesses
           Normal Door
           Plasma Beam Door
           Power Bomb Door
+          Screw Attack Door
           Spazer Beam Door
+          Spider Ball Door
           Super Missile Door
           Wave Beam Door
 

--- a/randovania/games/am2r/json_data/header.txt
+++ b/randovania/games/am2r/json_data/header.txt
@@ -307,6 +307,36 @@ Dock Weaknesses
       No lock
 
 
+  * Charge Beam Door
+      Open:
+          Charge Beam
+      No lock
+
+
+  * Wave Beam Door
+      Open:
+          Wave Beam
+      No lock
+
+
+  * Spazer Beam Door
+      Open:
+          Spazer Beam
+      No lock
+
+
+  * Plasma Beam Door
+      Open:
+          Plasma Beam
+      No lock
+
+
+  * Ice Beam Door
+      Open:
+          Ice Beam
+      No lock
+
+
   * Locked Door
       Open:
           Impossible
@@ -322,11 +352,16 @@ Dock Weaknesses
           Power Bomb Door
           Super Missile Door
       Change to:
+          Charge Beam Door
+          Ice Beam Door
           Locked Door
           Missile Door
           Normal Door
+          Plasma Beam Door
           Power Bomb Door
+          Spazer Beam Door
           Super Missile Door
+          Wave Beam Door
 
 
 > Tunnel


### PR DESCRIPTION
Adds doors for all available beams (charge, wave, spazer, plasma, ice)
The plasma beam chamber door was accidentally assigned the wrong type
And the tester arena logic has been revised to better reflect what actually happens in-game. (need to review this with @DruidVorse)