### PR TITLE
Enable word wrap for map tracker current location

### DIFF
--- a/randovania/gui/ui_files/tracker_window.ui
+++ b/randovania/gui/ui_files/tracker_window.ui
@@ -332,6 +332,9 @@
           <property name="text">
            <string>Current location:</string>
           </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
         <item>


### PR DESCRIPTION
This stops the tracker from forcibly increasing in size if the current location has a very long name