### PR TITLE
Echoes Door Lock Rando Exclusions

### DIFF
--- a/randovania/games/prime2/json_data/Great Temple.json
+++ b/randovania/games/prime2/json_data/Great Temple.json
@@ -2130,7 +2130,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Boost Ball Blast Shield",
+                        "Bomb Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -2470,7 +2473,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Boost Ball Blast Shield",
+                        "Bomb Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -2572,7 +2578,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Boost Ball Blast Shield",
+                        "Bomb Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -2616,7 +2625,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Boost Ball Blast Shield",
+                        "Bomb Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {

--- a/randovania/games/prime2/json_data/Great Temple.txt
+++ b/randovania/games/prime2/json_data/Great Temple.txt
@@ -391,7 +391,7 @@ Extra - in_dark_aether: True
 
 > Door to Sanctum Access; Heals? False
   * Layers: default
-  * Normal Door to Sanctum Access/Door to Sky Temple Energy Controller
+  * Normal Door to Sanctum Access/Door to Sky Temple Energy Controller; Dock Lock Rando incompatible with: Boost Ball Blast Shield, Bomb Blast Shield
   * Extra - dock_name: SouthLight
   > Save Station
       All of the following:
@@ -427,7 +427,7 @@ Extra - asset_id: 3417147547
 Extra - in_dark_aether: True
 > Door to Sky Temple Energy Controller; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Sky Temple Energy Controller/Door to Sanctum Access
+  * Normal Door to Sky Temple Energy Controller/Door to Sanctum Access; Dock Lock Rando incompatible with: Boost Ball Blast Shield, Bomb Blast Shield
   * Extra - dock_name: Darkbottom
   > Door to Sanctum
       Any of the following:
@@ -438,7 +438,7 @@ Extra - in_dark_aether: True
 
 > Door to Sanctum; Heals? False
   * Layers: default
-  * Normal Door to Sanctum/Door to Sanctum Access
+  * Normal Door to Sanctum/Door to Sanctum Access; Dock Lock Rando incompatible with: Boost Ball Blast Shield, Bomb Blast Shield
   * Extra - dock_name: DarkTop
   > Door to Sky Temple Energy Controller
       Dark World Damage ≥ 55
@@ -449,7 +449,7 @@ Extra - asset_id: 3619928121
 Extra - in_dark_aether: True
 > Door to Sanctum Access; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Sanctum Access/Door to Sanctum
+  * Normal Door to Sanctum Access/Door to Sanctum; Dock Lock Rando incompatible with: Boost Ball Blast Shield, Bomb Blast Shield
   * Extra - dock_name: SouthDark
   > Event - Emperor Ing
       All of the following:

--- a/randovania/games/prime2/json_data/Torvus Bog.json
+++ b/randovania/games/prime2/json_data/Torvus Bog.json
@@ -467,7 +467,9 @@
                     },
                     "default_dock_weakness": "Dark Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -969,7 +971,9 @@
                     },
                     "default_dock_weakness": "Dark Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -18646,7 +18650,9 @@
                     },
                     "default_dock_weakness": "Light Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -18757,7 +18763,9 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -18884,7 +18892,9 @@
                     },
                     "default_dock_weakness": "Dark Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -18979,7 +18989,7 @@
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": null,
-                    "description": "https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=134",
+                    "description": "<https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=134>",
                     "layers": [
                         "default"
                     ],
@@ -18995,154 +19005,11 @@
                     },
                     "default_dock_weakness": "Seeker Launcher Blast Shield",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
-                    "override_default_lock_requirement": {
-                        "type": "or",
-                        "data": {
-                            "comment": null,
-                            "items": [
-                                {
-                                    "type": "and",
-                                    "data": {
-                                        "comment": null,
-                                        "items": [
-                                            {
-                                                "type": "resource",
-                                                "data": {
-                                                    "type": "items",
-                                                    "name": "Seekers",
-                                                    "amount": 1,
-                                                    "negate": false
-                                                }
-                                            },
-                                            {
-                                                "type": "or",
-                                                "data": {
-                                                    "comment": null,
-                                                    "items": [
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": "items",
-                                                                "name": "Combat",
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": "items",
-                                                                "name": "DarkVisor",
-                                                                "amount": 1,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "type": "or",
-                                                "data": {
-                                                    "comment": null,
-                                                    "items": [
-                                                        {
-                                                            "type": "and",
-                                                            "data": {
-                                                                "comment": null,
-                                                                "items": [
-                                                                    {
-                                                                        "type": "template",
-                                                                        "data": "Use Screw Attack (Space Jump)"
-                                                                    },
-                                                                    {
-                                                                        "type": "resource",
-                                                                        "data": {
-                                                                            "type": "items",
-                                                                            "name": "Missile",
-                                                                            "amount": 4,
-                                                                            "negate": false
-                                                                        }
-                                                                    },
-                                                                    {
-                                                                        "type": "resource",
-                                                                        "data": {
-                                                                            "type": "tricks",
-                                                                            "name": "Knowledge",
-                                                                            "amount": 2,
-                                                                            "negate": false
-                                                                        }
-                                                                    },
-                                                                    {
-                                                                        "type": "resource",
-                                                                        "data": {
-                                                                            "type": "tricks",
-                                                                            "name": "AirUnderwater",
-                                                                            "amount": 3,
-                                                                            "negate": false
-                                                                        }
-                                                                    }
-                                                                ]
-                                                            }
-                                                        },
-                                                        {
-                                                            "type": "resource",
-                                                            "data": {
-                                                                "type": "items",
-                                                                "name": "Missile",
-                                                                "amount": 5,
-                                                                "negate": false
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "type": "and",
-                                    "data": {
-                                        "comment": null,
-                                        "items": [
-                                            {
-                                                "type": "template",
-                                                "data": "Use Screw Attack (Space Jump)"
-                                            },
-                                            {
-                                                "type": "resource",
-                                                "data": {
-                                                    "type": "items",
-                                                    "name": "Missile",
-                                                    "amount": 1,
-                                                    "negate": false
-                                                }
-                                            },
-                                            {
-                                                "type": "resource",
-                                                "data": {
-                                                    "type": "tricks",
-                                                    "name": "SeekerlessLocks",
-                                                    "amount": 4,
-                                                    "negate": false
-                                                }
-                                            },
-                                            {
-                                                "type": "resource",
-                                                "data": {
-                                                    "type": "tricks",
-                                                    "name": "AirUnderwater",
-                                                    "amount": 3,
-                                                    "negate": false
-                                                }
-                                            }
-                                        ]
-                                    }
-                                }
-                            ]
-                        }
-                    },
+                    "override_default_lock_requirement": null,
                     "connections": {
                         "Pickup (Missile)": {
                             "type": "and",
@@ -21634,7 +21501,9 @@
                     },
                     "default_dock_weakness": "Light Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -21742,7 +21611,9 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -21784,7 +21655,9 @@
                     },
                     "default_dock_weakness": "Dark Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -22026,7 +21899,9 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -22133,7 +22008,9 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -25382,7 +25259,9 @@
                     },
                     "default_dock_weakness": "Dark Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -25922,7 +25801,9 @@
                     },
                     "default_dock_weakness": "Light Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -27916,7 +27797,9 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -28837,7 +28720,9 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -31886,7 +31771,9 @@
                     },
                     "default_dock_weakness": "Light Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -31999,7 +31886,9 @@
                     },
                     "default_dock_weakness": "Dark Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -32899,7 +32788,9 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Screw Attack Blast Shield"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {

--- a/randovania/games/prime2/json_data/Torvus Bog.json
+++ b/randovania/games/prime2/json_data/Torvus Bog.json
@@ -19009,7 +19009,152 @@
                         "Screw Attack Blast Shield"
                     ],
                     "override_default_open_requirement": null,
-                    "override_default_lock_requirement": null,
+                    "override_default_lock_requirement": {
+                        "type": "or",
+                        "data": {
+                            "comment": null,
+                            "items": [
+                                {
+                                    "type": "and",
+                                    "data": {
+                                        "comment": null,
+                                        "items": [
+                                            {
+                                                "type": "resource",
+                                                "data": {
+                                                    "type": "items",
+                                                    "name": "Seekers",
+                                                    "amount": 1,
+                                                    "negate": false
+                                                }
+                                            },
+                                            {
+                                                "type": "or",
+                                                "data": {
+                                                    "comment": null,
+                                                    "items": [
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": "items",
+                                                                "name": "Combat",
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": "items",
+                                                                "name": "DarkVisor",
+                                                                "amount": 1,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "or",
+                                                "data": {
+                                                    "comment": null,
+                                                    "items": [
+                                                        {
+                                                            "type": "and",
+                                                            "data": {
+                                                                "comment": null,
+                                                                "items": [
+                                                                    {
+                                                                        "type": "template",
+                                                                        "data": "Use Screw Attack (Space Jump)"
+                                                                    },
+                                                                    {
+                                                                        "type": "resource",
+                                                                        "data": {
+                                                                            "type": "items",
+                                                                            "name": "Missile",
+                                                                            "amount": 4,
+                                                                            "negate": false
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "resource",
+                                                                        "data": {
+                                                                            "type": "tricks",
+                                                                            "name": "Knowledge",
+                                                                            "amount": 2,
+                                                                            "negate": false
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "resource",
+                                                                        "data": {
+                                                                            "type": "tricks",
+                                                                            "name": "AirUnderwater",
+                                                                            "amount": 3,
+                                                                            "negate": false
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "resource",
+                                                            "data": {
+                                                                "type": "items",
+                                                                "name": "Missile",
+                                                                "amount": 5,
+                                                                "negate": false
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "and",
+                                    "data": {
+                                        "comment": null,
+                                        "items": [
+                                            {
+                                                "type": "template",
+                                                "data": "Use Screw Attack (Space Jump)"
+                                            },
+                                            {
+                                                "type": "resource",
+                                                "data": {
+                                                    "type": "items",
+                                                    "name": "Missile",
+                                                    "amount": 1,
+                                                    "negate": false
+                                                }
+                                            },
+                                            {
+                                                "type": "resource",
+                                                "data": {
+                                                    "type": "tricks",
+                                                    "name": "SeekerlessLocks",
+                                                    "amount": 4,
+                                                    "negate": false
+                                                }
+                                            },
+                                            {
+                                                "type": "resource",
+                                                "data": {
+                                                    "type": "tricks",
+                                                    "name": "AirUnderwater",
+                                                    "amount": 3,
+                                                    "negate": false
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
                     "connections": {
                         "Pickup (Missile)": {
                             "type": "and",

--- a/randovania/games/prime2/json_data/Torvus Bog.txt
+++ b/randovania/games/prime2/json_data/Torvus Bog.txt
@@ -82,7 +82,7 @@ Extra - in_dark_aether: False
 
 > Door to Path of Roots; Heals? False
   * Layers: default
-  * Dark Door to Path of Roots/Door to Torvus Lagoon
+  * Dark Door to Path of Roots/Door to Torvus Lagoon; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: SouthLower (0B_Hall)
   > Door to Temple Transport Access
       Trivial
@@ -181,7 +181,7 @@ Extra - asset_id: 1950913308
 Extra - in_dark_aether: False
 > Door to Torvus Lagoon; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Dark Door to Torvus Lagoon/Door to Path of Roots
+  * Dark Door to Torvus Lagoon/Door to Path of Roots; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: North
   > Next to Pickup
       Gravity Boost and Space Jump Boots and Slope Jump (Intermediate)
@@ -2204,7 +2204,7 @@ Extra - in_dark_aether: False
 
 > Door to Gathering Access; Heals? False
   * Layers: default
-  * Light Door to Gathering Access/Door to Hydrodynamo Station
+  * Light Door to Gathering Access/Door to Hydrodynamo Station; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: West_0L
   > Door to Underground Transport
       Air Underwater (Advanced) and Standable Terrain (Advanced) and Disabled Door Randomizer and Shoot Light Beam and Use Screw Attack (Space Jump)
@@ -2217,7 +2217,7 @@ Extra - in_dark_aether: False
 
 > Door to Hydrodynamo Shaft; Heals? False
   * Layers: default
-  * Normal Door to Hydrodynamo Shaft/Door to Hydrodynamo Station
+  * Normal Door to Hydrodynamo Shaft/Door to Hydrodynamo Station; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: East (floor to 0q)
   > Door to Underground Transport
       After Hydrodynamo Station Lock (below Seeker Door) and After Hydrodynamo Station Lock (by Dark Door) and After Hydrodynamo Station Lock (by Light Door) and Air Underwater (Hypermode) and Movement (Hypermode) and Use Screw Attack (Space Jump)
@@ -2226,7 +2226,7 @@ Extra - in_dark_aether: False
 
 > Door to Catacombs Access; Heals? False
   * Layers: default
-  * Dark Door to Catacombs Access/Door to Hydrodynamo Station
+  * Dark Door to Catacombs Access/Door to Hydrodynamo Station; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: East_0M
   > Door to Underground Transport
       Air Underwater (Advanced) and Standable Terrain (Advanced) and Disabled Door Randomizer and Shoot Dark Beam and Use Screw Attack (Space Jump)
@@ -2239,8 +2239,8 @@ Extra - in_dark_aether: False
 
 > Door to Training Access; Heals? False
   * Layers: default
-  * Seeker Launcher Blast Shield to Training Access/Door to Hydrodynamo Station
-  * https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=134
+  * Seeker Launcher Blast Shield to Training Access/Door to Hydrodynamo Station; Dock Lock Rando incompatible with: Screw Attack Blast Shield
+  * <https://youtu.be/Myr8MRM5ZDc?list=PLPFZVy8SRe3tAkQMzVw8vWt_w_AF2_l91&t=134>
   * Extra - dock_name: North_OK
   > Pickup (Missile)
       Trivial
@@ -2536,7 +2536,7 @@ Extra - asset_id: 1393426305
 Extra - in_dark_aether: False
 > Door to Hydrodynamo Station; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Light Door to Hydrodynamo Station/Door to Gathering Access
+  * Light Door to Hydrodynamo Station/Door to Gathering Access; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: East
   > Door to Gathering Hall
       Trivial
@@ -2561,7 +2561,7 @@ Extra - in_dark_aether: False
 
 > Door to Hydrodynamo Station; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Hydrodynamo Station/Door to Training Access
+  * Normal Door to Hydrodynamo Station/Door to Training Access; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: South
   > Door to Training Chamber
       Trivial
@@ -2572,7 +2572,7 @@ Extra - asset_id: 2999623881
 Extra - in_dark_aether: False
 > Door to Hydrodynamo Station; Heals? False
   * Layers: default
-  * Dark Door to Hydrodynamo Station/Door to Catacombs Access
+  * Dark Door to Hydrodynamo Station/Door to Catacombs Access; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: West
   > Door to Catacombs
       Trivial
@@ -2617,7 +2617,7 @@ Extra - in_dark_aether: False
 
 > Door to Hydrodynamo Station; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Hydrodynamo Station/Door to Hydrodynamo Shaft
+  * Normal Door to Hydrodynamo Station/Door to Hydrodynamo Shaft; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: West
   > Portal to Undertemple Access
       Any of the following:
@@ -2628,7 +2628,7 @@ Extra - in_dark_aether: False
 
 > Door to Main Hydrochamber; Heals? False
   * Layers: default
-  * Normal Door to Main Hydrochamber/Door to Hydrodynamo Shaft
+  * Normal Door to Main Hydrochamber/Door to Hydrodynamo Shaft; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: Docks_North
   > Portal to Undertemple Access
       Gravity Boost
@@ -2959,7 +2959,7 @@ Extra - asset_id: 1270197856
 Extra - in_dark_aether: False
 > Door to Transit Tunnel East; Heals? False
   * Layers: default
-  * Dark Door to Transit Tunnel East/Door to Training Chamber
+  * Dark Door to Transit Tunnel East/Door to Training Chamber; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: East
   > Room Center
       Any of the following:
@@ -3012,7 +3012,7 @@ Extra - in_dark_aether: False
 
 > Door to Transit Tunnel West; Heals? False
   * Layers: default
-  * Light Door to Transit Tunnel West/Door to Training Chamber
+  * Light Door to Transit Tunnel West/Door to Training Chamber; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: West1
   > Room Center
       Any of the following:
@@ -3238,7 +3238,7 @@ Extra - asset_id: 3468345533
 Extra - in_dark_aether: False
 > Door to Hydrochamber Storage; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Hydrochamber Storage/Door to Main Hydrochamber
+  * Normal Door to Hydrochamber Storage/Door to Main Hydrochamber; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: South
   > Portal to Undertemple
       All of the following:
@@ -3302,7 +3302,7 @@ Extra - in_dark_aether: False
 
 > Door to Hydrodynamo Shaft; Heals? False
   * Layers: default
-  * Normal Door to Hydrodynamo Shaft/Door to Main Hydrochamber
+  * Normal Door to Hydrodynamo Shaft/Door to Main Hydrochamber; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: South2
   > Door to Hydrochamber Storage
       After Alpha Blogg or Before Hydrochamber Storage Item
@@ -3618,7 +3618,7 @@ Extra - asset_id: 3780180813
 Extra - in_dark_aether: False
 > Door to Training Chamber; Heals? False
   * Layers: default
-  * Light Door to Training Chamber/Door to Transit Tunnel West
+  * Light Door to Training Chamber/Door to Transit Tunnel West; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: East
   > Door to Gathering Hall
       Morph Ball Bomb and Morph Ball
@@ -3636,7 +3636,7 @@ Extra - asset_id: 1727410190
 Extra - in_dark_aether: False
 > Door to Training Chamber; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Dark Door to Training Chamber/Door to Transit Tunnel East
+  * Dark Door to Training Chamber/Door to Transit Tunnel East; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: West
   > Door to Catacombs
       Any of the following:
@@ -3742,7 +3742,7 @@ Extra - asset_id: 2527519102
 Extra - in_dark_aether: False
 > Door to Main Hydrochamber; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Normal Door to Main Hydrochamber/Door to Hydrochamber Storage
+  * Normal Door to Main Hydrochamber/Door to Hydrochamber Storage; Dock Lock Rando incompatible with: Screw Attack Blast Shield
   * Extra - dock_name: North
   > Event - Hydrochamber Storage Item
       Gravity Boost or Enabled Allow Vanilla Gravity Boost


### PR DESCRIPTION
- Removes Screw Attack weakness from all underwater doors
- Removes Bomb and Boost Ball weaknesses from Sky Temple doors

Fixes #4585 