### PR TITLE
AM2R: exclude underwater doors from screw+spider, fix bomb+spider door reqs

### DIFF
--- a/randovania/games/am2r/json_data/Distribution Center.json
+++ b/randovania/games/am2r/json_data/Distribution Center.json
@@ -280,7 +280,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -665,7 +668,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -6412,7 +6418,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -6622,7 +6631,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -6704,7 +6716,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -6794,7 +6809,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -6864,7 +6882,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -6909,7 +6930,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -6981,7 +7005,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -7094,7 +7121,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -7977,7 +8007,10 @@
                     },
                     "default_dock_weakness": "Missile Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -8159,7 +8192,7 @@
                         "node": "Door to Serris Arena"
                     },
                     "default_dock_weakness": "Serris Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -8201,7 +8234,7 @@
                         "node": "Door to Serris Arena"
                     },
                     "default_dock_weakness": "Serris Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -8375,7 +8408,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -8886,7 +8922,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -9104,7 +9143,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -9207,7 +9249,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -9297,7 +9342,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -10172,7 +10220,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -10316,7 +10367,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -10370,7 +10424,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Spider Ball Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -10536,7 +10593,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -10598,7 +10658,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -10640,7 +10703,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
@@ -10893,7 +10959,10 @@
                     },
                     "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {}
@@ -11197,7 +11266,7 @@
                         "node": "Door to Gravity Area Shaft"
                     },
                     "default_dock_weakness": "Missile Door",
-                    "exclude_from_dock_rando": false,
+                    "exclude_from_dock_rando": true,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
@@ -11342,9 +11411,12 @@
                         "area": "Gravity Area Blockade",
                         "node": "Door to Gravity Area Shaft"
                     },
-                    "default_dock_weakness": "Normal Door",
+                    "default_dock_weakness": "Missile Door",
                     "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {

--- a/randovania/games/am2r/json_data/Distribution Center.txt
+++ b/randovania/games/am2r/json_data/Distribution Center.txt
@@ -48,7 +48,7 @@ Distribution Center Exterior West
 Extra - map_name: rm_a5h04
 > Door to Facility Storage Tower West; Heals? False
   * Layers: default
-  * Normal Door to Facility Storage Tower West/Door to Distribution Center Exterior West
+  * Normal Door to Facility Storage Tower West/Door to Distribution Center Exterior West; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 132495
   > Dock to Distribution Center Exterior West Access
       Trivial
@@ -107,7 +107,7 @@ Extra - map_name: rm_a5h05
 
 > Door to Facility Storage Spiked Path; Heals? False
   * Layers: default
-  * Normal Door to Facility Storage Spiked Path/Door to Distribution Center Exterior East
+  * Normal Door to Facility Storage Spiked Path/Door to Distribution Center Exterior East; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 132575
   > Door to Distribution Center Exterior East Access
       Any of the following:
@@ -1022,7 +1022,7 @@ Moheek Hangout
 Extra - map_name: rm_a5c26
 > Door to Waterblob Habitat; Heals? False
   * Layers: default
-  * Normal Door to Waterblob Habitat/Door to Moheek Hangout
+  * Normal Door to Waterblob Habitat/Door to Moheek Hangout; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135119
   > Pipe to Meboid Blockade Interior
       Any of the following:
@@ -1048,7 +1048,7 @@ Waterblob Habitat
 Extra - map_name: rm_a5c27
 > Door to Facility Storage Save Station; Heals? False
   * Layers: default
-  * Normal Door to Facility Storage Save Station/Door to Waterblob Habitat
+  * Normal Door to Facility Storage Save Station/Door to Waterblob Habitat; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135156
   > Door to Moheek Hangout
       Any of the following:
@@ -1057,7 +1057,7 @@ Extra - map_name: rm_a5c27
 
 > Door to Moheek Hangout; Heals? False
   * Layers: default
-  * Normal Door to Moheek Hangout/Door to Waterblob Habitat
+  * Normal Door to Moheek Hangout/Door to Waterblob Habitat; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135157
   > Door to Facility Storage Save Station
       Any of the following:
@@ -1069,7 +1069,7 @@ Facility Storage Save Station
 Extra - map_name: rm_a5c28
 > Door to Facility Storage Intersection East; Heals? False
   * Layers: default
-  * Normal Door to Facility Storage Intersection East/Door to Facility Storage Save Station
+  * Normal Door to Facility Storage Intersection East/Door to Facility Storage Save Station; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135204
   > Save Station
       Trivial
@@ -1084,7 +1084,7 @@ Extra - map_name: rm_a5c28
 
 > Door to Waterblob Habitat; Heals? False
   * Layers: default
-  * Normal Door to Waterblob Habitat/Door to Facility Storage Save Station
+  * Normal Door to Waterblob Habitat/Door to Facility Storage Save Station; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135205
   > Save Station
       Trivial
@@ -1094,7 +1094,7 @@ Facility Storage Intersection East
 Extra - map_name: rm_a5c29
 > Door to Facility Storage Save Station; Heals? False
   * Layers: default
-  * Normal Door to Facility Storage Save Station/Door to Facility Storage Intersection East
+  * Normal Door to Facility Storage Save Station/Door to Facility Storage Intersection East; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135221
   > Door to Dual Gamma Nest
       Trivial
@@ -1107,7 +1107,7 @@ Extra - map_name: rm_a5c29
 
 > Door to Dual Gamma Nest; Heals? False
   * Layers: default
-  * Normal Door to Dual Gamma Nest/Door to Facility Storage Intersection East
+  * Normal Door to Dual Gamma Nest/Door to Facility Storage Intersection East; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135232
   > Door to Facility Storage Save Station
       Any of the following:
@@ -1124,7 +1124,7 @@ Dual Gamma Nest
 Extra - map_name: rm_a5c30
 > Door to Facility Storage Intersection East; Heals? False
   * Layers: default
-  * Normal Door to Facility Storage Intersection East/Door to Dual Gamma Nest
+  * Normal Door to Facility Storage Intersection East/Door to Dual Gamma Nest; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135253
   > Event - Left Gamma
       Defeat Gamma
@@ -1272,7 +1272,7 @@ Extra - map_name: rm_a5b02
 
 > Door to Serris Arena; Heals? False
   * Layers: default
-  * Missile Door to Serris Arena/Door to Serris Arena Access
+  * Missile Door to Serris Arena/Door to Serris Arena Access; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135404
   > Dock to Spiky Spider Trial
       Trivial
@@ -1301,14 +1301,14 @@ Serris Arena
 Extra - map_name: rm_a5b03a
 > Door to Serris Arena Access; Heals? False
   * Layers: default
-  * Serris Door to Serris Arena Access/Door to Serris Arena
+  * Serris Door to Serris Arena Access/Door to Serris Arena; Excluded from Dock Lock Rando
   * Extra - instance_id: 135449
   > Door to Serris Arena Pipe
       Power Grip Wall
 
 > Door to Serris Arena Pipe; Heals? False
   * Layers: default
-  * Serris Door to Serris Arena Pipe/Door to Serris Arena
+  * Serris Door to Serris Arena Pipe/Door to Serris Arena; Excluded from Dock Lock Rando
   * Extra - instance_id: 135448
   > Door to Serris Arena Access
       Power Grip Wall
@@ -1336,7 +1336,7 @@ Serris Arena Pipe
 Extra - map_name: rm_a5b03
 > Door to Serris Arena; Heals? False; Default Node
   * Layers: default
-  * Normal Door to Serris Arena/Door to Serris Arena Pipe
+  * Normal Door to Serris Arena/Door to Serris Arena Pipe; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135598
   > Pipe to Ice Beam Chamber Access
       Morph Ball
@@ -1418,7 +1418,7 @@ Extra - map_name: rm_a5b07
 
 > Door to Facility Storage Tower Route South; Heals? False
   * Layers: default
-  * Normal Door to Facility Storage Tower Route South/Door to Facility Storage Tower East
+  * Normal Door to Facility Storage Tower Route South/Door to Facility Storage Tower East; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135756
   > Dock to Facility Storage Clogged Pipe South
       Any of the following:
@@ -1449,7 +1449,7 @@ Facility Storage Spiked Path Pipe
 Extra - map_name: rm_a5b08
 > Door to Facility Storage Spiked Path; Heals? False; Default Node
   * Layers: default
-  * Normal Door to Facility Storage Spiked Path/Door to Facility Storage Spiked Path Pipe
+  * Normal Door to Facility Storage Spiked Path/Door to Facility Storage Spiked Path Pipe; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135783
   > Pipe to Gravity Area Blockade Pipe
       Morph Ball
@@ -1467,7 +1467,7 @@ Facility Storage Spiked Path
 Extra - map_name: rm_a5b09
 > Door to Distribution Center Exterior East; Heals? False
   * Layers: default
-  * Normal Door to Distribution Center Exterior East/Door to Facility Storage Spiked Path
+  * Normal Door to Distribution Center Exterior East/Door to Facility Storage Spiked Path; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135801
   > Door to Facility Storage Spiked Path Pipe
       Any of the following:
@@ -1476,7 +1476,7 @@ Extra - map_name: rm_a5b09
 
 > Door to Facility Storage Spiked Path Pipe; Heals? False
   * Layers: default
-  * Normal Door to Facility Storage Spiked Path Pipe/Door to Facility Storage Spiked Path
+  * Normal Door to Facility Storage Spiked Path Pipe/Door to Facility Storage Spiked Path; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135800
   > Door to Distribution Center Exterior East
       Any of the following:
@@ -1590,7 +1590,7 @@ Extra - map_name: rm_a5b20
 
 > Door to Facility Storage Tower West; Heals? False
   * Layers: default
-  * Normal Door to Facility Storage Tower West/Door to Facility Storage Tower Route North
+  * Normal Door to Facility Storage Tower West/Door to Facility Storage Tower Route North; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 136376
   > Dock to Facility Storage Tower East
       All of the following:
@@ -1611,7 +1611,7 @@ Facility Storage Tower West
 Extra - map_name: rm_a5b21
 > Door to Facility Storage Tower Route North; Heals? False
   * Layers: default
-  * Normal Door to Facility Storage Tower Route North/Door to Facility Storage Tower West
+  * Normal Door to Facility Storage Tower Route North/Door to Facility Storage Tower West; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 136414
   > Door to Facility Storage Tower Route South
       Trivial
@@ -1620,7 +1620,7 @@ Extra - map_name: rm_a5b21
 
 > Door to Facility Storage Tower Route South; Heals? False
   * Layers: default
-  * Normal Door to Facility Storage Tower Route South/Door to Facility Storage Tower West
+  * Normal Door to Facility Storage Tower Route South/Door to Facility Storage Tower West; Dock Lock Rando incompatible with: Spider Ball Door, Spider Ball Door
   * Extra - instance_id: 136415
   > Door to Facility Storage Tower Route North
       Any of the following:
@@ -1639,7 +1639,7 @@ Extra - map_name: rm_a5b21
 
 > Door to Distribution Center Exterior West; Heals? False
   * Layers: default
-  * Normal Door to Distribution Center Exterior West/Door to Facility Storage Tower West
+  * Normal Door to Distribution Center Exterior West/Door to Facility Storage Tower West; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 136413
   > Door to Facility Storage Tower Route North
       Gravity Suit
@@ -1651,14 +1651,14 @@ Facility Storage Tower Route South
 Extra - map_name: rm_a5b22
 > Door to Facility Storage Tower East; Heals? False
   * Layers: default
-  * Normal Door to Facility Storage Tower East/Door to Facility Storage Tower Route South
+  * Normal Door to Facility Storage Tower East/Door to Facility Storage Tower Route South; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 136488
   > Door to Facility Storage Tower West
       Destroy Ice Barrier
 
 > Door to Facility Storage Tower West; Heals? False
   * Layers: default
-  * Normal Door to Facility Storage Tower West/Door to Facility Storage Tower Route South
+  * Normal Door to Facility Storage Tower West/Door to Facility Storage Tower Route South; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 136487
   > Door to Facility Storage Tower East
       Destroy Ice Barrier
@@ -1703,7 +1703,7 @@ Gravity Area One-Way Route
 Extra - map_name: rm_a5a03
 > Door to Gravity Area Corridor; Heals? False
   * Layers: default
-  * Normal Door to Gravity Area Corridor/Door to Gravity Area One-Way Route
+  * Normal Door to Gravity Area Corridor/Door to Gravity Area One-Way Route; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 136529
 
 > Door to Gravity Area Moto Room; Heals? False
@@ -1760,7 +1760,7 @@ Extra - map_name: rm_a5a05
 
 > Door to Gravity Chamber Access; Heals? False
   * Layers: default
-  * Missile Door to Gravity Chamber Access/Door to Gravity Area Shaft
+  * Missile Door to Gravity Chamber Access/Door to Gravity Area Shaft; Excluded from Dock Lock Rando
   * Extra - instance_id: 136632
   > Door to Gravity Area Corridor
       No Varia Suit and Walljump (Intermediate) and Enabled Septogg Helpers
@@ -1772,7 +1772,7 @@ Extra - map_name: rm_a5a05
 
 > Door to Gravity Area Blockade; Heals? False
   * Layers: default
-  * Normal Door to Gravity Area Blockade/Door to Gravity Area Shaft
+  * Missile Door to Gravity Area Blockade/Door to Gravity Area Shaft; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 136636
   > Door to Gravity Area Corridor
       Trivial

--- a/randovania/games/am2r/json_data/header.json
+++ b/randovania/games/am2r/json_data/header.json
@@ -3543,26 +3543,16 @@
                     "Bomb Door": {
                         "extra": {},
                         "requirement": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Bombs",
-                                "amount": 1,
-                                "negate": false
-                            }
+                            "type": "template",
+                            "data": "Can Use Bombs"
                         },
                         "lock": null
                     },
                     "Spider Ball Door": {
                         "extra": {},
                         "requirement": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Spider Ball",
-                                "amount": 1,
-                                "negate": false
-                            }
+                            "type": "template",
+                            "data": "Can Use Spider Ball"
                         },
                         "lock": null
                     },

--- a/randovania/games/am2r/json_data/header.txt
+++ b/randovania/games/am2r/json_data/header.txt
@@ -369,13 +369,13 @@ Dock Weaknesses
 
   * Bomb Door
       Open:
-          Bombs
+          Can Use Bombs
       No lock
 
 
   * Spider Ball Door
       Open:
-          Spider Ball
+          Can Use Spider Ball
       No lock
 
 


### PR DESCRIPTION
- Excludes underwater doors from screw+spider
- fixes requirements for bombs+spider
- marks some doors as incompatible with DLR, specifically serris arena, and some in the gravity area