### PR TITLE
Clarify that leftover items will be nothings in GUI

### DIFF
--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -195,6 +195,8 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
                 message += " - ".join(parts)
 
             self.item_pool_count_label.setText(message)
+            self.item_pool_description_label.setText(f"If there are fewer than {maximum_size} items, the rest of the "
+                                                     f"item locations will contain 'Nothing' items.")
 
         except InvalidConfiguration as invalid_config:
             self.item_pool_count_label.setText(f"Invalid Configuration: {invalid_config}")

--- a/randovania/gui/ui_files/preset_item_pool.ui
+++ b/randovania/gui/ui_files/preset_item_pool.ui
@@ -52,14 +52,24 @@
         <pointsize>12</pointsize>
        </font>
       </property>
-      <property name="toolTip">
-       <string>If there are fewer than 119 items, the rest of the item locations will contain Energy Transfer Modules.</string>
-      </property>
       <property name="text">
        <string>Items in pool: #/119</string>
       </property>
       <property name="alignment">
        <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="item_pool_description_label">
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This label's text is changed from code.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
       </property>
      </widget>
     </item>


### PR DESCRIPTION
I removed this from the tooltip and made it into a proper label to be more discoverable.
Also made it not hardcode to echoes' ETM+119 pickups
Fixes #387
![grafik](https://github.com/randovania/randovania/assets/38186597/4445b586-5c0d-44d3-aa47-539f7af08df6)
![grafik](https://github.com/randovania/randovania/assets/38186597/fba60b08-e0b0-4e13-9863-a4d2d796196a)

And a full view for context:
![grafik](https://github.com/randovania/randovania/assets/38186597/bdcdfdbe-c9aa-4795-ae12-afc1656faf6c)
