### PR TITLE
Remove CLI command to directly open a session window

### DIFF
--- a/randovania/gui/multiplayer_session_window.py
+++ b/randovania/gui/multiplayer_session_window.py
@@ -26,7 +26,6 @@ from randovania.gui.widgets.item_tracker_popup_window import ItemTrackerPopupWin
 from randovania.gui.widgets.multiplayer_session_users_widget import MultiplayerSessionUsersWidget
 from randovania.interface_common import simplified_patcher
 from randovania.interface_common.options import Options
-from randovania.interface_common.preset_manager import PresetManager
 from randovania.layout.generator_parameters import GeneratorParameters
 from randovania.layout.layout_description import LayoutDescription
 from randovania.layout.permalink import Permalink
@@ -54,7 +53,7 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
     _can_stop_background_process = True
     _window_manager: WindowManager | None
 
-    def __init__(self, game_session_api: MultiplayerSessionApi, window_manager: WindowManager | PresetManager,
+    def __init__(self, game_session_api: MultiplayerSessionApi, window_manager: WindowManager,
                  options: Options):
         super().__init__()
         self.setupUi(self)
@@ -64,14 +63,8 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
         self.network_client = game_session_api.network_client
         self.failure_handler = GenerationFailureHandler(self)
 
-        if isinstance(window_manager, WindowManager):
-            self._window_manager = window_manager
-            self._preset_manager = window_manager.preset_manager
-        else:
-            assert isinstance(window_manager, PresetManager)
-            self._window_manager = None
-            self._preset_manager = window_manager
-            self.edit_game_connections_button.setVisible(False)
+        self._window_manager = window_manager
+        self._preset_manager = window_manager.preset_manager
 
         self._options = options
         self._trackers = load_trackers_configuration()
@@ -138,8 +131,7 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
 
         # Connectivity
         self.server_connection_button.clicked.connect(self._connect_to_server)
-        if self._window_manager is not None:
-            self.edit_game_connections_button.clicked.connect(self._window_manager.open_game_connection_window)
+        self.edit_game_connections_button.clicked.connect(self._window_manager.open_game_connection_window)
 
         # Signals
         self.users_widget.GameExportRequested.connect(self.game_export_listener)
@@ -158,7 +150,7 @@ class MultiplayerSessionWindow(QtWidgets.QMainWindow, Ui_MultiplayerSessionWindo
 
     @classmethod
     async def create_and_update(cls, network_client: QtNetworkClient, session_id: int,
-                                window_manager: WindowManager | PresetManager, options: Options
+                                window_manager: WindowManager, options: Options
                                 ) -> Self:
 
         logger.debug("Creating MultiplayerSessionWindow")

--- a/randovania/gui/qt.py
+++ b/randovania/gui/qt.py
@@ -142,25 +142,6 @@ async def show_game_details(app: QtWidgets.QApplication, options, file_path: Pat
     app.details_window = details_window
 
 
-async def show_game_session(app: QtWidgets.QApplication, options, session_id: int):
-    from randovania.gui.multiplayer_session_window import MultiplayerSessionWindow
-    from randovania.gui.lib.qt_network_client import QtNetworkClient
-    from randovania.interface_common.preset_manager import PresetManager
-
-    network_client: QtNetworkClient = app.network_client
-
-    new_session = await network_client.join_multiplayer_session(session_id, None)
-    preset_manager = PresetManager(options.presets_path)
-
-    app.game_session_window = await MultiplayerSessionWindow.create_and_update(
-        network_client,
-        new_session.id,
-        preset_manager,
-        options
-    )
-    app.game_session_window.show()
-
-
 async def display_window_for(app: QtWidgets.QApplication, options: Options, command: str, args):
     if command == "tracker":
         await show_tracker(app, options)
@@ -170,8 +151,6 @@ async def display_window_for(app: QtWidgets.QApplication, options: Options, comm
         show_data_editor(app, options, RandovaniaGame(args.game))
     elif command == "game":
         await show_game_details(app, options, args.rdvgame)
-    elif command == "session":
-        await show_game_session(app, options, args.session_id)
     else:
         raise RuntimeError(f"Unknown command: {command}")
 
@@ -346,10 +325,6 @@ def create_subparsers(sub_parsers):
     game_parser = gui_parsers.add_parser("game", help="Opens an rdvgame")
     game_parser.add_argument("rdvgame", type=Path, help="Path ")
     game_parser.set_defaults(func=run)
-
-    session_parser = gui_parsers.add_parser("session", help="Connects to a game session")
-    session_parser.add_argument("session_id", type=int, help="Id of the session")
-    session_parser.set_defaults(func=run)
 
     def check_command(args):
         if args.command is None:

--- a/test/gui/test_multiplayer_session_window.py
+++ b/test/gui/test_multiplayer_session_window.py
@@ -12,6 +12,7 @@ from pytest_mock import MockerFixture
 from randovania.game_connection.game_connection import GameConnection
 from randovania.games.game import RandovaniaGame
 from randovania.gui.dialog.text_prompt_dialog import TextPromptDialog
+from randovania.gui.lib.window_manager import WindowManager
 from randovania.gui.multiplayer_session_window import MultiplayerSessionWindow
 from randovania.interface_common.preset_manager import PresetManager
 from randovania.layout.generator_parameters import GeneratorParameters
@@ -29,7 +30,7 @@ from randovania.network_common.session_state import MultiplayerSessionState
 
 @pytest.fixture()
 async def window(skip_qtbot) -> MultiplayerSessionWindow:
-    window = MultiplayerSessionWindow(MagicMock(), MagicMock(spec=PresetManager), MagicMock())
+    window = MultiplayerSessionWindow(MagicMock(), MagicMock(spec=WindowManager), MagicMock())
     skip_qtbot.addWidget(window)
     window.connect_to_events()
     return window
@@ -108,7 +109,7 @@ async def test_on_session_meta_update(preset_manager, skip_qtbot, sample_session
         allowed_games=[RandovaniaGame.METROID_PRIME_ECHOES],
     )
     window = await MultiplayerSessionWindow.create_and_update(network_client, initial_session.id,
-                                                              MagicMock(spec=PresetManager), MagicMock())
+                                                              MagicMock(spec=WindowManager), MagicMock())
     skip_qtbot.addWidget(window)
 
     # Run


### PR DESCRIPTION
Without the session cli command, there should be no reason anymore to do this `WindowManager | PresetManager` shenanigans.