### PR TITLE
Rejoin rooms when restoring a session, not when raw connecting

### DIFF
--- a/randovania/__init__.py
+++ b/randovania/__init__.py
@@ -113,7 +113,7 @@ def setup_logging(default_level: str, log_to_file: Path | None, quiet: bool = Fa
         },
         'handlers': handlers,
         'loggers': {
-            'randovania.network_client.network_client': {
+            'NetworkClient': {
                 'level': 'DEBUG',
             },
             'randovania.game_connection.connection_backend': {

--- a/randovania/gui/lib/qt_network_client.py
+++ b/randovania/gui/lib/qt_network_client.py
@@ -69,6 +69,7 @@ def handle_network_errors(fn):
 
     return wrapper
 
+
 class QtNetworkClient(QWidget, NetworkClient):
     Connect = Signal()
     ConnectError = Signal()

--- a/randovania/server/server_app.py
+++ b/randovania/server/server_app.py
@@ -129,7 +129,7 @@ class ServerApp:
         @functools.wraps(handler)
         def _handler(*args):
             setattr(flask.request, "message", message)
-            logger().debug("Starting call")
+            logger().debug("Starting call with args %s", args)
 
             with sentry_sdk.start_transaction(op="message", name=message) as span:
                 if with_header_check:


### PR DESCRIPTION
Since we have a reverse proxy in front of the server, the socket itself is not broken when the server itself restarts.

This means `_internal_connect_to_server` is not called every time, so rejoining rooms there is not a good location.
Move the code to where the exact same thing was done before, ooops!