### PR TITLE
Revise MW description in Main window

### DIFF
--- a/randovania/gui/ui_files/main_window.ui
+++ b/randovania/gui/ui_files/main_window.ui
@@ -300,9 +300,7 @@
         <item>
          <widget class="QLabel" name="multiworld_intro_label">
           <property name="text">
-           <string>Multiworld is a co-op multiplayer game mode for the randomizer.
-
-In a multiworld game, each player has their own unique world filled with items destined for an specific player. When you collect an item, it is instantly delivered to the owner.
+           <string>Multiworld is a game mode for the randomizer where multiple games and/or multiple players can come together to create a larger experience.
 
 For more information, check [Randovania Help](help://tab_multiworld)!</string>
           </property>


### PR DESCRIPTION
I think this now raises the minimum height of the main RDV window, but I don't think shortening this text would be a good idea to for UX.

preview:
![grafik](https://github.com/randovania/randovania/assets/38186597/faea7ea1-fd6a-4d25-a044-21cf7c257805)
