### PR TITLE
Do more query shenanigans

### DIFF
--- a/randovania/server/database.py
+++ b/randovania/server/database.py
@@ -172,11 +172,14 @@ class MultiplayerSession(BaseModel):
         return datetime.datetime.fromisoformat(self.creation_date)
 
     def is_user_in_session(self, user: User):
-        try:
-            MultiplayerMembership.get_by_ids(user, self.id)
-        except peewee.DoesNotExist:
-            return False
-        return True
+        is_in_session = getattr(self, "is_in_session", None)
+        if is_in_session is None:
+            try:
+                MultiplayerMembership.get_by_ids(user, self.id)
+            except peewee.DoesNotExist:
+                is_in_session = False
+            is_in_session = True
+        return is_in_session
 
     def create_list_entry(self, user: User):
         num_players = getattr(self, "num_players", None)


### PR DESCRIPTION
Should remove the additional query used for user in session.

We should also check https://github.com/randovania/randovania/blob/7c1c3f14a2d02165d26b61612fbccb16bfd31d35/randovania/server/multiplayer/world_api.py#L195-L199
AFAIK that `world.session.create_list_entry(user)` uses none of the optimizations we did because it just access the session via `world` which is fetched by `world = World.get_by_uuid(uid)`