### PR TITLE
Dread multiworld improvements

### DIFF
--- a/randovania/games/dread/assets/lua/bootstrap_part_3.lua
+++ b/randovania/games/dread/assets/lua/bootstrap_part_3.lua
@@ -10,6 +10,11 @@ end
 function RL.UpdateRDVClient(new_scenario)
     RL.GetGameStateAndSend()
     if Game.GetCurrentGameModeID() == 'INGAME' then
+        local playerSection =  Game.GetPlayerBlackboardSectionName()
+        local currentSaveRandoIdentifier = Blackboard.GetProp(playerSection, "THIS_RANDO_IDENTIFIER")
+        if currentSaveRandoIdentifier ~= Init.sThisRandoIdentifier then
+            return
+        end
         if new_scenario == true then
             RL.PendingPickup = nil
         end

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -187,20 +187,32 @@ class DreadPatchDataFactory(BasePatchDataFactory):
         # target.
 
         alt_model = _ALTERNATIVE_MODELS.get(detail.model.name, [detail.model.name])
+        model_names = alt_model
 
-        if detail.model.game != RandovaniaGame.METROID_DREAD or alt_model[0] == "itemsphere":
+        if detail.other_player:
+            if detail.model.game != RandovaniaGame.METROID_DREAD:
+                base_icon = "unknown"
+                model_names = ["itemsphere"]
+            else:
+                base_icon = detail.model.name
+
             map_icon = {
                 # TODO: more specific icons for pickups in other games
+                "custom_icon": {
+                    "label": detail.name.upper(),
+                    "base_icon": base_icon
+                }
+            }
+        elif alt_model[0] == "itemsphere":
+            map_icon = {
                 "custom_icon": {
                     "label": detail.original_pickup.name.upper(),
                 }
             }
-            model_names = ["itemsphere"]
         else:
             map_icon = {
                 "icon_id": detail.model.name
             }
-            model_names = alt_model
 
         resources = get_resources_for_details(detail)
 

--- a/test/test_files/patcher_data/dread/dread_dread_multiworld_expected.json
+++ b/test/test_files/patcher_data/dread/dread_dread_multiworld_expected.json
@@ -70,7 +70,10 @@
                 "powerup_powerbomb"
             ],
             "map_icon": {
-                "icon_id": "powerup_powerbomb"
+                "custom_icon": {
+                    "label": "PLAYER 2'S POWER BOMB",
+                    "base_icon": "powerup_powerbomb"
+                }
             }
         },
         {
@@ -145,7 +148,10 @@
                 "powerup_wavebeam"
             ],
             "map_icon": {
-                "icon_id": "PROGRESSIVE_BEAM"
+                "custom_icon": {
+                    "label": "PLAYER 2'S PROGRESSIVE BEAM",
+                    "base_icon": "PROGRESSIVE_BEAM"
+                }
             }
         },
         {
@@ -237,7 +243,10 @@
                 "item_powerbombtank"
             ],
             "map_icon": {
-                "icon_id": "item_powerbombtank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S POWER BOMB TANK",
+                    "base_icon": "item_powerbombtank"
+                }
             }
         },
         {
@@ -283,7 +292,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -306,7 +318,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -329,7 +344,10 @@
                 "powerup_morphball"
             ],
             "map_icon": {
-                "icon_id": "powerup_morphball"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MORPH BALL",
+                    "base_icon": "powerup_morphball"
+                }
             }
         },
         {
@@ -352,7 +370,10 @@
                 "powerup_spidermagnet"
             ],
             "map_icon": {
-                "icon_id": "powerup_spidermagnet"
+                "custom_icon": {
+                    "label": "PLAYER 2'S SPIDER MAGNET",
+                    "base_icon": "powerup_spidermagnet"
+                }
             }
         },
         {
@@ -421,7 +442,10 @@
                 "item_energytank"
             ],
             "map_icon": {
-                "icon_id": "item_energytank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S ENERGY TANK",
+                    "base_icon": "item_energytank"
+                }
             }
         },
         {
@@ -490,7 +514,10 @@
                 "item_missiletankplus"
             ],
             "map_icon": {
-                "icon_id": "item_missiletankplus"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE+ TANK",
+                    "base_icon": "item_missiletankplus"
+                }
             }
         },
         {
@@ -513,7 +540,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -640,7 +670,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank",
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                },
                 "original_actor": {
                     "scenario": "s010_cave",
                     "layer": "default",
@@ -691,7 +724,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank",
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                },
                 "original_actor": {
                     "scenario": "s010_cave",
                     "layer": "default",
@@ -719,7 +755,10 @@
                 "item_energyfragment"
             ],
             "map_icon": {
-                "icon_id": "item_energyfragment"
+                "custom_icon": {
+                    "label": "PLAYER 2'S ENERGY PART",
+                    "base_icon": "item_energyfragment"
+                }
             }
         },
         {
@@ -743,7 +782,10 @@
                 "powerup_spacejump"
             ],
             "map_icon": {
-                "icon_id": "PROGRESSIVE_SPIN"
+                "custom_icon": {
+                    "label": "PLAYER 2'S PROGRESSIVE SPIN",
+                    "base_icon": "PROGRESSIVE_SPIN"
+                }
             }
         },
         {
@@ -812,7 +854,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -835,7 +880,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -858,7 +906,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -881,7 +932,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank",
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                },
                 "original_actor": {
                     "scenario": "s020_magma",
                     "layer": "default",
@@ -1001,7 +1055,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1024,7 +1081,10 @@
                 "item_powerbombtank"
             ],
             "map_icon": {
-                "icon_id": "item_powerbombtank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S POWER BOMB TANK",
+                    "base_icon": "item_powerbombtank"
+                }
             }
         },
         {
@@ -1047,7 +1107,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1070,7 +1133,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1093,7 +1159,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1116,7 +1185,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1139,7 +1211,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1231,7 +1306,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1300,7 +1378,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1346,7 +1427,10 @@
                 "item_powerbombtank"
             ],
             "map_icon": {
-                "icon_id": "item_powerbombtank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S POWER BOMB TANK",
+                    "base_icon": "item_powerbombtank"
+                }
             }
         },
         {
@@ -1392,7 +1476,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank",
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                },
                 "original_actor": {
                     "scenario": "s030_baselab",
                     "layer": "default",
@@ -1420,7 +1507,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank",
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                },
                 "original_actor": {
                     "scenario": "s030_baselab",
                     "layer": "default",
@@ -1448,7 +1538,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1494,7 +1587,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1517,7 +1613,10 @@
                 "powerup_ghostaura"
             ],
             "map_icon": {
-                "icon_id": "powerup_ghostaura"
+                "custom_icon": {
+                    "label": "PLAYER 2'S FLASH SHIFT",
+                    "base_icon": "powerup_ghostaura"
+                }
             }
         },
         {
@@ -1540,7 +1639,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1609,7 +1711,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1632,7 +1737,10 @@
                 "item_powerbombtank"
             ],
             "map_icon": {
-                "icon_id": "item_powerbombtank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S POWER BOMB TANK",
+                    "base_icon": "item_powerbombtank"
+                }
             }
         },
         {
@@ -1655,7 +1763,10 @@
                 "item_energyfragment"
             ],
             "map_icon": {
-                "icon_id": "item_energyfragment"
+                "custom_icon": {
+                    "label": "PLAYER 2'S ENERGY PART",
+                    "base_icon": "item_energyfragment"
+                }
             }
         },
         {
@@ -1678,7 +1789,10 @@
                 "item_missiletankplus"
             ],
             "map_icon": {
-                "icon_id": "item_missiletankplus"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE+ TANK",
+                    "base_icon": "item_missiletankplus"
+                }
             }
         },
         {
@@ -1701,7 +1815,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1724,7 +1841,10 @@
                 "item_energyfragment"
             ],
             "map_icon": {
-                "icon_id": "item_energyfragment"
+                "custom_icon": {
+                    "label": "PLAYER 2'S ENERGY PART",
+                    "base_icon": "item_energyfragment"
+                }
             }
         },
         {
@@ -1747,7 +1867,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1793,7 +1916,10 @@
                 "item_energyfragment"
             ],
             "map_icon": {
-                "icon_id": "item_energyfragment"
+                "custom_icon": {
+                    "label": "PLAYER 2'S ENERGY PART",
+                    "base_icon": "item_energyfragment"
+                }
             }
         },
         {
@@ -1862,7 +1988,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -1885,7 +2014,10 @@
                 "item_energyfragment"
             ],
             "map_icon": {
-                "icon_id": "item_energyfragment"
+                "custom_icon": {
+                    "label": "PLAYER 2'S ENERGY PART",
+                    "base_icon": "item_energyfragment"
+                }
             }
         },
         {
@@ -1990,7 +2122,10 @@
                 "powerup_icemissile"
             ],
             "map_icon": {
-                "icon_id": "PROGRESSIVE_MISSILE"
+                "custom_icon": {
+                    "label": "PLAYER 2'S PROGRESSIVE MISSILE",
+                    "base_icon": "PROGRESSIVE_MISSILE"
+                }
             }
         },
         {
@@ -2036,7 +2171,10 @@
                 "powerup_screwattack"
             ],
             "map_icon": {
-                "icon_id": "powerup_screwattack"
+                "custom_icon": {
+                    "label": "PLAYER 2'S SCREW ATTACK",
+                    "base_icon": "powerup_screwattack"
+                }
             }
         },
         {
@@ -2059,7 +2197,10 @@
                 "item_powerbombtank"
             ],
             "map_icon": {
-                "icon_id": "item_powerbombtank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S POWER BOMB TANK",
+                    "base_icon": "item_powerbombtank"
+                }
             }
         },
         {
@@ -2082,7 +2223,10 @@
                 "item_missiletankplus"
             ],
             "map_icon": {
-                "icon_id": "item_missiletankplus"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE+ TANK",
+                    "base_icon": "item_missiletankplus"
+                }
             }
         },
         {
@@ -2128,7 +2272,10 @@
                 "item_missiletankplus"
             ],
             "map_icon": {
-                "icon_id": "item_missiletankplus"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE+ TANK",
+                    "base_icon": "item_missiletankplus"
+                }
             }
         },
         {
@@ -2244,7 +2391,10 @@
                 "powerup_spacejump"
             ],
             "map_icon": {
-                "icon_id": "PROGRESSIVE_SPIN"
+                "custom_icon": {
+                    "label": "PLAYER 2'S PROGRESSIVE SPIN",
+                    "base_icon": "PROGRESSIVE_SPIN"
+                }
             }
         },
         {
@@ -2267,7 +2417,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -2313,7 +2466,10 @@
                 "item_powerbombtank"
             ],
             "map_icon": {
-                "icon_id": "item_powerbombtank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S POWER BOMB TANK",
+                    "base_icon": "item_powerbombtank"
+                }
             }
         },
         {
@@ -2359,7 +2515,10 @@
                 "powerup_grapplebeam"
             ],
             "map_icon": {
-                "icon_id": "powerup_grapplebeam"
+                "custom_icon": {
+                    "label": "PLAYER 2'S GRAPPLE BEAM",
+                    "base_icon": "powerup_grapplebeam"
+                }
             }
         },
         {
@@ -2405,7 +2564,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank",
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                },
                 "original_actor": {
                     "scenario": "s050_forest",
                     "layer": "default",
@@ -2456,7 +2618,10 @@
                 "item_energytank"
             ],
             "map_icon": {
-                "icon_id": "item_energytank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S ENERGY TANK",
+                    "base_icon": "item_energytank"
+                }
             }
         },
         {
@@ -2479,7 +2644,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -2553,7 +2721,10 @@
                 "powerup_speedbooster"
             ],
             "map_icon": {
-                "icon_id": "powerup_speedbooster"
+                "custom_icon": {
+                    "label": "PLAYER 2'S SPEED BOOSTER",
+                    "base_icon": "powerup_speedbooster"
+                }
             }
         },
         {
@@ -2599,7 +2770,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -2622,7 +2796,10 @@
                 "item_powerbombtank"
             ],
             "map_icon": {
-                "icon_id": "item_powerbombtank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S POWER BOMB TANK",
+                    "base_icon": "item_powerbombtank"
+                }
             }
         },
         {
@@ -2646,7 +2823,10 @@
                 "powerup_icemissile"
             ],
             "map_icon": {
-                "icon_id": "PROGRESSIVE_MISSILE"
+                "custom_icon": {
+                    "label": "PLAYER 2'S PROGRESSIVE MISSILE",
+                    "base_icon": "PROGRESSIVE_MISSILE"
+                }
             }
         },
         {
@@ -2669,7 +2849,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -2752,7 +2935,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -2849,7 +3035,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -2872,7 +3061,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank",
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                },
                 "original_actor": {
                     "scenario": "s070_basesanc",
                     "layer": "default",
@@ -2969,7 +3161,10 @@
                 "item_powerbombtank"
             ],
             "map_icon": {
-                "icon_id": "item_powerbombtank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S POWER BOMB TANK",
+                    "base_icon": "item_powerbombtank"
+                }
             }
         },
         {
@@ -3038,7 +3233,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -3084,7 +3282,10 @@
                 "item_energyfragment"
             ],
             "map_icon": {
-                "icon_id": "item_energyfragment"
+                "custom_icon": {
+                    "label": "PLAYER 2'S ENERGY PART",
+                    "base_icon": "item_energyfragment"
+                }
             }
         },
         {
@@ -3107,7 +3308,10 @@
                 "item_energyfragment"
             ],
             "map_icon": {
-                "icon_id": "item_energyfragment"
+                "custom_icon": {
+                    "label": "PLAYER 2'S ENERGY PART",
+                    "base_icon": "item_energyfragment"
+                }
             }
         },
         {
@@ -3153,7 +3357,10 @@
                 "item_missiletank"
             ],
             "map_icon": {
-                "icon_id": "item_missiletank"
+                "custom_icon": {
+                    "label": "PLAYER 2'S MISSILE TANK",
+                    "base_icon": "item_missiletank"
+                }
             }
         },
         {
@@ -3176,7 +3383,10 @@
                 "item_energyfragment"
             ],
             "map_icon": {
-                "icon_id": "item_energyfragment"
+                "custom_icon": {
+                    "label": "PLAYER 2'S ENERGY PART",
+                    "base_icon": "item_energyfragment"
+                }
             }
         },
         {
@@ -3200,7 +3410,10 @@
                 "powerup_crossbomb"
             ],
             "map_icon": {
-                "icon_id": "PROGRESSIVE_BOMB"
+                "custom_icon": {
+                    "label": "PLAYER 2'S PROGRESSIVE BOMB",
+                    "base_icon": "PROGRESSIVE_BOMB"
+                }
             }
         },
         {
@@ -3610,10 +3823,10 @@
         }
     ],
     "text_patches": {
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."

--- a/test/test_files/patcher_data/dread/dread_prime1_multiworld_expected.json
+++ b/test/test_files/patcher_data/dread/dread_prime1_multiworld_expected.json
@@ -78,7 +78,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "CHARGE BEAM"
+                    "label": "PLAYER 2'S CHARGE BEAM",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -149,7 +150,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -220,7 +222,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE LAUNCHER"
+                    "label": "PLAYER 2'S MISSILE LAUNCHER",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -245,7 +248,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -438,7 +442,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "X-RAY VISOR"
+                    "label": "PLAYER 2'S X-RAY VISOR",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -463,7 +468,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "ENERGY TANK"
+                    "label": "PLAYER 2'S ENERGY TANK",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -571,7 +577,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "ARTIFACT OF WILD"
+                    "label": "PLAYER 2'S ARTIFACT OF WILD",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -647,7 +654,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "ENERGY TANK"
+                    "label": "PLAYER 2'S ENERGY TANK",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -672,7 +680,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
@@ -753,7 +762,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -778,7 +788,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -826,7 +837,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "SPACE JUMP BOOTS"
+                    "label": "PLAYER 2'S SPACE JUMP BOOTS",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -899,7 +911,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -924,7 +937,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "CHARGE BEAM"
+                    "label": "PLAYER 2'S CHARGE BEAM",
+                    "base_icon": "unknown"
                 },
                 "original_actor": {
                     "scenario": "s020_magma",
@@ -954,7 +968,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1002,7 +1017,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1050,7 +1066,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "ARTIFACT OF STRENGTH"
+                    "label": "PLAYER 2'S ARTIFACT OF STRENGTH",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1075,7 +1092,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1123,7 +1141,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "ENERGY TANK"
+                    "label": "PLAYER 2'S ENERGY TANK",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1270,7 +1289,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1295,7 +1315,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "SUPER MISSILE"
+                    "label": "PLAYER 2'S SUPER MISSILE",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1343,7 +1364,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "ARTIFACT OF WARRIOR"
+                    "label": "PLAYER 2'S ARTIFACT OF WARRIOR",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1368,7 +1390,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1416,7 +1439,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "ARTIFACT OF TRUTH"
+                    "label": "PLAYER 2'S ARTIFACT OF TRUTH",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1441,7 +1465,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1494,7 +1519,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
@@ -1547,7 +1573,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "WAVEBUSTER"
+                    "label": "PLAYER 2'S WAVEBUSTER",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1710,7 +1737,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1735,7 +1763,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1806,7 +1835,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1861,7 +1891,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MORPH BALL BOMB"
+                    "label": "PLAYER 2'S MORPH BALL BOMB",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1886,7 +1917,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -1911,7 +1943,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "WAVE BEAM"
+                    "label": "PLAYER 2'S WAVE BEAM",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -2127,7 +2160,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -2281,7 +2315,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "ENERGY TANK"
+                    "label": "PLAYER 2'S ENERGY TANK",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -2375,7 +2410,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -2400,7 +2436,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -2425,7 +2462,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "BOOST BALL"
+                    "label": "PLAYER 2'S BOOST BALL",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -2549,7 +2587,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "GRAPPLE BEAM"
+                    "label": "PLAYER 2'S GRAPPLE BEAM",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -2574,7 +2613,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -2622,7 +2662,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "ENERGY TANK"
+                    "label": "PLAYER 2'S ENERGY TANK",
+                    "base_icon": "unknown"
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
@@ -2700,7 +2741,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "ENERGY TANK"
+                    "label": "PLAYER 2'S ENERGY TANK",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -2725,7 +2767,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -2750,7 +2793,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -2775,7 +2819,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -2996,7 +3041,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 },
                 "original_actor": {
                     "scenario": "s070_basesanc",
@@ -3102,7 +3148,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "ARTIFACT OF LIFEGIVER"
+                    "label": "PLAYER 2'S ARTIFACT OF LIFEGIVER",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -3219,7 +3266,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -3290,7 +3338,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -3338,7 +3387,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "MISSILE EXPANSION"
+                    "label": "PLAYER 2'S MISSILE EXPANSION",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -3409,7 +3459,8 @@
             ],
             "map_icon": {
                 "custom_icon": {
-                    "label": "ENERGY TANK"
+                    "label": "PLAYER 2'S ENERGY TANK",
+                    "base_icon": "unknown"
                 }
             }
         },
@@ -3751,10 +3802,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."


### PR DESCRIPTION
- skip everything besides game state updates if rando identifier is wrong
- use unknown map icon for pickups with an item for other games
- change map text to include the world name for the item iff it belongs to another world
![image](https://github.com/randovania/randovania/assets/117127188/8e5d7860-1588-4d20-8487-956496ad172e)
