### PR TITLE
Fix multiworld with non-required mains

### DIFF
--- a/randovania/game_connection/connector/dread_remote_connector.py
+++ b/randovania/game_connection/connector/dread_remote_connector.py
@@ -18,7 +18,7 @@ from randovania.game_description.resources.pickup_entry import PickupEntry
 from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.game_description.resources.resource_database import ResourceDatabase
 from randovania.game_description.resources.resource_info import ResourceCollection
-from randovania.games.dread.exporter.patch_data_factory import convert_conditional_resource
+from randovania.games.dread.exporter.patch_data_factory import get_resources_for_details
 from randovania.games.game import RandovaniaGame
 
 
@@ -40,11 +40,8 @@ def resources_to_give_for_pickup(db: ResourceDatabase, pickup: PickupEntry, inve
     else:
         item_name = pickup.name
 
-    resources = _conditional_resources_for_pickup(pickup)
-    resources = [
-        list(convert_conditional_resource(conditional_resource))
-        for conditional_resource in resources
-    ]
+    conditional_resources = _conditional_resources_for_pickup(pickup)
+    resources = get_resources_for_details(pickup, conditional_resources, False)
 
     return item_name, resources
 

--- a/test/games/dread/exporter/test_dread_patch_data_factory.py
+++ b/test/games/dread/exporter/test_dread_patch_data_factory.py
@@ -90,7 +90,7 @@ def test_pickup_data_for_pb_expansion(locked, dread_game_description, preset_man
 
     # Run
     details = creator.export(PickupIndex(0), PickupTarget(pickup, 0), pickup, PickupModelStyle.ALL_VISIBLE)
-    result = get_resources_for_details(details)
+    result = get_resources_for_details(details.original_pickup, details.conditional_resources, details.other_player)
 
     # Assert
     assert result == [
@@ -121,7 +121,7 @@ def test_pickup_data_for_main_pb(locked, dread_game_description, preset_manager)
 
     # Run
     details = creator.export(PickupIndex(0), PickupTarget(pickup, 0), pickup, PickupModelStyle.ALL_VISIBLE)
-    result = get_resources_for_details(details)
+    result = get_resources_for_details(details.original_pickup, details.conditional_resources, details.other_player)
 
     # Assert
     assert result == [


### PR DESCRIPTION
- refactored `get_resources_for_details` to take only the parts needed...
- such that multiworld can use the same function...
- which fixes non-required mains e.g. like flash shift upgrade