### PR TITLE
UI improvements for multiplayer session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.X.X] - 2023-08-??
 
 - Added: Importing permalinks and rdvgames in a multiworld session now creates new worlds if missing.
+- Added: An "Export Game" button has been added to "Session and Connectivity" tab as a shortcut to export any of your worlds.
 - Fixed: The generation order for multiworld session now correctly handles any kind of names.
+- Fixed: Any buttons for changing presets or deleting worlds are properly disabled when a game is being generated.
 
 ### Metroid Dread
 

--- a/randovania/gui/ui_files/multiplayer_session.ui
+++ b/randovania/gui/ui_files/multiplayer_session.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>773</width>
-    <height>418</height>
+    <height>458</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -65,6 +65,13 @@
              </property>
              <property name="text">
               <string>Generate Game</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QPushButton" name="export_game_button">
+             <property name="text">
+              <string>Export Game</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
- Added: An "Export Game" button has been added to "Session and Connectivity" tab as a shortcut to export any of your worlds.
- Fixed: Any buttons for changing presets or deleting worlds are properly disabled when a game is being generated.