### PR TITLE
AM2R: Fixes Hi-Jump name

### DIFF
--- a/randovania/games/am2r/pickup_database/pickup-database.json
+++ b/randovania/games/am2r/pickup_database/pickup-database.json
@@ -190,10 +190,10 @@
             "default_starting_count": 0,
             "preferred_location_category": "major"
         },
-        "Hi-Jump": {
+        "Hi-Jump Boots": {
             "pickup_category": "movement",
             "broad_category": "movement",
-            "model_name": "Hi-Jump",
+            "model_name": "Hi-Jump Boots",
             "progression": [
                 "Hi-Jump"
             ],

--- a/randovania/games/am2r/presets/starter_preset.rdvpreset
+++ b/randovania/games/am2r/presets/starter_preset.rdvpreset
@@ -50,7 +50,7 @@
                 "Speed Booster": {
                     "num_shuffled_pickups": 1
                 },
-                "Hi-Jump": {
+                "Hi-Jump Boots": {
                     "num_shuffled_pickups": 1
                 },
                 "Gravity Suit": {


### PR DESCRIPTION
Noticed that this should be `Hi-Jump Boots`, not `Hi-Jump`