### PR TITLE
Fix models of dread-dread multiworld

### DIFF
--- a/randovania/exporter/pickup_exporter.py
+++ b/randovania/exporter/pickup_exporter.py
@@ -245,6 +245,7 @@ class PickupExporterMulti(PickupExporter):
                 )
             )
 
+            is_different_game = self.game != model.game
             return ExportedPickupDetails(
                 index=original_index,
                 name=f"{other_name}'s {name}",
@@ -256,7 +257,7 @@ class PickupExporterMulti(PickupExporter):
                     resources=(),
                 )],
                 conversion=[],
-                model=offworld_model,
+                model=offworld_model if is_different_game else model,
                 original_model=model,
                 other_player=True,
                 original_pickup=pickup_target.pickup,

--- a/test/test_files/patcher_data/dread/crazy_settings.json
+++ b/test/test_files/patcher_data/dread/crazy_settings.json
@@ -3678,8 +3678,8 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",

--- a/test/test_files/patcher_data/dread/dread_dread_multiworld_expected.json
+++ b/test/test_files/patcher_data/dread/dread_dread_multiworld_expected.json
@@ -67,12 +67,12 @@
                 "actor": "Item_MissileTank011"
             },
             "model": [
-                "itemsphere"
+                "powerup_powerbomb"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S POWER BOMB",
-                    "base_icon": "unknown"
+                    "base_icon": "powerup_powerbomb"
                 }
             }
         },
@@ -143,12 +143,14 @@
                 "actor": "Item_MissileTank001"
             },
             "model": [
-                "itemsphere"
+                "powerup_widebeam",
+                "powerup_plasmabeam",
+                "powerup_wavebeam"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S PROGRESSIVE BEAM",
-                    "base_icon": "unknown"
+                    "base_icon": "PROGRESSIVE_BEAM"
                 }
             }
         },
@@ -238,12 +240,12 @@
                 "actor": "Item_MissileTank004"
             },
             "model": [
-                "itemsphere"
+                "item_powerbombtank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S POWER BOMB TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_powerbombtank"
                 }
             }
         },
@@ -287,12 +289,12 @@
                 "actor": "Item_MissileTank006"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -313,12 +315,12 @@
                 "actor": "Item_MissileTank007"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -339,12 +341,12 @@
                 "actor": "Item_MissileTank003_1"
             },
             "model": [
-                "itemsphere"
+                "powerup_morphball"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MORPH BALL",
-                    "base_icon": "unknown"
+                    "base_icon": "powerup_morphball"
                 }
             }
         },
@@ -365,12 +367,12 @@
                 "actor": "Item_MissileTank009"
             },
             "model": [
-                "itemsphere"
+                "powerup_spidermagnet"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S SPIDER MAGNET",
-                    "base_icon": "unknown"
+                    "base_icon": "powerup_spidermagnet"
                 }
             }
         },
@@ -437,12 +439,12 @@
                 "actor": "item_energyfragment_001"
             },
             "model": [
-                "itemsphere"
+                "item_energytank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S ENERGY TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_energytank"
                 }
             }
         },
@@ -509,12 +511,12 @@
                 "actor": "item_powerbombtank_000"
             },
             "model": [
-                "itemsphere"
+                "item_missiletankplus"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE+ TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletankplus"
                 }
             }
         },
@@ -535,12 +537,12 @@
                 "actor": "item_missiletank_003"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -665,12 +667,12 @@
                 "actor": "ItemSphere_GrappleBeam"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
@@ -719,12 +721,12 @@
                 "actor": "ItemSphere_ScrewAttack"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 },
                 "original_actor": {
                     "scenario": "s010_cave",
@@ -750,12 +752,12 @@
                 "actor": "Item_MissileTank015"
             },
             "model": [
-                "itemsphere"
+                "item_energyfragment"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S ENERGY PART",
-                    "base_icon": "unknown"
+                    "base_icon": "item_energyfragment"
                 }
             }
         },
@@ -776,12 +778,13 @@
                 "actor": "Item_MissileTank016"
             },
             "model": [
-                "itemsphere"
+                "powerup_doublejump",
+                "powerup_spacejump"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S PROGRESSIVE SPIN",
-                    "base_icon": "unknown"
+                    "base_icon": "PROGRESSIVE_SPIN"
                 }
             }
         },
@@ -848,12 +851,12 @@
                 "actor": "item_missiletank_006"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -874,12 +877,12 @@
                 "actor": "item_powerbombtank_002"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -900,12 +903,12 @@
                 "actor": "item_missiletank_012"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -926,12 +929,12 @@
                 "actor": "itemsphere_diffusionbeam"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 },
                 "original_actor": {
                     "scenario": "s020_magma",
@@ -1049,12 +1052,12 @@
                 "actor": "item_missiletank_004"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1075,12 +1078,12 @@
                 "actor": "item_missiletank_005"
             },
             "model": [
-                "itemsphere"
+                "item_powerbombtank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S POWER BOMB TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_powerbombtank"
                 }
             }
         },
@@ -1101,12 +1104,12 @@
                 "actor": "item_energyfragment_001"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1127,12 +1130,12 @@
                 "actor": "item_missiletank_007"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1153,12 +1156,12 @@
                 "actor": "item_energyfragment_000"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1179,12 +1182,12 @@
                 "actor": "item_missiletank_009"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1205,12 +1208,12 @@
                 "actor": "item_missiletank_010"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1300,12 +1303,12 @@
                 "actor": "item_missiletankplus_000"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1372,12 +1375,12 @@
                 "actor": "item_missiletank_006"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1421,12 +1424,12 @@
                 "actor": "item_missiletank_004"
             },
             "model": [
-                "itemsphere"
+                "item_powerbombtank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S POWER BOMB TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_powerbombtank"
                 }
             }
         },
@@ -1470,12 +1473,12 @@
                 "actor": "itemsphere_widebeam"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
@@ -1501,12 +1504,12 @@
                 "actor": "itemsphere_bomb"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 },
                 "original_actor": {
                     "scenario": "s030_baselab",
@@ -1532,12 +1535,12 @@
                 "actor": "item_missiletank"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1581,12 +1584,12 @@
                 "actor": "item_powerbombtank_000"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1607,12 +1610,12 @@
                 "actor": "item_missiletank_003"
             },
             "model": [
-                "itemsphere"
+                "powerup_ghostaura"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S FLASH SHIFT",
-                    "base_icon": "unknown"
+                    "base_icon": "powerup_ghostaura"
                 }
             }
         },
@@ -1633,12 +1636,12 @@
                 "actor": "item_energyfragment_000"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1705,12 +1708,12 @@
                 "actor": "item_missiletank_007"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1731,12 +1734,12 @@
                 "actor": "item_missiletank_008"
             },
             "model": [
-                "itemsphere"
+                "item_powerbombtank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S POWER BOMB TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_powerbombtank"
                 }
             }
         },
@@ -1757,12 +1760,12 @@
                 "actor": "item_missiletankplus_000"
             },
             "model": [
-                "itemsphere"
+                "item_energyfragment"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S ENERGY PART",
-                    "base_icon": "unknown"
+                    "base_icon": "item_energyfragment"
                 }
             }
         },
@@ -1783,12 +1786,12 @@
                 "actor": "item_missiletank_010"
             },
             "model": [
-                "itemsphere"
+                "item_missiletankplus"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE+ TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletankplus"
                 }
             }
         },
@@ -1809,12 +1812,12 @@
                 "actor": "item_energyfragment_002"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1835,12 +1838,12 @@
                 "actor": "item_energytank"
             },
             "model": [
-                "itemsphere"
+                "item_energyfragment"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S ENERGY PART",
-                    "base_icon": "unknown"
+                    "base_icon": "item_energyfragment"
                 }
             }
         },
@@ -1861,12 +1864,12 @@
                 "actor": "item_energyfragment_003"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -1910,12 +1913,12 @@
                 "actor": "item_missiletank_001"
             },
             "model": [
-                "itemsphere"
+                "item_energyfragment"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S ENERGY PART",
-                    "base_icon": "unknown"
+                    "base_icon": "item_energyfragment"
                 }
             }
         },
@@ -1982,12 +1985,12 @@
                 "actor": "item_missiletank"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -2008,12 +2011,12 @@
                 "actor": "powerup_ghostaura"
             },
             "model": [
-                "itemsphere"
+                "item_energyfragment"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S ENERGY PART",
-                    "base_icon": "unknown"
+                    "base_icon": "item_energyfragment"
                 }
             }
         },
@@ -2115,12 +2118,13 @@
                 "actor": "item_energytank_000"
             },
             "model": [
-                "itemsphere"
+                "powerup_supermissile",
+                "powerup_icemissile"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S PROGRESSIVE MISSILE",
-                    "base_icon": "unknown"
+                    "base_icon": "PROGRESSIVE_MISSILE"
                 }
             }
         },
@@ -2164,12 +2168,12 @@
                 "actor": "item_missiletank_005"
             },
             "model": [
-                "itemsphere"
+                "powerup_screwattack"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S SCREW ATTACK",
-                    "base_icon": "unknown"
+                    "base_icon": "powerup_screwattack"
                 }
             }
         },
@@ -2190,12 +2194,12 @@
                 "actor": "item_powerbombtank_000"
             },
             "model": [
-                "itemsphere"
+                "item_powerbombtank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S POWER BOMB TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_powerbombtank"
                 }
             }
         },
@@ -2216,12 +2220,12 @@
                 "actor": "item_energyfragment_002"
             },
             "model": [
-                "itemsphere"
+                "item_missiletankplus"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE+ TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletankplus"
                 }
             }
         },
@@ -2265,12 +2269,12 @@
                 "actor": "item_missiletankplus"
             },
             "model": [
-                "itemsphere"
+                "item_missiletankplus"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE+ TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletankplus"
                 }
             }
         },
@@ -2383,12 +2387,13 @@
                 "actor": "item_missiletank_004"
             },
             "model": [
-                "itemsphere"
+                "powerup_doublejump",
+                "powerup_spacejump"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S PROGRESSIVE SPIN",
-                    "base_icon": "unknown"
+                    "base_icon": "PROGRESSIVE_SPIN"
                 }
             }
         },
@@ -2409,12 +2414,12 @@
                 "actor": "item_missiletank_007"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -2458,12 +2463,12 @@
                 "actor": "item_powerbombtank_000"
             },
             "model": [
-                "itemsphere"
+                "item_powerbombtank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S POWER BOMB TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_powerbombtank"
                 }
             }
         },
@@ -2507,12 +2512,12 @@
                 "actor": "item_missiletank_005"
             },
             "model": [
-                "itemsphere"
+                "powerup_grapplebeam"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S GRAPPLE BEAM",
-                    "base_icon": "unknown"
+                    "base_icon": "powerup_grapplebeam"
                 }
             }
         },
@@ -2556,12 +2561,12 @@
                 "actor": "itemsphere_supermissile"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 },
                 "original_actor": {
                     "scenario": "s050_forest",
@@ -2610,12 +2615,12 @@
                 "actor": "item_missiletankplus_000"
             },
             "model": [
-                "itemsphere"
+                "item_energytank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S ENERGY TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_energytank"
                 }
             }
         },
@@ -2636,12 +2641,12 @@
                 "actor": "item_missiletank_004"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -2713,12 +2718,12 @@
                 "actor": "item_missiletank_006"
             },
             "model": [
-                "itemsphere"
+                "powerup_speedbooster"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S SPEED BOOSTER",
-                    "base_icon": "unknown"
+                    "base_icon": "powerup_speedbooster"
                 }
             }
         },
@@ -2762,12 +2767,12 @@
                 "actor": "item_missiletank_003"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -2788,12 +2793,12 @@
                 "actor": "item_energytank_000"
             },
             "model": [
-                "itemsphere"
+                "item_powerbombtank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S POWER BOMB TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_powerbombtank"
                 }
             }
         },
@@ -2814,12 +2819,13 @@
                 "actor": "powerup_sonar"
             },
             "model": [
-                "itemsphere"
+                "powerup_supermissile",
+                "powerup_icemissile"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S PROGRESSIVE MISSILE",
-                    "base_icon": "unknown"
+                    "base_icon": "PROGRESSIVE_MISSILE"
                 }
             }
         },
@@ -2840,12 +2846,12 @@
                 "actor": "item_missiletank_009"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -2926,12 +2932,12 @@
                 "actor": "item_energytank_000"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -3026,12 +3032,12 @@
                 "actor": "item_missiletank_000"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -3052,12 +3058,12 @@
                 "actor": "itemsphere_spacejump"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 },
                 "original_actor": {
                     "scenario": "s070_basesanc",
@@ -3152,12 +3158,12 @@
                 "actor": "item_energyfragment_002"
             },
             "model": [
-                "itemsphere"
+                "item_powerbombtank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S POWER BOMB TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_powerbombtank"
                 }
             }
         },
@@ -3224,12 +3230,12 @@
                 "actor": "item_powerbombtank_001"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -3273,12 +3279,12 @@
                 "actor": "item_missiletankplus_001"
             },
             "model": [
-                "itemsphere"
+                "item_energyfragment"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S ENERGY PART",
-                    "base_icon": "unknown"
+                    "base_icon": "item_energyfragment"
                 }
             }
         },
@@ -3299,12 +3305,12 @@
                 "actor": "item_missiletank_002"
             },
             "model": [
-                "itemsphere"
+                "item_energyfragment"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S ENERGY PART",
-                    "base_icon": "unknown"
+                    "base_icon": "item_energyfragment"
                 }
             }
         },
@@ -3348,12 +3354,12 @@
                 "actor": "item_energyfragment_000"
             },
             "model": [
-                "itemsphere"
+                "item_missiletank"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE TANK",
-                    "base_icon": "unknown"
+                    "base_icon": "item_missiletank"
                 }
             }
         },
@@ -3374,12 +3380,12 @@
                 "actor": "item_missiletank_005"
             },
             "model": [
-                "itemsphere"
+                "item_energyfragment"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S ENERGY PART",
-                    "base_icon": "unknown"
+                    "base_icon": "item_energyfragment"
                 }
             }
         },
@@ -3400,12 +3406,13 @@
                 "actor": "item_energyfragment"
             },
             "model": [
-                "itemsphere"
+                "powerup_bomb",
+                "powerup_crossbomb"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S PROGRESSIVE BOMB",
-                    "base_icon": "unknown"
+                    "base_icon": "PROGRESSIVE_BOMB"
                 }
             }
         },
@@ -3816,8 +3823,8 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",

--- a/test/test_files/patcher_data/dread/dread_prime1_multiworld_expected.json
+++ b/test/test_files/patcher_data/dread/dread_prime1_multiworld_expected.json
@@ -3802,8 +3802,8 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",

--- a/test/test_files/patcher_data/dread/starter_preset.json
+++ b/test/test_files/patcher_data/dread/starter_preset.json
@@ -3659,8 +3659,8 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",


### PR DESCRIPTION
I have the feeling that I'm using it wrong.
Logically, it's now an `offgame_model` and not an `offworld_model`