### PR TITLE
Add pickup search to PickupDetailsTab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Importing permalinks and rdvgames in a multiworld session now creates new worlds if missing.
 - Added: An "Export Game" button has been added to "Session and Connectivity" tab as a shortcut to export any of your worlds.
 - Added: It's now possible to filter the history tab in a Multiworld Session.
+- Added: A new tool was added to the Pickup tab of Game Details that lets you quickly find in which worlds your pickups are.
 - Changed: Text prompts now default to accepting when pressing enter.
 - Fixed: The generation order for multiworld session now correctly handles any kind of names.
 - Fixed: Any buttons for changing presets or deleting worlds are properly disabled when a game is being generated.

--- a/randovania/gui/lib/foldable.py
+++ b/randovania/gui/lib/foldable.py
@@ -11,7 +11,7 @@ class Foldable(QtWidgets.QWidget):
     _content_area: QtWidgets.QFrame
     _folded: bool
 
-    def __init__(self, title: str, initially_folded: bool = True, parent: QtWidgets.QWidget = None):
+    def __init__(self, parent: QtWidgets.QWidget | None, title: str = "", initially_folded: bool = True):
         super().__init__(parent)
 
         self._folded = initially_folded
@@ -72,3 +72,6 @@ class Foldable(QtWidgets.QWidget):
             self._fold()
         else:
             self._unfold()
+
+    def setTitle(self, title: str):
+        self._toggle_button.setText(title)

--- a/randovania/gui/preset_settings/dock_rando_tab.py
+++ b/randovania/gui/preset_settings/dock_rando_tab.py
@@ -73,7 +73,7 @@ class PresetDockRando(PresetTab, Ui_PresetDockRando):
     def _add_dock_type(self, dock_type: DockType, type_params: DockRandoParams):
         self.type_checks[dock_type] = defaultdict(dict)
 
-        type_box = Foldable(dock_type.long_name)
+        type_box = Foldable(self.dock_types_group, dock_type.long_name)
         type_box.setObjectName(f"type_box {dock_type.short_name}")
         type_layout = QtWidgets.QHBoxLayout()
         type_layout.setObjectName(f"type_layout {dock_type.short_name}")

--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -232,7 +232,7 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
 
         all_categories = list(pickup_database.pickup_categories.values())
         for standard_pickup_category in sorted(categories, key=lambda it: all_categories.index(it)):
-            category_box = Foldable(standard_pickup_category.long_name)
+            category_box = Foldable(None, standard_pickup_category.long_name)
             category_box.setObjectName(f"category_box {standard_pickup_category}")
             category_layout = QtWidgets.QGridLayout()
             category_layout.setObjectName(f"category_layout {standard_pickup_category}")

--- a/randovania/gui/preset_settings/location_pool_tab.py
+++ b/randovania/gui/preset_settings/location_pool_tab.py
@@ -61,7 +61,7 @@ class PresetLocationPool(PresetTab, Ui_PresetLocationPool, NodeListHelper):
                             node_names[node] = f"{region_list.nodes_to_area(node).name} ({node_name})"
 
         for region_name in sorted(nodes_by_region.keys()):
-            spoiler = Foldable(region_name)
+            spoiler = Foldable(None, region_name)
             vbox_layout = QtWidgets.QVBoxLayout()
 
             first_node = True

--- a/randovania/gui/ui_files/game_details_window.ui
+++ b/randovania/gui/ui_files/game_details_window.ui
@@ -267,7 +267,7 @@
      <x>0</x>
      <y>0</y>
      <width>624</width>
-     <height>20</height>
+     <height>17</height>
     </rect>
    </property>
   </widget>

--- a/randovania/gui/ui_files/pickup_details_tab.ui
+++ b/randovania/gui/ui_files/pickup_details_tab.ui
@@ -23,7 +23,17 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="2" column="2">
+   <item row="1" column="0" colspan="3">
+    <widget class="QLabel" name="spoiler_starting_items_label">
+     <property name="text">
+      <string>Starting Items</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
     <widget class="QComboBox" name="pickup_spoiler_pickup_combobox">
      <item>
       <property name="text">
@@ -32,24 +42,14 @@
      </item>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="pickup_spoiler_label">
-     <property name="toolTip">
-      <string>Enter text to the right to filter the list below</string>
-     </property>
+   <item row="0" column="0" colspan="3">
+    <widget class="QLabel" name="spoiler_starting_location_label">
      <property name="text">
-      <string>Search Pickup</string>
+      <string>Starting Location</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="pickup_spoiler_show_all_button">
-     <property name="text">
-      <string>Show All</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="3">
+   <item row="5" column="0" colspan="3">
     <widget class="QScrollArea" name="pickup_spoiler_scroll_area">
      <property name="verticalScrollBarPolicy">
       <enum>Qt::ScrollBarAlwaysOn</enum>
@@ -68,8 +68,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>604</width>
-        <height>387</height>
+        <width>608</width>
+        <height>198</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -89,26 +89,74 @@
      </widget>
     </widget>
    </item>
-   <item row="0" column="0" colspan="3">
-    <widget class="QLabel" name="spoiler_starting_location_label">
+   <item row="3" column="0">
+    <widget class="QLabel" name="pickup_spoiler_label">
+     <property name="toolTip">
+      <string>Enter text to the right to filter the list below</string>
+     </property>
      <property name="text">
-      <string>Starting Location</string>
+      <string>Filter locations</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="3">
-    <widget class="QLabel" name="spoiler_starting_items_label">
+   <item row="3" column="1">
+    <widget class="QPushButton" name="pickup_spoiler_show_all_button">
      <property name="text">
-      <string>Starting Items</string>
+      <string>Show All</string>
      </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <widget class="Foldable" name="search_pickup_group">
+     <property name="title">
+      <string>Search for own pickup</string>
      </property>
+     <layout class="QVBoxLayout" name="search_pickup_layout">
+      <item>
+       <widget class="QComboBox" name="search_pickup_combo">
+        <item>
+         <property name="text">
+          <string>Select pickup</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item>
+       <widget class="QTableView" name="search_pickup_view">
+        <property name="horizontalScrollBarPolicy">
+         <enum>Qt::ScrollBarAlwaysOff</enum>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+        </property>
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <property name="sortingEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="cornerButtonEnabled">
+         <bool>false</bool>
+        </property>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>Foldable</class>
+   <extends>QGroupBox</extends>
+   <header location="global">randovania/gui/lib/foldable</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/test/gui/game_details/test_pickup_details_tab.py
+++ b/test/gui/game_details/test_pickup_details_tab.py
@@ -1,0 +1,47 @@
+from PySide6 import QtWidgets
+
+from randovania.gui.game_details.pickup_details_tab import PickupDetailsTab
+from randovania.gui.lib import signal_handling
+from randovania.interface_common.players_configuration import PlayersConfiguration
+from randovania.layout.layout_description import LayoutDescription
+
+
+def test_search_pickup(skip_qtbot, test_files_dir):
+    layout = LayoutDescription.from_file(
+        test_files_dir.joinpath("log_files", "dread", "dread_prime1_multiworld.rdvgame")
+    )
+
+    root = QtWidgets.QWidget()
+    skip_qtbot.addWidget(root)
+
+    players = PlayersConfiguration(
+        0,
+        {0: "You", 1: "They"}
+    )
+
+    tab = PickupDetailsTab(root, layout.all_patches[0].game.game)
+    tab.update_content(layout.all_patches[0].configuration, layout.all_patches, players)
+
+    def get_texts(model):
+        return [
+            [
+                model.data(model.index(row, i))
+                for i in range(4)
+            ]
+            for row in range(model.rowCount())
+        ]
+
+    assert tab.search_pickup_combo.currentIndex() == 0
+    assert get_texts(tab.search_pickup_proxy) == []
+
+    signal_handling.set_combo_with_value(tab.search_pickup_combo, "Progressive Beam")
+    assert get_texts(tab.search_pickup_proxy) == [
+        ['You', 'Artaria', 'Speed Hallway', 'Pickup (Energy Part)'],
+        ['You', 'Cataris', 'Central Unit Access', 'Pickup (Morph Ball)'],
+        ['They', 'Tallon Overworld', 'Frigate Crash Site', 'Pickup (Missile Expansion)']
+    ]
+
+    signal_handling.set_combo_with_value(tab.search_pickup_combo, "Screw Attack")
+    assert get_texts(tab.search_pickup_proxy) == [
+        ['They', 'Magmoor Caverns', 'Storage Cavern', 'Pickup (Missile)'],
+    ]

--- a/test/gui/lib/test_foldable.py
+++ b/test/gui/lib/test_foldable.py
@@ -5,8 +5,8 @@ from randovania.gui.lib.foldable import Foldable
 
 def test_foldable_initial_state(skip_qtbot):
     # Setup & Run
-    foldable = Foldable("My foldable title", False)
-    foldable_2 = Foldable("")
+    foldable = Foldable(None, "My foldable title", False)
+    foldable_2 = Foldable(None, "")
 
     skip_qtbot.addWidget(foldable)
     skip_qtbot.addWidget(foldable_2)
@@ -19,7 +19,7 @@ def test_foldable_initial_state(skip_qtbot):
 
 def test_foldable_actions(skip_qtbot):
     # Setup
-    foldable = Foldable("My foldable title")
+    foldable = Foldable(None, "My foldable title")
 
     skip_qtbot.addWidget(foldable)
 


### PR DESCRIPTION
Does not show up for solo games:
![image](https://github.com/randovania/randovania/assets/884928/1487376f-0ffa-4298-ab55-be1a7fbcab5d)

Defaults to hidden in multis:
![image](https://github.com/randovania/randovania/assets/884928/9ca77455-7c8c-451b-a153-b358971b1a0b)

Shows where pickups for the currently selected world are:
![image](https://github.com/randovania/randovania/assets/884928/2482704e-9601-45a2-878e-7c4e8221ca89)

