### PR TITLE
AM2R: add offworld models

### DIFF
--- a/randovania/games/am2r/pickup_database/pickup-database.json
+++ b/randovania/games/am2r/pickup_database/pickup-database.json
@@ -100,7 +100,11 @@
             "pickup_category": "morph_ball",
             "broad_category": "morph_ball_related",
             "model_name": "Bombs",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Morph Ball Bomb",
+                "prime2": "MorphBallBomb",
+                "dread": "powerup_bomb"
+            },
             "progression": [
                 "Bombs"
             ],
@@ -124,7 +128,11 @@
             "pickup_category": "morph_ball",
             "broad_category": "movement",
             "model_name": "Spider Ball",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Spider Ball",
+                "prime2": "SpiderBall",
+                "dread": "powerup_spidermagnet"
+            },
             "progression": [
                 "Spider Ball"
             ],
@@ -148,7 +156,10 @@
             "pickup_category": "movement",
             "broad_category": "movement",
             "model_name": "Screw Attack",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime2": "ScrewAttack",
+                "dread": "powerup_screwattack"
+            },
             "progression": [
                 "Screw Attack"
             ],
@@ -160,7 +171,11 @@
             "pickup_category": "suit",
             "broad_category": "life_support",
             "model_name": "Varia Suit",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Varia Suit",
+                "prime2": "VariaSuit INCOMPLETE",
+                "dread": "powerup_variasuit"
+            },
             "progression": [
                 "Varia Suit"
             ],
@@ -172,7 +187,11 @@
             "pickup_category": "movement",
             "broad_category": "movement",
             "model_name": "Space Jump",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Space Jump Boots",
+                "prime2": "SpaceJumpBoots",
+                "dread": "powerup_spacejump"
+            },
             "progression": [
                 "Space Jump"
             ],
@@ -184,7 +203,11 @@
             "pickup_category": "movement",
             "broad_category": "movement",
             "model_name": "Speed Booster",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Boost Ball",
+                "prime2": "BoostBall",
+                "dread": "powerup_speedbooster"
+            },
             "progression": [
                 "Speed Booster"
             ],
@@ -196,7 +219,11 @@
             "pickup_category": "movement",
             "broad_category": "movement",
             "model_name": "Hi-Jump Boots",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Space Jump Boots",
+                "prime2": "SpaceJumpBoots",
+                "dread": "powerup_doublejump"
+            },
             "progression": [
                 "Hi-Jump"
             ],
@@ -208,7 +235,11 @@
             "pickup_category": "suit",
             "broad_category": "life_support",
             "model_name": "Gravity Suit",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Gravity Suit",
+                "prime2": "VariaSuit INCOMPLETE",
+                "dread": "powerup_gravitysuit"
+            },
             "progression": [
                 "Gravity Suit"
             ],
@@ -220,7 +251,11 @@
             "pickup_category": "beam",
             "broad_category": "beam_related",
             "model_name": "Charge Beam",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Charge Beam",
+                "prime2": "ChargeBeam INCOMPLETE",
+                "dread": "powerup_chargebeam"
+            },
             "progression": [
                 "Charge Beam"
             ],
@@ -232,7 +267,10 @@
             "pickup_category": "beam",
             "broad_category": "beam_related",
             "model_name": "Ice Beam",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Ice Beam",
+                "dread": "powerup_icemissile"
+            },
             "progression": [
                 "Ice Beam"
             ],
@@ -244,7 +282,10 @@
             "pickup_category": "beam",
             "broad_category": "beam_related",
             "model_name": "Wave Beam",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Wave Beam",
+                "dread": "powerup_wavebeam"
+            },
             "progression": [
                 "Wave Beam"
             ],
@@ -256,7 +297,10 @@
             "pickup_category": "beam",
             "broad_category": "beam_related",
             "model_name": "Spazer Beam",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Power Beam",
+                "dread": "powerup_widebeam"
+            },
             "progression": [
                 "Spazer Beam"
             ],
@@ -268,7 +312,10 @@
             "pickup_category": "beam",
             "broad_category": "beam_related",
             "model_name": "Plasma Beam",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Plasma Beam",
+                "dread": "powerup_plasmabeam"
+            },
             "progression": [
                 "Plasma Beam"
             ],
@@ -280,7 +327,10 @@
             "pickup_category": "morph_ball",
             "broad_category": "morph_ball_related",
             "model_name": "Morph Ball",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Morph Ball",
+                "dread": "powerup_morphball"
+            },
             "progression": [
                 "Morph Ball"
             ],
@@ -292,7 +342,11 @@
             "pickup_category": "missile",
             "broad_category": "missile_related",
             "model_name": "Missile Launcher",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Missile",
+                "prime2": "MissileLauncher",
+                "dread": "powerup_icemissile"
+            },
             "progression": [
                 "Missile Launcher"
             ],
@@ -308,7 +362,11 @@
             "pickup_category": "missile",
             "broad_category": "missile_related",
             "model_name": "Super Missile Launcher",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Super Missile",
+                "prime2": "SuperMissile",
+                "dread": "powerup_supermissile"
+            },
             "progression": [
                 "Super Missile Launcher"
             ],
@@ -324,7 +382,11 @@
             "pickup_category": "morph_ball",
             "broad_category": "morph_ball_related",
             "model_name": "Power Bomb Launcher",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Power Bomb",
+                "prime2": "PowerBomb",
+                "dread": "powerup_powerbomb"
+            },
             "progression": [
                 "Power Bomb Launcher"
             ],
@@ -340,7 +402,11 @@
             "pickup_category": "energy_tank",
             "broad_category": "life_support",
             "model_name": "Energy Tank",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Energy Tank",
+                "prime2": "EnergyTank",
+                "dread": "item_energytank"
+            },
             "progression": [
                 "Energy Tank"
             ],
@@ -353,7 +419,11 @@
         "Missile Expansion": {
             "broad_category": "missile_related",
             "model_name": "Missiles",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Missile",
+                "prime2": "MissileExpansion",
+                "dread": "item_missiletank"
+            },
             "items": [
                 "Missiles"
             ],
@@ -364,7 +434,11 @@
         "Super Missile Expansion": {
             "broad_category": "missile_related",
             "model_name": "Super Missiles",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Missile",
+                "prime2": "MissileExpansionLarge",
+                "dread": "item_missiletankplus"
+            },
             "items": [
                 "Super Missiles"
             ],
@@ -375,7 +449,11 @@
         "Power Bomb Expansion": {
             "broad_category": "morph_ball_related",
             "model_name": "Power Bombs",
-            "offworld_models": {},
+            "offworld_models": {
+                "prime1": "Power Bomb Expansion",
+                "prime2": "PowerBombExpansion",
+                "dread": "item_powerbombtank"
+            },
             "items": [
                 "Power Bombs"
             ],
@@ -385,5 +463,5 @@
         }
     },
     "default_pickups": {},
-    "default_offworld_model": ""
+    "default_offworld_model": "Offworld"
 }


### PR DESCRIPTION
Adds offworld models to AM2R

While this is probably a good enough base, some thoughts i had earlier were:
- AM2R's power grip could potentially be represented primes/dreads grapple beam
- AM2R's spring ball could potentially be represented by morph ball models
- AM2R's space jump could potentially be represented in echoes by gravity booster. Currently it's space jump boots for consistency

Adding am2r as offworld models to other games will follow in a different PR