### PR TITLE
Improve feedback with connection errors.

### DIFF
--- a/randovania/game_connection/game_connection.py
+++ b/randovania/game_connection/game_connection.py
@@ -158,6 +158,12 @@ class GameConnection(QObject):
         connected_state.current_inventory = inventory
         self.GameStateUpdated.emit(connected_state)
 
+    def get_builder_for_connector(self, connector: RemoteConnector) -> ConnectorBuilder:
+        for builder, this_connector in self.remote_connectors.items():
+            if this_connector == connector:
+                return builder
+        raise KeyError("Unknown connector")
+
     def get_backend_choice_for_state(self, state: ConnectedGameState) -> ConnectorBuilderChoice:
         for builder, connector in self.remote_connectors.items():
             if connector == state.source:

--- a/randovania/gui/ui_files/multiplayer_session.ui
+++ b/randovania/gui/ui_files/multiplayer_session.ui
@@ -31,7 +31,7 @@
       </property>
       <widget class="QWidget" name="tab_players">
        <attribute name="title">
-        <string>Players</string>
+        <string>Users and Worlds</string>
        </attribute>
       </widget>
       <widget class="QWidget" name="tab_session">


### PR DESCRIPTION
MultiplayerSessionWindow:
- 60s after losing connection and not regaining it, display an error message for it
- In the connectivity tab, for each world list if you have a connected game for it and what state

MultiworldClient:
- Consider a disconnection as reason to request a new sync, to make sure we're connected and receiving remote pickups

![image](https://github.com/randovania/randovania/assets/884928/346217df-e77c-41c5-807c-93755bcae897)
