### PR TITLE
Fix Major/Minor interacting badly with full randomization in multiworld

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: The time a world last had any activity is now displayed in the Multiworld session.
 - Changed: Text prompts now default to accepting when pressing enter.
 - Changed: Reorganized the top menu bar. The Advanced menu is now called Preferences, with an Advanced sub-menu. Opening the Login window is now in the Open menu.
+- Fixed: Multiworld now properly respects major/minor configuration of each world.
 - Fixed: The generation order for multiworld session now correctly handles any kind of names.
 - Fixed: Any buttons for changing presets or deleting worlds are properly disabled when a game is being generated.
 - Fixed: Import rdvgames for games that uses certain features, like Sky Temple Keys on Bosses or Metroid DNA in Dread, now works properly.

--- a/randovania/generator/filler/filler_logging.py
+++ b/randovania/generator/filler/filler_logging.py
@@ -6,7 +6,8 @@ from randovania.generator.filler.filler_library import UncollectedState, find_no
 from randovania.resolver import debug
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+
+    from collections.abc import Iterable
 
     from randovania.game_description.db.node_identifier import NodeIdentifier
     from randovania.game_description.db.resource_node import ResourceNode
@@ -23,7 +24,7 @@ def debug_print_collect_event(event: ResourceNode, game: GameDescription):
 
 
 def print_retcon_loop_start(game: GameDescription,
-                            pickups_left: Iterator[PickupEntry],
+                            pickups_left: Iterable[PickupEntry],
                             reach: GeneratorReach,
                             player_index: int,
                             ):

--- a/randovania/generator/filler/player_state.py
+++ b/randovania/generator/filler/player_state.py
@@ -5,7 +5,6 @@ import re
 from typing import TYPE_CHECKING
 
 from randovania.game_description.db.dock_node import DockNode
-from randovania.game_description.resources.pickup_index import PickupIndex
 from randovania.game_description.resources.resource_type import ResourceType
 from randovania.generator import reach_lib
 from randovania.generator.filler import filler_logging
@@ -27,8 +26,11 @@ if TYPE_CHECKING:
     from randovania.game_description.db.region_list import RegionList
     from randovania.game_description.db.resource_node import ResourceNode
     from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.resources.location_category import LocationCategory
     from randovania.game_description.resources.pickup_entry import PickupEntry
+    from randovania.game_description.resources.pickup_index import PickupIndex
     from randovania.generator.filler.filler_configuration import FillerConfiguration
+    from randovania.generator.filler.weighted_locations import WeightedLocations
     from randovania.resolver.state import State
 
 
@@ -112,13 +114,14 @@ class PlayerState:
         self._unfiltered_potential_actions = pickups, tuple(uncollected_resource_nodes)
 
     def potential_actions(self, locations_weighted: WeightedLocations) -> list[Action]:
-        num_available_indices = len(self.filter_usable_locations(locations_weighted))
-        num_available_indices += (self.configuration.maximum_random_starting_pickups
-                                  - self.num_starting_pickups_placed)
+        extra_indices = self.configuration.maximum_random_starting_pickups - self.num_starting_pickups_placed
 
-        pickups, uncollected_resource_nodes = self._unfiltered_potential_actions
-        result: list[Action] = [Action(pickup_tuple) for pickup_tuple in pickups
-                                if len(pickup_tuple) <= num_available_indices]
+        pickup_groups, uncollected_resource_nodes = self._unfiltered_potential_actions
+        result: list[Action] = [
+            action
+            for pickup_tuple in pickup_groups
+            if locations_weighted.can_fit(action := Action(pickup_tuple), extra_indices=extra_indices)
+        ]
 
         logical_resource_action = self.configuration.logical_resource_action
         if (logical_resource_action == LayoutLogicalResourceAction.RANDOMLY
@@ -176,7 +179,7 @@ class PlayerState:
         teleporter_dock_types = self.reach.game.dock_weakness_database.all_teleporter_dock_types
         for node in wl.iterate_nodes():
             if (isinstance(node, DockNode) and node.dock_type in teleporter_dock_types
-                 and self.reach.is_reachable_node(node)):
+                    and self.reach.is_reachable_node(node)):
                 other = wl.resolve_dock_node(node, s.patches)
                 teleporters.append("* {} to {}".format(
                     elevators.get_elevator_or_area_name(self.game.game, wl,
@@ -213,36 +216,28 @@ class PlayerState:
         )
 
     def filter_usable_locations(self, locations_weighted: WeightedLocations,
-                                action: PickupEntry | None = None) -> WeightedLocations:
+                                pickup: PickupEntry | None = None) -> WeightedLocations:
         weighted = locations_weighted
 
         if self.configuration.first_progression_must_be_local and self.num_assigned_pickups == 0:
-            weighted = {
-                loc: weight
-                for loc, weight in weighted.items()
-                if loc[0] is self
-            }
+            weighted = weighted.filter_for_player(self)
 
-        if action is not None and self.configuration.randomization_mode is RandomizationMode.MAJOR_MINOR_SPLIT:
-            weighted = {
-                loc: weight
-                for loc, weight in weighted.items()
-                if (loc[0].game.region_list.node_from_pickup_index(loc[1]).location_category ==
-                    action.generator_params.preferred_location_category)
-            }
+        if pickup is not None:
+            weighted = weighted.filter_major_minor_for_pickup(pickup)
 
         return weighted
 
     def should_have_hint(self, pickup: PickupEntry, current_uncollected: UncollectedState,
-                         all_locations_weighted: WeightedLocations) -> bool:
+                         all_locations: WeightedLocations) -> bool:
 
         if not pickup.pickup_category.hinted_as_major:
             return False
 
         config = self.configuration
+
         valid_locations = [
             index
-            for (owner, index), weight in all_locations_weighted.items()
+            for owner, index, weight in all_locations.all_items()
             if (owner == self
                 and weight >= config.minimum_location_weight_for_hint_placement
                 and index in current_uncollected.indices)
@@ -254,7 +249,16 @@ class PlayerState:
         return can_hint
 
     def count_self_locations(self, locations: WeightedLocations) -> int:
-        return sum(1 for player, _ in locations.keys() if player == self)
+        return locations.count_for_player(self)
+
+    def get_location_category(self, index: PickupIndex) -> LocationCategory:
+        return self.game.region_list.node_from_pickup_index(index).location_category
+
+    def can_place_pickup_at(self, pickup: PickupEntry, index: PickupIndex) -> bool:
+        if self.configuration.randomization_mode is RandomizationMode.MAJOR_MINOR_SPLIT:
+            return self.get_location_category(index) == pickup.generator_params.preferred_location_category
+        else:
+            return True
 
 
 def build_available_indices(region_list: RegionList, configuration: FillerConfiguration,
@@ -269,6 +273,3 @@ def build_available_indices(region_list: RegionList, configuration: FillerConfig
     all_indices = set().union(*indices_groups)
 
     return indices_groups, all_indices
-
-
-WeightedLocations = dict[tuple[PlayerState, PickupIndex], float]

--- a/randovania/generator/filler/retcon.py
+++ b/randovania/generator/filler/retcon.py
@@ -10,6 +10,7 @@ from randovania.generator import reach_lib
 from randovania.generator.filler import filler_logging
 from randovania.generator.filler.filler_library import UnableToGenerate, UncollectedState
 from randovania.generator.filler.filler_logging import debug_print_collect_event
+from randovania.generator.filler.weighted_locations import WeightedLocations
 from randovania.lib.random_lib import select_element_with_weight
 from randovania.resolver import debug
 
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
     from randovania.game_description.resources.pickup_entry import PickupEntry
     from randovania.game_description.resources.pickup_index import PickupIndex
     from randovania.generator.filler.action import Action
-    from randovania.generator.filler.player_state import PlayerState, WeightedLocations
+    from randovania.generator.filler.player_state import PlayerState
     from randovania.generator.generator_reach import GeneratorReach
 
 _DANGEROUS_ACTION_MULTIPLIER = 0.75
@@ -159,7 +160,7 @@ def select_weighted_action(rng: Random, weighted_actions: dict[Action, float]) -
 
 
 def increment_considered_count(locations_weighted: WeightedLocations):
-    for player, location in locations_weighted.keys():
+    for player, location, _ in locations_weighted.all_items():
         was_present = location in player.pickup_index_considered_count
         player.pickup_index_considered_count[location] += 1
         if not was_present:
@@ -273,7 +274,7 @@ def retcon_playthrough_filler(rng: Random,
 
 def debug_print_weighted_locations(all_locations_weighted: WeightedLocations):
     print("==> Weighted Locations")
-    for (owner, index), weight in all_locations_weighted.items():
+    for owner, index, weight in all_locations_weighted.all_items():
         print("[Player {}] {} - {}".format(
             owner.index, owner.game.region_list.node_name(owner.game.region_list.node_from_pickup_index(index)), weight,
         ))
@@ -284,7 +285,7 @@ def should_be_starting_pickup(player: PlayerState, locations: WeightedLocations)
     minimum_starting_pickups = player.configuration.minimum_random_starting_pickups
     maximum_starting_pickups = player.configuration.maximum_random_starting_pickups
 
-    result = cur_starting_pickups < minimum_starting_pickups or not locations
+    result = cur_starting_pickups < minimum_starting_pickups or locations.is_empty()
 
     # Prefer a starting pickup over off-db locations.
     # This simulates how in solo games, you get more starting pickups if you start in weird places
@@ -298,7 +299,7 @@ def _assign_pickup_somewhere(action: PickupEntry,
                              current_player: PlayerState,
                              player_states: list[PlayerState],
                              rng: Random,
-                             all_locations_weighted: WeightedLocations,
+                             all_locations: WeightedLocations,
                              ) -> str:
     """
     Assigns a PickupEntry to a free, collected PickupIndex or as a starting item.
@@ -310,23 +311,23 @@ def _assign_pickup_somewhere(action: PickupEntry,
     """
     assert action in current_player.pickups_left
 
-    locations_weighted = current_player.filter_usable_locations(all_locations_weighted, action)
+    usable_locations = current_player.filter_usable_locations(all_locations, action)
 
-    if not should_be_starting_pickup(current_player, locations_weighted):
+    if not should_be_starting_pickup(current_player, usable_locations):
         if debug.debug_level() > 2:
-            debug_print_weighted_locations(all_locations_weighted)
+            debug_print_weighted_locations(all_locations)
 
-        index_owner_state, pickup_index = select_element_with_weight(locations_weighted, rng)
+        index_owner_state, pickup_index = usable_locations.select_location(rng)
         index_owner_state.assign_pickup(pickup_index, PickupTarget(action, current_player.index))
 
-        increment_considered_count(all_locations_weighted)
-        all_locations_weighted.pop((index_owner_state, pickup_index))
+        increment_considered_count(all_locations)
+        all_locations.remove(index_owner_state, pickup_index)
 
         # Place a hint for the new item
         hint_location = _calculate_hint_location_for_action(
             action,
             index_owner_state,
-            all_locations_weighted,
+            all_locations,
             UncollectedState.from_reach(index_owner_state.reach),
             pickup_index,
             rng,
@@ -386,12 +387,12 @@ def _calculate_all_pickup_indices_weight(player_states: list[PlayerState]) -> We
     #     print(f"> {player_state.index} - {wl.node_name(wl.node_from_pickup_index(pickup_index))}: {weight}")
     # print("============================================")
 
-    return all_weights
+    return WeightedLocations(all_weights)
 
 
 def _calculate_hint_location_for_action(action: PickupEntry,
                                         index_owner_state: PlayerState,
-                                        all_locations_weighted: WeightedLocations,
+                                        all_locations: WeightedLocations,
                                         current_uncollected: UncollectedState,
                                         pickup_index: PickupIndex,
                                         rng: Random,
@@ -401,7 +402,7 @@ def _calculate_hint_location_for_action(action: PickupEntry,
     Calculates where a hint for the given action should be placed.
     :return: A LogbookAsset to use, or None if no hint should be placed.
     """
-    if index_owner_state.should_have_hint(action, current_uncollected, all_locations_weighted):
+    if index_owner_state.should_have_hint(action, current_uncollected, all_locations):
         potential_hint_locations = [
             identifier
             for identifier in current_uncollected.logbooks

--- a/randovania/generator/filler/weighted_locations.py
+++ b/randovania/generator/filler/weighted_locations.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from randovania.game_description.resources.location_category import LocationCategory
+from randovania.layout.base.available_locations import RandomizationMode
+from randovania.lib import random_lib
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from random import Random
+
+    from randovania.game_description.resources.pickup_entry import PickupEntry
+    from randovania.game_description.resources.pickup_index import PickupIndex
+    from randovania.generator.filler.action import Action
+    from randovania.generator.filler.player_state import PlayerState
+
+
+class WeightedLocations:
+    _items: dict[tuple[PlayerState, PickupIndex], float]
+
+    def __init__(self, items: dict[tuple[PlayerState, PickupIndex], float]):
+        self._items = items
+
+    def __eq__(self, other):
+        return isinstance(other, WeightedLocations) and self._items == other._items
+
+    def __str__(self):
+        return str(self._items)
+
+    def is_empty(self) -> bool:
+        """True if there are no locations."""
+        return not self._items
+
+    def total_count(self) -> int:
+        """How many locations are available, across all worlds."""
+        return len(self._items)
+
+    def count_for_player(self, player: PlayerState) -> int:
+        """How many locations are available, for one player in particular."""
+        return sum(1 for p, _ in self._items.keys() if p == player)
+
+    def filter_for_player(self, player: PlayerState) -> WeightedLocations:
+        """Returns only the locations of one player in particular."""
+        return WeightedLocations({
+            loc: weight
+            for loc, weight in self._items.items()
+            if loc[0] is player
+        })
+
+    def filter_major_minor_for_pickup(self, pickup: PickupEntry) -> WeightedLocations:
+        """Returns only the locations whose player's major/minor configuration allow this pickup."""
+        return WeightedLocations({
+            (player, index): weight
+            for (player, index), weight in self._items.items()
+            if player.can_place_pickup_at(pickup, index)
+        })
+
+    def all_items(self) -> Iterator[tuple[PlayerState, PickupIndex, float]]:
+        for (player, index), weight in self._items.items():
+            yield player, index, weight
+
+    def select_location(self, rng: Random) -> tuple[PlayerState, PickupIndex]:
+        return random_lib.select_element_with_weight(self._items, rng)
+
+    def remove(self, player: PlayerState, index: PickupIndex):
+        self._items.pop((player, index))
+
+    def can_fit(self, action: Action, *, extra_indices: int = 0) -> bool:
+        # Find how many locations are major, minor or both
+        num_major_locs = 0
+        num_minor_locs = 0
+        num_free_locs = extra_indices
+        for player, index in self._items.keys():
+            if player.configuration.randomization_mode is RandomizationMode.MAJOR_MINOR_SPLIT:
+                if player.get_location_category(index) == LocationCategory.MAJOR:
+                    num_major_locs += 1
+                else:
+                    num_minor_locs += 1
+            else:
+                num_free_locs += 1
+
+        # Count how many pickups are major and minor in the action
+        num_major_picks = 0
+        num_minor_picks = 0
+        for pickup in action.split_pickups()[1]:
+            if pickup.generator_params.preferred_location_category == LocationCategory.MAJOR:
+                num_major_picks += 1
+            else:
+                num_minor_picks += 1
+
+        # Calculate the answer
+        num_major_picks = max(0, num_major_picks - num_major_locs)
+        num_minor_picks = max(0, num_minor_picks - num_minor_locs)
+        num_remaining_picks = num_major_picks + num_minor_picks
+        return num_remaining_picks <= num_free_locs


### PR DESCRIPTION
Current code ensures that your major pickups are always placed in major locations, even in other worlds. But other people's major pickups can be placed in your minors.