### PR TITLE
AM2R: fix logic in BG2 and BG3

### DIFF
--- a/randovania/games/am2r/json_data/Hydro Station.json
+++ b/randovania/games/am2r/json_data/Hydro Station.json
@@ -7015,12 +7015,46 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Screw Attack",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Screw Attack",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed Booster",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "EntranceRando",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {

--- a/randovania/games/am2r/json_data/Hydro Station.txt
+++ b/randovania/games/am2r/json_data/Hydro Station.txt
@@ -1070,7 +1070,11 @@ Extra - map_name: rm_a2c03
   * Layers: default
   * Open Passage to Breeding Grounds Overgrown Alley/Dock to Breeding Grounds Shaft
   > Middle
-      Screw Attack and Go Through Vines
+      All of the following:
+          Go Through Vines
+          Any of the following:
+              Screw Attack
+              Speed Booster and Disabled Entrance Rando
 
 > Middle; Heals? False
   * Layers: default

--- a/randovania/games/am2r/json_data/Industrial Complex.json
+++ b/randovania/games/am2r/json_data/Industrial Complex.json
@@ -7877,7 +7877,7 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Dock to Breeding Grounds Access East": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -7896,32 +7896,138 @@
                                                     }
                                                 },
                                                 {
+                                                    "type": "template",
+                                                    "data": "Can Use Spider Ball"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Walljump up with helpers with the edge",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "Septogg",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "IBJ",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Can Use Bombs"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "IBJ",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "Charged bomb jump",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Can Use Charged Bomb Jump"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "ChargedBombJump",
+                                                                                            "amount": 3,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Walljump",
-                                                        "amount": 3,
+                                                        "amount": 4,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Use Spider Ball"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "WJ + hijump",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Hi-Jump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "IBJ expert",
                                             "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Bombs"
+                                                },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "misc",
-                                                        "name": "Septogg",
-                                                        "amount": 1,
+                                                        "type": "tricks",
+                                                        "name": "IBJ",
+                                                        "amount": 4,
                                                         "negate": false
                                                     }
                                                 },
@@ -7929,7 +8035,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Walljump",
+                                                        "name": "MidAirMorph",
                                                         "amount": 4,
                                                         "negate": false
                                                     }
@@ -8034,7 +8140,7 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Tunnel Climb"
+                                        "data": "Low Mid-Air Morph Tunnel Climb"
                                     },
                                     {
                                         "type": "template",

--- a/randovania/games/am2r/json_data/Industrial Complex.txt
+++ b/randovania/games/am2r/json_data/Industrial Complex.txt
@@ -1253,9 +1253,25 @@ Extra - map_name: rm_a3b02
   * Layers: default
   * Open Passage to Breeding Grounds Gamma Nest Middle/Dock to Breeding Grounds Crossroads
   > Dock to Breeding Grounds Access East
-      All of the following:
-          Space Jump or Walljump (Advanced) or Can Use Spider Ball
-          Walljump (Expert) or Enabled Septogg Helpers
+      Any of the following:
+          Space Jump or Walljump (Expert) or Can Use Spider Ball
+          All of the following:
+              # Walljump up with helpers with the edge
+              Walljump (Advanced)
+              Any of the following:
+                  Enabled Septogg Helpers
+                  All of the following:
+                      # IBJ
+                      Infinite Bomb Jumping (Advanced) and Can Use Bombs
+                  All of the following:
+                      # Charged bomb jump
+                      Charged Bomb Jump (Advanced) and Can Use Charged Bomb Jump
+          All of the following:
+              # WJ + hijump
+              Hi-Jump Boots and Walljump (Intermediate)
+          All of the following:
+              # IBJ expert
+              Infinite Bomb Jumping (Expert) and Mid-Air Morph (Expert) and Can Use Bombs
   > Dock to Breeding Grounds Gamma Nest West
       Any of the following:
           Space Jump Wall
@@ -1269,7 +1285,7 @@ Extra - map_name: rm_a3b02
   * Layers: default
   * Open Passage to Breeding Grounds Gamma Nest Bottom/Dock to Breeding Grounds Crossroads
   > Dock to Breeding Grounds Gamma Nest Middle
-      Can Use Any Bombs and Power Grip Wall and Tunnel Climb
+      Can Use Any Bombs and Low Mid-Air Morph Tunnel Climb and Power Grip Wall
 
 ----------------
 Breeding Grounds Gamma Nest West


### PR DESCRIPTION
BG2 blocks change to speedbooster blocks in vanilla if you come from the left and dont have screw
BG3 just had completely screwed up logic

Already reviewed by @DruidVorse