### PR TITLE
Partially remove default_node

### DIFF
--- a/randovania/cli/commands/new_game.py
+++ b/randovania/cli/commands/new_game.py
@@ -179,7 +179,6 @@ def create_new_database(game_enum: RandovaniaGame, output_path: Path) -> GameDes
             name="Main",
             areas=[Area(
                 name="First Area",
-                default_node=None,
                 nodes=[intro_node],
                 connections={intro_node: {}},
                 extra={},

--- a/randovania/game_description/data_reader.py
+++ b/randovania/game_description/data_reader.py
@@ -416,8 +416,8 @@ class RegionReader:
             self.next_node_index += 1
 
         try:
-            return Area(area_name, data["default_node"],
-                        nodes, connections, data["extra"])
+            return Area(area_name, nodes, connections, data["extra"],
+                        data["default_node"])
         except KeyError as e:
             raise KeyError(f"Missing key `{e}` for area `{area_name}`")
 

--- a/randovania/game_description/db/area.py
+++ b/randovania/game_description/db/area.py
@@ -17,10 +17,10 @@ if typing.TYPE_CHECKING:
 @dataclasses.dataclass(frozen=True, slots=True)
 class Area:
     name: str
-    default_node: str | None
     nodes: list[Node]
     connections: dict[Node, dict[Node, Requirement]]
     extra: dict[str, typing.Any]
+    default_node: str | None = None
 
     def __repr__(self):
         return f"Area[{self.name}]"

--- a/randovania/game_description/db/node_provider.py
+++ b/randovania/game_description/db/node_provider.py
@@ -78,17 +78,6 @@ class NodeProvider:
             area_name=self.nodes_to_area(node).name,
         )
 
-    def default_node_for_area(self, connection: AreaIdentifier) -> Node:
-        area = self.area_by_area_location(connection)
-        if area.default_node is None:
-            raise IndexError(f"Area '{area.name}' does not have a default_node")
-
-        node = area.node_with_name(area.default_node)
-        if node is None:
-            raise IndexError(f"Area '{area.name}' default_node ({area.default_node}) is missing")
-
-        return node
-
     def open_requirement_for(self, weakness: DockWeakness) -> Requirement:
         return weakness.requirement
 

--- a/randovania/game_description/derived_nodes.py
+++ b/randovania/game_description/derived_nodes.py
@@ -21,8 +21,6 @@ def remove_inactive_layers(game: GameDescription, active_layers: set[str]) -> Ga
             connections = {
                 node: copy.copy(connection) for node, connection in area.connections.items()
             }
-            has_default_node = area.default_node is not None
-
             for node in area.nodes:
                 if set(node.layers).isdisjoint(active_layers):
                     nodes.remove(node)
@@ -30,12 +28,8 @@ def remove_inactive_layers(game: GameDescription, active_layers: set[str]) -> Ga
                     for connection in connections.values():
                         connection.pop(node, None)
 
-                    if area.default_node == node.name:
-                        has_default_node = False
-
             areas.append(Area(
                 name=area.name,
-                default_node=area.default_node if has_default_node else None,
                 nodes=nodes,
                 connections=connections,
                 extra=area.extra,

--- a/randovania/game_description/game_patches.py
+++ b/randovania/game_description/game_patches.py
@@ -5,13 +5,12 @@ import dataclasses
 import typing
 from dataclasses import dataclass
 
-from randovania.game_description.db.area_identifier import AreaIdentifier
 from randovania.game_description.db.node_identifier import NodeIdentifier
 from randovania.game_description.resources.pickup_entry import PickupEntry
 from randovania.game_description.resources.resource_info import ResourceCollection, ResourceGain
 from randovania.game_description.resources.resource_type import ResourceType
 
-ElevatorConnection = dict[NodeIdentifier, AreaIdentifier]
+ElevatorConnection = dict[NodeIdentifier, NodeIdentifier]
 StartingEquipment = list[PickupEntry] | ResourceCollection
 
 

--- a/randovania/game_description/integrity_check.py
+++ b/randovania/game_description/integrity_check.py
@@ -11,6 +11,7 @@ from randovania.game_description.db.pickup_node import PickupNode
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.requirements.base import Requirement
 from randovania.game_description.resources.resource_info import ResourceCollection
+from randovania.games.game import RandovaniaGame
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -146,12 +147,6 @@ def find_area_errors(game: GameDescription, area: Area) -> Iterator[str]:
     if len(start_nodes) > 1 and not game.game.data.multiple_start_nodes_per_area:
         names = [node.name for node in start_nodes]
         yield f"{area.name} has multiple valid start nodes {names}, but is not allowed for {game.game.long_name}"
-
-    if area.default_node is not None and area.node_with_name(area.default_node) is None:
-        yield f"{area.name} has default node {area.default_node}, but no node with that name exists"
-
-    # elif area.default_node is not None:
-    #     nodes_with_paths_in.add(area.node_with_name(area.default_node))
 
     for node in area.nodes:
         if isinstance(node, DockNode) or area.connections[node]:

--- a/randovania/games/prime2/generator/base_patches_factory.py
+++ b/randovania/games/prime2/generator/base_patches_factory.py
@@ -124,8 +124,8 @@ class EchoesBasePatchesFactory(PrimeTrilogyBasePatchesFactory):
             raise KeyError(f"{identifier} has no valid starting location")
 
         def link_to(source: AreaIdentifier, target: AreaIdentifier):
-            result[area_to_node(source)] = target
-            result[area_to_node(target)] = source
+            result[area_to_node(source)] = area_to_node(target)
+            result[area_to_node(target)] = area_to_node(source)
 
         def tg_link_to(source: str, target: AreaIdentifier):
             link_to(AreaIdentifier("Temple Grounds", source), target)

--- a/randovania/games/samus_returns/exporter/patch_data_factory.py
+++ b/randovania/games/samus_returns/exporter/patch_data_factory.py
@@ -75,14 +75,8 @@ class MSRPatchDataFactory(BasePatchDataFactory):
 
         return details
 
-    def _node_for(self, identifier: AreaIdentifier | NodeIdentifier) -> Node:
-        if isinstance(identifier, NodeIdentifier):
-            return self.game.region_list.node_by_identifier(identifier)
-        else:
-            area = self.game.region_list.area_by_area_location(identifier)
-            node = area.node_with_name(area.default_node)
-            assert node is not None
-            return node
+    def _node_for(self, identifier:  NodeIdentifier) -> Node:
+        return self.game.region_list.node_by_identifier(identifier)
 
     def create_data(self) -> dict:
         starting_location = self._start_point_ref_for(self._node_for(self.patches.starting_location))

--- a/randovania/generator/base_patches_factory.py
+++ b/randovania/generator/base_patches_factory.py
@@ -144,10 +144,10 @@ class PrimeTrilogyBasePatchesFactory(BasePatchesFactory):
             elevator_connection.update(connections)
 
         for teleporter, destination in elevators.static_teleporters.items():
-            elevator_connection[teleporter] = destination.area_identifier
+            elevator_connection[teleporter] = destination
 
         assignment = [
-            (region_list.typed_node_by_identifier(identifier, DockNode), region_list.default_node_for_area(target))
+            (region_list.typed_node_by_identifier(identifier, DockNode), region_list.node_by_identifier(target))
             for identifier, target in elevator_connection.items()
         ]
 

--- a/randovania/generator/elevator_distributor.py
+++ b/randovania/generator/elevator_distributor.py
@@ -18,10 +18,10 @@ if TYPE_CHECKING:
 
 class ElevatorHelper:
     teleporter: NodeIdentifier
-    destination: AreaIdentifier
+    destination: NodeIdentifier
     connected_elevator: ElevatorHelper | None
 
-    def __init__(self, teleporter: NodeIdentifier, destination: AreaIdentifier):
+    def __init__(self, teleporter: NodeIdentifier, destination: NodeIdentifier):
         self.teleporter = teleporter
         self.destination = destination
         self.connected_elevator = None
@@ -35,8 +35,8 @@ class ElevatorHelper:
         return self.teleporter.area_location.area_name
 
     def connect_to(self, other: ElevatorHelper):
-        self.destination = other.teleporter.area_location
-        other.destination = self.teleporter.area_location
+        self.destination = other.teleporter
+        other.destination = self.teleporter
         self.connected_elevator = other
         other.connected_elevator = self
 
@@ -112,14 +112,14 @@ def two_way_elevator_connections(rng: Random,
             elevators.pop().connect_to(elevators.pop())
 
     return {
-        elevator.teleporter: elevator.connected_elevator.area_location
+        elevator.teleporter: elevator.connected_elevator.teleporter
         for elevator in elevator_database
     }
 
 
 def one_way_elevator_connections(rng: Random,
                                  elevator_database: tuple[ElevatorHelper, ...],
-                                 target_locations: list[AreaIdentifier],
+                                 target_locations: list[NodeIdentifier],
                                  replacement: bool,
                                  ) -> ElevatorConnection:
     target_locations.sort()

--- a/randovania/gui/data_editor.py
+++ b/randovania/gui/data_editor.py
@@ -129,7 +129,6 @@ class DataEditorWindow(QMainWindow, Ui_DataEditorWindow):
         self.node_details_label.linkActivated.connect(self._on_click_link_to_other_node)
         self.node_heals_check.stateChanged.connect(self.on_node_heals_check)
         self.area_spawn_check.stateChanged.connect(self.on_area_spawn_check)
-        self.default_node_check.stateChanged.connect(self.on_default_node_check)
         self.node_edit_button.clicked.connect(self.on_node_edit_button)
         self.other_node_connection_swap_button.clicked.connect(self._swap_selected_connection)
         self.other_node_connection_edit_button.clicked.connect(self._open_edit_connection)
@@ -355,7 +354,7 @@ class DataEditorWindow(QMainWindow, Ui_DataEditorWindow):
             self.focus_on_region_by_name(region_name)
             self.focus_on_area_by_name(area_name)
             if node_name is None:
-                node_name = self.current_area.default_node
+                node_name = self.current_area.nodes[0]
 
             for radio_button in self.radio_button_to_node.keys():
                 if radio_button.text() == node_name:
@@ -373,14 +372,6 @@ class DataEditorWindow(QMainWindow, Ui_DataEditorWindow):
         assert old_node is not None
         new_node = dataclasses.replace(old_node, valid_starting_location=bool(state))
         self.replace_node_with(self.current_area, old_node, new_node)
-
-    def on_default_node_check(self, state: int):
-        state = bool(state)
-        if not state:
-            return
-
-        object.__setattr__(self.current_area, "default_node", self.current_node.name)
-        self.default_node_check.setEnabled(False)
 
     def replace_node_with(self, area: Area, old_node: Node, new_node: Node):
         if old_node == new_node:
@@ -448,10 +439,6 @@ class DataEditorWindow(QMainWindow, Ui_DataEditorWindow):
 
         is_area_spawn = self.current_node.valid_starting_location
         self.area_spawn_check.setChecked(is_area_spawn)
-
-        is_default_node = self.current_area.default_node == node.name
-        self.default_node_check.setChecked(is_default_node)
-        self.default_node_check.setEnabled(self.edit_mode and not is_default_node)
 
         self.area_view_canvas.highlight_node(node)
 
@@ -829,7 +816,6 @@ class DataEditorWindow(QMainWindow, Ui_DataEditorWindow):
         self.other_node_connection_edit_button.setVisible(self.edit_mode)
         self.node_heals_check.setEnabled(self.edit_mode)
         self.area_spawn_check.setEnabled(self.edit_mode)
-        self.default_node_check.setEnabled(self.edit_mode and self.default_node_check.isEnabled())
         self.node_edit_button.setVisible(self.edit_mode)
         self.resource_editor.set_allow_edits(self.edit_mode)
         self.area_view_canvas.set_edit_mode(self.edit_mode)

--- a/randovania/gui/tracker_window.py
+++ b/randovania/gui/tracker_window.py
@@ -604,7 +604,8 @@ class TrackerWindow(QtWidgets.QMainWindow, Ui_TrackerWindow):
                                                                location_names, 0, False)
                 area_location = area_locations[location_names.index(selected_name[0])]
 
-            self._initial_state.node = region_list.area_by_area_location(area_location).default_node
+            # TODO If there is no `default_node` anymore, what would be the replacement?
+            self._initial_state.node = region_list.area_by_area_location(area_location).get_start_nodes()[0]
 
         def is_resource_node_present(node: Node, state: State):
             if node.is_resource_node:
@@ -757,7 +758,8 @@ class TrackerWindow(QtWidgets.QMainWindow, Ui_TrackerWindow):
 
         state.patches = state.patches.assign_dock_connections(
             (region_list.typed_node_by_identifier(teleporter, DockNode),
-              region_list.default_node_for_area(combo.currentData()))
+            # TODO If there is no `default_node` anymore, what would be the replacement?
+              region_list.area_by_area_location(combo.currentData()).get_start_nodes()[0])
             for teleporter, combo in self._elevator_id_to_combo.items() if combo.currentData() is not None
         )
 

--- a/randovania/gui/ui_files/data_editor.ui
+++ b/randovania/gui/ui_files/data_editor.ui
@@ -86,8 +86,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>164</width>
-          <height>262</height>
+          <width>156</width>
+          <height>193</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="nodes_scroll_layout">
@@ -170,30 +170,10 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="2">
-         <widget class="QCheckBox" name="node_heals_check">
-          <property name="maximumSize">
-           <size>
-            <width>100</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Heals?</string>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="2">
          <widget class="QCheckBox" name="area_spawn_check">
           <property name="text">
            <string>Area spawn</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QCheckBox" name="default_node_check">
-          <property name="text">
-           <string>Default node</string>
           </property>
          </widget>
         </item>
@@ -207,6 +187,19 @@
           </property>
           <property name="openExternalLinks">
            <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QCheckBox" name="node_heals_check">
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Heals?</string>
           </property>
          </widget>
         </item>
@@ -238,23 +231,15 @@
         </item>
         <item row="1" column="0" colspan="3">
          <widget class="QTreeWidget" name="other_node_alternatives_contents">
-           <property name="geometry">
-            <rect>
-             <x>0</x>
-             <y>0</y>
-             <width>256</width>
-             <height>210</height>
-            </rect>
+          <attribute name="headerVisible">
+           <bool>false</bool>
+          </attribute>
+          <column>
+           <property name="text">
+            <string notr="true">1</string>
            </property>
-           <attribute name="headerVisible">
-            <bool>false</bool>
-           </attribute>
-           <column>
-            <property name="text">
-             <string notr="true">1</string>
-            </property>
-           </column>
-          </widget>
+          </column>
+         </widget>
         </item>
         <item row="0" column="1">
          <widget class="QPushButton" name="other_node_connection_swap_button">

--- a/randovania/layout/lib/teleporters.py
+++ b/randovania/layout/lib/teleporters.py
@@ -100,12 +100,11 @@ class TeleporterList(location_list.LocationList):
 
 def _valid_teleporter_target(area: Area, node: Node, game: RandovaniaGame):
     if (game in (RandovaniaGame.METROID_PRIME, RandovaniaGame.METROID_PRIME_ECHOES) and
-            area.name == "Credits" and node.name == area.default_node):
+            area.name == "Credits" and node.name == "Event - Credits"):
         return True
 
     has_save_station = any(node.name == "Save Station" for node in area.nodes)
-    return (area.has_start_node() and area.default_node is not None and
-            area.default_node == node.name and not has_save_station)
+    return (area.has_start_node() and node in area.get_start_nodes() and not has_save_station)
 
 
 class TeleporterTargetList(location_list.LocationList):
@@ -164,9 +163,9 @@ class TeleporterConfiguration(BitPackDataclass, JsonDataclass, DataclassPostInit
         return static
 
     @property
-    def valid_targets(self) -> list[AreaIdentifier]:
+    def valid_targets(self) -> list[NodeIdentifier]:
         if self.mode == TeleporterShuffleMode.ONE_WAY_ANYTHING:
-            return [location.area_identifier for location in self.excluded_targets.nodes_list(self.game)
+            return [location for location in self.excluded_targets.nodes_list(self.game)
                     if location not in self.excluded_targets.locations]
 
         elif self.mode in {TeleporterShuffleMode.ONE_WAY_ELEVATOR, TeleporterShuffleMode.ONE_WAY_ELEVATOR_REPLACEMENT}:
@@ -181,7 +180,7 @@ class TeleporterConfiguration(BitPackDataclass, JsonDataclass, DataclassPostInit
                     # Valid destinations must be valid starting areas
                     area = region_list.nodes_to_area(node)
                     if area.has_start_node():
-                        result.append(identifier.area_identifier)
+                        result.append(identifier)
                     # Hack for Metroid Prime 1, where the scripting for Metroid Prime Lair is dependent
                     # on the previous room
                     elif area.name == "Metroid Prime Lair":

--- a/test/game_description/db/test_region_list.py
+++ b/test/game_description/db/test_region_list.py
@@ -47,8 +47,8 @@ def test_connections_from_dock_blast_shield(empty_patches):
                       node_1_identifier, weak_2, None, None, False, ())
     node_2_lock = DockLockNode.create_from_dock(node_2, 3)
 
-    area_1 = Area("Area 1", None, [node_1, node_1_lock], {}, {})
-    area_2 = Area("Area 2", None, [node_2, node_2_lock], {}, {})
+    area_1 = Area("Area 1", [node_1, node_1_lock], {}, {})
+    area_2 = Area("Area 2", [node_2, node_2_lock], {}, {})
 
     region = Region("W", [area_1, area_2], {})
     region_list = RegionList([region])

--- a/test/game_description/test_data_writer.py
+++ b/test/game_description/test_data_writer.py
@@ -5,6 +5,7 @@ import pytest
 from randovania.game_description import data_reader, data_writer
 from randovania.games import default_data
 from randovania.games.game import RandovaniaGame
+# from randovania.lib import json_lib
 
 
 @pytest.mark.parametrize("game_enum", RandovaniaGame)

--- a/test/game_description/test_game_description.py
+++ b/test/game_description/test_game_description.py
@@ -38,7 +38,7 @@ def test_calculate_dangerous_resources(danger_a, danger_b, expected_result):
     n4.node_index = 3
 
     area_a = Area(
-        "area_a", 0, [n1, n2],
+        "area_a", [n1, n2],
         {
             n1: {
                 n2: set_a
@@ -48,7 +48,7 @@ def test_calculate_dangerous_resources(danger_a, danger_b, expected_result):
         {}
     )
     area_b = Area(
-        "area_b", 0, [n3, n4],
+        "area_b", [n3, n4],
         {
             n3: {},
             n4: {

--- a/test/games/prime/patcher_file_lib/test_item_hints.py
+++ b/test/games/prime/patcher_file_lib/test_item_hints.py
@@ -53,8 +53,8 @@ def _create_region_list(asset_id: int, pickup_index: PickupIndex):
 
     region_list = RegionList([
         Region("World", [
-            Area("Area", None, [logbook_node, pickup_node], {}, {}),
-            Area("Other Area", None,
+            Area("Area", [logbook_node, pickup_node], {}, {}),
+            Area("Other Area",
                  [PickupNode(nc("World", "Other Area", f"Pickup {i}"),
                              2 + i, True, None, "", ("default",), {}, False, PickupIndex(i), True)
                   for i in range(pickup_index.index)],

--- a/test/games/prime2/generator/test_echoes_base_patches_factory.py
+++ b/test/games/prime2/generator/test_echoes_base_patches_factory.py
@@ -15,28 +15,28 @@ def test_elevator_echoes_shuffled(echoes_game_patches, default_echoes_configurat
 
     # Assert
     simpler = {
-        source.area_identifier.as_string: target.as_string
+        source.as_string: target.as_string
         for source, target in result.items()
     }
     assert simpler == {
-        'Agon Wastes/Transport to Sanctuary Fortress': 'Temple Grounds/Temple Transport B',
-        'Agon Wastes/Transport to Temple Grounds': 'Temple Grounds/Temple Transport A',
-        'Agon Wastes/Transport to Torvus Bog': 'Temple Grounds/Temple Transport C',
-        'Great Temple/Temple Transport A': 'Temple Grounds/Transport to Agon Wastes',
-        'Great Temple/Temple Transport B': 'Sanctuary Fortress/Transport to Agon Wastes',
-        'Great Temple/Temple Transport C': 'Torvus Bog/Transport to Agon Wastes',
-        'Sanctuary Fortress/Transport to Agon Wastes': 'Great Temple/Temple Transport B',
-        'Sanctuary Fortress/Transport to Temple Grounds': 'Temple Grounds/Transport to Sanctuary Fortress',
-        'Sanctuary Fortress/Transport to Torvus Bog': 'Torvus Bog/Transport to Sanctuary Fortress',
-        'Temple Grounds/Temple Transport A': 'Agon Wastes/Transport to Temple Grounds',
-        'Temple Grounds/Temple Transport B': 'Agon Wastes/Transport to Sanctuary Fortress',
-        'Temple Grounds/Temple Transport C': 'Agon Wastes/Transport to Torvus Bog',
-        'Temple Grounds/Transport to Agon Wastes': 'Great Temple/Temple Transport A',
-        'Temple Grounds/Transport to Sanctuary Fortress': 'Sanctuary Fortress/Transport to Temple Grounds',
-        'Temple Grounds/Transport to Torvus Bog': 'Torvus Bog/Transport to Temple Grounds',
-        'Torvus Bog/Transport to Agon Wastes': 'Great Temple/Temple Transport C',
-        'Torvus Bog/Transport to Sanctuary Fortress': 'Sanctuary Fortress/Transport to Torvus Bog',
-        'Torvus Bog/Transport to Temple Grounds': 'Temple Grounds/Transport to Torvus Bog',
+        'Agon Wastes/Transport to Sanctuary Fortress/Elevator to Sanctuary Fortress': 'Temple Grounds/Temple Transport B/Elevator to Great Temple',
+        'Agon Wastes/Transport to Temple Grounds/Elevator to Temple Grounds': 'Temple Grounds/Temple Transport A/Elevator to Great Temple',
+        'Agon Wastes/Transport to Torvus Bog/Elevator to Torvus Bog': 'Temple Grounds/Temple Transport C/Elevator to Great Temple',
+        'Great Temple/Temple Transport A/Elevator to Temple Grounds': 'Temple Grounds/Transport to Agon Wastes/Elevator to Agon Wastes',
+        'Great Temple/Temple Transport B/Elevator to Temple Grounds': 'Sanctuary Fortress/Transport to Agon Wastes/Elevator to Agon Wastes',
+        'Great Temple/Temple Transport C/Elevator to Temple Grounds': 'Torvus Bog/Transport to Agon Wastes/Elevator to Agon Wastes',
+        'Sanctuary Fortress/Transport to Agon Wastes/Elevator to Agon Wastes': 'Great Temple/Temple Transport B/Elevator to Temple Grounds',
+        'Sanctuary Fortress/Transport to Temple Grounds/Elevator to Temple Grounds': 'Temple Grounds/Transport to Sanctuary Fortress/Elevator to Sanctuary Fortress',
+        'Sanctuary Fortress/Transport to Torvus Bog/Elevator to Torvus Bog': 'Torvus Bog/Transport to Sanctuary Fortress/Elevator to Sanctuary Fortress',
+        'Temple Grounds/Temple Transport A/Elevator to Great Temple': 'Agon Wastes/Transport to Temple Grounds/Elevator to Temple Grounds',
+        'Temple Grounds/Temple Transport B/Elevator to Great Temple': 'Agon Wastes/Transport to Sanctuary Fortress/Elevator to Sanctuary Fortress',
+        'Temple Grounds/Temple Transport C/Elevator to Great Temple': 'Agon Wastes/Transport to Torvus Bog/Elevator to Torvus Bog',
+        'Temple Grounds/Transport to Agon Wastes/Elevator to Agon Wastes': 'Great Temple/Temple Transport A/Elevator to Temple Grounds',
+        'Temple Grounds/Transport to Sanctuary Fortress/Elevator to Sanctuary Fortress': 'Sanctuary Fortress/Transport to Temple Grounds/Elevator to Temple Grounds',
+        'Temple Grounds/Transport to Torvus Bog/Elevator to Torvus Bog': 'Torvus Bog/Transport to Temple Grounds/Elevator to Temple Grounds',
+        'Torvus Bog/Transport to Agon Wastes/Elevator to Agon Wastes': 'Great Temple/Temple Transport C/Elevator to Temple Grounds',
+        'Torvus Bog/Transport to Sanctuary Fortress/Elevator to Sanctuary Fortress': 'Sanctuary Fortress/Transport to Torvus Bog/Elevator to Torvus Bog',
+        'Torvus Bog/Transport to Temple Grounds/Elevator to Temple Grounds': 'Temple Grounds/Transport to Torvus Bog/Elevator to Torvus Bog',
     }
 
 

--- a/test/games/prime2/patcher/test_patch_data_generator.py
+++ b/test/games/prime2/patcher/test_patch_data_generator.py
@@ -190,20 +190,20 @@ def test_create_elevators_field_elevators_for_a_seed(vanilla_gateway: bool,
     wl = echoes_game_description.region_list
     elevator_connection: list[tuple[DockNode, Node]] = []
 
-    def add(region: str, area: str, node: str, target_world: str, target_area: str):
+    def add(region: str, area: str, node: str, target_world: str, target_area: str, target_node: str):
         elevator_connection.append((
             wl.typed_node_by_identifier(NodeIdentifier.create(region, area, node), DockNode),
-            wl.default_node_for_area(AreaIdentifier(target_world, target_area)),
+            wl.node_by_identifier(NodeIdentifier.create(target_world, target_area, target_node)),
         ))
 
     add("Temple Grounds", "Temple Transport C", "Elevator to Great Temple",
-        "Sanctuary Fortress", "Transport to Agon Wastes")
+        "Sanctuary Fortress", "Transport to Agon Wastes", "Elevator to Agon Wastes")
     add("Temple Grounds", "Transport to Agon Wastes", "Elevator to Agon Wastes",
-        "Torvus Bog", "Transport to Agon Wastes")
+        "Torvus Bog", "Transport to Agon Wastes", "Elevator to Agon Wastes")
 
     if not vanilla_gateway:
         add("Temple Grounds", "Sky Temple Gateway", "Elevator to Great Temple",
-            "Great Temple", "Sanctum")
+            "Great Temple", "Sanctum", "Door to Sanctum Access")
 
     patches = echoes_game_patches.assign_dock_connections(elevator_connection)
 

--- a/test/generator/test_elevator_distributor.py
+++ b/test/generator/test_elevator_distributor.py
@@ -69,8 +69,8 @@ def test_two_way_elevator_connections_between_areas(mock_try_randomize_elevators
     # Assert
     mock_try_randomize_elevators.assert_called_once_with(rng, (elevator_a, elevator_b))
     assert result == {
-        elevator_a.teleporter: elevator_a.connected_elevator.area_location,
-        elevator_b.teleporter: elevator_b.connected_elevator.area_location,
+        elevator_a.teleporter: elevator_a.connected_elevator.teleporter,
+        elevator_b.teleporter: elevator_b.connected_elevator.teleporter,
     }
 
 
@@ -78,7 +78,7 @@ def test_two_way_elevator_connections_unchecked():
     # Setup
     rng = random.Random(5000)
     elevators = [
-        ElevatorHelper(NodeIdentifier.create(f"w{i}", f"a{i}", f"n{i}"), AreaIdentifier(f"w{i}", f"a{i}"))
+        ElevatorHelper(NodeIdentifier.create(f"w{i}", f"a{i}", f"n{i}"), NodeIdentifier.create(f"w{i}", f"a{i}", f"n{i}"))
         for i in range(6)
     ]
     database = tuple(elevators)
@@ -88,12 +88,12 @@ def test_two_way_elevator_connections_unchecked():
 
     # Assert
     assert result == {
-        NodeIdentifier.create("w0", "a0", "n0"): AreaIdentifier("w4", "a4"),
-        NodeIdentifier.create("w1", "a1", "n1"): AreaIdentifier("w2", "a2"),
-        NodeIdentifier.create("w2", "a2", "n2"): AreaIdentifier("w1", "a1"),
-        NodeIdentifier.create("w3", "a3", "n3"): AreaIdentifier("w5", "a5"),
-        NodeIdentifier.create("w4", "a4", "n4"): AreaIdentifier("w0", "a0"),
-        NodeIdentifier.create("w5", "a5", "n5"): AreaIdentifier("w3", "a3"),
+        NodeIdentifier.create("w0", "a0", "n0"):  NodeIdentifier.create("w4", "a4", "n4"),
+        NodeIdentifier.create("w1", "a1", "n1"):  NodeIdentifier.create("w2", "a2", "n2"),
+        NodeIdentifier.create("w2", "a2", "n2"):  NodeIdentifier.create("w1", "a1", "n1"),
+        NodeIdentifier.create("w3", "a3", "n3"):  NodeIdentifier.create("w5", "a5", "n5"),
+        NodeIdentifier.create("w4", "a4", "n4"):  NodeIdentifier.create("w0", "a0", "n0"),
+        NodeIdentifier.create("w5", "a5", "n5"):  NodeIdentifier.create("w3", "a3", "n3"),
     }
 
 

--- a/test/generator/test_generator_reach.py
+++ b/test/generator/test_generator_reach.py
@@ -195,7 +195,7 @@ def test_basic_search_with_translator_gate(has_translator: bool, echoes_resource
 
     region_list = RegionList([
         Region("Test World", [
-            Area("Test Area A", None, [node_a, node_b, node_c, translator_node],
+            Area("Test Area A", [node_a, node_b, node_c, translator_node],
                  {
                      node_a: {
                          node_b: Requirement.trivial(),

--- a/test/gui/test_tracker_window.py
+++ b/test/gui/test_tracker_window.py
@@ -295,7 +295,9 @@ async def test_apply_previous_state(skip_qtbot, tmp_path: Path, default_echoes_p
 
     if shuffle_advanced:
         for elevator in state["elevators"]:
-            if elevator["teleporter"]["node"] == "Elevator to Sanctuary Fortress":
+            if (elevator["teleporter"]["region"] == "Agon Wastes" 
+                and elevator["teleporter"]["node"] == "Elevator to Sanctuary Fortress"
+                and elevator["teleporter"]["area"] == "Transport to Sanctuary Fortress"):
                 elevator["data"] = {'area': "Agon Energy Controller", 'region': "Agon Wastes"}
         state["configurable_nodes"]['Temple Grounds/Hive Access Tunnel/Translator Gate'] = "violet"
     VersionedPreset.with_preset(preset).save_to_file(tmp_path.joinpath("preset.rdvpreset"))

--- a/test/layout/test_teleporters.py
+++ b/test/layout/test_teleporters.py
@@ -60,7 +60,7 @@ def _a(region, area, instance_id=None):
            mode="one-way-elevator", excluded_teleporters=[
                 _a("Temple Grounds", "Temple Transport C", "Elevator to Great Temple")
             ]),
-        _m(b'\xe4\x03,\xd0', 28, 'One-way, anywhere; excluded 1 targets', mode="one-way-anything", excluded_targets=[
+        _m(b'\xe4\x03,\x90', 28, 'One-way, anywhere; excluded 1 targets', mode="one-way-anything", excluded_targets=[
             _a("Temple Grounds", "Temple Transport C", "Elevator to Great Temple")
         ]),
     ],


### PR DESCRIPTION
Definitely goes into the "I have no idea what I'm doing", especially with some of the reverts I had to do.
Should also go over the changes myself again because of that.

What this PR should acheive:
- remove `default_node` from ui and all usages
- except for keeping them in the db without any intended way to change
- `default_node`s are not removed from db because of the integrity check skipping strongly connected components for `default_node`s  (only dread has a lot of them)
- as `default_node`s will be logically gone, elevators now needs to be connected directly to a node. It is also a logical consequence of making elevators `DockNode`s and they are already connected to nodes in the db.