### PR TITLE
AM2R: change screw block option to be true for starter preset

### DIFF
--- a/randovania/games/am2r/presets/starter_preset.rdvpreset
+++ b/randovania/games/am2r/presets/starter_preset.rdvpreset
@@ -160,7 +160,7 @@
         "septogg_helpers": true,
         "skip_cutscenes": true,
         "respawn_bomb_blocks": false,
-        "screw_blocks": false,
+        "screw_blocks": true,
         "artifacts": {
             "prefer_metroids": true,
             "prefer_bosses": false,


### PR DESCRIPTION
For some reason it was false before