### PR TITLE
AM2R: Add queen doors

### DIFF
--- a/randovania/games/am2r/json_data/Genetics Laboratory.json
+++ b/randovania/games/am2r/json_data/Genetics Laboratory.json
@@ -4079,7 +4079,25 @@
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
-                    "connections": {}
+                    "connections": {
+                        "Event - Queen": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "BossQueen",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
                 },
                 "Dock from Queen Arena Access": {
                     "node_type": "dock",
@@ -4107,7 +4125,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Hatchling Room": {
+                        "Event - Queen": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4267,6 +4285,31 @@
                                         }
                                     }
                                 ]
+                            }
+                        }
+                    }
+                },
+                "Event - Queen": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 591.6,
+                        "y": 96.08,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "BossQueen",
+                    "connections": {
+                        "Dock to Hatchling Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }

--- a/randovania/games/am2r/json_data/Genetics Laboratory.txt
+++ b/randovania/games/am2r/json_data/Genetics Laboratory.txt
@@ -644,11 +644,13 @@ Extra - map_name: rm_a7b11
 > Dock to Hatchling Room; Heals? False
   * Layers: default
   * Open Passage to Hatchling Room/Dock to Queen Arena
+  > Event - Queen
+      After Boss - Queen Defeated
 
 > Dock from Queen Arena Access; Heals? False
   * Layers: default
   * Back Only to Queen Arena Access/Dock to Queen Arena
-  > Dock to Hatchling Room
+  > Event - Queen
       All of the following:
           Any of the following:
               # Item requirements to damage
@@ -666,6 +668,12 @@ Extra - map_name: rm_a7b11
           Any of the following:
               # Energy requirements
               Combat (Expert) or Normal Damage ≥ 530
+
+> Event - Queen; Heals? False
+  * Layers: default
+  * Event Boss - Queen Defeated
+  > Dock to Hatchling Room
+      Trivial
 
 ----------------
 Hatchling Room

--- a/randovania/games/am2r/json_data/header.json
+++ b/randovania/games/am2r/json_data/header.json
@@ -467,6 +467,10 @@
                 "long_name": "Boss - Genesis Defeated",
                 "extra": {}
             },
+            "BossQueen": {
+                "long_name": "Boss - Queen Defeated",
+                "extra": {}
+            },
             "EMPA1": {
                 "long_name": "EMP - Golden Temple",
                 "extra": {}
@@ -3398,6 +3402,19 @@
                             "data": {
                                 "type": "events",
                                 "name": "BossGenesis",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "lock": null
+                    },
+                    "Metroid Queen-Locked Door": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "BossQueen",
                                 "amount": 1,
                                 "negate": false
                             }

--- a/randovania/games/am2r/json_data/header.txt
+++ b/randovania/games/am2r/json_data/header.txt
@@ -300,6 +300,12 @@ Dock Weaknesses
       No lock
 
 
+  * Metroid Queen-Locked Door
+      Open:
+          After Boss - Queen Defeated
+      No lock
+
+
   * Tower Energy Restored Door
       Open:
           After Area 4 - Tower Energy Activated


### PR DESCRIPTION
On the process of adding Queen doors, this also does the following:
- Adds a queen defeated event (no clue why this wasnt done before)
- Changes queen arena for top door to go to event first, instead of the hatchling door.

Primary use for plando and room rando