### PR TITLE
Prime: Fix tower of light access -> ruined shrine door

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Introduction of non-critical fixes and improvements to the base game such as fixed sound effects and removed tutorial popups. Those wanting an untainted experience of the vanilla game may still do so at their own risk by activating "Legacy Mode". For technical description of what's changed, see [qol.jsonc](https://github.com/toasterparty/randomprime/blob/randovania/generated/json_data/qol.jsonc)
 - Changed: Non-NTSC enemies now have their health reset to match NTSC 0-00
 
+#### Logic Database
+
+##### Chozo Ruins
+
+- Fixed: The Door in Tower of Light Access that leads to Ruined Shrine is now a normal Door instead of a Wave Beam Door.
+
 ### Metroid Prime 2: Echoes
 
 - Added: Tracker layout "Debug Info", which also shows details useful for investigating errors.

--- a/randovania/games/prime1/json_data/Chozo Ruins.json
+++ b/randovania/games/prime1/json_data/Chozo Ruins.json
@@ -4068,7 +4068,7 @@
                         "area": "Ruined Shrine",
                         "node": "Door to Tower of Light Access"
                     },
-                    "default_dock_weakness": "Wave Door",
+                    "default_dock_weakness": "Normal Door",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,

--- a/randovania/games/prime1/json_data/Chozo Ruins.txt
+++ b/randovania/games/prime1/json_data/Chozo Ruins.txt
@@ -695,7 +695,7 @@ Extra - aabb: [-149.03557, -2.303732, 18.729618, -95.536766, 27.518578, 26.91997
 
 > Door to Ruined Shrine; Heals? False; Spawn Point; Default Node
   * Layers: default
-  * Wave Door to Ruined Shrine/Door to Tower of Light Access
+  * Normal Door to Ruined Shrine/Door to Tower of Light Access
   * Extra - dock_index: 1
   * Extra - nonstandard: False
   > Door to Tower of Light


### PR DESCRIPTION
The door from ToL acces -> ruined shrine is a normal door.
![grafik](https://github.com/randovania/randovania/assets/38186597/892aaa31-d0e8-49fa-9324-1c95642717e1)
