### PR TITLE
Add optional model parameter to create_nothing_pickup

### DIFF
--- a/randovania/games/am2r/exporter/patch_data_factory.py
+++ b/randovania/games/am2r/exporter/patch_data_factory.py
@@ -6,9 +6,6 @@ from randovania.exporter import pickup_exporter
 from randovania.exporter.hints import guaranteed_item_hint
 from randovania.exporter.patch_data_factory import BasePatchDataFactory
 from randovania.game_description.assignment import PickupTarget
-from randovania.game_description.pickup import pickup_category
-from randovania.game_description.resources.location_category import LocationCategory
-from randovania.game_description.resources.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
 from randovania.games.am2r.exporter.hint_namer import AM2RHintNamer
 from randovania.games.am2r.layout.hint_configuration import ItemHintMode
 from randovania.games.game import RandovaniaGame

--- a/randovania/games/am2r/exporter/patch_data_factory.py
+++ b/randovania/games/am2r/exporter/patch_data_factory.py
@@ -192,24 +192,8 @@ class AM2RPatchDataFactory(BasePatchDataFactory):
     def create_data(self) -> dict:
         db = self.game
 
-        # TODO: instead of manually creating the pickup here, modify pickup_creator.create_nothing_pickup to take an
-        # arg for model name
-        useless_pickup = PickupEntry(
-            name="Nothing",
-            progression=(
-                (db.resource_database.get_item_by_name("Nothing"), 1),
-            ),
-            model=PickupModel(
-                game=db.resource_database.game_enum,
-                name="sItemNothing",
-            ),
-            pickup_category=pickup_category.USELESS_PICKUP_CATEGORY,
-            broad_category=pickup_category.USELESS_PICKUP_CATEGORY,
-            generator_params=PickupGeneratorParams(
-                preferred_location_category=LocationCategory.MAJOR,  # TODO
-            ),
-        )
-        useless_target = PickupTarget(useless_pickup, self.players_config.player_index)
+        useless_target = PickupTarget(pickup_creator.create_nothing_pickup(db.resource_database, "sItemNothing"),
+                                      self.players_config.player_index)
 
         item_data = self._get_item_data()
         memo_data = {

--- a/randovania/generator/pickup_pool/pickup_creator.py
+++ b/randovania/generator/pickup_pool/pickup_creator.py
@@ -113,10 +113,11 @@ def create_ammo_pickup(ammo: AmmoPickupDefinition,
     )
 
 
-def create_nothing_pickup(resource_database: ResourceDatabase) -> PickupEntry:
+def create_nothing_pickup(resource_database: ResourceDatabase, model_name: str = "Nothing") -> PickupEntry:
     """
     Creates a Nothing pickup.
     :param resource_database:
+    :param model_name:
     :return:
     """
     return PickupEntry(
@@ -126,7 +127,7 @@ def create_nothing_pickup(resource_database: ResourceDatabase) -> PickupEntry:
         ),
         model=PickupModel(
             game=resource_database.game_enum,
-            name="Nothing",
+            name=model_name,
         ),
         pickup_category=pickup_category.USELESS_PICKUP_CATEGORY,
         broad_category=pickup_category.USELESS_PICKUP_CATEGORY,

--- a/test/games/am2r/exporter/test_am2r_patch_data_factory.py
+++ b/test/games/am2r/exporter/test_am2r_patch_data_factory.py
@@ -4,9 +4,6 @@ import pytest
 
 from randovania.exporter import pickup_exporter
 from randovania.game_description.assignment import PickupTarget
-from randovania.game_description.pickup import pickup_category
-from randovania.game_description.resources.location_category import LocationCategory
-from randovania.game_description.resources.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
 from randovania.games.am2r.exporter.patch_data_factory import AM2RPatchDataFactory
 from randovania.games.am2r.layout.am2r_cosmetic_patches import AM2RCosmeticPatches
 from randovania.generator.pickup_pool import pickup_creator

--- a/test/games/am2r/exporter/test_am2r_patch_data_factory.py
+++ b/test/games/am2r/exporter/test_am2r_patch_data_factory.py
@@ -72,24 +72,8 @@ def test_create_pickups_dict_shiny(test_files_dir, rdvgame_filename,
 
     db = data.game
 
-    # TODO: instead of manually creating the pickup here, modify pickup_creator.create_nothing_pickup to take an
-    # arg for model name
-    useless_pickup = PickupEntry(
-        name="Nothing",
-        progression=(
-            (db.resource_database.get_item_by_name("Nothing"), 1),
-        ),
-        model=PickupModel(
-            game=db.resource_database.game_enum,
-            name="sItemNothing",
-        ),
-        pickup_category=pickup_category.USELESS_PICKUP_CATEGORY,
-        broad_category=pickup_category.USELESS_PICKUP_CATEGORY,
-        generator_params=PickupGeneratorParams(
-            preferred_location_category=LocationCategory.MAJOR,  # TODO
-        ),
-    )
-    useless_target = PickupTarget(useless_pickup, data.players_config.player_index)
+    useless_target = PickupTarget(pickup_creator.create_nothing_pickup(db.resource_database, "sItemNothing"),
+                                  data.players_config.player_index)
 
     item_data = data._get_item_data()
     memo_data = {}


### PR DESCRIPTION
Defaults to `Nothing` for backwards compatibility. Games (like AM2R) who have a different model name for Nothing can specify it now there without needing to create the whole pickup from scratch.