### PR TITLE
Multiple fixes for the SelectPresetWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Tracking another user's inventory now properly keeps working after a connection loss.
 - Fixed: Sorting the session history and audit log now works properly.
 - Fixed: In Multiworld session, the Claim world button is now properly disabled when you don't have permissions.
+- Fixed: Changing a preset no longer causes it to lose its position in the tree.
 - Removed: Connecting to Dolphin on Linux executable builds is now hidden on known situations that it doesn't work properly.
 
 ### Metroid Dread

--- a/randovania/gui/dialog/preset_history_dialog.py
+++ b/randovania/gui/dialog/preset_history_dialog.py
@@ -20,6 +20,13 @@ if TYPE_CHECKING:
     from randovania.interface_common.preset_manager import PresetManager
 
 
+def _get_invalid_preset_error(preset: VersionedPreset, error: InvalidPreset) -> str:
+    return (
+        f"Preset {preset.name} at this version can't be used as it contains the following error:"
+        f"\n{error.original_exception}"
+    )
+
+
 def _get_old_preset(preset_str: str) -> Preset | str:
     try:
         old_preset = VersionedPreset.from_str(preset_str)
@@ -30,10 +37,7 @@ def _get_old_preset(preset_str: str) -> Preset | str:
         return old_preset.get_preset()
 
     except InvalidPreset as e:
-        return (
-            f"Preset {old_preset.name} at this version can't be used as it contains the following error:"
-            f"\n{e.original_exception}"
-        )
+        return _get_invalid_preset_error(old_preset, e)
 
 
 def _describe_preset(preset: Preset) -> list[str]:
@@ -68,6 +72,14 @@ def _calculate_previous_versions(preset_manager: PresetManager, preset: Versione
         yield date, old_preset, old_description
 
 
+def _set_item_data(item: QtWidgets.QListWidgetItem, data: tuple[Preset | None, tuple[str, ...]]):
+    item.setData(QtCore.Qt.ItemDataRole.UserRole, data)
+
+
+def _get_item_data(item: QtWidgets.QListWidgetItem) -> tuple[Preset | None, tuple[str, ...]]:
+    return item.data(QtCore.Qt.ItemDataRole.UserRole)
+
+
 class PresetHistoryDialog(QtWidgets.QDialog, Ui_PresetHistoryDialog):
     def __init__(self, preset_manager: PresetManager, preset: VersionedPreset):
         super().__init__()
@@ -79,17 +91,19 @@ class PresetHistoryDialog(QtWidgets.QDialog, Ui_PresetHistoryDialog):
 
         try:
             self._original_lines = tuple(_describe_preset(preset.get_preset()))
-        except InvalidPreset:
+            original_description = self._original_lines
+        except InvalidPreset as e:
             self._original_lines = None
+            original_description = (_get_invalid_preset_error(preset, e),)
 
         item = QtWidgets.QListWidgetItem("Current Version")
-        item.setData(QtCore.Qt.ItemDataRole.UserRole, (None, self._original_lines))
+        _set_item_data(item, (None, original_description))
         self.version_widget.addItem(item)
 
         for date, old_preset, old_description in _calculate_previous_versions(self.preset_manager, self.preset,
                                                                               self._original_lines):
             item = QtWidgets.QListWidgetItem(date.astimezone().strftime("%c"))
-            item.setData(QtCore.Qt.ItemDataRole.UserRole, (old_preset, old_description))
+            _set_item_data(item, (old_preset, old_description))
             self.version_widget.addItem(item)
 
         self.accept_button.clicked.connect(self.accept)
@@ -101,7 +115,7 @@ class PresetHistoryDialog(QtWidgets.QDialog, Ui_PresetHistoryDialog):
     def selected_preset(self) -> Preset | None:
         items = self.version_widget.selectedItems()
         if items:
-            return items[0].data(QtCore.Qt.ItemDataRole.UserRole)[0]
+            return _get_item_data(items[0])[0]
         else:
             return None
 
@@ -124,7 +138,7 @@ class PresetHistoryDialog(QtWidgets.QDialog, Ui_PresetHistoryDialog):
             self.label.setText("Select a version on the left")
             return
 
-        old_preset, old_description = items[0].data(QtCore.Qt.ItemDataRole.UserRole)
+        old_preset, old_description = _get_item_data(items[0])
         self.accept_button.setEnabled(old_preset is not None)
         self.export_button.setEnabled(self.accept_button.isEnabled())
 
@@ -134,9 +148,7 @@ class PresetHistoryDialog(QtWidgets.QDialog, Ui_PresetHistoryDialog):
                 old_description,
             ))
             description = "\n\n".join(k[2:])
-        elif old_description is not None:
-            description = "\n\n".join(old_description)
         else:
-            description = "Preset has errors"
+            description = "\n\n".join(old_description)
 
         self.label.setText(description)

--- a/randovania/gui/dialog/preset_history_dialog.py
+++ b/randovania/gui/dialog/preset_history_dialog.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 def _get_old_preset(preset_str: str) -> Preset | str:
     try:
-        old_preset = VersionedPreset(json.loads(preset_str))
+        old_preset = VersionedPreset.from_str(preset_str)
     except json.JSONDecodeError as e:
         return f"Preset at this version contains json errors: {e}"
 
@@ -83,13 +83,13 @@ class PresetHistoryDialog(QtWidgets.QDialog, Ui_PresetHistoryDialog):
             self._original_lines = None
 
         item = QtWidgets.QListWidgetItem("Current Version")
-        item.setData(QtCore.Qt.UserRole, (None, self._original_lines))
+        item.setData(QtCore.Qt.ItemDataRole.UserRole, (None, self._original_lines))
         self.version_widget.addItem(item)
 
         for date, old_preset, old_description in _calculate_previous_versions(self.preset_manager, self.preset,
                                                                               self._original_lines):
             item = QtWidgets.QListWidgetItem(date.astimezone().strftime("%c"))
-            item.setData(QtCore.Qt.UserRole, (old_preset, old_description))
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, (old_preset, old_description))
             self.version_widget.addItem(item)
 
         self.accept_button.clicked.connect(self.accept)
@@ -101,7 +101,7 @@ class PresetHistoryDialog(QtWidgets.QDialog, Ui_PresetHistoryDialog):
     def selected_preset(self) -> Preset | None:
         items = self.version_widget.selectedItems()
         if items:
-            return items[0].data(QtCore.Qt.UserRole)[0]
+            return items[0].data(QtCore.Qt.ItemDataRole.UserRole)[0]
         else:
             return None
 
@@ -124,7 +124,7 @@ class PresetHistoryDialog(QtWidgets.QDialog, Ui_PresetHistoryDialog):
             self.label.setText("Select a version on the left")
             return
 
-        old_preset, old_description = items[0].data(QtCore.Qt.UserRole)
+        old_preset, old_description = items[0].data(QtCore.Qt.ItemDataRole.UserRole)
         self.accept_button.setEnabled(old_preset is not None)
         self.export_button.setEnabled(self.accept_button.isEnabled())
 
@@ -134,7 +134,9 @@ class PresetHistoryDialog(QtWidgets.QDialog, Ui_PresetHistoryDialog):
                 old_description,
             ))
             description = "\n\n".join(k[2:])
-        else:
+        elif old_description is not None:
             description = "\n\n".join(old_description)
+        else:
+            description = "Preset has errors"
 
         self.label.setText(description)

--- a/test/gui/widgets/test_select_preset_widget.py
+++ b/test/gui/widgets/test_select_preset_widget.py
@@ -148,7 +148,7 @@ def test_on_tree_context_menu_on_item(widget: SelectPresetWidget):
     widget._on_tree_context_menu(QtCore.QPoint(0, 0))
 
     # Assert
-    assert widget._preset_menu.preset is not None
+    assert widget._preset_menu.action_customize.isEnabled()
     widget._preset_menu.exec.assert_called_once()
 
 
@@ -158,5 +158,5 @@ def test_on_tree_context_menu_on_nothing(widget: SelectPresetWidget):
     widget._on_tree_context_menu(QtCore.QPoint(0, 500))
 
     # Assert
-    assert widget._preset_menu.preset is None
+    assert not widget._preset_menu.action_customize.isEnabled()
     widget._preset_menu.exec.assert_called_once()

--- a/test/gui/widgets/test_select_preset_widget.py
+++ b/test/gui/widgets/test_select_preset_widget.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
@@ -160,3 +161,31 @@ def test_on_tree_context_menu_on_nothing(widget: SelectPresetWidget):
     # Assert
     assert not widget._preset_menu.action_customize.isEnabled()
     widget._preset_menu.exec.assert_called_once()
+
+
+def test_menu_set_preset_broken(widget: SelectPresetWidget):
+    broken_data = copy.deepcopy(widget._window_manager.preset_manager.default_preset_for_game(widget._game).as_json)
+    broken_data["schema_version"] = 6
+
+    broken_preset = VersionedPreset(broken_data)
+    widget._preset_menu.set_preset(broken_preset)
+
+    menu = widget._preset_menu
+    actions = [
+        menu.action_delete,
+        menu.action_history,
+        menu.action_export,
+        menu.action_customize,
+        menu.action_duplicate,
+        menu.action_map_tracker,
+        menu.action_required_tricks,
+    ]
+    assert [p.isEnabled() for p in actions] == [
+        True,
+        True,
+        False,
+        False,
+        False,
+        False,
+        False,
+    ]


### PR DESCRIPTION
- Customizing a preset no longer loses it's position in the tree
- Delete/View History for a preset can be used for invalid presets (Fixes #4922)
- View History no longer errors if the current version is broken