### PR TITLE
Add Phazon Suit Hint location to Hints page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Dairon - Navigation Station North can no longer be assigned a hint, which would then be replaced with DNA Hints.
 - Added: A new auto-tracker layout featuring progressive items.
 
-### Metroid Prime
-
-- Added: The "Hints" page in the "Game" window now lists the location of the Phazon Suit hint.
-
 #### Logic Database
 
 - Added: Slide from right to left in Cataris - Total Recharge Station South.
@@ -40,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Entering Hanubia Orange EMMI Introduction from the right now requires having beaten the Red Chozo.
 - Fixed: The Pseudo Wave Beam in Burenia - Burenia Hub to Dairon now correctly requires Wide Beam.
 - Removed: In Cataris - Green EMMI Introduction, the advanced Pseudo Wave Beam to break the blob from below is removed.
+
+### Metroid Prime
+
+- Added: The "Hints" page in the "Game" window now lists the location of the Phazon Suit hint.
 
 ### Metroid Prime 2: Echoes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Dairon - Navigation Station North can no longer be assigned a hint, which would then be replaced with DNA Hints.
 - Added: A new auto-tracker layout featuring progressive items.
 
+### Metroid Prime
+
+- Added: The "Hints" page in the "Game" window now lists the location of the Phazon Suit hint.
+
 #### Logic Database
 
 - Added: Slide from right to left in Cataris - Total Recharge Station South.

--- a/randovania/gui/ui_files/games_tab_prime_widget.ui
+++ b/randovania/gui/ui_files/games_tab_prime_widget.ui
@@ -94,7 +94,7 @@
          <x>0</x>
          <y>0</y>
          <width>432</width>
-         <height>367</height>
+         <height>364</height>
         </rect>
        </property>
        <layout class="QGridLayout" name="gridLayout_10">
@@ -148,21 +148,14 @@
          <x>0</x>
          <y>0</y>
          <width>432</width>
-         <height>367</height>
+         <height>364</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="hints_scroll_layout_4">
         <item>
          <widget class="QLabel" name="hints_label">
           <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;In
-                                                Metroid Prime, you can find hints from the following
-                                                sources:&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;&lt;span
-                                                style=&quot; font-weight:600;&quot;&gt;Artifact Temple&lt;/span&gt;:
-                                                Hints for where each of your 12 Artifacts are located.
-                                                In a Multiworld, describes which player has the
-                                                artifacts as well.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-                                            </string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;In Metroid Prime, you can find hints from the following sources:&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Artifact Temple&lt;/span&gt;: Hints for where each of your 12 Artifacts are located. In a Multiworld, describes which player has the artifacts as well. &lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Crater Entry Point&lt;/span&gt;: A scan point on the wall next to the door hints where the Phazon Suit is located for the player. In a Multiworld, describes which player has the Phazon Suit as well. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -212,7 +205,7 @@
          <x>0</x>
          <y>0</y>
          <width>432</width>
-         <height>367</height>
+         <height>364</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="hint_item_names_scroll_layout_4">

--- a/randovania/gui/ui_files/games_tab_prime_widget.ui
+++ b/randovania/gui/ui_files/games_tab_prime_widget.ui
@@ -155,7 +155,7 @@
         <item>
          <widget class="QLabel" name="hints_label">
           <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;In Metroid Prime, you can find hints from the following sources:&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Artifact Temple&lt;/span&gt;: Hints for where each of your 12 Artifacts are located. In a Multiworld, describes which player has the artifacts as well. &lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Crater Entry Point&lt;/span&gt;: A scan point on the wall next to the door hints where the Phazon Suit is located for the player. In a Multiworld, describes which player has the Phazon Suit as well. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;In Metroid Prime, you can find hints from the following sources:&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Artifact Temple&lt;/span&gt;: Hints for where each of your 12 Artifacts are located. In a Multiworld, describes which player has the artifacts as well. &lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Crater Entry Point&lt;/span&gt;: A scan point next to the door has been added. It hints to where the Phazon Suit is located for the player. In a Multiworld, describes which player has the Phazon Suit as well. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>


### PR DESCRIPTION
Fixes #4926 

![image](https://github.com/randovania/randovania/assets/38679103/9e2e8859-430d-4244-b909-df5653b9b575)
