### PR TITLE
Super Metroid: Add DB options for (map) tweaks

### DIFF
--- a/randovania/games/super_metroid/game_data.py
+++ b/randovania/games/super_metroid/game_data.py
@@ -23,14 +23,14 @@ def _gui() -> game.GameGui:
 
 
 def _generator() -> game.GameGenerator:
+    from randovania.games.super_metroid.generator.bootstrap import SuperMetroidBootstrap
     from randovania.games.super_metroid.generator.item_pool.pool_creator import super_metroid_specific_pool
     from randovania.generator.base_patches_factory import BasePatchesFactory
     from randovania.generator.hint_distributor import AllJokesHintDistributor
-    from randovania.resolver.bootstrap import Bootstrap
 
     return game.GameGenerator(
         pickup_pool_creator=super_metroid_specific_pool,
-        bootstrap=Bootstrap(),
+        bootstrap=SuperMetroidBootstrap(),
         base_patches_factory=BasePatchesFactory(),
         hint_distributor=AllJokesHintDistributor(),
     )

--- a/randovania/games/super_metroid/generator/bootstrap.py
+++ b/randovania/games/super_metroid/generator/bootstrap.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+from randovania.games.super_metroid.layout import SuperMetroidConfiguration
+from randovania.resolver.bootstrap import MetroidBootstrap
+
+if TYPE_CHECKING:
+
+    from randovania.game_description.resources.resource_database import ResourceDatabase
+    from randovania.game_description.resources.resource_info import ResourceCollection
+    from randovania.layout.base.base_configuration import BaseConfiguration
+
+
+class SuperMetroidBootstrap(MetroidBootstrap):
+    def _get_enabled_misc_resources(self, configuration: BaseConfiguration,
+                                    resource_database: ResourceDatabase) -> set[str]:
+
+        assert isinstance(configuration, SuperMetroidConfiguration)
+
+        enabled_resources = set()
+
+        logical_patches = {
+            "dachora_pit": "DachoraPitTweaks",
+            "early_supers_bridge": "SupersBridgeTweaks",
+            "pre_hi_jump": "PreHijumpTweaks",
+            "moat": "MoatTweaks",
+            "pre_spazer": "PreSpazerTweaks",
+            "red_tower": "RedTowerTweaks",
+            "nova_boost_platform": "NovaBoostTweaks",
+            "cant_use_supers_on_red_doors": "CantUseSupersOnRedDoors",
+            "nerfed_rainbow_beam": "MBRainbowBeamNerf",
+            "no_ln_chozo_inventory_check": "NoLowerNorfairInventoryCheck",
+        }
+
+        for name, index in logical_patches.items():
+            if getattr(configuration.patches, name):
+                enabled_resources.add(index)
+
+        return enabled_resources
+
+    def _damage_reduction(self, db: ResourceDatabase, current_resources: ResourceCollection):
+        num_suits = sum(current_resources[db.get_item_by_name(suit)]
+                        for suit in ["Varia Suit", "Gravity Suit"])
+        return 2 ** (-num_suits)
+
+    def patch_resource_database(self, db: ResourceDatabase, configuration: BaseConfiguration) -> ResourceDatabase:
+        base_damage_reduction = self._damage_reduction
+
+        return dataclasses.replace(db, base_damage_reduction=base_damage_reduction)

--- a/randovania/games/super_metroid/generator/bootstrap.py
+++ b/randovania/games/super_metroid/generator/bootstrap.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING
 
-from randovania.games.super_metroid.layout import SuperMetroidConfiguration
+from randovania.games.super_metroid.layout.super_metroid_configuration import SuperMetroidConfiguration
 from randovania.resolver.bootstrap import MetroidBootstrap
 
 if TYPE_CHECKING:

--- a/randovania/games/super_metroid/json_data/header.json
+++ b/randovania/games/super_metroid/json_data/header.json
@@ -326,7 +326,48 @@
                 "extra": {}
             }
         },
-        "misc": {},
+        "misc": {
+            "DachoraPitTweaks": {
+                "long_name": "Dachora Pit Tweaks",
+                "extra": {}
+            },
+            "SupersBridgeTweaks": {
+                "long_name": "Early Supers Bridge Tweaks",
+                "extra": {}
+            },
+            "PreHijumpTweaks": {
+                "long_name": "Pre Hi-Jump Tweaks",
+                "extra": {}
+            },
+            "MoatTweaks": {
+                "long_name": "Moat Tweaks",
+                "extra": {}
+            },
+            "PreSpazerTweaks": {
+                "long_name": "Pre Spazer Tweaks",
+                "extra": {}
+            },
+            "RedTowerTweaks": {
+                "long_name": "Red Tower Tweaks",
+                "extra": {}
+            },
+            "NovaBoostTweaks": {
+                "long_name": "Nova Boost Tweaks",
+                "extra": {}
+            },
+            "CantUseSupersOnRedDoors": {
+                "long_name": "Can't Use Supers On Red Doors",
+                "extra": {}
+            },
+            "MBRainbowBeamNerf": {
+                "long_name": "Mother Brain Rainbow Beam Nerf",
+                "extra": {}
+            },
+            "NoLowerNorfairInventoryCheck": {
+                "long_name": "No Lower Norfair Space Jump Check",
+                "extra": {}
+            }
+        },
         "requirement_template": {},
         "damage_reductions": [],
         "energy_tank_item_index": "ETank"
@@ -400,6 +441,32 @@
                                                 "name": "Missile",
                                                 "amount": 5,
                                                 "negate": false
+                                            }
+                                        },
+                                        {
+                                            "type": "and",
+                                            "data": {
+                                                "comment": null,
+                                                "items": [
+                                                    {
+                                                        "type": "resource",
+                                                        "data": {
+                                                            "type": "items",
+                                                            "name": "Supers",
+                                                            "amount": 1,
+                                                            "negate": false
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "resource",
+                                                        "data": {
+                                                            "type": "misc",
+                                                            "name": "CantUseSupersOnRedDoors",
+                                                            "amount": 1,
+                                                            "negate": true
+                                                        }
+                                                    }
+                                                ]
                                             }
                                         }
                                     ]

--- a/randovania/games/super_metroid/json_data/header.txt
+++ b/randovania/games/super_metroid/json_data/header.txt
@@ -15,7 +15,9 @@ Dock Weaknesses
       Open:
           Trivial
       Lock type: FRONT_BLAST_BACK_FREE_UNLOCK
-          Missile ≥ 5
+          Any of the following:
+              Missile ≥ 5
+              Super Missile and Disabled Can't Use Supers On Red Doors
 
 
   * Super Missile Door

--- a/randovania/games/super_metroid/layout/super_metroid_configuration.py
+++ b/randovania/games/super_metroid/layout/super_metroid_configuration.py
@@ -10,6 +10,7 @@ from randovania.layout.base.base_configuration import BaseConfiguration
 @dataclasses.dataclass(frozen=True)
 class SuperMetroidConfiguration(BaseConfiguration):
     patches: SuperPatchConfiguration
+    energy_per_tank: int = dataclasses.field(metadata={"min": 1, "max": 1000, "precision": 1})
 
     @classmethod
     def game_enum(cls) -> RandovaniaGame:

--- a/randovania/games/super_metroid/layout/super_metroid_patch_configuration.py
+++ b/randovania/games/super_metroid/layout/super_metroid_patch_configuration.py
@@ -32,3 +32,4 @@ class SuperPatchConfiguration(BitPackDataclass, JsonDataclass):
     fix_heat_echoes: bool
     fix_screw_attack_menu: bool
     no_gt_code: bool
+    no_ln_chozo_inventory_check: bool

--- a/randovania/games/super_metroid/presets/starter_preset.rdvpreset
+++ b/randovania/games/super_metroid/presets/starter_preset.rdvpreset
@@ -138,6 +138,7 @@
         },
         "single_set_for_pickups_that_solve": false,
         "staggered_multi_pickup_placement": false,
+        "energy_per_tank": 100,
         "patches": {
             "instant_g4": true,
             "fast_doors_and_elevators": true,

--- a/randovania/games/super_metroid/presets/starter_preset.rdvpreset
+++ b/randovania/games/super_metroid/presets/starter_preset.rdvpreset
@@ -162,7 +162,8 @@
             "fix_spacetime": true,
             "fix_heat_echoes": true,
             "fix_screw_attack_menu": true,
-            "no_gt_code": true
+            "no_gt_code": true,
+            "no_ln_chozo_inventory_check": true
         }
     }
 }

--- a/test/test_files/presets/super_test_preset.rdvpreset
+++ b/test/test_files/presets/super_test_preset.rdvpreset
@@ -129,6 +129,7 @@
         "pickup_model_data_source": "etm",
         "multi_pickup_placement": false,
         "logical_resource_action": "randomly",
+        "energy_per_tank": 100,
         "patches": {
             "instant_g4": false,
             "fast_doors_and_elevators": true,

--- a/test/test_files/presets/super_test_preset.rdvpreset
+++ b/test/test_files/presets/super_test_preset.rdvpreset
@@ -153,7 +153,8 @@
             "fix_spacetime": true,
             "fix_heat_echoes": true,
             "fix_screw_attack_menu": true,
-            "no_gt_code": true
+            "no_gt_code": true,
+            "no_ln_chozo_inventory_check": true
         }
     }
 }

--- a/test/test_files/sdm_expected_result.json
+++ b/test/test_files/sdm_expected_result.json
@@ -827,6 +827,7 @@
     "fix_heat_echoes": true,
     "fix_screw_attack_menu": true,
     "no_gt_code": true,
+    "no_ln_chozo_inventory_check": true,
     "colorblind_mode": false,
     "max_ammo_display": true,
     "no_demo": false,

--- a/test/test_files/sdm_test_game.rdvgame
+++ b/test/test_files/sdm_test_game.rdvgame
@@ -163,7 +163,8 @@
                         "fix_spacetime": true,
                         "fix_heat_echoes": true,
                         "fix_screw_attack_menu": true,
-                        "no_gt_code": true
+                        "no_gt_code": true,
+                        "no_ln_chozo_inventory_check": true
                     }
                 }
             }

--- a/test/test_files/sdm_test_game.rdvgame
+++ b/test/test_files/sdm_test_game.rdvgame
@@ -139,6 +139,7 @@
                     "pickup_model_data_source": "etm",
                     "multi_pickup_placement": false,
                     "logical_resource_action": "randomly",
+                    "energy_per_tank": 100,
                     "patches": {
                         "instant_g4": true,
                         "fast_doors_and_elevators": true,


### PR DESCRIPTION
- Adds DB options for `Dachora Pit Tweaks`, `Early Supers Bridge Tweaks`, `Pre Hi-Jump Tweaks`, `Moat Tweaks`, `Pre Spazer Tweaks`, `Red Tower Tweaks`, `Nova Boost Tweaks`, `Can't Use Supers On Red Doors` and `Mother Brain Rainbow Beam Nerf`
- Also adds `No Lower Norfair Space Jump Check` as a patch, but doesn't expose it in the GUI yet
- Fix logic condition for missile doors to account for `Can't Use Supers On Red Doors`
- Add damage reduction with suits