### PR TITLE
Slightly improve SM patcher page

### DIFF
--- a/randovania/gui/ui_files/preset_patcher_super_patches.ui
+++ b/randovania/gui/ui_files/preset_patcher_super_patches.ui
@@ -46,8 +46,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>474</width>
-         <height>2126</height>
+         <width>472</width>
+         <height>2124</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -79,6 +79,9 @@
             <widget class="QLabel" name="backup_saves_label">
              <property name="text">
               <string>When saving the game, your previous save is backed up to the unused save slots.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -155,7 +158,7 @@
            <item row="17" column="0">
             <widget class="QLabel" name="skip_intro_label">
              <property name="text">
-              <string>Removes the game's intro cutscene.</string>
+              <string>Removes Samus' intro monologue.</string>
              </property>
             </widget>
            </item>
@@ -236,7 +239,7 @@
               <string/>
              </property>
              <property name="text">
-              <string>Pre-Spazer Tweaks</string>
+              <string>Pre Spazer Tweaks</string>
              </property>
              <property name="checked">
               <bool>true</bool>
@@ -247,6 +250,9 @@
             <widget class="QLabel" name="moat_label">
              <property name="text">
               <string>Replaces the bomb block underneath the center post with a shot block.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -314,12 +320,18 @@
              <property name="text">
               <string>Replaces the bomb blocks at the top of the room with shot blocks.</string>
              </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item row="6" column="0">
             <widget class="QLabel" name="early_supers_label">
              <property name="text">
               <string>Replaces a segment of the Early Supers Bridge with a shot block to prevent softlocks.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -341,12 +353,18 @@
              <property name="text">
               <string>Replaces a bomb block in the room before Spazer Beam with a shot block.</string>
              </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item row="2" column="0">
             <widget class="QLabel" name="dachora_pit_label">
              <property name="text">
               <string>Changes the speed blocks in Dachora Pit not to respawn after being broken.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -407,12 +425,18 @@
              <property name="text">
               <string>Samus maintains her air speed when landing.</string>
              </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item row="5" column="0">
             <widget class="QLabel" name="save_refill_label">
              <property name="text">
               <string>Save Stations refill Samus' energy and ammo when used.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -441,6 +465,9 @@
              <property name="text">
               <string>Samus has access to a weakened version of the Charge Beam before finding it.</string>
              </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item row="17" column="0">
@@ -448,12 +475,18 @@
              <property name="text">
               <string>Makes it easier to chain Space Jumps together.</string>
              </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item row="8" column="0">
             <widget class="QLabel" name="cant_use_supers_on_red_doors_label">
              <property name="text">
               <string>Super Missiles can no longer be used to open red doors.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Adds a few word wraps, makes pre spazer and pre hijump consistent in naming, clarifies skip intro better to indicate that its not ceres.