### PR TITLE
Super Metroid: Add vanilla locations

### DIFF
--- a/randovania/games/super_metroid/pickup_database/pickup-database.json
+++ b/randovania/games/super_metroid/pickup_database/pickup-database.json
@@ -101,6 +101,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 23,
             "preferred_location_category": "major"
         },
         "Ice Beam": {
@@ -113,6 +114,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 50,
             "preferred_location_category": "major"
         },
         "Wave Beam": {
@@ -125,6 +127,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 68,
             "preferred_location_category": "major"
         },
         "Spazer Beam": {
@@ -137,6 +140,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 42,
             "preferred_location_category": "major"
         },
         "Plasma Beam": {
@@ -149,6 +153,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 143,
             "preferred_location_category": "major"
         },
         "Missile Launcher": {
@@ -203,6 +208,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 60,
             "preferred_location_category": "major"
         },
         "X-Ray Scope": {
@@ -215,6 +221,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 38,
             "preferred_location_category": "major"
         },
         "Varia Suit": {
@@ -227,6 +234,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 48,
             "preferred_location_category": "major"
         },
         "Gravity Suit": {
@@ -239,6 +247,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 135,
             "preferred_location_category": "major"
         },
         "Morph Ball": {
@@ -251,6 +260,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 26,
             "preferred_location_category": "major"
         },
         "Morph Ball Bomb": {
@@ -263,6 +273,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 7,
             "preferred_location_category": "major"
         },
         "Spring Ball": {
@@ -275,6 +286,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 150,
             "preferred_location_category": "major"
         },
         "Screw Attack": {
@@ -287,6 +299,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 79,
             "preferred_location_category": "major"
         },
         "Hi-Jump Boots": {
@@ -299,6 +312,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 53,
             "preferred_location_category": "major"
         },
         "Space Jump": {
@@ -311,6 +325,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 154,
             "preferred_location_category": "major"
         },
         "Speed Booster": {
@@ -323,6 +338,7 @@
             ],
             "default_shuffled_count": 1,
             "default_starting_count": 0,
+            "original_location": 66,
             "preferred_location_category": "major"
         },
         "Energy Tank": {


### PR DESCRIPTION
Missile launcher, super launcher and PB launcher don't have one assigned. *technically* the first vanilla locations could be assigned but as these are actually expansions and not launchers i feel like it'd be weird to do that.