### PR TITLE
Super Metroid: Fix Elevators after teleporter refactor

### DIFF
--- a/randovania/games/super_metroid/json_data/Brinstar.json
+++ b/randovania/games/super_metroid/json_data/Brinstar.json
@@ -5,7 +5,7 @@
     },
     "areas": {
         "Green Brinstar Main Shaft": {
-            "default_node": "Elevator - Elevator to Green Brinstar",
+            "default_node": "Teleporter to Crateria",
             "extra": {
                 "map_name": "79AD9",
                 "asset_id": 67
@@ -37,7 +37,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Elevator to Green Brinstar": {
+                        "Teleporter to Crateria": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -72,7 +72,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Elevator to Green Brinstar": {
+                        "Teleporter to Crateria": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -107,7 +107,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Elevator to Green Brinstar": {
+                        "Teleporter to Crateria": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -142,7 +142,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Elevator to Green Brinstar": {
+                        "Teleporter to Crateria": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -177,7 +177,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Elevator to Green Brinstar": {
+                        "Teleporter to Crateria": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -254,7 +254,7 @@
                                 "items": []
                             }
                         },
-                        "Elevator - Elevator to Green Brinstar": {
+                        "Teleporter to Crateria": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -282,12 +282,12 @@
                         }
                     }
                 },
-                "Elevator - Elevator to Green Brinstar": {
+                "Teleporter to Crateria": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 248.99194847020934,
-                        "y": 4717.65539452496,
+                        "x": 248.99,
+                        "y": 4717.66,
                         "z": 0.0
                     },
                     "description": "",
@@ -303,7 +303,7 @@
                     "default_connection": {
                         "region": "Crateria",
                         "area": "Elevator to Green Brinstar",
-                        "node": "Door to Lower Mushrooms"
+                        "node": "Teleporter to Brinstar"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,
@@ -4230,7 +4230,7 @@
             }
         },
         "Retro Brinstar": {
-            "default_node": "Elevator - Elevator to Blue Brinstar",
+            "default_node": "Teleporter to Crateria",
             "extra": {
                 "map_name": "79E9F",
                 "asset_id": 93
@@ -4262,7 +4262,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Elevator to Blue Brinstar": {
+                        "Teleporter to Crateria": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4359,7 +4359,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Elevator to Blue Brinstar": {
+                        "Teleporter to Crateria": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4368,12 +4368,12 @@
                         }
                     }
                 },
-                "Elevator - Elevator to Blue Brinstar": {
+                "Teleporter to Crateria": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 2808.850627722265,
-                        "y": 122.58877786318203,
+                        "x": 2808.85,
+                        "y": 122.59,
                         "z": 0.0
                     },
                     "description": "",
@@ -4389,7 +4389,7 @@
                     "default_connection": {
                         "region": "Crateria",
                         "area": "Elevator to Blue Brinstar",
-                        "node": "Door to Old Mother Brain"
+                        "node": "Teleporter to Brinstar"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,
@@ -4507,7 +4507,7 @@
                     "valid_starting_location": false,
                     "event_name": "Event9",
                     "connections": {
-                        "Elevator - Elevator to Blue Brinstar": {
+                        "Teleporter to Crateria": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4586,7 +4586,7 @@
                                 ]
                             }
                         },
-                        "Elevator - Elevator to Blue Brinstar": {
+                        "Teleporter to Crateria": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6132,7 +6132,7 @@
             }
         },
         "Red Brinstar Zoro Room": {
-            "default_node": "Elevator - Elevator to Red Brinstar",
+            "default_node": "Teleporter to Crateria",
             "extra": {
                 "map_name": "7A322",
                 "asset_id": 105
@@ -6267,7 +6267,7 @@
                                 "items": []
                             }
                         },
-                        "Elevator - Elevator to Red Brinstar": {
+                        "Teleporter to Crateria": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6391,12 +6391,12 @@
                         }
                     }
                 },
-                "Elevator - Elevator to Red Brinstar": {
+                "Teleporter to Crateria": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 246.9307568438003,
-                        "y": 2678.9994632313474,
+                        "x": 246.93,
+                        "y": 2679.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -6412,7 +6412,7 @@
                     "default_connection": {
                         "region": "Crateria",
                         "area": "Elevator to Red Brinstar",
-                        "node": "Door to Crateria Kihunter Room"
+                        "node": "Teleporter to Brinstar"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,
@@ -7252,7 +7252,7 @@
                                 ]
                             }
                         },
-                        "Elevator - Business Center": {
+                        "Teleporter to Norfair": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7332,12 +7332,12 @@
                         }
                     }
                 },
-                "Elevator - Business Center": {
+                "Teleporter to Norfair": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 250.49039200614916,
-                        "y": 700.2449397899052,
+                        "x": 250.49,
+                        "y": 700.24,
                         "z": 0.0
                     },
                     "description": "",
@@ -7353,7 +7353,7 @@
                     "default_connection": {
                         "region": "Norfair",
                         "area": "Business Center",
-                        "node": "Elevator - Warehouse Entrance"
+                        "node": "Teleporter to Brinstar"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,

--- a/randovania/games/super_metroid/json_data/Brinstar.txt
+++ b/randovania/games/super_metroid/json_data/Brinstar.txt
@@ -5,31 +5,31 @@ Extra - asset_id: 67
 > Door to Green Brinstar Map Access; Heals? False
   * Layers: default
   * Missile Door to Green Brinstar Map Access/Door to Green Brinstar Main Shaft
-  > Elevator - Elevator to Green Brinstar
+  > Teleporter to Crateria
       Trivial
 
 > Door to Green Brinstar Upper Save Station; Heals? False
   * Layers: default
   * Missile Door to Green Brinstar Upper Save Station/Door to Green Brinstar Main Shaft
-  > Elevator - Elevator to Green Brinstar
+  > Teleporter to Crateria
       Trivial
 
 > Door to Early Supers Room; Heals? False
   * Layers: default
   * Missile Door to Early Supers Room/Door to Green Brinstar Main Shaft
-  > Elevator - Elevator to Green Brinstar
+  > Teleporter to Crateria
       Trivial
 
 > Door to Green Brinstar Fireflea Room; Heals? False
   * Layers: default
   * Missile Door to Green Brinstar Fireflea Room/Door to Green Brinstar Main Shaft
-  > Elevator - Elevator to Green Brinstar
+  > Teleporter to Crateria
       Trivial
 
 > Door to Dachora Room; Heals? False
   * Layers: default
   * Missile Door to Dachora Room/Door to Green Brinstar Main Shaft
-  > Elevator - Elevator to Green Brinstar
+  > Teleporter to Crateria
       Trivial
 
 > Door from Green Brinstar Main Shaft; Heals? False
@@ -43,12 +43,12 @@ Extra - asset_id: 67
   * Normal Door to Green Brinstar Beetom Room/Door to Green Brinstar Main Shaft
   > Door from Green Brinstar Main Shaft
       Trivial
-  > Elevator - Elevator to Green Brinstar
+  > Teleporter to Crateria
       Morph Ball and Power Bombs
 
-> Elevator - Elevator to Green Brinstar; Heals? False; Default Node
+> Teleporter to Crateria; Heals? False; Default Node
   * Layers: default
-  * Teleporter to Elevator to Green Brinstar/Door to Lower Mushrooms
+  * Teleporter to Elevator to Green Brinstar/Teleporter to Brinstar
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Green Brinstar Map Access
@@ -700,7 +700,7 @@ Extra - asset_id: 93
 > Door to Green Hill Zone; Heals? False
   * Layers: default
   * Normal Door to Green Hill Zone/Door to Retro Brinstar
-  > Elevator - Elevator to Blue Brinstar
+  > Teleporter to Crateria
       Morph Ball and Power Bombs
   > Pickup (Power Bomb Expansion)
       All of the following:
@@ -710,12 +710,12 @@ Extra - asset_id: 93
 > Door to Construction Zone; Heals? False
   * Layers: default
   * Normal Door to Construction Zone/Door to Retro Brinstar
-  > Elevator - Elevator to Blue Brinstar
+  > Teleporter to Crateria
       Trivial
 
-> Elevator - Elevator to Blue Brinstar; Heals? False; Default Node
+> Teleporter to Crateria; Heals? False; Default Node
   * Layers: default
-  * Teleporter to Elevator to Blue Brinstar/Door to Old Mother Brain
+  * Teleporter to Elevator to Blue Brinstar/Teleporter to Brinstar
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Green Hill Zone
@@ -736,7 +736,7 @@ Extra - asset_id: 93
 > Event - Crateria Wakeup; Heals? False
   * Layers: default
   * Event Crateria Wakeup
-  > Elevator - Elevator to Blue Brinstar
+  > Teleporter to Crateria
       Morph Ball
 
 > Pickup (Power Bomb Expansion); Heals? False
@@ -746,7 +746,7 @@ Extra - asset_id: 93
       All of the following:
           Morph Ball
           Morph Ball Bombs or Power Bombs
-  > Elevator - Elevator to Blue Brinstar
+  > Teleporter to Crateria
       Morph Ball and Power Bombs
 
 ----------------
@@ -1021,7 +1021,7 @@ Extra - asset_id: 105
   * Super Missile Door to Red Brinstar Beta PBs Room/Door to Red Brinstar Zoro Room
   > Door to Red Tower Save Station
       Trivial
-  > Elevator - Elevator to Red Brinstar
+  > Teleporter to Crateria
       Trivial
 
 > Door to Red Tower Save Station; Heals? False
@@ -1038,9 +1038,9 @@ Extra - asset_id: 105
   > Door to Red Brinstar Beta PBs Room
       Morph Ball and Super Missile
 
-> Elevator - Elevator to Red Brinstar; Heals? False; Default Node
+> Teleporter to Crateria; Heals? False; Default Node
   * Layers: default
-  * Teleporter to Elevator to Red Brinstar/Door to Crateria Kihunter Room
+  * Teleporter to Elevator to Red Brinstar/Teleporter to Brinstar
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Red Brinstar Beta PBs Room
@@ -1180,7 +1180,7 @@ Extra - asset_id: 112
                   # https://www.youtube.com/watch?v=rHMHqTHHqHs&ab_channel=VGsWalkthrough
                   Movement (Beginner) and Wall Jumps (Beginner)
               Morph Ball Bombs and Morph Ball and Infinite Bomb Jump (Beginner)
-  > Elevator - Business Center
+  > Teleporter to Norfair
       Trivial
 
 > Door to Warehouse Zeela Room; Heals? False
@@ -1191,9 +1191,9 @@ Extra - asset_id: 112
           Super Missile ≥ 3
           Morph Ball and Super Missile
 
-> Elevator - Business Center; Heals? False
+> Teleporter to Norfair; Heals? False
   * Layers: default
-  * Teleporter to Business Center/Elevator - Warehouse Entrance
+  * Teleporter to Business Center/Teleporter to Brinstar
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Red Brinstar East Tunnel

--- a/randovania/games/super_metroid/json_data/Ceres Station.json
+++ b/randovania/games/super_metroid/json_data/Ceres Station.json
@@ -38,7 +38,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Escape": {
+                        "Teleporter to Crateria": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -49,12 +49,12 @@
                         }
                     }
                 },
-                "Escape": {
+                "Teleporter to Crateria": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 192.00000000000003,
-                        "y": 922.1030595813204,
+                        "x": 192.0,
+                        "y": 922.1,
                         "z": 0.0
                     },
                     "description": "",

--- a/randovania/games/super_metroid/json_data/Ceres Station.txt
+++ b/randovania/games/super_metroid/json_data/Ceres Station.txt
@@ -6,10 +6,10 @@ Extra - save_index: 0
 > Door to Hallway A; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Normal Door to Hallway A/Door to Elevator Shaft
-  > Escape
+  > Teleporter to Crateria
       After Fight Ridley At Ceres
 
-> Escape; Heals? False
+> Teleporter to Crateria; Heals? False
   * Layers: default
   * Teleporter to Landing Site/Landing Site Save Station
   * Extra - scan_asset_id: None

--- a/randovania/games/super_metroid/json_data/Crateria.json
+++ b/randovania/games/super_metroid/json_data/Crateria.json
@@ -4259,7 +4259,7 @@
             }
         },
         "Gold Four": {
-            "default_node": "Elevator - Tourian Entrance",
+            "default_node": "Teleporter to Tourian",
             "extra": {
                 "map_name": "7A66A",
                 "asset_id": 25
@@ -4291,7 +4291,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Tourian Entrance": {
+                        "Teleporter to Tourian": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4337,12 +4337,12 @@
                         }
                     }
                 },
-                "Elevator - Tourian Entrance": {
+                "Teleporter to Tourian": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 250.50348899624262,
-                        "y": 146.48201825013416,
+                        "x": 250.5,
+                        "y": 146.48,
                         "z": 0.0
                     },
                     "description": "",
@@ -4358,7 +4358,7 @@
                     "default_connection": {
                         "region": "Tourian",
                         "area": "Tourian Entrance",
-                        "node": "Elevator - Golden Four"
+                        "node": "Teleporter to Crateria"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,
@@ -5213,7 +5213,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Retro Brinstar": {
+                        "Teleporter to Brinstar": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5222,12 +5222,12 @@
                         }
                     }
                 },
-                "Elevator - Retro Brinstar": {
+                "Teleporter to Brinstar": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 251.99374021909233,
-                        "y": 181.55033907146583,
+                        "x": 251.99,
+                        "y": 181.55,
                         "z": 0.0
                     },
                     "description": "",
@@ -5243,7 +5243,7 @@
                     "default_connection": {
                         "region": "Brinstar",
                         "area": "Retro Brinstar",
-                        "node": "Elevator - Elevator to Blue Brinstar"
+                        "node": "Teleporter to Crateria"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,
@@ -5295,7 +5295,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Elevator to Green Brinstar": {
+                        "Teleporter to Brinstar": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5304,12 +5304,12 @@
                         }
                     }
                 },
-                "Elevator - Elevator to Green Brinstar": {
+                "Teleporter to Brinstar": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 254.66458007303078,
-                        "y": 182.88575899843505,
+                        "x": 254.66,
+                        "y": 182.89,
                         "z": 0.0
                     },
                     "description": "",
@@ -5325,7 +5325,7 @@
                     "default_connection": {
                         "region": "Brinstar",
                         "area": "Green Brinstar Main Shaft",
-                        "node": "Elevator - Elevator to Green Brinstar"
+                        "node": "Teleporter to Crateria"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,
@@ -5377,7 +5377,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Red Brinstar Zoro Room": {
+                        "Teleporter to Brinstar": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5386,12 +5386,12 @@
                         }
                     }
                 },
-                "Elevator - Red Brinstar Zoro Room": {
+                "Teleporter to Brinstar": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 251.99374021909233,
-                        "y": 116.78247261345854,
+                        "x": 251.99,
+                        "y": 116.78,
                         "z": 0.0
                     },
                     "description": "",
@@ -5407,7 +5407,7 @@
                     "default_connection": {
                         "region": "Brinstar",
                         "area": "Red Brinstar Zoro Room",
-                        "node": "Elevator - Elevator to Red Brinstar"
+                        "node": "Teleporter to Crateria"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,
@@ -5427,7 +5427,7 @@
             }
         },
         "Forgotten Highway Elevator": {
-            "default_node": "Elevator - Maridia Elevator Room",
+            "default_node": "Teleporter to Maridia",
             "extra": {
                 "map_name": "794CC",
                 "asset_id": 32
@@ -5459,7 +5459,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Maridia Elevator Room": {
+                        "Teleporter to Maridia": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5468,12 +5468,12 @@
                         }
                     }
                 },
-                "Elevator - Maridia Elevator Room": {
+                "Teleporter to Maridia": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 254.66458007303078,
-                        "y": 117.45018257694312,
+                        "x": 254.66,
+                        "y": 117.45,
                         "z": 0.0
                     },
                     "description": "",
@@ -5489,7 +5489,7 @@
                     "default_connection": {
                         "region": "Maridia",
                         "area": "Maridia Elevator Room",
-                        "node": "Elevator - Forgotten Highway Elevator"
+                        "node": "Teleporter to Crateria"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,

--- a/randovania/games/super_metroid/json_data/Crateria.txt
+++ b/randovania/games/super_metroid/json_data/Crateria.txt
@@ -666,12 +666,12 @@ Extra - asset_id: 25
 > Door to Gold Four Hallway; Heals? False
   * Layers: default
   * Normal Door to Gold Four Hallway/Door to Gold Four
-  > Elevator - Tourian Entrance
+  > Teleporter to Tourian
       After Kraid Defeated and After Phantoon Defeated and After Draygon Defeated and After Ridley Defeated
 
-> Elevator - Tourian Entrance; Heals? False; Default Node
+> Teleporter to Tourian; Heals? False; Default Node
   * Layers: default
-  * Teleporter to Tourian Entrance/Elevator - Golden Four
+  * Teleporter to Tourian Entrance/Teleporter to Crateria
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Gold Four Hallway
@@ -788,12 +788,12 @@ Extra - asset_id: 29
 > Door to Old Mother Brain; Heals? False; Default Node
   * Layers: default
   * Normal Door to Old Mother Brain/Door to Elevator to Blue Brinstar
-  > Elevator - Retro Brinstar
+  > Teleporter to Brinstar
       Trivial
 
-> Elevator - Retro Brinstar; Heals? False
+> Teleporter to Brinstar; Heals? False
   * Layers: default
-  * Teleporter to Retro Brinstar/Elevator - Elevator to Blue Brinstar
+  * Teleporter to Retro Brinstar/Teleporter to Crateria
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Old Mother Brain
@@ -806,12 +806,12 @@ Extra - asset_id: 30
 > Door to Lower Mushrooms; Heals? False; Default Node
   * Layers: default
   * Normal Door to Lower Mushrooms/Door to Elevator to Green Brinstar
-  > Elevator - Elevator to Green Brinstar
+  > Teleporter to Brinstar
       Trivial
 
-> Elevator - Elevator to Green Brinstar; Heals? False
+> Teleporter to Brinstar; Heals? False
   * Layers: default
-  * Teleporter to Green Brinstar Main Shaft/Elevator - Elevator to Green Brinstar
+  * Teleporter to Green Brinstar Main Shaft/Teleporter to Crateria
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Lower Mushrooms
@@ -824,12 +824,12 @@ Extra - asset_id: 31
 > Door to Crateria Kihunter Room; Heals? False; Default Node
   * Layers: default
   * Power Bomb Door to Crateria Kihunter Room/Door to Elevator to Red Brinstar
-  > Elevator - Red Brinstar Zoro Room
+  > Teleporter to Brinstar
       Trivial
 
-> Elevator - Red Brinstar Zoro Room; Heals? False
+> Teleporter to Brinstar; Heals? False
   * Layers: default
-  * Teleporter to Red Brinstar Zoro Room/Elevator - Elevator to Red Brinstar
+  * Teleporter to Red Brinstar Zoro Room/Teleporter to Crateria
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Crateria Kihunter Room
@@ -842,12 +842,12 @@ Extra - asset_id: 32
 > Door to Forgotten Highway Elbow; Heals? False
   * Layers: default
   * Normal Door to Forgotten Highway Elbow/Door to Forgotten Highway Elevator
-  > Elevator - Maridia Elevator Room
+  > Teleporter to Maridia
       Trivial
 
-> Elevator - Maridia Elevator Room; Heals? False; Default Node
+> Teleporter to Maridia; Heals? False; Default Node
   * Layers: default
-  * Teleporter to Maridia Elevator Room/Elevator - Forgotten Highway Elevator
+  * Teleporter to Maridia Elevator Room/Teleporter to Crateria
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Forgotten Highway Elbow

--- a/randovania/games/super_metroid/json_data/Maridia.json
+++ b/randovania/games/super_metroid/json_data/Maridia.json
@@ -8287,7 +8287,7 @@
             }
         },
         "Maridia Elevator Room": {
-            "default_node": "Elevator - Forgotten Highway Elevator",
+            "default_node": "Teleporter to Crateria",
             "extra": {
                 "map_name": "7D30B",
                 "asset_id": 175
@@ -8326,7 +8326,7 @@
                                 "items": []
                             }
                         },
-                        "Elevator - Forgotten Highway Elevator": {
+                        "Teleporter to Crateria": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -8408,12 +8408,12 @@
                         }
                     }
                 },
-                "Elevator - Forgotten Highway Elevator": {
+                "Teleporter to Crateria": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 251.0097465886939,
-                        "y": 1652.4392462638075,
+                        "x": 251.01,
+                        "y": 1652.44,
                         "z": 0.0
                     },
                     "description": "",
@@ -8429,7 +8429,7 @@
                     "default_connection": {
                         "region": "Crateria",
                         "area": "Forgotten Highway Elevator",
-                        "node": "Elevator - Maridia Elevator Room"
+                        "node": "Teleporter to Maridia"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,

--- a/randovania/games/super_metroid/json_data/Maridia.txt
+++ b/randovania/games/super_metroid/json_data/Maridia.txt
@@ -1300,7 +1300,7 @@ Extra - asset_id: 175
   * Missile Door to Maridia Elevator Save Station/Door to Maridia Elevator Room
   > Door to Thread the Needle Room
       Trivial
-  > Elevator - Forgotten Highway Elevator
+  > Teleporter to Crateria
       Ice Beam or Space Jump
 
 > Door to Thread the Needle Room; Heals? False
@@ -1309,9 +1309,9 @@ Extra - asset_id: 175
   > Door to Maridia Elevator Save Station
       Hi-Jump Boots or Space Jump
 
-> Elevator - Forgotten Highway Elevator; Heals? False; Default Node
+> Teleporter to Crateria; Heals? False; Default Node
   * Layers: default
-  * Teleporter to Forgotten Highway Elevator/Elevator - Maridia Elevator Room
+  * Teleporter to Forgotten Highway Elevator/Teleporter to Maridia
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Maridia Elevator Save Station

--- a/randovania/games/super_metroid/json_data/Norfair.json
+++ b/randovania/games/super_metroid/json_data/Norfair.json
@@ -5,7 +5,7 @@
     },
     "areas": {
         "Business Center": {
-            "default_node": "Elevator - Warehouse Entrance",
+            "default_node": "Teleporter to Brinstar",
             "extra": {
                 "map_name": "7A7DE",
                 "asset_id": 177
@@ -37,7 +37,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Warehouse Entrance": {
+                        "Teleporter to Brinstar": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -72,7 +72,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Warehouse Entrance": {
+                        "Teleporter to Brinstar": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -107,7 +107,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Warehouse Entrance": {
+                        "Teleporter to Brinstar": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -142,7 +142,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Warehouse Entrance": {
+                        "Teleporter to Brinstar": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -177,7 +177,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Warehouse Entrance": {
+                        "Teleporter to Brinstar": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -212,7 +212,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Warehouse Entrance": {
+                        "Teleporter to Brinstar": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -221,12 +221,12 @@
                         }
                     }
                 },
-                "Elevator - Warehouse Entrance": {
+                "Teleporter to Brinstar": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 250.1780376868096,
-                        "y": 2168.486896252978,
+                        "x": 250.18,
+                        "y": 2168.49,
                         "z": 0.0
                     },
                     "description": "",
@@ -242,7 +242,7 @@
                     "default_connection": {
                         "region": "Brinstar",
                         "area": "Warehouse Entrance",
-                        "node": "Door to Red Brinstar East Tunnel"
+                        "node": "Teleporter to Norfair"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,
@@ -7473,7 +7473,7 @@
             }
         },
         "Elevator to Lower Norfair": {
-            "default_node": "Elevator - Main Hall",
+            "default_node": "Teleporter to Main Hall",
             "extra": {
                 "map_name": "7AF3F",
                 "asset_id": 228
@@ -7551,7 +7551,7 @@
                                 "negate": false
                             }
                         },
-                        "Elevator - Main Hall": {
+                        "Teleporter to Main Hall": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -7562,12 +7562,12 @@
                         }
                     }
                 },
-                "Elevator - Main Hall": {
+                "Teleporter to Main Hall": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 252.97691894793343,
-                        "y": 183.72088030059047,
+                        "x": 252.98,
+                        "y": 183.72,
                         "z": 0.0
                     },
                     "description": "",
@@ -7583,7 +7583,7 @@
                     "default_connection": {
                         "region": "Norfair",
                         "area": "Main Hall",
-                        "node": "Elevator - Elevator to Lower Norfair"
+                        "node": "Teleporter to Elevator to Lower Norfair"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,
@@ -11841,7 +11841,7 @@
             }
         },
         "Main Hall": {
-            "default_node": "Elevator - Elevator to Lower Norfair",
+            "default_node": "Teleporter to Elevator to Lower Norfair",
             "extra": {
                 "map_name": "7B236",
                 "asset_id": 252
@@ -11873,7 +11873,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Elevator to Lower Norfair": {
+                        "Teleporter to Elevator to Lower Norfair": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -11910,7 +11910,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Elevator - Elevator to Lower Norfair": {
+                        "Teleporter to Elevator to Lower Norfair": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -11921,12 +11921,12 @@
                         }
                     }
                 },
-                "Elevator - Elevator to Lower Norfair": {
+                "Teleporter to Elevator to Lower Norfair": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 2295.15771951727,
-                        "y": 179.93508114856422,
+                        "x": 2295.16,
+                        "y": 179.94,
                         "z": 0.0
                     },
                     "description": "",
@@ -11942,7 +11942,7 @@
                     "default_connection": {
                         "region": "Norfair",
                         "area": "Elevator to Lower Norfair",
-                        "node": "Elevator - Main Hall"
+                        "node": "Teleporter to Main Hall"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,

--- a/randovania/games/super_metroid/json_data/Norfair.txt
+++ b/randovania/games/super_metroid/json_data/Norfair.txt
@@ -5,42 +5,42 @@ Extra - asset_id: 177
 > Door to Ice Beam Gate Room; Heals? False
   * Layers: default
   * Super Missile Door to Ice Beam Gate Room/Door to Business Center
-  > Elevator - Warehouse Entrance
+  > Teleporter to Brinstar
       Trivial
 
 > Door to Hi-Jump Energy Tank Room; Heals? False
   * Layers: default
   * Missile Door to Hi-Jump Energy Tank Room/Door to Business Center
-  > Elevator - Warehouse Entrance
+  > Teleporter to Brinstar
       Trivial
 
 > Door to Norfair Map Station; Heals? False
   * Layers: default
   * Power Bomb Door to Norfair Map Station/Door to Business Center
-  > Elevator - Warehouse Entrance
+  > Teleporter to Brinstar
       Trivial
 
 > Door to Business Center Save Station; Heals? False
   * Layers: default
   * Normal Door to Business Center Save Station/Door to Business Center
-  > Elevator - Warehouse Entrance
+  > Teleporter to Brinstar
       Trivial
 
 > Door to Crocomire Escape; Heals? False
   * Layers: default
   * Normal Door to Crocomire Escape/Door to Business Center
-  > Elevator - Warehouse Entrance
+  > Teleporter to Brinstar
       Trivial
 
 > Door to Cathedral Access; Heals? False
   * Layers: default
   * Normal Door to Cathedral Access/Door to Business Center
-  > Elevator - Warehouse Entrance
+  > Teleporter to Brinstar
       Trivial
 
-> Elevator - Warehouse Entrance; Heals? False; Default Node
+> Teleporter to Brinstar; Heals? False; Default Node
   * Layers: default
-  * Teleporter to Warehouse Entrance/Door to Red Brinstar East Tunnel
+  * Teleporter to Warehouse Entrance/Teleporter to Norfair
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Ice Beam Gate Room
@@ -1226,12 +1226,12 @@ Extra - asset_id: 228
   * Normal Door to Lava Dive/Door to Elevator to Lower Norfair
   > Door to Elevator to Lower Norfair Save Station
       Varia Suit
-  > Elevator - Main Hall
+  > Teleporter to Main Hall
       Varia Suit
 
-> Elevator - Main Hall; Heals? False; Default Node
+> Teleporter to Main Hall; Heals? False; Default Node
   * Layers: default
-  * Teleporter to Main Hall/Elevator - Elevator to Lower Norfair
+  * Teleporter to Main Hall/Teleporter to Elevator to Lower Norfair
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Lava Dive
@@ -1843,18 +1843,18 @@ Extra - asset_id: 252
 > Door to Acid Statue Room; Heals? False
   * Layers: default
   * Normal Door to Acid Statue Room/Door to Main Hall
-  > Elevator - Elevator to Lower Norfair
+  > Teleporter to Elevator to Lower Norfair
       Varia Suit
 
 > Door to Fast Pillars Setup Room; Heals? False
   * Layers: default
   * Normal Door to Fast Pillars Setup Room/Door to Main Hall
-  > Elevator - Elevator to Lower Norfair
+  > Teleporter to Elevator to Lower Norfair
       Varia Suit
 
-> Elevator - Elevator to Lower Norfair; Heals? False; Default Node
+> Teleporter to Elevator to Lower Norfair; Heals? False; Default Node
   * Layers: default
-  * Teleporter to Elevator to Lower Norfair/Elevator - Main Hall
+  * Teleporter to Elevator to Lower Norfair/Teleporter to Main Hall
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Acid Statue Room

--- a/randovania/games/super_metroid/json_data/Tourian.json
+++ b/randovania/games/super_metroid/json_data/Tourian.json
@@ -5,7 +5,7 @@
     },
     "areas": {
         "Tourian Entrance": {
-            "default_node": "Elevator - Golden Four",
+            "default_node": "Teleporter to Crateria",
             "extra": {
                 "map_name": "7DAAE",
                 "asset_id": 33
@@ -79,7 +79,7 @@
                                 "items": []
                             }
                         },
-                        "Elevator - Golden Four": {
+                        "Teleporter to Crateria": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -88,12 +88,12 @@
                         }
                     }
                 },
-                "Elevator - Golden Four": {
+                "Teleporter to Crateria": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": 251.56421918995022,
-                        "y": 622.5618366904914,
+                        "x": 251.56,
+                        "y": 622.56,
                         "z": 0.0
                     },
                     "description": "",
@@ -109,7 +109,7 @@
                     "default_connection": {
                         "region": "Crateria",
                         "area": "Gold Four",
-                        "node": "Elevator - Tourian Entrance"
+                        "node": "Teleporter to Tourian"
                     },
                     "default_dock_weakness": "Teleporter",
                     "exclude_from_dock_rando": false,

--- a/randovania/games/super_metroid/json_data/Tourian.txt
+++ b/randovania/games/super_metroid/json_data/Tourian.txt
@@ -13,12 +13,12 @@ Extra - asset_id: 33
   * Normal Door to Metroid Room 1/Door to Tourian Entrance
   > Door to Upper Tourian Save Station
       Trivial
-  > Elevator - Golden Four
+  > Teleporter to Crateria
       Trivial
 
-> Elevator - Golden Four; Heals? False; Default Node
+> Teleporter to Crateria; Heals? False; Default Node
   * Layers: default
-  * Teleporter to Gold Four/Elevator - Tourian Entrance
+  * Teleporter to Gold Four/Teleporter to Tourian
   * Extra - scan_asset_id: None
   * Extra - teleporter_instance_id: None
   > Door to Metroid Room 1


### PR DESCRIPTION
Fixes the teleporters to adhere to new naming scheme, and to not go to previous default nodes.

Would be appreciated if someone can double check the elevator to lower norfair <-> main hall connection in norfair, because based on the names, not sure if it sounds correct.