### PR TITLE
AM2R: Get rid of serris entrance doors

### DIFF
--- a/randovania/games/am2r/json_data/Distribution Center.json
+++ b/randovania/games/am2r/json_data/Distribution Center.json
@@ -8335,13 +8335,16 @@
                         "area": "Serris Arena Access",
                         "node": "Door to Serris Arena"
                     },
-                    "default_dock_weakness": "Serris Arena Entrance Door",
-                    "exclude_from_dock_rando": true,
-                    "incompatible_dock_weaknesses": [],
+                    "default_dock_weakness": "Normal Door",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Serris Arena Pipe": {
+                        "Left Platform": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8377,11 +8380,99 @@
                         "area": "Serris Arena Pipe",
                         "node": "Door to Serris Arena"
                     },
-                    "default_dock_weakness": "Serris Arena Entrance Door",
-                    "exclude_from_dock_rando": true,
-                    "incompatible_dock_weaknesses": [],
+                    "default_dock_weakness": "Normal Door",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [
+                        "Spider Ball Door",
+                        "Screw Attack Door"
+                    ],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
+                    "connections": {
+                        "Left Platform": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "A5IceItem",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "BossSerris",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Inside Serris Trigger": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "A5IceItem",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Event - Serris": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 303.9741957389016,
+                        "y": 267.97725150666326,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "BossSerris",
+                    "connections": {
+                        "Door to Serris Arena Access": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Left Platform": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 103.58826358826359,
+                        "y": 113.4776334776335,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Serris Arena Access": {
                             "type": "and",
@@ -8395,6 +8486,66 @@
                                 ]
                             }
                         },
+                        "Door to Serris Arena Pipe": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "A5IceItem",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "BossSerris",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Inside Serris Trigger": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "A5IceItem",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Inside Serris Trigger": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 71.57287157287158,
+                        "y": 203.98268398268397,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "connections": {
                         "Event - Serris": {
                             "type": "and",
                             "data": {
@@ -8628,31 +8779,6 @@
                                         }
                                     }
                                 ]
-                            }
-                        }
-                    }
-                },
-                "Event - Serris": {
-                    "node_type": "event",
-                    "heal": false,
-                    "coordinates": {
-                        "x": 343.46,
-                        "y": 264.42,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "valid_starting_location": false,
-                    "event_name": "BossSerris",
-                    "connections": {
-                        "Door to Serris Arena Access": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }

--- a/randovania/games/am2r/json_data/Distribution Center.txt
+++ b/randovania/games/am2r/json_data/Distribution Center.txt
@@ -1314,17 +1314,37 @@ Serris Arena
 Extra - map_name: rm_a5b03a
 > Door to Serris Arena Access; Heals? False
   * Layers: default
-  * Serris Arena Entrance Door to Serris Arena Access/Door to Serris Arena; Excluded from Dock Lock Rando
+  * Normal Door to Serris Arena Access/Door to Serris Arena; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135449
-  > Door to Serris Arena Pipe
+  > Left Platform
       Power Grip Wall
 
 > Door to Serris Arena Pipe; Heals? False
   * Layers: default
-  * Serris Arena Entrance Door to Serris Arena Pipe/Door to Serris Arena; Excluded from Dock Lock Rando
+  * Normal Door to Serris Arena Pipe/Door to Serris Arena; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door
   * Extra - instance_id: 135448
+  > Left Platform
+      Before Area 5 - Distribution Center Item at Ice location Collected or After Boss - Serris Defeated
+  > Inside Serris Trigger
+      After Area 5 - Distribution Center Item at Ice location Collected
+
+> Event - Serris; Heals? False
+  * Layers: default
+  * Event Boss - Serris Defeated
+  > Door to Serris Arena Access
+      Trivial
+
+> Left Platform; Heals? False
+  * Layers: default
   > Door to Serris Arena Access
       Power Grip Wall
+  > Door to Serris Arena Pipe
+      Before Area 5 - Distribution Center Item at Ice location Collected or After Boss - Serris Defeated
+  > Inside Serris Trigger
+      After Area 5 - Distribution Center Item at Ice location Collected
+
+> Inside Serris Trigger; Heals? False
+  * Layers: default
   > Event - Serris
       All of the following:
           All of the following:
@@ -1352,12 +1372,6 @@ Extra - map_name: rm_a5b03a
           Any of the following:
               # Fusion Mode requirements
               Missiles or Super Missiles or Disabled Fusion Mode
-
-> Event - Serris; Heals? False
-  * Layers: default
-  * Event Boss - Serris Defeated
-  > Door to Serris Arena Access
-      Trivial
 
 ----------------
 Serris Arena Pipe

--- a/randovania/games/am2r/json_data/header.json
+++ b/randovania/games/am2r/json_data/header.json
@@ -4018,36 +4018,6 @@
                         },
                         "lock": null
                     },
-                    "Serris Arena Entrance Door": {
-                        "extra": {},
-                        "requirement": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "A5IceItem",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "BossSerris",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "lock": null
-                    },
                     "Charge Beam Door": {
                         "extra": {},
                         "requirement": {

--- a/randovania/games/am2r/json_data/header.txt
+++ b/randovania/games/am2r/json_data/header.txt
@@ -426,12 +426,6 @@ Dock Weaknesses
       No lock
 
 
-  * Serris Arena Entrance Door
-      Open:
-          Before Area 5 - Distribution Center Item at Ice location Collected or After Boss - Serris Defeated
-      No lock
-
-
   * Charge Beam Door
       Open:
           Charge Beam


### PR DESCRIPTION
Can't get rid of the BEFORE's sadly, but should make serris logic a bit easier to follow.