### PR TITLE
AM2R: Hydro Station Database Updates

### DIFF
--- a/randovania/games/am2r/json_data/Hydro Station.json
+++ b/randovania/games/am2r/json_data/Hydro Station.json
@@ -206,6 +206,18 @@
                                 "items": []
                             }
                         },
+                        "Dock to Arachnus Save Station": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Space Jump Wall"
+                                    }
+                                ]
+                            }
+                        },
                         "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
@@ -393,7 +405,17 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph Ball",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -428,7 +450,17 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph Ball",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Dock to Exterior Alpha Nest": {
@@ -1146,6 +1178,15 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
                                                 }
                                             ]
                                         }
@@ -1672,10 +1713,85 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Dock to Varia Chamber Access Water Pipe": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space Jump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Walljump",
+                                            "amount": 3,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Spider Ball"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Hi-Jump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -1729,12 +1845,29 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "misc",
-                                            "name": "EntranceRando",
-                                            "amount": 1,
-                                            "negate": true
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -2350,7 +2483,17 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph Ball",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -2389,6 +2532,10 @@
                                     {
                                         "type": "template",
                                         "data": "Can Use Any Bombs"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Tunnel Climb"
                                     }
                                 ]
                             }
@@ -2418,7 +2565,17 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph Ball",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -2673,7 +2830,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Alpha event",
+                                            "comment": "Alpha Event",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -2896,6 +3053,87 @@
                                             "name": "Morph Ball",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": "To Climb",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Space Jump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Walljump",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": "To climb into tunnel",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Power Grip",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "MidAirMorph",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Spider Ball"
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -3467,7 +3705,7 @@
                                         "data": {
                                             "type": "tricks",
                                             "name": "Walljump",
-                                            "amount": 4,
+                                            "amount": 2,
                                             "negate": false
                                         }
                                     },
@@ -3504,6 +3742,15 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Hi-Jump",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -3848,7 +4095,17 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph Ball",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -4095,7 +4352,7 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Dock to Autrack Corridor Right Water Pipe": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -4107,6 +4364,37 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Hi-Jump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space Jump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Walljump",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Spider Ball"
                                     }
                                 ]
                             }
@@ -4274,12 +4562,29 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "misc",
-                                            "name": "EntranceRando",
-                                            "amount": 1,
-                                            "negate": true
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -4305,7 +4610,7 @@
                                         "data": "Can Use Spider Ball"
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
@@ -4998,25 +5303,8 @@
                                         "data": "Can Use Any Bombs"
                                     },
                                     {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Tunnel Climb"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "MidAirMorph",
-                                                        "amount": 3,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
+                                        "type": "template",
+                                        "data": "Low Mid-Air Morph Tunnel Climb"
                                     }
                                 ]
                             }
@@ -5089,25 +5377,8 @@
                                         "data": "Can Use Any Bombs"
                                     },
                                     {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Tunnel Climb"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "MidAirMorph",
-                                                        "amount": 3,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
+                                        "type": "template",
+                                        "data": "Low Mid-Air Morph Tunnel Climb"
                                     }
                                 ]
                             }

--- a/randovania/games/am2r/json_data/Hydro Station.txt
+++ b/randovania/games/am2r/json_data/Hydro Station.txt
@@ -38,6 +38,8 @@ Extra - map_name: rm_a2h02
   * Open Passage to Hydro Station Entrance/Dock to Hydro Station Exterior
   > Dock to Broken Save Station
       Trivial
+  > Dock to Arachnus Save Station
+      Space Jump Wall
   > Pickup (Missile Tank)
       Can Use Spider Ball
 
@@ -67,13 +69,13 @@ Extra - map_name: rm_a2h02
   * Layers: default
   * Morph Ball Tunnel to Inner Alpha Nest North/Tunnel to Hydro Station Exterior
   > Dock to Broken Save Station
-      Trivial
+      Morph Ball
 
 > Dock to Arachnus Save Station; Heals? False
   * Layers: default
   * Open Passage to Arachnus Save Station/Dock to Hydro Station Exterior
   > Tunnel to Inner Alpha Nest North
-      Trivial
+      Morph Ball
   > Dock to Exterior Alpha Nest
       Any of the following:
           Space Jump
@@ -163,7 +165,7 @@ Extra - map_name: rm_a2h02
   > Dock to Breeding Grounds Access (Top)
       All of the following:
           # Shinespark from the room on the right
-          Morph Ball and Speed Booster and Shinesparking Tricks (Beginner)
+          Morph Ball and Speed Booster and Shinesparking Tricks (Beginner) and Disabled Entrance Rando
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
@@ -266,7 +268,10 @@ Extra - map_name: rm_a2a02A
   * Layers: default
   * Open Passage to Wave Beam Chamber Access/Dock to Autrack Corridor Right Water Pipe
   > Dock to Varia Chamber Access Water Pipe
-      Trivial
+      Any of the following:
+          Space Jump or Walljump (Advanced) or Can Use Spider Ball
+          Morph Ball and Disabled Entrance Rando
+          Hi-Jump Boots and Walljump (Intermediate)
 
 ----------------
 Autrack Corridor Left Water Pipe
@@ -276,7 +281,8 @@ Extra - map_name: rm_a2a02B
   * Open Passage to Wave Beam Chamber Access Water Pipe/Dock to Autrack Corridor Left Water Pipe
   > Dock to Varia Chamber Access
       Any of the following:
-          Space Jump or Walljump (Advanced) or Disabled Entrance Rando or Can Use Spider Ball
+          Space Jump or Walljump (Advanced) or Can Use Spider Ball
+          Morph Ball and Disabled Entrance Rando
           Hi-Jump Boots and Walljump (Intermediate)
 
 > Dock to Varia Chamber Access; Heals? False
@@ -371,20 +377,20 @@ Extra - map_name: rm_a2a05
   * Layers: default
   * Morph Ball Tunnel to Hydro Station Exterior/Tunnel to Inner Alpha Nest North
   > Pickup (Missile Tank)
-      Trivial
+      Morph Ball
 
 > Dock to Varia Chamber Access Water Pipe; Heals? False
   * Layers: default
   * Open Passage to Varia Chamber Access Water Pipe/Dock to Inner Alpha Nest North
   > Dock to Hydro Station Exterior
-      Can Use Any Bombs
+      Can Use Any Bombs and Tunnel Climb
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
   * Pickup 152; Category? Minor
   * Extra - object_name: oItemM_152
   > Tunnel to Hydro Station Exterior
-      Trivial
+      Morph Ball
 
 > Event - Alpha; Heals? False
   * Layers: default
@@ -428,7 +434,7 @@ Extra - map_name: rm_a2a06
       Any of the following:
           High Mid-Air Morph Tunnel Climb
           All of the following:
-              # Alpha event
+              # Alpha Event
               Morph Ball and After Metroids Area 2 - Interior Lower Alpha and Disabled Entrance Rando
 
 > Pickup (Missile Tank); Heals? False
@@ -460,7 +466,17 @@ Extra - map_name: rm_a2a06A
   * Layers: default
   * Open Passage to Autrack Corridor Right Water Pipe/Dock to Varia Chamber Access Water Pipe
   > Dock to Inner Alpha Nest North
-      Morph Ball
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Disabled Entrance Rando or Can Use Spider Ball
+              All of the following:
+                  Any of the following:
+                      # To Climb
+                      Space Jump or Walljump (Intermediate)
+                  Any of the following:
+                      # To climb into tunnel
+                      Power Grip or Mid-Air Morph (Advanced)
 
 ----------------
 Varia Chamber
@@ -552,7 +568,7 @@ Extra - map_name: rm_a2a09
   * Open Passage to Water Turbine Station/Dock to Inner Alpha Nest South
   > Dock to Wave Beam Chamber Access Water Pipe
       Any of the following:
-          Space Jump or Walljump (Expert) or Can Use Spider Ball
+          Hi-Jump Boots or Space Jump or Walljump (Intermediate) or Can Use Spider Ball
           All of the following:
               # Use water pipe
               Morph Ball and After Metroids Area 2 - Interior Lower Alpha
@@ -600,7 +616,7 @@ Extra - map_name: rm_a2a09
   * Pickup 151; Category? Minor
   * Extra - object_name: oItemM_151
   > Dock to Water Turbine Station
-      Trivial
+      Morph Ball
 
 > Pickup (Alpha); Heals? False
   * Layers: default
@@ -651,7 +667,7 @@ Extra - map_name: rm_a2a11
 > Waterpipe; Heals? False
   * Layers: default
   > Dock to Autrack Corridor Right Water Pipe
-      Morph Ball
+      Hi-Jump Boots or Morph Ball or Space Jump or Walljump (Intermediate) or Can Use Spider Ball
   > Dock to Lower Hydro Station Hub
       Can Use Any Bombs
   > Left Wallfire
@@ -681,7 +697,10 @@ Extra - map_name: rm_a2a11A
   * Layers: default
   * Open Passage to Inner Alpha Nest South/Dock to Wave Beam Chamber Access Water Pipe
   > Dock to Autrack Corridor Left Water Pipe
-      Hi-Jump Boots or Space Jump or Walljump (Intermediate) or Walljump (Advanced) or Disabled Entrance Rando or Can Use Spider Ball
+      Any of the following:
+          Space Jump or Walljump (Advanced) or Can Use Spider Ball
+          Morph Ball and Disabled Entrance Rando
+          Hi-Jump Boots and Walljump (Intermediate)
 
 ----------------
 Lower Hydro Station Hub
@@ -790,9 +809,7 @@ Extra - map_name: rm_a2a15
   > Dock to Wallfire Venue
       Trivial
   > Pickup (Bottom Missile Tank)
-      All of the following:
-          Can Use Any Bombs
-          Mid-Air Morph (Advanced) or Tunnel Climb
+      Can Use Any Bombs and Low Mid-Air Morph Tunnel Climb
 
 > Pickup (Top Missile Tank); Heals? False
   * Layers: default
@@ -806,9 +823,7 @@ Extra - map_name: rm_a2a15
   * Pickup 154; Category? Minor
   * Extra - object_name: oItemM_154
   > Dock to Lower Hydro Station Hub
-      All of the following:
-          Can Use Any Bombs
-          Mid-Air Morph (Advanced) or Tunnel Climb
+      Can Use Any Bombs and Low Mid-Air Morph Tunnel Climb
 
 ----------------
 Wallfire Venue


### PR DESCRIPTION
- Changed: Autoad Playground - Updated bottom missile tank to use appropriate template
- Added: Autrack Corridor Right Water Pipe - Added climb requirements
- Changed: Autrack Corridor Left Water Pipe - Aligned climb reqs with Right Pipe
- Added: Hydro Station Exterior - Inner Alpha Nest North now has morph requirement to enter/exit
- Added: Hydro Station Exterior - Middle Left to BGA (Top) shinespark now requires entrance rando off
- Added: Hydro Station Exterior - Hydro Station Entrance now has connection to Arachnus Save
- Added: Inner Alpha Nest North - Tunnel to Exterior connection now has morph requirement to enter/exit
- Added: Inner Alpha Nest North - VCA Pipe to Exterior now has Tunnel Climb requirement
- Changed: Inner Apha Nest South - Pipe can now be reached with Hi-Jump and Walljump bumped down
- Added: Inner Apha Nest South - Missile Tank now has morph required to leave
- Added: Varia Chamber Access Water Pipe - Added climb requirements
- Changed: Wave Beam Chamber Access - To Waterpipe now has none morph requirements