### PR TITLE
AM2R: Tower (A4) Database Updates

### DIFF
--- a/randovania/games/am2r/json_data/The Tower.json
+++ b/randovania/games/am2r/json_data/The Tower.json
@@ -1243,10 +1243,33 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Top": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space Jump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Walljump",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Spider Ball"
+                                    }
+                                ]
                             }
                         }
                     }
@@ -1278,10 +1301,33 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Top": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space Jump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Walljump",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Spider Ball"
+                                    }
+                                ]
                             }
                         }
                     }
@@ -1316,7 +1362,92 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Any Bombs"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "MidAirMorph",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "SoftlockPrevention",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Space Jump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Walljump",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Spider Ball"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -1583,37 +1714,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can Use Spider Ball"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Power Grip",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "MidAirMorph",
-                                                        "amount": 2,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
+                                            "comment": "Break the bomb blocks",
                                             "items": [
                                                 {
                                                     "type": "template",
@@ -1642,7 +1743,7 @@
                                                                             "data": {
                                                                                 "type": "tricks",
                                                                                 "name": "IBJ",
-                                                                                "amount": 2,
+                                                                                "amount": 3,
                                                                                 "negate": false
                                                                             }
                                                                         }
@@ -1658,21 +1759,55 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Getting up to the tunnel",
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Space Jump",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": "Space Jump Climb",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Space Jump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Power Grip",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "MidAirMorph",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Shinespark Method",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -1688,24 +1823,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "Shinesparking",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Hi-Jump",
-                                                                    "amount": 1,
+                                                                    "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
@@ -1717,9 +1835,9 @@
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "MidAirMorph",
-                                                                                "amount": 2,
+                                                                                "type": "items",
+                                                                                "name": "Power Grip",
+                                                                                "amount": 1,
                                                                                 "negate": false
                                                                             }
                                                                         },
@@ -1731,9 +1849,9 @@
                                                                                     {
                                                                                         "type": "resource",
                                                                                         "data": {
-                                                                                            "type": "items",
-                                                                                            "name": "Power Grip",
-                                                                                            "amount": 1,
+                                                                                            "type": "tricks",
+                                                                                            "name": "Walljump",
+                                                                                            "amount": 3,
                                                                                             "negate": false
                                                                                         }
                                                                                     },
@@ -1741,21 +1859,12 @@
                                                                                         "type": "resource",
                                                                                         "data": {
                                                                                             "type": "tricks",
-                                                                                            "name": "Movement",
+                                                                                            "name": "MidAirMorph",
                                                                                             "amount": 3,
                                                                                             "negate": false
                                                                                         }
                                                                                     }
                                                                                 ]
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Walljump",
-                                                                                "amount": 2,
-                                                                                "negate": false
                                                                             }
                                                                         }
                                                                     ]
@@ -1765,12 +1874,28 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "template",
+                                                    "data": "Can Use Spider Ball"
+                                                },
+                                                {
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Walljump",
-                                                        "amount": 3,
-                                                        "negate": false
+                                                        "comment": "IBJ",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Bombs"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "IBJ",
+                                                                    "amount": 4,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -1947,6 +2072,15 @@
                                             "amount": 2,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph Ball",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -2048,6 +2182,15 @@
                                             "type": "tricks",
                                             "name": "Movement",
                                             "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph Ball",
+                                            "amount": 1,
                                             "negate": false
                                         }
                                     }
@@ -2428,7 +2571,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "MidAirMorph",
+                                                        "name": "MorphGlide",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -2589,7 +2732,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "MidAirMorph",
+                                                        "name": "MorphGlide",
                                                         "amount": 3,
                                                         "negate": false
                                                     }
@@ -2709,6 +2852,41 @@
                                                                     "name": "MidAirMorph",
                                                                     "amount": 2,
                                                                     "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed Booster",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Shinesparking",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "EntranceRando",
+                                                                    "amount": 1,
+                                                                    "negate": true
                                                                 }
                                                             }
                                                         ]
@@ -7499,106 +7677,78 @@
                                 "comment": null,
                                 "items": [
                                     {
+                                        "type": "template",
+                                        "data": "Can Use Spider Ball"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space Jump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
                                         "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "or",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Power Grip",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "MidAirMorph",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "items",
+                                                        "name": "Hi-Jump",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "or",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Speed Booster",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Shinesparking",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "or",
-                                                                            "data": {
-                                                                                "comment": null,
-                                                                                "items": [
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "items",
-                                                                                            "name": "Power Grip",
-                                                                                            "amount": 1,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "template",
-                                                                                        "data": "Can Use Spring Ball"
-                                                                                    }
-                                                                                ]
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Space Jump",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Can Use Spider Ball"
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Walljump",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed Booster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Shinesparking",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -7696,6 +7846,173 @@
                                     {
                                         "type": "template",
                                         "data": "Defeat Zeta"
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Get into Tunnel",
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed Booster",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Shinesparking",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Power Grip",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Spring Ball",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "EntranceRando",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Spider Ball"
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "or",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Power Grip",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "MidAirMorph",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "or",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Space Jump",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Walljump",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "and",
+                                                                                        "data": {
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "items",
+                                                                                                        "name": "Hi-Jump",
+                                                                                                        "amount": 1,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "tricks",
+                                                                                                        "name": "Walljump",
+                                                                                                        "amount": 1,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -8164,6 +8481,15 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Hi-Jump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -8338,13 +8664,39 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Dock to Power Plant Destroyed Shaft": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Low Mid-Air Morph Tunnel Climb"
+                                        "data": "Tunnel Climb"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "MidAirMorph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/am2r/json_data/The Tower.json
+++ b/randovania/games/am2r/json_data/The Tower.json
@@ -1024,7 +1024,7 @@
                         "Dock to Tower Exterior North": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "(TODO: Revisit later for climb from rock wall)",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -1245,7 +1245,7 @@
                         "Top": {
                             "type": "or",
                             "data": {
-                                "comment": "Climb from tower side (Editor Note: Revisit later for climb from rock wall)",
+                                "comment": "Climb from tower side (TODO: Revisit later for climb from rock wall)",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -1678,20 +1678,20 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "Break the bomb blocks",
+                                            "comment": null,
                                             "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can Use Power Bombs"
-                                                },
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Spider Method",
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Use Bombs"
+                                                                "data": "Can Use Spider Ball"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Any Bombs"
                                                             },
                                                             {
                                                                 "type": "or",
@@ -1699,30 +1699,206 @@
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Hi-Jump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "MorphGlide",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "EntranceRando",
+                                                                                "amount": 1,
+                                                                                "negate": true
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "MidAirMorph",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Non-Spider Methods",
+                                                        "items": [
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": "Way to break the blocks",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Use Power Bombs"
+                                                                        },
+                                                                        {
                                                                             "type": "and",
                                                                             "data": {
                                                                                 "comment": null,
                                                                                 "items": [
                                                                                     {
                                                                                         "type": "template",
-                                                                                        "data": "Can Use Spider Ball"
+                                                                                        "data": "Can Use Bombs"
                                                                                     },
                                                                                     {
-                                                                                        "type": "and",
+                                                                                        "type": "or",
                                                                                         "data": {
-                                                                                            "comment": "Method to cross the gap to the rock wall",
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "tricks",
+                                                                                                        "name": "IBJ",
+                                                                                                        "amount": 3,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "and",
+                                                                                                    "data": {
+                                                                                                        "comment": null,
+                                                                                                        "items": [
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "items",
+                                                                                                                    "name": "Space Jump",
+                                                                                                                    "amount": 1,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "tricks",
+                                                                                                                    "name": "MidAirMorph",
+                                                                                                                    "amount": 2,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": "Ways to climb to the tunnel",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "Space Jump Method",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Space Jump",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "or",
+                                                                                        "data": {
+                                                                                            "comment": null,
                                                                                             "items": [
                                                                                                 {
                                                                                                     "type": "resource",
                                                                                                     "data": {
                                                                                                         "type": "items",
-                                                                                                        "name": "Hi-Jump",
+                                                                                                        "name": "Power Grip",
                                                                                                         "amount": 1,
                                                                                                         "negate": false
                                                                                                     }
                                                                                                 },
                                                                                                 {
-                                                                                                    "type": "or",
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "tricks",
+                                                                                                        "name": "MidAirMorph",
+                                                                                                        "amount": 2,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "Shinespark Method",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Speed Booster",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Shinesparking",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "or",
+                                                                                        "data": {
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "items",
+                                                                                                        "name": "Power Grip",
+                                                                                                        "amount": 1,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "and",
                                                                                                     "data": {
                                                                                                         "comment": null,
                                                                                                         "items": [
@@ -1731,7 +1907,7 @@
                                                                                                                 "data": {
                                                                                                                     "type": "tricks",
                                                                                                                     "name": "Walljump",
-                                                                                                                    "amount": 2,
+                                                                                                                    "amount": 3,
                                                                                                                     "negate": false
                                                                                                                 }
                                                                                                             },
@@ -1739,8 +1915,8 @@
                                                                                                                 "type": "resource",
                                                                                                                 "data": {
                                                                                                                     "type": "tricks",
-                                                                                                                    "name": "MorphGlide",
-                                                                                                                    "amount": 1,
+                                                                                                                    "name": "MidAirMorph",
+                                                                                                                    "amount": 3,
                                                                                                                     "negate": false
                                                                                                                 }
                                                                                                             }
@@ -1754,169 +1930,27 @@
                                                                             }
                                                                         },
                                                                         {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "IBJ",
-                                                                                "amount": 3,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Space Jump",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": "Getting up to the tunnel",
-                                            "items": [
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": "Space Jump Climb",
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Space Jump",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "or",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Power Grip",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "MidAirMorph",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": "Shinespark Method",
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Speed Booster",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Shinesparking",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "or",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Power Grip",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
                                                                             "type": "and",
                                                                             "data": {
-                                                                                "comment": null,
+                                                                                "comment": "IBJ from mid-air or very close to the edge",
                                                                                 "items": [
                                                                                     {
                                                                                         "type": "resource",
                                                                                         "data": {
                                                                                             "type": "tricks",
-                                                                                            "name": "Walljump",
-                                                                                            "amount": 3,
+                                                                                            "name": "IBJ",
+                                                                                            "amount": 4,
                                                                                             "negate": false
                                                                                         }
                                                                                     },
                                                                                     {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "tricks",
-                                                                                            "name": "MidAirMorph",
-                                                                                            "amount": 3,
-                                                                                            "negate": false
-                                                                                        }
+                                                                                        "type": "template",
+                                                                                        "data": "Can Use Bombs"
                                                                                     }
                                                                                 ]
                                                                             }
                                                                         }
                                                                     ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can Use Spider Ball"
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": "IBJ from mid-air or very close to edge",
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Can Use Bombs"
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "IBJ",
-                                                                    "amount": 4,
-                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]
@@ -2115,6 +2149,15 @@
                                                                     "amount": 3,
                                                                     "negate": false
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 50,
+                                                                    "negate": false
+                                                                }
                                                             }
                                                         ]
                                                     }
@@ -2229,17 +2272,51 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Dock to Gamma Nest West Access": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "Movement",
-                                            "amount": 2,
-                                            "negate": false
+                                            "comment": "Spin Cancels",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Morph Glide",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "MorphGlide",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -2922,15 +2999,6 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Shinesparking",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
                                                                     "type": "misc",
                                                                     "name": "EntranceRando",
                                                                     "amount": 1,
@@ -2983,15 +3051,6 @@
                                                     "data": {
                                                         "type": "items",
                                                         "name": "Speed Booster",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Shinesparking",
                                                         "amount": 1,
                                                         "negate": false
                                                     }

--- a/randovania/games/am2r/json_data/The Tower.json
+++ b/randovania/games/am2r/json_data/The Tower.json
@@ -2075,35 +2075,77 @@
                             }
                         },
                         "Door to Tower Activation Station": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "MidAirMorph",
-                                            "amount": 3,
-                                            "negate": false
+                                            "comment": "Spin Cancels",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "DamageBoost",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "tricks",
-                                            "name": "Movement",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph Ball",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": "Morph Glide",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "MidAirMorph",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/am2r/json_data/The Tower.json
+++ b/randovania/games/am2r/json_data/The Tower.json
@@ -1245,7 +1245,7 @@
                         "Top": {
                             "type": "or",
                             "data": {
-                                "comment": null,
+                                "comment": "Climb from tower side (Editor Note: Revisit later for climb from rock wall)",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -1359,90 +1359,54 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Top": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "or",
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space Jump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Walljump",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Spider Ball"
+                                    },
+                                    {
+                                        "type": "and",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "and",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Can Use Any Bombs"
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "MidAirMorph",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
+                                                        "type": "items",
+                                                        "name": "Hi-Jump",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "misc",
-                                                        "name": "SoftlockPrevention",
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "or",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Space Jump",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Walljump",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can Use Spider Ball"
                                                 }
                                             ]
                                         }
@@ -1735,8 +1699,59 @@
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
-                                                                            "type": "template",
-                                                                            "data": "Can Use Spider Ball"
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Can Use Spider Ball"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "and",
+                                                                                        "data": {
+                                                                                            "comment": "Method to cross the gap to the rock wall",
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "items",
+                                                                                                        "name": "Hi-Jump",
+                                                                                                        "amount": 1,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "or",
+                                                                                                    "data": {
+                                                                                                        "comment": null,
+                                                                                                        "items": [
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "tricks",
+                                                                                                                    "name": "Walljump",
+                                                                                                                    "amount": 2,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "tricks",
+                                                                                                                    "name": "MorphGlide",
+                                                                                                                    "amount": 1,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
                                                                         },
                                                                         {
                                                                             "type": "resource",
@@ -1744,6 +1759,15 @@
                                                                                 "type": "tricks",
                                                                                 "name": "IBJ",
                                                                                 "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Space Jump",
+                                                                                "amount": 1,
                                                                                 "negate": false
                                                                             }
                                                                         }
@@ -1880,7 +1904,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "IBJ",
+                                                        "comment": "IBJ from mid-air or very close to edge",
                                                         "items": [
                                                             {
                                                                 "type": "template",
@@ -2171,26 +2195,8 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "MidAirMorph",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
                                             "name": "Movement",
                                             "amount": 2,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph Ball",
-                                            "amount": 1,
                                             "negate": false
                                         }
                                     }
@@ -2943,8 +2949,8 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Knowledge",
-                                                        "amount": 2,
+                                                        "name": "Shinesparking",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -8489,6 +8495,27 @@
                                             "name": "Hi-Jump",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "ChargedBombJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Charged Bomb Jump"
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/am2r/json_data/The Tower.json
+++ b/randovania/games/am2r/json_data/The Tower.json
@@ -1699,12 +1699,29 @@
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
-                                                                            "type": "resource",
+                                                                            "type": "and",
                                                                             "data": {
-                                                                                "type": "items",
-                                                                                "name": "Hi-Jump",
-                                                                                "amount": 1,
-                                                                                "negate": false
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Hi-Jump",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "MidAirMorph",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         },
                                                                         {
@@ -1726,15 +1743,6 @@
                                                                             }
                                                                         }
                                                                     ]
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "MidAirMorph",
-                                                                    "amount": 1,
-                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]

--- a/randovania/games/am2r/json_data/The Tower.txt
+++ b/randovania/games/am2r/json_data/The Tower.txt
@@ -126,7 +126,9 @@ Extra - map_name: rm_a4h02
   * Layers: default
   * Open Passage to Exterior Save Station/Dock to Tower Exterior North East
   > Dock to Tower Exterior North
-      Hi-Jump Boots and Power Grip and Walljump (Advanced)
+      All of the following:
+          # (TODO: Revisit later for climb from rock wall)
+          Hi-Jump Boots and Power Grip and Walljump (Advanced)
   > Tunnel to Inner Zeta Nest Access
       All of the following:
           Hi-Jump Boots
@@ -154,7 +156,7 @@ Extra - map_name: rm_a4h03
   * Open Passage to Tower Exterior North East/Dock to Tower Exterior North
   > Top
       Any of the following:
-          # Climb from tower side (Editor Note: Revisit later for climb from rock wall)
+          # Climb from tower side (TODO: Revisit later for climb from rock wall)
           Space Jump or Walljump (Intermediate) or Can Use Spider Ball
 
 > Dock to Tower Exterior West; Heals? False
@@ -216,34 +218,35 @@ Extra - map_name: rm_a4h03
       All of the following:
           Morph Ball
           Any of the following:
-              # Break the bomb blocks
-              Can Use Power Bombs
               All of the following:
-                  Can Use Bombs
+                  # Spider Method
+                  Mid-Air Morph (Beginner) and Can Use Any Bombs and Can Use Spider Ball
+                  Hi-Jump Boots or Morph Glide (Intermediate) or Disabled Entrance Rando
+              All of the following:
+                  # Non-Spider Methods
                   Any of the following:
-                      Space Jump or Infinite Bomb Jumping (Advanced)
+                      # Way to break the blocks
+                      Can Use Power Bombs
                       All of the following:
-                          Can Use Spider Ball
-                          All of the following:
-                              # Method to cross the gap to the rock wall
-                              Hi-Jump Boots
-                              Morph Glide (Beginner) or Walljump (Intermediate)
-          Any of the following:
-              # Getting up to the tunnel
-              Can Use Spider Ball
-              All of the following:
-                  # Space Jump Climb
-                  Space Jump
-                  Power Grip or Mid-Air Morph (Intermediate)
-              All of the following:
-                  # Shinespark Method
-                  Speed Booster and Shinesparking Tricks (Intermediate)
+                          Can Use Bombs
+                          Any of the following:
+                              Infinite Bomb Jumping (Advanced)
+                              Space Jump and Mid-Air Morph (Intermediate)
                   Any of the following:
-                      Power Grip
-                      Mid-Air Morph (Advanced) and Walljump (Advanced)
-              All of the following:
-                  # IBJ from mid-air or very close to edge
-                  Infinite Bomb Jumping (Expert) and Can Use Bombs
+                      # Ways to climb to the tunnel
+                      All of the following:
+                          # Space Jump Method
+                          Space Jump
+                          Power Grip or Mid-Air Morph (Intermediate)
+                      All of the following:
+                          # Shinespark Method
+                          Speed Booster and Shinesparking Tricks (Intermediate)
+                          Any of the following:
+                              Power Grip
+                              Mid-Air Morph (Advanced) and Walljump (Advanced)
+                      All of the following:
+                          # IBJ from mid-air or very close to the edge
+                          Infinite Bomb Jumping (Expert) and Can Use Bombs
 
 ----------------
 Tower Exterior West
@@ -271,7 +274,7 @@ Extra - map_name: rm_a4h04
           Any of the following:
               # Spin Cancels
               Movement (Expert)
-              Damage Boost (Advanced) and Movement (Advanced)
+              Damage Boost (Advanced) and Movement (Advanced) and Normal Damage ≥ 50
           All of the following:
               # Morph Glide
               Morph Ball and Mid-Air Morph (Intermediate)
@@ -290,7 +293,13 @@ Extra - map_name: rm_a4h04
   * Layers: default
   * Morph Ball Tunnel to Plasma Beam Chamber/Tunnel to Tower Exterior West
   > Dock to Gamma Nest West Access
-      Movement (Intermediate)
+      Any of the following:
+          All of the following:
+              # Spin Cancels
+              Movement (Intermediate)
+          All of the following:
+              # Morph Glide
+              Morph Ball and Morph Glide (Beginner)
   > Dock to Tower Exterior North
       Any of the following:
           Space Jump or Can Use Spider Ball
@@ -376,15 +385,13 @@ Extra - map_name: rm_a4h06
           Any of the following:
               Tunnel Climb
               Morph Ball and Mid-Air Morph (Intermediate)
-              Speed Booster and Shinesparking Tricks (Beginner) and Disabled Entrance Rando
+              Speed Booster and Disabled Entrance Rando
 
 > Event - Zeta; Heals? False
   * Layers: default
   * Event Metroids Area 4 - Right Zeta
   > Dock to Exterior Zeta Nest East Access
-      Any of the following:
-          High Mid-Air Morph Tunnel Climb
-          Speed Booster and Shinesparking Tricks (Beginner)
+      Speed Booster or High Mid-Air Morph Tunnel Climb
   > Pickup (Zeta)
       Trivial
 

--- a/randovania/games/am2r/json_data/The Tower.txt
+++ b/randovania/games/am2r/json_data/The Tower.txt
@@ -153,7 +153,9 @@ Extra - map_name: rm_a4h03
   * Layers: default
   * Open Passage to Tower Exterior North East/Dock to Tower Exterior North
   > Top
-      Space Jump or Walljump (Intermediate) or Can Use Spider Ball
+      Any of the following:
+          # Climb from tower side (Editor Note: Revisit later for climb from rock wall)
+          Space Jump or Walljump (Intermediate) or Can Use Spider Ball
 
 > Dock to Tower Exterior West; Heals? False
   * Layers: default
@@ -165,11 +167,9 @@ Extra - map_name: rm_a4h03
   * Layers: default
   * Open Passage to Dark Maze/Dock to Tower Exterior North (Left)
   > Top
-      All of the following:
-          Any of the following:
-              Enabled Softlock Prevention
-              Mid-Air Morph (Beginner) and Can Use Any Bombs
+      Any of the following:
           Space Jump or Walljump (Intermediate) or Can Use Spider Ball
+          Hi-Jump Boots and Walljump (Beginner)
 
 > Dock to Dark Maze (Right); Heals? False
   * Layers: default
@@ -220,7 +220,14 @@ Extra - map_name: rm_a4h03
               Can Use Power Bombs
               All of the following:
                   Can Use Bombs
-                  Infinite Bomb Jumping (Advanced) or Can Use Spider Ball
+                  Any of the following:
+                      Space Jump or Infinite Bomb Jumping (Advanced)
+                      All of the following:
+                          Can Use Spider Ball
+                          All of the following:
+                              # Method to cross the gap to the rock wall
+                              Hi-Jump Boots
+                              Morph Glide (Beginner) or Walljump (Intermediate)
           Any of the following:
               # Getting up to the tunnel
               Can Use Spider Ball
@@ -235,7 +242,7 @@ Extra - map_name: rm_a4h03
                       Power Grip
                       Mid-Air Morph (Advanced) and Walljump (Advanced)
               All of the following:
-                  # IBJ
+                  # IBJ from mid-air or very close to edge
                   Infinite Bomb Jumping (Expert) and Can Use Bombs
 
 ----------------
@@ -276,7 +283,7 @@ Extra - map_name: rm_a4h04
   * Layers: default
   * Morph Ball Tunnel to Plasma Beam Chamber/Tunnel to Tower Exterior West
   > Dock to Gamma Nest West Access
-      Morph Ball and Mid-Air Morph (Intermediate) and Movement (Intermediate)
+      Movement (Intermediate)
   > Dock to Tower Exterior North
       Any of the following:
           Space Jump or Can Use Spider Ball
@@ -370,7 +377,7 @@ Extra - map_name: rm_a4h06
   > Dock to Exterior Zeta Nest East Access
       Any of the following:
           High Mid-Air Morph Tunnel Climb
-          Speed Booster and Knowledge (Intermediate)
+          Speed Booster and Shinesparking Tricks (Beginner)
   > Pickup (Zeta)
       Trivial
 
@@ -1164,7 +1171,9 @@ Extra - map_name: rm_a4a13
 > Left Bottom; Heals? False
   * Layers: default
   > Dock to Tower Exterior North (Left)
-      Hi-Jump Boots or Space Jump or Walljump (Intermediate) or Can Use Spider Ball
+      Any of the following:
+          Hi-Jump Boots or Space Jump or Walljump (Intermediate) or Can Use Spider Ball
+          Charged Bomb Jump (Beginner) and Can Use Charged Bomb Jump
   > Top Middle
       Morph Ball and Can Use Any Bombs and High Mid-Air Morph Tunnel Climb and Tunnel Climb
 

--- a/randovania/games/am2r/json_data/The Tower.txt
+++ b/randovania/games/am2r/json_data/The Tower.txt
@@ -153,19 +153,23 @@ Extra - map_name: rm_a4h03
   * Layers: default
   * Open Passage to Tower Exterior North East/Dock to Tower Exterior North
   > Top
-      Trivial
+      Space Jump or Walljump (Intermediate) or Can Use Spider Ball
 
 > Dock to Tower Exterior West; Heals? False
   * Layers: default
   * Open Passage to Tower Exterior West/Dock to Tower Exterior North
   > Top
-      Trivial
+      Space Jump or Walljump (Intermediate) or Can Use Spider Ball
 
 > Dock to Dark Maze (Left); Heals? False
   * Layers: default
   * Open Passage to Dark Maze/Dock to Tower Exterior North (Left)
   > Top
-      Trivial
+      All of the following:
+          Any of the following:
+              Enabled Softlock Prevention
+              Mid-Air Morph (Beginner) and Can Use Any Bombs
+          Space Jump or Walljump (Intermediate) or Can Use Spider Ball
 
 > Dock to Dark Maze (Right); Heals? False
   * Layers: default
@@ -211,20 +215,28 @@ Extra - map_name: rm_a4h03
   > Pickup (Missile Tank)
       All of the following:
           Morph Ball
-          Power Grip or Mid-Air Morph (Intermediate) or Can Use Spider Ball
           Any of the following:
+              # Break the bomb blocks
               Can Use Power Bombs
               All of the following:
                   Can Use Bombs
-                  Infinite Bomb Jumping (Intermediate) or Can Use Spider Ball
+                  Infinite Bomb Jumping (Advanced) or Can Use Spider Ball
           Any of the following:
-              Space Jump or Walljump (Advanced)
-              Speed Booster and Shinesparking Tricks (Beginner)
+              # Getting up to the tunnel
+              Can Use Spider Ball
               All of the following:
-                  Hi-Jump Boots
+                  # Space Jump Climb
+                  Space Jump
+                  Power Grip or Mid-Air Morph (Intermediate)
+              All of the following:
+                  # Shinespark Method
+                  Speed Booster and Shinesparking Tricks (Intermediate)
                   Any of the following:
-                      Mid-Air Morph (Intermediate) or Walljump (Intermediate)
-                      Power Grip and Movement (Advanced)
+                      Power Grip
+                      Mid-Air Morph (Advanced) and Walljump (Advanced)
+              All of the following:
+                  # IBJ
+                  Infinite Bomb Jumping (Expert) and Can Use Bombs
 
 ----------------
 Tower Exterior West
@@ -248,7 +260,7 @@ Extra - map_name: rm_a4h04
   > Dock to Exterior Zeta Nest West Access
       Trivial
   > Door to Tower Activation Station
-      Mid-Air Morph (Advanced) and Movement (Intermediate)
+      Morph Ball and Mid-Air Morph (Advanced) and Movement (Intermediate)
   > Door to Inner Save Station West Access
       Trivial
 
@@ -264,7 +276,7 @@ Extra - map_name: rm_a4h04
   * Layers: default
   * Morph Ball Tunnel to Plasma Beam Chamber/Tunnel to Tower Exterior West
   > Dock to Gamma Nest West Access
-      Mid-Air Morph (Intermediate) and Movement (Intermediate)
+      Morph Ball and Mid-Air Morph (Intermediate) and Movement (Intermediate)
   > Dock to Tower Exterior North
       Any of the following:
           Space Jump or Can Use Spider Ball
@@ -323,7 +335,7 @@ Extra - map_name: rm_a4h05
   > Dock to Tower Exterior South East
       Any of the following:
           Space Jump
-          Hi-Jump Boots and Mid-Air Morph (Intermediate)
+          Hi-Jump Boots and Morph Glide (Intermediate)
           Damage Boost (Beginner) and Normal Damage ≥ 25
           Diagonal Infinite Bomb Jumping (Intermediate) and Can Use Bombs
           Speed Booster and Shinesparking Tricks (Intermediate)
@@ -335,7 +347,7 @@ Extra - map_name: rm_a4h05
       Any of the following:
           Space Jump or Can Use Spider Ball
           Damage Boost (Beginner) and Normal Damage ≥ 50
-          Hi-Jump Boots and Mid-Air Morph (Advanced)
+          Hi-Jump Boots and Morph Glide (Advanced)
           Diagonal Infinite Bomb Jumping (Intermediate) and Can Use Bombs
 
 ----------------
@@ -350,6 +362,7 @@ Extra - map_name: rm_a4h06
           Any of the following:
               Tunnel Climb
               Morph Ball and Mid-Air Morph (Intermediate)
+              Speed Booster and Shinesparking Tricks (Beginner) and Disabled Entrance Rando
 
 > Event - Zeta; Heals? False
   * Layers: default
@@ -1060,14 +1073,9 @@ Extra - map_name: rm_a4a11
   * Layers: default
   > Dock to Inner Zeta Nest
       Any of the following:
-          Can Use Spider Ball
-          All of the following:
-              Power Grip or Mid-Air Morph (Intermediate)
-              Any of the following:
-                  Space Jump
-                  All of the following:
-                      Speed Booster and Shinesparking Tricks (Beginner)
-                      Power Grip or Can Use Spring Ball
+          Space Jump or Walljump (Intermediate) or Can Use Spider Ball
+          Hi-Jump Boots and Walljump (Beginner)
+          Speed Booster and Shinesparking Tricks (Beginner)
   > Tunnel to Tower Exterior North East
       Any of the following:
           Morph Ball and Power Grip Wall
@@ -1080,7 +1088,19 @@ Extra - map_name: rm_a4a12
   * Layers: default
   * Open Passage to Inner Zeta Nest Access/Dock to Inner Zeta Nest
   > Event - Zeta
-      Can Use Any Bombs and Defeat Zeta
+      All of the following:
+          Can Use Any Bombs and Defeat Zeta
+          Any of the following:
+              # Get into Tunnel
+              Can Use Spider Ball
+              All of the following:
+                  Speed Booster and Shinesparking Tricks (Beginner) and Disabled Entrance Rando
+                  Power Grip or Spring Ball
+              All of the following:
+                  Power Grip or Mid-Air Morph (Intermediate)
+                  Any of the following:
+                      Space Jump or Walljump (Intermediate)
+                      Hi-Jump Boots and Walljump (Beginner)
 
 > Event - Zeta; Heals? False
   * Layers: default
@@ -1144,7 +1164,7 @@ Extra - map_name: rm_a4a13
 > Left Bottom; Heals? False
   * Layers: default
   > Dock to Tower Exterior North (Left)
-      Space Jump or Walljump (Intermediate) or Can Use Spider Ball
+      Hi-Jump Boots or Space Jump or Walljump (Intermediate) or Can Use Spider Ball
   > Top Middle
       Morph Ball and Can Use Any Bombs and High Mid-Air Morph Tunnel Climb and Tunnel Climb
 
@@ -1171,7 +1191,9 @@ Extra - map_name: rm_a4b01
   * Normal Door to Tower Exterior West/Door to Power Plant Entrance
   * Extra - instance_id: 129395
   > Dock to Power Plant Destroyed Shaft
-      Low Mid-Air Morph Tunnel Climb
+      Any of the following:
+          Tunnel Climb
+          Morph Ball and Mid-Air Morph (Beginner)
 
 > Dock to Power Plant Destroyed Shaft; Heals? False
   * Layers: default

--- a/randovania/games/am2r/json_data/The Tower.txt
+++ b/randovania/games/am2r/json_data/The Tower.txt
@@ -267,7 +267,14 @@ Extra - map_name: rm_a4h04
   > Dock to Exterior Zeta Nest West Access
       Trivial
   > Door to Tower Activation Station
-      Morph Ball and Mid-Air Morph (Advanced) and Movement (Intermediate)
+      Any of the following:
+          Any of the following:
+              # Spin Cancels
+              Movement (Expert)
+              Damage Boost (Advanced) and Movement (Advanced)
+          All of the following:
+              # Morph Glide
+              Morph Ball and Mid-Air Morph (Intermediate)
   > Door to Inner Save Station West Access
       Trivial
 

--- a/randovania/games/am2r/json_data/The Tower.txt
+++ b/randovania/games/am2r/json_data/The Tower.txt
@@ -220,8 +220,10 @@ Extra - map_name: rm_a4h03
           Any of the following:
               All of the following:
                   # Spider Method
-                  Mid-Air Morph (Beginner) and Can Use Any Bombs and Can Use Spider Ball
-                  Hi-Jump Boots or Morph Glide (Intermediate) or Disabled Entrance Rando
+                  Can Use Any Bombs and Can Use Spider Ball
+                  Any of the following:
+                      Morph Glide (Intermediate) or Disabled Entrance Rando
+                      Hi-Jump Boots and Mid-Air Morph (Beginner)
               All of the following:
                   # Non-Spider Methods
                   Any of the following:


### PR DESCRIPTION
- Dark Maze
	- Added: Escape from Left Bottom now has High Jump option
- Ext. Zeta Nest East
	- Added: Speedboost method from access to enter the arena
	- Changed: Speedboost escape from knowledge to shinespark trick??????
- Ext. Zeta Nest East Access
	- Changed: HJ method from mid-air morph to morph glide
- Inner Zeta Nest Access
	- Removed: Moved tunnel climbing requirements to Inner Zeta Nest
- Inner Zeta Nest
	- Added: Tunnel climbing requirements
- Power Plant Entrance
	- Changed: Now uses tunnel climb or lower difficulty mid-air morph
- Tower Ext. N
	- Added: Dark Maze (left) escape requirements
	- Changed: Reworked requirements to reach top missile
	- Added: Requirements from exterior lower sides to top climb
- Tower Ext. W
	- Fixed: Missing morph requirement for morph glides