### PR TITLE
Add AM2R credits in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ New here or looking to install? Check [our website](https://randovania.github.io
 <!-- Begin EXPERIMENTAL -->
 
 ### Experimental Games
+ - Another Metroid 2 Remake
  - Metroid Prime 3: Corruption
  - Metroid: Samus Returns
  - Super Metroid
@@ -160,9 +161,27 @@ Linux Flatpak build contributed by [Ethan Lee](https://flibitijibibo.com/).
   * Spider Magnet pickup texture by duncathan_salt with help from BigSharkZ.
   * New map icons by [SkyTheLucario](https://github.com/TheSkyknight100).
 
+### Another Metroid 2 Remake
+* Game Patching by:
+  * [Miepee](https://github.com/Miepee)
+  * [JesRight](https://github.com/Jesright73)
+  
+* Logic Database by:
+  * [Miepee](https://github.com/Miepee)
+  * [DruidVorse](https://www.youtube.com/@DruidVorse)
+  * [JeffGainsNGames](https://www.youtube.com/@jeffgainsngames)
+
+* Assets by:
+  * Morph Ball, and the Missile Launcher sprites were made by ShirtyScarab554 licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+  * Power Grip and the Shiny Nothing Orb were made by ShirtyScarab554, used under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/), modified by [AbyssalCreature](https://github.com/AbyssalCreature) and licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+  * New door sprites and other AM2R item sprites were made by [AbyssalCreature](https://github.com/AbyssalCreature) licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+  
 ## Auto Tracker
 * Game theme assets were provided by [MaskedTAS](https://twitter.com/MaskedTAS).
 * Pixel theme assets were provided by [Uncle Reggie](https://www.twitch.tv/unclereggie).
+* AM2R 1.5.5 item sprites were made by [Eskimode7](https://twitter.com/shmegleskimo) licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+* The AM2R DNA sprite was made by [AbyssalCreature](https://github.com/AbyssalCreature) licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+* The AM2R Morph Ball and Power Grip sprites were made by ShirtyScarab554 licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
 
 ## Multiworld
 Server and logic written by Henrique, including Dolphin and Nintendont integrations. These were based on [Dolphin Memory Engine](https://github.com/aldelaro5/Dolphin-memory-engine) and Pwootage's Nintendont fork, respectively. In-game message alert initially written by [encounter](https://github.com/encounter).


### PR DESCRIPTION
See title.
orange indicates new stuff in the *autotracker* section.
![grafik](https://github.com/randovania/randovania/assets/38186597/ee355ce7-3210-476e-a0cc-7a9984702603)
