### PR TITLE
AM2R: Add pipe rando

### DIFF
--- a/randovania/games/am2r/generator/base_patches_factory.py
+++ b/randovania/games/am2r/generator/base_patches_factory.py
@@ -1,7 +1,23 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from randovania.generator.base_patches_factory import BasePatchesFactory
+from randovania.generator.elevator_distributor import get_dock_connections_for_elevators
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from random import Random
+
+    from randovania.game_description.db.dock_node import DockNode
+    from randovania.game_description.db.node import Node
+    from randovania.game_description.game_description import GameDescription
+    from randovania.games.am2r.layout.am2r_configuration import AM2RConfiguration
 
 
 class AM2RBasePatchesFactory(BasePatchesFactory):
-    pass
+
+    def dock_connections_assignment(self, configuration: AM2RConfiguration,
+                                game: GameDescription, rng: Random ) -> Iterable[tuple[DockNode, Node]]:
+        dock_assignment = get_dock_connections_for_elevators(configuration, game, rng)
+        yield from dock_assignment

--- a/randovania/games/am2r/gui/preset_settings/__init__.py
+++ b/randovania/games/am2r/gui/preset_settings/__init__.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 
 def preset_tabs(editor: PresetEditor, window_manager: WindowManager):
+    from randovania.games.am2r.gui.preset_settings.am2r_elevators_tab import PresetElevatorsAM2R
     from randovania.games.am2r.gui.preset_settings.am2r_goal_tab import PresetAM2RGoal
     from randovania.games.am2r.gui.preset_settings.am2r_hints_tab import PresetAM2RHints
     from randovania.games.am2r.gui.preset_settings.am2r_patches_tab import PresetAM2RPatches
@@ -30,6 +31,6 @@ def preset_tabs(editor: PresetEditor, window_manager: WindowManager):
         PresetPatcherEnergy,
         PresetMetroidStartingArea,
         PresetDockRando,
-        # TODO: add elevator rando. at one point:tm:
+        PresetElevatorsAM2R,
         PresetAM2RPatches
     ]

--- a/randovania/games/am2r/gui/preset_settings/am2r_elevators_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_elevators_tab.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import copy
+import dataclasses
+from typing import TYPE_CHECKING
+
+from PySide6 import QtCore, QtWidgets
+
+from randovania.game_description.db.dock_node import DockNode
+from randovania.gui.generated.preset_elevators_am2r_ui import Ui_PresetElevatorsAM2R
+from randovania.gui.lib import signal_handling
+from randovania.gui.lib.node_list_helper import NodeListHelper
+from randovania.gui.preset_settings.preset_tab import PresetTab
+from randovania.layout.lib.teleporters import (
+    TeleporterConfiguration,
+    TeleporterList,
+    TeleporterShuffleMode,
+    TeleporterTargetList,
+)
+from randovania.patching.prime import elevators
+
+if TYPE_CHECKING:
+    from randovania.game_description.db.area import Area
+    from randovania.game_description.db.area_identifier import AreaIdentifier
+    from randovania.game_description.db.node_identifier import NodeIdentifier
+    from randovania.game_description.game_description import GameDescription
+    from randovania.gui.lib.window_manager import WindowManager
+    from randovania.interface_common.preset_editor import PresetEditor
+    from randovania.layout.preset import Preset
+
+
+class PresetElevatorsAM2R(PresetTab, Ui_PresetElevatorsAM2R, NodeListHelper):
+    _elevator_source_for_location: dict[NodeIdentifier, QtWidgets.QCheckBox]
+    _elevator_source_destination: dict[NodeIdentifier, NodeIdentifier | None]
+    _elevator_target_for_region: dict[str, QtWidgets.QCheckBox]
+    _elevator_target_for_area: dict[AreaIdentifier, QtWidgets.QCheckBox]
+    _elevator_target_for_node: dict[NodeIdentifier, QtWidgets.QCheckBox]
+    custom_weights = {}
+    compatible_modes = [
+        TeleporterShuffleMode.VANILLA,
+        TeleporterShuffleMode.TWO_WAY_RANDOMIZED,
+        TeleporterShuffleMode.TWO_WAY_UNCHECKED,
+        TeleporterShuffleMode.ONE_WAY_ELEVATOR,
+        TeleporterShuffleMode.ONE_WAY_ELEVATOR_REPLACEMENT,
+    ]
+
+    def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
+        super().__init__(editor, game_description, window_manager)
+        self.setupUi(self)
+
+        self.elevator_layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
+        self.teleporter_types = game_description.dock_weakness_database.all_teleporter_dock_types
+
+        descriptions = ["<p>Controls where each elevator connects to.</p>"]
+        for value in self.compatible_modes:
+            self.elevators_combo.addItem(value.long_name, value)
+            descriptions.append(
+                f'<p><span style="font-weight:600;">{value.long_name}</span>: {value.description}</p>'
+            )
+
+        self.elevators_description_label.setText("".join(descriptions))
+
+        self.elevators_combo.currentIndexChanged.connect(self._update_elevator_mode)
+
+        # Elevator Source
+        self._create_source_elevators()
+
+        # Elevator Target
+        result = self.create_node_list_selection(
+            self.elevators_target_group,
+            self.elevators_target_layout,
+            TeleporterTargetList.nodes_list(self.game_enum),
+            self._on_elevator_target_check_changed,
+        )
+        self._elevator_target_for_region, self._elevator_target_for_area, self._elevator_target_for_node = result
+
+    @classmethod
+    def tab_title(cls) -> str:
+        return "Teleporter Pipes"
+
+    @classmethod
+    def uses_patches_tab(cls) -> bool:
+        return True
+
+    @property
+    def game_enum(self):
+        return self.game_description.game
+
+    def _create_check_for_source_elevator(self, location: NodeIdentifier):
+        name = elevators.get_elevator_or_area_name(self.game_enum, self.game_description.region_list,
+                                                   location.area_location, True)
+
+        check = QtWidgets.QCheckBox(self.elevators_source_group)
+        check.setText(name)
+        check.area_location = location
+        signal_handling.on_checked(check, self._on_elevator_source_check_changed)
+        return check
+
+    def _create_source_elevators(self):
+        row = 0
+        region_list = self.game_description.region_list
+
+        locations = TeleporterList.nodes_list(self.game_enum)
+        node_identifiers: dict[NodeIdentifier, Area] = {
+            loc: region_list.area_by_area_location(loc.area_location)
+            for loc in locations
+        }
+        checks: dict[NodeIdentifier, QtWidgets.QCheckBox] = {
+            loc: self._create_check_for_source_elevator(loc) for loc in locations
+        }
+        self._elevator_source_for_location = copy.copy(checks)
+        self._elevator_source_destination = {}
+
+        for location in sorted(locations,
+                               key=lambda loc: (self.custom_weights.get(loc.area_location.region_name, 0),
+                                                checks[loc].text())):
+            if location not in checks:
+                continue
+
+            self.elevators_source_layout.addWidget(checks.pop(location), row, 1)
+
+            other_locations = [
+                node.default_connection
+                for node in node_identifiers[location].nodes
+                if isinstance(node, DockNode) and node.dock_type in self.teleporter_types
+                and region_list.identifier_for_node(node) == location
+            ]
+            assert len(other_locations) == 1
+            teleporters_in_target = [
+                region_list.identifier_for_node(node)
+                for node in region_list.area_by_area_location(other_locations[0]).nodes
+                if isinstance(node, DockNode) and node.dock_type in self.teleporter_types
+            ]
+
+            self._elevator_source_destination[location] = None
+
+            if teleporters_in_target:
+                other_loc = teleporters_in_target[0]
+
+                if other_loc in checks:
+                    self.elevators_source_layout.addWidget(checks.pop(other_loc), row, 2)
+                    self._elevator_source_destination[location] = other_loc
+
+            row += 1
+
+    def _update_elevator_mode(self):
+        with self._editor as editor:
+            editor.layout_configuration_elevators = dataclasses.replace(
+                editor.layout_configuration_elevators,
+                mode=self.elevators_combo.currentData(),
+            )
+
+    def _update_require_final_bosses(self, checked: bool):
+        with self._editor as editor:
+            editor.layout_configuration_elevators = dataclasses.replace(
+                editor.layout_configuration_elevators,
+                skip_final_bosses=checked,
+            )
+
+    def _update_allow_unvisited_names(self, checked: bool):
+        with self._editor as editor:
+            editor.layout_configuration_elevators = dataclasses.replace(
+                editor.layout_configuration_elevators,
+                allow_unvisited_room_names=checked,
+            )
+
+    def _on_elevator_source_check_changed(self, checked: bool):
+        with self._editor as editor:
+            config = editor.layout_configuration_elevators
+            editor.layout_configuration_elevators = dataclasses.replace(
+                config,
+                excluded_teleporters=TeleporterList.with_elements([
+                    location
+                    for location, check in self._elevator_source_for_location.items()
+                    if not check.isChecked()
+
+                ], self.game_enum)
+            )
+
+    def _on_elevator_target_check_changed(self, areas: list[NodeIdentifier], checked: bool):
+        with self._editor as editor:
+            config = editor.layout_configuration_elevators
+            editor.layout_configuration_elevators = dataclasses.replace(
+                config,
+                excluded_targets=config.excluded_targets.ensure_has_locations(areas, not checked),
+            )
+
+    def on_preset_changed(self, preset: Preset):
+        config = preset.configuration
+        config_elevators: TeleporterConfiguration = config.elevators
+
+        descriptions = [
+            "<p>Controls where each elevator connects to.</p>",
+            f'<p><span style="font-weight:600;">{config_elevators.mode.long_name}</span>:'
+            f' {config_elevators.mode.description}</p>',
+        ]
+        self.elevators_description_label.setText("".join(descriptions))
+
+        signal_handling.set_combo_with_value(self.elevators_combo, config_elevators.mode)
+        can_shuffle_source = config_elevators.mode not in (TeleporterShuffleMode.VANILLA,
+                                                           TeleporterShuffleMode.ECHOES_SHUFFLED)
+        can_shuffle_target = config_elevators.mode not in (TeleporterShuffleMode.VANILLA,
+                                                           TeleporterShuffleMode.ECHOES_SHUFFLED,
+                                                           TeleporterShuffleMode.TWO_WAY_RANDOMIZED,
+                                                           TeleporterShuffleMode.TWO_WAY_UNCHECKED)
+        static_nodes = set(config_elevators.static_teleporters.keys())
+
+        for origin, destination in self._elevator_source_destination.items():
+            origin_check = self._elevator_source_for_location[origin]
+            dest_check = self._elevator_source_for_location.get(destination)
+
+            assert origin_check or dest_check
+
+            is_locked = origin in static_nodes
+            if not is_locked and not can_shuffle_target:
+                is_locked = (destination in static_nodes) or (origin_check and not dest_check)
+
+            origin_check.setEnabled(can_shuffle_source and not is_locked)
+            origin_check.setChecked(origin not in config_elevators.excluded_teleporters.locations and not is_locked)
+
+            origin_check.setToolTip("The destination for this teleporter is locked due to other settings."
+                                    if is_locked else "")
+
+            if dest_check is None:
+                if not can_shuffle_target:
+                    origin_check.setEnabled(False)
+                continue
+
+            dest_check.setEnabled(can_shuffle_target and destination not in static_nodes)
+            if can_shuffle_target:
+                dest_check.setChecked(destination not in config_elevators.excluded_teleporters.locations
+                                      and destination not in static_nodes)
+            else:
+                dest_check.setChecked(origin_check.isChecked())
+
+        self.elevators_source_group.setVisible(can_shuffle_source)
+        self.elevators_target_group.setVisible(config_elevators.has_shuffled_target)
+        self.elevators_target_group.setEnabled(config_elevators.has_shuffled_target)
+        self.update_node_list(
+            config_elevators.excluded_targets.locations,
+            True,
+            self._elevator_target_for_region,
+            self._elevator_target_for_area,
+            self._elevator_target_for_node
+        )

--- a/randovania/games/am2r/layout/am2r_configuration.py
+++ b/randovania/games/am2r/layout/am2r_configuration.py
@@ -4,6 +4,7 @@ import dataclasses
 
 from randovania.bitpacking.bitpacking import BitPackDataclass
 from randovania.bitpacking.json_dataclass import JsonDataclass
+from randovania.games.am2r.layout.am2r_teleporters import AM2RTeleporterConfiguration
 from randovania.games.am2r.layout.hint_configuration import HintConfiguration
 from randovania.games.game import RandovaniaGame
 from randovania.layout.base.base_configuration import BaseConfiguration
@@ -18,6 +19,7 @@ class AM2RArtifactConfig(BitPackDataclass, JsonDataclass):
 
 @dataclasses.dataclass(frozen=True)
 class AM2RConfiguration(BaseConfiguration):
+    elevators: AM2RTeleporterConfiguration
     energy_per_tank: int = dataclasses.field(metadata={"min": 1, "max": 1000, "precision": 1})
     softlock_prevention_blocks: bool
     septogg_helpers: bool

--- a/randovania/games/am2r/layout/am2r_teleporters.py
+++ b/randovania/games/am2r/layout/am2r_teleporters.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+from randovania.game_description import default_database
+from randovania.game_description.db.dock_node import DockNode
+from randovania.layout.lib.teleporters import TeleporterConfiguration, TeleporterShuffleMode
+
+if TYPE_CHECKING:
+    from randovania.game_description.db.node_identifier import NodeIdentifier
+    pass
+
+@dataclasses.dataclass(frozen=True)
+class AM2RTeleporterConfiguration(TeleporterConfiguration):
+    # AM2R has only save stations as start nodes in the db. Elevators are no start nodes but
+    # are valid targets and also the only valid targets. Preset settings makes sure
+    # that nothing else is selected
+    @property
+    def valid_targets(self) -> list[NodeIdentifier]:
+        if self.mode in {TeleporterShuffleMode.ONE_WAY_ELEVATOR, TeleporterShuffleMode.ONE_WAY_ELEVATOR_REPLACEMENT}:
+            game_description = default_database.game_description_for(self.game)
+            teleporter_dock_types = game_description.dock_weakness_database.all_teleporter_dock_types
+            region_list = game_description.region_list
+
+            result = []
+            for identifier in self.editable_teleporters:
+                node = region_list.node_by_identifier(identifier)
+                if isinstance(node, DockNode) and node.dock_type in teleporter_dock_types:
+                    result.append(identifier)
+            return result
+        else:
+            return []

--- a/randovania/games/am2r/presets/starter_preset.rdvpreset
+++ b/randovania/games/am2r/presets/starter_preset.rdvpreset
@@ -162,6 +162,11 @@
         "skip_item_cutscenes": false,
         "respawn_bomb_blocks": false,
         "screw_blocks": true,
+        "elevators": {
+            "mode": "vanilla",
+            "excluded_teleporters": [],
+            "excluded_targets": []
+        },
         "artifacts": {
             "prefer_metroids": true,
             "prefer_bosses": false,

--- a/randovania/gui/ui_files/preset_elevators_am2r.ui
+++ b/randovania/gui/ui_files/preset_elevators_am2r.ui
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PresetElevatorsAM2R</class>
+ <widget class="QMainWindow" name="PresetElevatorsAM2R">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>505</width>
+    <height>463</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Elevators</string>
+  </property>
+  <widget class="QWidget" name="centralWidget">
+   <property name="maximumSize">
+    <size>
+     <width>16777215</width>
+     <height>16777215</height>
+    </size>
+   </property>
+   <layout class="QVBoxLayout" name="elevator_parent_layout">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <widget class="QScrollArea" name="elevator_scroll_area">
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <widget class="QWidget" name="elevator_scroll_area_contents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>501</width>
+         <height>459</height>
+        </rect>
+       </property>
+       <layout class="QVBoxLayout" name="elevator_layout">
+        <property name="leftMargin">
+         <number>4</number>
+        </property>
+        <property name="topMargin">
+         <number>6</number>
+        </property>
+        <property name="rightMargin">
+         <number>4</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="ScrollProtectedComboBox" name="elevators_combo"/>
+        </item>
+        <item>
+         <widget class="QLabel" name="elevators_description_label">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;lt;description generated dynamically&amp;gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="scaledContents">
+           <bool>true</bool>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Line" name="elevators_line_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="elevators_source_group">
+          <property name="title">
+           <string>Elevators to randomize</string>
+          </property>
+          <layout class="QGridLayout" name="elevators_source_layout">
+           <property name="leftMargin">
+            <number>1</number>
+           </property>
+           <property name="topMargin">
+            <number>1</number>
+           </property>
+           <property name="rightMargin">
+            <number>1</number>
+           </property>
+           <property name="bottomMargin">
+            <number>1</number>
+           </property>
+           <property name="spacing">
+            <number>3</number>
+           </property>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="elevators_target_group">
+          <property name="title">
+           <string>Valid elevator targets</string>
+          </property>
+          <layout class="QGridLayout" name="elevators_target_layout">
+           <property name="leftMargin">
+            <number>1</number>
+           </property>
+           <property name="topMargin">
+            <number>1</number>
+           </property>
+           <property name="rightMargin">
+            <number>1</number>
+           </property>
+           <property name="bottomMargin">
+            <number>1</number>
+           </property>
+           <property name="spacing">
+            <number>3</number>
+           </property>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>ScrollProtectedComboBox</class>
+   <extends>QComboBox</extends>
+   <header>randovania/gui/lib/scroll_protected.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/test/test_files/log_files/am2r/door_lock.rdvgame
+++ b/test/test_files/log_files/am2r/door_lock.rdvgame
@@ -170,6 +170,11 @@
                     "skip_item_cutscenes": false,
                     "respawn_bomb_blocks": false,
                     "screw_blocks": false,
+                    "elevators": {
+                        "mode": "vanilla",
+                        "excluded_teleporters": [],
+                        "excluded_targets": []
+                    },
                     "artifacts": {
                         "prefer_metroids": true,
                         "prefer_bosses": false,

--- a/test/test_files/log_files/am2r/starter_preset.rdvgame
+++ b/test/test_files/log_files/am2r/starter_preset.rdvgame
@@ -171,6 +171,11 @@
                     "skip_item_cutscenes": false,
                     "respawn_bomb_blocks": false,
                     "screw_blocks": false,
+                    "elevators": {
+                        "mode": "vanilla",
+                        "excluded_teleporters": [],
+                        "excluded_targets": []
+                    },
                     "artifacts": {
                         "prefer_metroids": true,
                         "prefer_bosses": false,

--- a/test/test_files/patcher_data/am2r/door_lock.json
+++ b/test/test_files/patcher_data/am2r/door_lock.json
@@ -10083,6 +10083,7 @@
             ]
         }
     },
+    "pipes": {},
     "game_patches": {
         "septogg_helpers": true,
         "respawn_bomb_blocks": false,

--- a/test/test_files/patcher_data/am2r/starter_preset.json
+++ b/test/test_files/patcher_data/am2r/starter_preset.json
@@ -10083,6 +10083,7 @@
             ]
         }
     },
+    "pipes": {},
     "game_patches": {
         "septogg_helpers": true,
         "respawn_bomb_blocks": false,


### PR DESCRIPTION
Adds teleporter pipe rando to am2r.
Needs #5036 to get merged first 

Also note that this has some buggyness due to elevator rando still being primarily designed for primes. most notably, doesnt take into account the pipes that only exist on a certain setting, as well as the lower pipes from Distribution Facility Tower East causing generation to fail.