### PR TITLE
Bump am2r-yams to 0.0.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ aiohttp==3.8.5
     #   randovania (setup.py)
 aiosignal==1.3.1
     # via aiohttp
-am2r-yams==0.0.12
+am2r-yams==0.0.13
     # via randovania (setup.py)
 appdirs==1.4.4
     # via randovania (setup.py)


### PR DESCRIPTION
Opening this instead of letting dependabot do it, just so I can announce the relation between current open am2r PRs.  
These PRs rely on the new version:
- #5066 
- #5065
- #5059

---
- #5039 has no effect on this.  
- #5037 can be merged, and has functionality here, but will have some slight bugs on both the RDV side, and game side
- #5025 is not implemented at all here.

