### PR TITLE
AM2R: Energy Distribution Logic

### DIFF
--- a/randovania/games/am2r/json_data/Distribution Center.json
+++ b/randovania/games/am2r/json_data/Distribution Center.json
@@ -3672,7 +3672,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": "Climb room to pipe",
+                                            "comment": "Get to upper platform in front of pipe",
                                             "items": [
                                                 {
                                                     "type": "template",
@@ -3729,22 +3729,39 @@
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
                                             "comment": "Get into Pipe",
                                             "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "MidAirMorph",
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Power Grip Wall"
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "MidAirMorph",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Power Grip Wall"
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }

--- a/randovania/games/am2r/json_data/Distribution Center.json
+++ b/randovania/games/am2r/json_data/Distribution Center.json
@@ -1427,7 +1427,7 @@
                         "Door to Energy Distribution Activation Shaft": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "TODO: Add combat logic",
                                 "items": [
                                     {
                                         "type": "template",
@@ -1507,12 +1507,29 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "misc",
-                                                        "name": "EntranceRando",
-                                                        "amount": 1,
-                                                        "negate": true
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "DoorLockRando",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "EntranceRando",
+                                                                    "amount": 1,
+                                                                    "negate": true
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -2298,12 +2315,29 @@
                                                     "data": "Can Use Power Bombs"
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Missiles",
-                                                        "amount": 10,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Missiles",
+                                                                    "amount": 10,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Super Missiles",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -2512,12 +2546,29 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "or",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Walljump",
-                                                                    "amount": 2,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Hi-Jump",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Walljump",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -2779,7 +2830,7 @@
                                                                 "data": {
                                                                     "type": "damage",
                                                                     "name": "Damage",
-                                                                    "amount": 25,
+                                                                    "amount": 51,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -2886,7 +2937,7 @@
                                                                 "data": {
                                                                     "type": "damage",
                                                                     "name": "Damage",
-                                                                    "amount": 25,
+                                                                    "amount": 51,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -3647,6 +3698,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "Septogg",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -3948,53 +4008,6 @@
                                             "name": "Morph Ball",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Pipe to The Tower": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "Septogg",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Hijump Wall"
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed Booster",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Shinesparking",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/am2r/json_data/Distribution Center.json
+++ b/randovania/games/am2r/json_data/Distribution Center.json
@@ -3665,47 +3665,88 @@
                             }
                         },
                         "Pipe to The Tower": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Hijump With Power Grip Wall"
-                                    },
-                                    {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Climb room to pipe",
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "template",
+                                                    "data": "Hijump With Power Grip Wall"
+                                                },
+                                                {
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Speed Booster",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Speed Booster",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Shinesparking",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Shinesparking",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "Septogg",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Power Grip Wall"
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "misc",
-                                            "name": "Septogg",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": "Get into Pipe",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "MidAirMorph",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Power Grip Wall"
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/am2r/json_data/Distribution Center.json
+++ b/randovania/games/am2r/json_data/Distribution Center.json
@@ -1390,32 +1390,6 @@
                                     {
                                         "type": "template",
                                         "data": "Can Use Any Bombs"
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Morph Ball",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Screw Attack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
                                     }
                                 ]
                             }
@@ -1458,32 +1432,6 @@
                                     {
                                         "type": "template",
                                         "data": "Can Use Any Bombs"
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Morph Ball",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Screw Attack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
                                     }
                                 ]
                             }
@@ -1534,6 +1482,41 @@
                                     {
                                         "type": "template",
                                         "data": "Space Jump Wall"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed Booster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Shinesparking",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -1613,6 +1596,44 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Door to Energy Distribution Emergency Exit": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Space Jump Wall"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed Booster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Shinesparking",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Event - EMP Activation Statue": {
                             "type": "or",
                             "data": {
@@ -1660,7 +1681,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - EMP Activation Statue": {
+                        "Door to Energy Distribution Activation Shaft": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1690,44 +1711,6 @@
                             "data": {
                                 "comment": null,
                                 "items": []
-                            }
-                        },
-                        "Door to Energy Distribution Emergency Exit": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Space Jump Wall"
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Speed Booster",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Shinesparking",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
                             }
                         }
                     }
@@ -1989,11 +1972,32 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Door to Energy Distribution Emergency Exit": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Any Bombs"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Space Jump Tunnel Climb"
+                                    }
+                                ]
+                            }
+                        },
                         "Event - EMPPuzzle": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Any Bombs"
+                                    }
+                                ]
                             }
                         }
                     }
@@ -2026,7 +2030,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - EMPPuzzle": {
+                        "Door to Energy Distribution Robot Home": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2061,22 +2065,6 @@
                             "data": {
                                 "comment": null,
                                 "items": []
-                            }
-                        },
-                        "Door to Energy Distribution Emergency Exit": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Any Bombs"
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Space Jump Tunnel Climb"
-                                    }
-                                ]
                             }
                         }
                     }
@@ -2117,7 +2105,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - EMPPuzzle": {
+                        "Door to EMP Ball Introduction": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2154,6 +2142,13 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Door to Energy Distribution Tower East": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Event - EMPPuzzle": {
                             "type": "or",
                             "data": {
@@ -2202,13 +2197,6 @@
                     "valid_starting_location": false,
                     "event_name": "EMPA5RobotHome",
                     "connections": {
-                        "Door to Energy Distribution Tower East": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
                         "Door to EMP Ball Introduction": {
                             "type": "and",
                             "data": {
@@ -2254,7 +2242,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Energy Distribution Zeta Nest": {
+                        "Bottom": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2323,6 +2311,18 @@
                                     }
                                 ]
                             }
+                        },
+                        "Bottom": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Use Any Bombs"
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -2354,7 +2354,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Energy Distribution Tower West": {
+                        "Bottom": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2367,8 +2367,8 @@
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 155.36,
-                        "y": 71.28,
+                        "x": 151.89318073438244,
+                        "y": 132.0553171196948,
                         "z": 0.0
                     },
                     "description": "",
@@ -2378,6 +2378,30 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "event_name": "EMPA5EnergyDistributionTowerEast",
+                    "connections": {
+                        "Bottom": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Bottom": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 184.32045779685265,
+                        "y": 70.06199332379583,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
                     "connections": {
                         "Door to Energy Distribution Tower West": {
                             "type": "and",
@@ -2392,8 +2416,17 @@
                                 "comment": null,
                                 "items": [
                                     {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "EMPA5EnergyDistributionTowerEast",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
                                         "type": "template",
-                                        "data": "Can Use Power Bombs"
+                                        "data": "Can Use Any Bombs"
                                     },
                                     {
                                         "type": "or",
@@ -2416,7 +2449,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "HJ + WJ",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -2430,8 +2463,8 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "Power Grip",
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
@@ -2453,6 +2486,36 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "IBJ",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "CBJ",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Charged Bomb Jump"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "ChargedBombJump",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -2632,65 +2695,92 @@
                                         "data": "Power Grip Wall"
                                     },
                                     {
+                                        "type": "template",
+                                        "data": "Can Use Any Bombs"
+                                    },
+                                    {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Pass by the Zeta",
                                             "items": [
                                                 {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Hi-Jump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Space Jump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "Zeta4",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
                                                     "type": "template",
-                                                    "data": "Can Use Power Bombs"
+                                                    "data": "Can Use Spider Ball"
                                                 },
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Roll underneath",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Morph Ball",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Damage Boost over",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "MidAirMorph",
-                                                                    "amount": 2,
+                                                                    "name": "DamageBoost",
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
-                                                                "type": "or",
+                                                                "type": "resource",
                                                                 "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Hi-Jump",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Space Jump",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Walljump",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "template",
-                                                                            "data": "Can Use Spider Ball"
-                                                                        }
-                                                                    ]
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 25,
+                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]
@@ -2712,65 +2802,92 @@
                                         "data": "Power Grip Wall"
                                     },
                                     {
+                                        "type": "template",
+                                        "data": "Can Use Any Bombs"
+                                    },
+                                    {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Pass by the Zeta",
                                             "items": [
                                                 {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Hi-Jump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Space Jump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
                                                     "type": "template",
-                                                    "data": "Can Use Power Bombs"
+                                                    "data": "Can Use Spider Ball"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "Zeta4",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 },
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Roll underneath",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Morph Ball",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Damage Boost over",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "MidAirMorph",
-                                                                    "amount": 2,
+                                                                    "name": "DamageBoost",
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
-                                                                "type": "or",
+                                                                "type": "resource",
                                                                 "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Walljump",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Hi-Jump",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Space Jump",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "template",
-                                                                            "data": "Can Use Spider Ball"
-                                                                        }
-                                                                    ]
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 25,
+                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]
@@ -3496,6 +3613,44 @@
                                 ]
                             }
                         },
+                        "Pipe to The Tower": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Hijump With Power Grip Wall"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Speed Booster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Shinesparking",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Pipe to Industrial Complex": {
                             "type": "and",
                             "data": {
@@ -3742,7 +3897,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Pipe to Industrial Complex": {
+                        "Door to Distribution Facility Tower West": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/am2r/json_data/Distribution Center.txt
+++ b/randovania/games/am2r/json_data/Distribution Center.txt
@@ -589,12 +589,13 @@ Extra - map_name: rm_a5c14
   > Pipe to The Tower
       All of the following:
           Any of the following:
-              # Climb room to pipe
+              # Get to upper platform in front of pipe
               Hijump With Power Grip Wall
               Speed Booster and Shinesparking Tricks (Beginner)
               Enabled Septogg Helpers and Power Grip Wall
-          Any of the following:
+          All of the following:
               # Get into Pipe
+              Morph Ball
               Mid-Air Morph (Beginner) or Power Grip Wall
   > Pipe to Industrial Complex
       All of the following:

--- a/randovania/games/am2r/json_data/Distribution Center.txt
+++ b/randovania/games/am2r/json_data/Distribution Center.txt
@@ -587,9 +587,15 @@ Extra - map_name: rm_a5c14
               Mid-Air Morph (Beginner) or Power Grip Wall
               Speed Booster and Shinesparking Tricks (Beginner)
   > Pipe to The Tower
-      Any of the following:
-          Enabled Septogg Helpers or Hijump With Power Grip Wall
-          Speed Booster and Shinesparking Tricks (Beginner)
+      All of the following:
+          Any of the following:
+              # Climb room to pipe
+              Hijump With Power Grip Wall
+              Speed Booster and Shinesparking Tricks (Beginner)
+              Enabled Septogg Helpers and Power Grip Wall
+          Any of the following:
+              # Get into Pipe
+              Mid-Air Morph (Beginner) or Power Grip Wall
   > Pipe to Industrial Complex
       All of the following:
           Morph Ball

--- a/randovania/games/am2r/json_data/Distribution Center.txt
+++ b/randovania/games/am2r/json_data/Distribution Center.txt
@@ -233,18 +233,14 @@ Extra - map_name: rm_a5c05
   * Normal Door to Energy Distribution Activation Shaft/Door to Meat Boy Room
   * Extra - instance_id: 133616
   > Door to Energy Distribution Tower West
-      All of the following:
-          Can Use Any Bombs
-          Morph Ball or Screw Attack
+      Can Use Any Bombs
 
 > Door to Energy Distribution Tower West; Heals? False
   * Layers: default
   * Normal Door to Energy Distribution Tower West/Door to Meat Boy Room
   * Extra - instance_id: 133615
   > Door to Energy Distribution Activation Shaft
-      All of the following:
-          Can Use Any Bombs
-          Morph Ball or Screw Attack
+      Can Use Any Bombs
 
 ----------------
 Energy Distribution Activation Shaft
@@ -254,7 +250,9 @@ Extra - map_name: rm_a5c06
   * Normal Door to Meat Boy Room/Door to Energy Distribution Activation Shaft
   * Extra - instance_id: 133682
   > Door to Energy Distribution Activation
-      Space Jump Wall
+      Any of the following:
+          Space Jump Wall
+          Speed Booster and Shinesparking Tricks (Beginner) and Disabled Entrance Rando
 
 > Door to Energy Distribution Activation; Heals? False
   * Layers: default
@@ -270,6 +268,10 @@ Extra - map_name: rm_a5c07
   * Layers: default
   * Distribution Center Energy Restored Door to Energy Distribution Activation Shaft/Door to Energy Distribution Activation
   * Extra - instance_id: 133732
+  > Door to Energy Distribution Emergency Exit
+      Any of the following:
+          Space Jump Wall
+          Speed Booster and Shinesparking Tricks (Beginner)
   > Event - EMP Activation Statue
       Morph Ball
 
@@ -277,7 +279,7 @@ Extra - map_name: rm_a5c07
   * Layers: default
   * Distribution Center Energy Restored Door to Energy Distribution Emergency Exit/Door to Energy Distribution Activation
   * Extra - instance_id: 133731
-  > Event - EMP Activation Statue
+  > Door to Energy Distribution Activation Shaft
       Trivial
 
 > Event - EMP Activation Statue; Heals? False
@@ -285,10 +287,6 @@ Extra - map_name: rm_a5c07
   * Event Area 5 - Distribution Center Energy Activated
   > Door to Energy Distribution Activation Shaft
       Trivial
-  > Door to Energy Distribution Emergency Exit
-      Any of the following:
-          Space Jump Wall
-          Speed Booster and Shinesparking Tricks (Beginner)
 
 ----------------
 Energy Distribution Emergency Exit
@@ -327,14 +325,16 @@ Extra - map_name: rm_a5c09
   * Layers: default
   * Distribution Center EMP Ball Introduction EMP Door to Energy Distribution Robot Home/Door to EMP Ball Introduction
   * Extra - instance_id: 133836
+  > Door to Energy Distribution Emergency Exit
+      Can Use Any Bombs and Space Jump Tunnel Climb
   > Event - EMPPuzzle
-      Trivial
+      Can Use Any Bombs
 
 > Door to Energy Distribution Emergency Exit; Heals? False
   * Layers: default
   * Normal Door to Energy Distribution Emergency Exit/Door to EMP Ball Introduction
   * Extra - instance_id: 133841
-  > Event - EMPPuzzle
+  > Door to Energy Distribution Robot Home
       Can Use Any Bombs
 
 > Event - EMPPuzzle; Heals? False
@@ -342,8 +342,6 @@ Extra - map_name: rm_a5c09
   * Event EMP - Area 5 EMP Ball Introduction
   > Door to Energy Distribution Robot Home
       Trivial
-  > Door to Energy Distribution Emergency Exit
-      Can Use Any Bombs and Space Jump Tunnel Climb
 
 ----------------
 Energy Distribution Robot Home
@@ -352,21 +350,21 @@ Extra - map_name: rm_a5c10
   * Layers: default
   * Distribution Center Robot Home EMP Door to Energy Distribution Tower East/Door to Energy Distribution Robot Home
   * Extra - instance_id: 133903
-  > Event - EMPPuzzle
+  > Door to EMP Ball Introduction
       Trivial
 
 > Door to EMP Ball Introduction; Heals? False
   * Layers: default
   * Normal Door to EMP Ball Introduction/Door to Energy Distribution Robot Home
   * Extra - instance_id: 133904
+  > Door to Energy Distribution Tower East
+      Trivial
   > Event - EMPPuzzle
       Missiles ≥ 2 or Super Missiles or Can Use Bombs
 
 > Event - EMPPuzzle; Heals? False
   * Layers: default
   * Event EMP - Area 5 Robot Home
-  > Door to Energy Distribution Tower East
-      Trivial
   > Door to EMP Ball Introduction
       Trivial
 
@@ -377,7 +375,7 @@ Extra - map_name: rm_a5c11
   * Layers: default
   * Distribution Center Energy Distribution Tower East EMP Door to Energy Distribution Tower West/Door to Energy Distribution Tower East
   * Extra - instance_id: 133914
-  > Door to Energy Distribution Zeta Nest
+  > Bottom
       Trivial
 
 > Door to Energy Distribution Robot Home; Heals? False
@@ -388,28 +386,40 @@ Extra - map_name: rm_a5c11
       Any of the following:
           Can Use Bombs
           Missiles ≥ 10 and Can Use Power Bombs
+  > Bottom
+      Can Use Any Bombs
 
 > Door to Energy Distribution Zeta Nest; Heals? False
   * Layers: default
   * Distribution Center Energy Distribution Tower East EMP Door to Energy Distribution Zeta Nest/Door to Energy Distribution Tower East
   * Extra - instance_id: 133911
-  > Door to Energy Distribution Tower West
+  > Bottom
       Trivial
 
 > Event - EMP Puzzle; Heals? False
   * Layers: default
   * Event EMP - Area 5 Energy Distribution Tower East
+  > Bottom
+      Trivial
+
+> Bottom; Heals? False
+  * Layers: default
   > Door to Energy Distribution Tower West
       Trivial
   > Door to Energy Distribution Robot Home
       All of the following:
-          Can Use Power Bombs
+          After EMP - Area 5 Energy Distribution Tower East and Can Use Any Bombs
           Any of the following:
               Space Jump or Can Use Spider Ball
-              Hi-Jump Boots and Power Grip
+              All of the following:
+                  # HJ + WJ
+                  Hi-Jump Boots and Walljump (Beginner)
               All of the following:
                   # IBJ
                   Infinite Bomb Jumping (Intermediate) and Can Use Bombs
+              All of the following:
+                  # CBJ
+                  Charged Bomb Jump (Intermediate) and Walljump (Intermediate) and Can Use Charged Bomb Jump
   > Door to Energy Distribution Zeta Nest
       Trivial
 
@@ -442,20 +452,28 @@ Extra - map_name: rm_a5c12
   * Layers: default
   > Door to Distribution Facility Tower West
       All of the following:
-          Power Grip Wall
+          Can Use Any Bombs and Power Grip Wall
           Any of the following:
-              Can Use Power Bombs
+              # Pass by the Zeta
+              Hi-Jump Boots or Space Jump or After Metroids Area 5 - Interior Zeta or Can Use Spider Ball
               All of the following:
-                  Mid-Air Morph (Intermediate)
-                  Hi-Jump Boots or Space Jump or Walljump (Beginner) or Can Use Spider Ball
+                  # Roll underneath
+                  Morph Ball and Movement (Beginner)
+              All of the following:
+                  # Damage Boost over
+                  Damage Boost (Beginner) and Normal Damage ≥ 25
   > Door to Energy Distribution Tower East
       All of the following:
-          Power Grip Wall
+          Can Use Any Bombs and Power Grip Wall
           Any of the following:
-              Can Use Power Bombs
+              # Pass by the Zeta
+              Hi-Jump Boots or Space Jump or After Metroids Area 5 - Interior Zeta or Can Use Spider Ball
               All of the following:
-                  Mid-Air Morph (Intermediate)
-                  Hi-Jump Boots or Space Jump or Walljump (Beginner) or Can Use Spider Ball
+                  # Roll underneath
+                  Morph Ball and Movement (Beginner)
+              All of the following:
+                  # Damage Boost over
+                  Damage Boost (Beginner) and Normal Damage ≥ 25
   > Event - Zeta
       Defeat Zeta
 
@@ -563,6 +581,10 @@ Extra - map_name: rm_a5c14
           Any of the following:
               Mid-Air Morph (Beginner) or Power Grip Wall
               Speed Booster and Shinesparking Tricks (Beginner)
+  > Pipe to The Tower
+      Any of the following:
+          Hijump With Power Grip Wall
+          Speed Booster and Shinesparking Tricks (Beginner)
   > Pipe to Industrial Complex
       All of the following:
           Morph Ball
@@ -598,7 +620,7 @@ Extra - map_name: rm_a5c14
   * Extra - instance_id: 134411
   * Extra - dest_x: 808
   * Extra - dest_y: 128
-  > Pipe to Industrial Complex
+  > Door to Distribution Facility Tower West
       Trivial
 
 > Pipe to Industrial Complex; Heals? False

--- a/randovania/games/am2r/json_data/Distribution Center.txt
+++ b/randovania/games/am2r/json_data/Distribution Center.txt
@@ -240,7 +240,9 @@ Extra - map_name: rm_a5c05
   * Normal Door to Energy Distribution Tower West/Door to Meat Boy Room
   * Extra - instance_id: 133615
   > Door to Energy Distribution Activation Shaft
-      Can Use Any Bombs
+      All of the following:
+          # TODO: Add combat logic
+          Can Use Any Bombs
 
 ----------------
 Energy Distribution Activation Shaft
@@ -252,7 +254,7 @@ Extra - map_name: rm_a5c06
   > Door to Energy Distribution Activation
       Any of the following:
           Space Jump Wall
-          Speed Booster and Shinesparking Tricks (Beginner) and Disabled Entrance Rando
+          Speed Booster and Shinesparking Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
 
 > Door to Energy Distribution Activation; Heals? False
   * Layers: default
@@ -385,7 +387,9 @@ Extra - map_name: rm_a5c11
   > Event - EMP Puzzle
       Any of the following:
           Can Use Bombs
-          Missiles ≥ 10 and Can Use Power Bombs
+          All of the following:
+              Can Use Power Bombs
+              Missiles ≥ 10 or Super Missiles ≥ 3
   > Bottom
       Can Use Any Bombs
 
@@ -419,7 +423,8 @@ Extra - map_name: rm_a5c11
                   Infinite Bomb Jumping (Intermediate) and Can Use Bombs
               All of the following:
                   # CBJ
-                  Charged Bomb Jump (Intermediate) and Walljump (Intermediate) and Can Use Charged Bomb Jump
+                  Charged Bomb Jump (Intermediate) and Can Use Charged Bomb Jump
+                  Hi-Jump Boots or Walljump (Intermediate)
   > Door to Energy Distribution Zeta Nest
       Trivial
 
@@ -461,7 +466,7 @@ Extra - map_name: rm_a5c12
                   Morph Ball and Movement (Beginner)
               All of the following:
                   # Damage Boost over
-                  Damage Boost (Beginner) and Normal Damage ≥ 25
+                  Damage Boost (Beginner) and Normal Damage ≥ 51
   > Door to Energy Distribution Tower East
       All of the following:
           Can Use Any Bombs and Power Grip Wall
@@ -473,7 +478,7 @@ Extra - map_name: rm_a5c12
                   Morph Ball and Movement (Beginner)
               All of the following:
                   # Damage Boost over
-                  Damage Boost (Beginner) and Normal Damage ≥ 25
+                  Damage Boost (Beginner) and Normal Damage ≥ 51
   > Event - Zeta
       Defeat Zeta
 
@@ -583,7 +588,7 @@ Extra - map_name: rm_a5c14
               Speed Booster and Shinesparking Tricks (Beginner)
   > Pipe to The Tower
       Any of the following:
-          Hijump With Power Grip Wall
+          Enabled Septogg Helpers or Hijump With Power Grip Wall
           Speed Booster and Shinesparking Tricks (Beginner)
   > Pipe to Industrial Complex
       All of the following:
@@ -631,10 +636,6 @@ Extra - map_name: rm_a5c14
   * Extra - dest_y: 368
   > Door to Distribution Facility Tower West
       Morph Ball
-  > Pipe to The Tower
-      Any of the following:
-          Enabled Septogg Helpers or Hijump Wall
-          Speed Booster and Shinesparking Tricks (Beginner)
 
 > Pipe to Golden Temple; Heals? False
   * Layers: default


### PR DESCRIPTION
- Energy Distribution Activation
	- Changed: Moved connections between doors instead of through event

- Energy Distribution Activation Access
	- Added: Shinespark trick to climb room

- EMP Ball Introduction
	- Changed: Moved connection between EMP puzzle to the bottom door, this allows entrance rando to not have to climb to the top

- Energy Distribution Robot Home
	- Changed: Moved connections between doors instead of through event

- Energy Distibution Tower East
	- Added: Node for bottom of room, allows traversal without EMP puzzle

- Energy Distribution Zeta Nest
	- Changed: Requirements for bypassing Zeta are updated

- Pipe Hub
	- Changed: Moved tower pipe connection to door in line with others

- Meat Boy Room 
	-Removed: Redundant requirements for morph ball as using bombs already covers this