### PR TITLE
Check for dotnet --info instead of --help

### DIFF
--- a/randovania/games/am2r/exporter/game_exporter.py
+++ b/randovania/games/am2r/exporter/game_exporter.py
@@ -42,7 +42,7 @@ class AM2RGameExporter(GameExporter):
     def _do_export_game(self, patch_data: dict, export_params: AM2RGameExportParams,
                         progress_update: status_update_lib.ProgressUpdateCallable):
         # Check if dotnet is available
-        dotnet_process = subprocess.run(["dotnet", "--help"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        dotnet_process = subprocess.run(["dotnet", "--info"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         if dotnet_process.returncode != 0:
             raise UnableToExportError("You do not have .NET installed!\n"
                                          "Please ensure that it is installed and located in PATH. It can be installed "


### PR DESCRIPTION
For some reason unknownst to me, `dotnet --help` on windows sometimes returns the error code `-2147450751` which is described as `One of the specified arguments for the operation is invalid.`
For even more stranger reasons, that error code does not appear when calling `--info`. So we'll try to call that now instead.