### PR TITLE
AM2R: start refactoring docks in DB for GT

### DIFF
--- a/randovania/games/am2r/json_data/Golden Temple.json
+++ b/randovania/games/am2r/json_data/Golden Temple.json
@@ -42,7 +42,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Needler Shaft": {
+                        "Horizontal Dock to Needler Shaft": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -51,7 +51,7 @@
                         }
                     }
                 },
-                "Dock to Needler Shaft": {
+                "Horizontal Dock to Needler Shaft": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -65,13 +65,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Needler Shaft",
-                        "node": "Dock to Guardian Arena"
+                        "node": "Horizontal Dock to Guardian Arena"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -474,7 +474,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Needler Shaft": {
+                        "Horizontal Dock to Needler Shaft": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -499,7 +499,7 @@
                     "valid_starting_location": false,
                     "event_name": "BossGuardian",
                     "connections": {
-                        "Dock to Needler Shaft": {
+                        "Horizontal Dock to Needler Shaft": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -539,14 +539,14 @@
                     },
                     "valid_starting_location": true,
                     "connections": {
-                        "Dock to Needler Shaft": {
+                        "Horizontal Dock to Needler Shaft": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Dock to Breeding Grounds Entrance": {
+                        "Horizontal Dock to Breeding Grounds Entrance": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -555,7 +555,7 @@
                         }
                     }
                 },
-                "Dock to Needler Shaft": {
+                "Horizontal Dock to Needler Shaft": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -569,13 +569,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Needler Shaft",
-                        "node": "Dock to Breeding Grounds Save Station"
+                        "node": "Horizontal Dock to Breeding Grounds Save Station"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -590,7 +590,7 @@
                         }
                     }
                 },
-                "Dock to Breeding Grounds Entrance": {
+                "Horizontal Dock to Breeding Grounds Entrance": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -604,13 +604,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds Entrance",
-                        "node": "Dock to Breeding Grounds Save Station"
+                        "node": "Horizontal Dock to Breeding Grounds Save Station"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -651,7 +651,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Guardian Arena": {
+                "Horizontal Dock to Guardian Arena": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -665,26 +665,26 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Guardian Arena",
-                        "node": "Dock to Needler Shaft"
+                        "node": "Horizontal Dock to Needler Shaft"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Gawron Gangway": {
+                        "Horizontal Dock to Gawron Gangway": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Dock to Breeding Grounds Save Station": {
+                        "Horizontal Dock to Breeding Grounds Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -693,7 +693,7 @@
                         }
                     }
                 },
-                "Dock to Gawron Gangway": {
+                "Horizontal Dock to Gawron Gangway": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -707,19 +707,19 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Gawron Gangway",
-                        "node": "Dock to Needler Shaft"
+                        "node": "Horizontal Dock to Needler Shaft"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Guardian Arena": {
+                        "Horizontal Dock to Guardian Arena": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -728,7 +728,7 @@
                         }
                     }
                 },
-                "Dock to Breeding Grounds Save Station": {
+                "Horizontal Dock to Breeding Grounds Save Station": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -742,19 +742,19 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds Save Station",
-                        "node": "Dock to Needler Shaft"
+                        "node": "Horizontal Dock to Needler Shaft"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Guardian Arena": {
+                        "Horizontal Dock to Guardian Arena": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -793,7 +793,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Needler Shaft": {
+                "Horizontal Dock to Needler Shaft": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -807,19 +807,19 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Needler Shaft",
-                        "node": "Dock to Gawron Gangway"
+                        "node": "Horizontal Dock to Gawron Gangway"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Golden Temple Exterior": {
+                        "Horizontal Dock to Golden Temple Exterior": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -828,7 +828,7 @@
                         }
                     }
                 },
-                "Dock to Golden Temple Exterior": {
+                "Horizontal Dock to Golden Temple Exterior": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -842,19 +842,19 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Golden Temple Exterior",
-                        "node": "Dock to Gawron Gangway"
+                        "node": "Horizontal Dock to Gawron Gangway"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Needler Shaft": {
+                        "Horizontal Dock to Needler Shaft": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1033,7 +1033,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Gawron Gangway": {
+                "Horizontal Dock to Gawron Gangway": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1047,13 +1047,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Gawron Gangway",
-                        "node": "Dock to Golden Temple Exterior"
+                        "node": "Horizontal Dock to Golden Temple Exterior"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -1068,7 +1068,7 @@
                         }
                     }
                 },
-                "Dock to Outer Temple Save Station": {
+                "Horizontal Dock to Outer Temple Save Station": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1082,13 +1082,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Outer Temple Save Station",
-                        "node": "Dock to Golden Temple Exterior"
+                        "node": "Horizontal Dock to Golden Temple Exterior"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -1101,7 +1101,7 @@
                                 "items": []
                             }
                         },
-                        "Dock to Exterior Alpha Nest": {
+                        "Horizontal Dock to Exterior Alpha Nest": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -1630,7 +1630,7 @@
                         }
                     }
                 },
-                "Dock to 3-Orb Hallway": {
+                "Horizontal Dock to 3-Orb Hallway": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1644,13 +1644,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "3-Orb Hallway",
-                        "node": "Dock to Golden Temple Exterior"
+                        "node": "Horizontal Dock to Golden Temple Exterior"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "3-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -1698,7 +1698,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Outer Temple Save Station": {
+                        "Horizontal Dock to Outer Temple Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1805,7 +1805,7 @@
                         }
                     }
                 },
-                "Dock to Exterior Alpha Nest": {
+                "Horizontal Dock to Exterior Alpha Nest": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1819,19 +1819,19 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Exterior Alpha Nest",
-                        "node": "Dock to Golden Temple Exterior"
+                        "node": "Horizontal Dock to Golden Temple Exterior"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "3-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Outer Temple Save Station": {
+                        "Horizontal Dock to Outer Temple Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1933,7 +1933,7 @@
                                 "items": []
                             }
                         },
-                        "Dock to 3-Orb Hallway": {
+                        "Horizontal Dock to 3-Orb Hallway": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2197,7 +2197,7 @@
                                 "items": []
                             }
                         },
-                        "Dock to Exterior Alpha Nest": {
+                        "Horizontal Dock to Exterior Alpha Nest": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -2494,7 +2494,7 @@
                     "valid_starting_location": false,
                     "event_name": "A1Visited",
                     "connections": {
-                        "Dock to Gawron Gangway": {
+                        "Horizontal Dock to Gawron Gangway": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2528,7 +2528,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Golden Temple Exterior": {
+                "Horizontal Dock to Golden Temple Exterior": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2542,13 +2542,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Golden Temple Exterior",
-                        "node": "Dock to Exterior Alpha Nest"
+                        "node": "Horizontal Dock to Exterior Alpha Nest"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "3-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -2584,7 +2584,7 @@
                     "valid_starting_location": false,
                     "event_name": "Alpha2",
                     "connections": {
-                        "Dock to Golden Temple Exterior": {
+                        "Horizontal Dock to Golden Temple Exterior": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2663,7 +2663,7 @@
                     },
                     "valid_starting_location": true,
                     "connections": {
-                        "Dock to Golden Temple Exterior": {
+                        "Horizontal Dock to Golden Temple Exterior": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2689,7 +2689,7 @@
                         }
                     }
                 },
-                "Dock to Golden Temple Exterior": {
+                "Horizontal Dock to Golden Temple Exterior": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2703,13 +2703,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Golden Temple Exterior",
-                        "node": "Dock to Outer Temple Save Station"
+                        "node": "Horizontal Dock to Outer Temple Save Station"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -3680,7 +3680,7 @@
                                 "items": []
                             }
                         },
-                        "Dock to Inner Temple West Hall": {
+                        "Horizontal Dock to Inner Temple West Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3726,7 +3726,7 @@
                         }
                     }
                 },
-                "Dock to Inner Temple West Hall": {
+                "Horizontal Dock to Inner Temple West Hall": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3740,13 +3740,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Inner Temple West Hall",
-                        "node": "Dock to Inner Temple Save Station"
+                        "node": "Horizontal Dock to Inner Temple Save Station"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -3783,7 +3783,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Inner Temple Save Station": {
+                "Horizontal Dock to Inner Temple Save Station": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3797,13 +3797,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Inner Temple Save Station",
-                        "node": "Dock to Inner Temple West Hall"
+                        "node": "Horizontal Dock to Inner Temple West Hall"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -3818,7 +3818,7 @@
                         }
                     }
                 },
-                "Dock to Bomb Chamber Access": {
+                "Horizontal Dock to Bomb Chamber Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3832,13 +3832,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Bomb Chamber Access",
-                        "node": "Dock to Inner Temple West Hall"
+                        "node": "Horizontal Dock to Inner Temple West Hall"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -3923,7 +3923,7 @@
                         }
                     }
                 },
-                "Dock to 1-Orb Hallway": {
+                "Horizontal Dock to 1-Orb Hallway": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3937,19 +3937,19 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "1-Orb Hallway",
-                        "node": "Dock to Inner Temple West Hall"
+                        "node": "Horizontal Dock to Inner Temple West Hall"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Bomb Chamber Access": {
+                        "Horizontal Dock to Bomb Chamber Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3994,21 +3994,21 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Dock to Inner Temple Save Station": {
+                        "Horizontal Dock to Inner Temple Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Dock to Bomb Chamber Access": {
+                        "Horizontal Dock to Bomb Chamber Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Dock to 1-Orb Hallway": {
+                        "Horizontal Dock to 1-Orb Hallway": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4035,7 +4035,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Inner Temple West Hall": {
+                "Horizontal Dock to Inner Temple West Hall": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4049,13 +4049,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Inner Temple West Hall",
-                        "node": "Dock to Bomb Chamber Access"
+                        "node": "Horizontal Dock to Bomb Chamber Access"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -4098,7 +4098,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Inner Temple West Hall": {
+                        "Horizontal Dock to Inner Temple West Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4257,7 +4257,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Inner Temple East Hall": {
+                "Horizontal Dock to Inner Temple East Hall": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4271,19 +4271,19 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Inner Temple East Hall",
-                        "node": "Dock to 3-Orb Hallway"
+                        "node": "Horizontal Dock to 3-Orb Hallway"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Golden Temple Exterior": {
+                        "Horizontal Dock to Golden Temple Exterior": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4340,7 +4340,7 @@
                         }
                     }
                 },
-                "Dock to Golden Temple Exterior": {
+                "Horizontal Dock to Golden Temple Exterior": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4354,19 +4354,19 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Golden Temple Exterior",
-                        "node": "Dock to 3-Orb Hallway"
+                        "node": "Horizontal Dock to 3-Orb Hallway"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "3-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Inner Temple East Hall": {
+                        "Horizontal Dock to Inner Temple East Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4418,7 +4418,7 @@
                     "pickup_index": 101,
                     "location_category": "minor",
                     "connections": {
-                        "Dock to Golden Temple Exterior": {
+                        "Horizontal Dock to Golden Temple Exterior": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4446,7 +4446,7 @@
                     "pickup_index": 102,
                     "location_category": "major",
                     "connections": {
-                        "Dock to Inner Temple East Hall": {
+                        "Horizontal Dock to Inner Temple East Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4484,7 +4484,7 @@
                     "pickup_index": 108,
                     "location_category": "minor",
                     "connections": {
-                        "Dock to Inner Temple East Hall": {
+                        "Horizontal Dock to Inner Temple East Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4519,7 +4519,7 @@
                     "valid_starting_location": false,
                     "event_name": "A1Orb3",
                     "connections": {
-                        "Dock to Golden Temple Exterior": {
+                        "Horizontal Dock to Golden Temple Exterior": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4595,7 +4595,7 @@
                         }
                     }
                 },
-                "Dock to Charge Beam Chamber Access": {
+                "Horizontal Dock to Charge Beam Chamber Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4609,13 +4609,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Charge Beam Chamber Access",
-                        "node": "Dock to Inner Temple East Hall"
+                        "node": "Horizontal Dock to Inner Temple East Hall"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -4630,7 +4630,7 @@
                         }
                     }
                 },
-                "Dock to Armory": {
+                "Horizontal Dock to Armory": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4644,13 +4644,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Armory",
-                        "node": "Dock to Inner Temple East Hall"
+                        "node": "Horizontal Dock to Inner Temple East Hall"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -4665,7 +4665,7 @@
                         }
                     }
                 },
-                "Dock to 3-Orb Hallway": {
+                "Horizontal Dock to 3-Orb Hallway": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4679,13 +4679,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "3-Orb Hallway",
-                        "node": "Dock to Inner Temple East Hall"
+                        "node": "Horizontal Dock to Inner Temple East Hall"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -4700,7 +4700,7 @@
                         }
                     }
                 },
-                "Dock to 1-Orb Hallway": {
+                "Horizontal Dock to 1-Orb Hallway": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4714,13 +4714,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "1-Orb Hallway",
-                        "node": "Dock to Inner Temple East Hall"
+                        "node": "Horizontal Dock to Inner Temple East Hall"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -4735,7 +4735,7 @@
                         }
                     }
                 },
-                "Dock to Inner Temple Pipe": {
+                "Horizontal Dock to Inner Temple Pipe": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4749,13 +4749,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Inner Temple Pipe",
-                        "node": "Dock to Inner Temple East Hall"
+                        "node": "Horizontal Dock to Inner Temple East Hall"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "3-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -4853,35 +4853,35 @@
                                 "items": []
                             }
                         },
-                        "Dock to Charge Beam Chamber Access": {
+                        "Horizontal Dock to Charge Beam Chamber Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Dock to Armory": {
+                        "Horizontal Dock to Armory": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Dock to 3-Orb Hallway": {
+                        "Horizontal Dock to 3-Orb Hallway": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Dock to 1-Orb Hallway": {
+                        "Horizontal Dock to 1-Orb Hallway": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Dock to Inner Temple Pipe": {
+                        "Horizontal Dock to Inner Temple Pipe": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -5006,7 +5006,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Inner Temple West Hall": {
+                "Horizontal Dock to Inner Temple West Hall": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5020,13 +5020,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Inner Temple West Hall",
-                        "node": "Dock to 1-Orb Hallway"
+                        "node": "Horizontal Dock to 1-Orb Hallway"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -5046,7 +5046,7 @@
                         }
                     }
                 },
-                "Dock to Inner Temple East Hall": {
+                "Horizontal Dock to Inner Temple East Hall": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5060,13 +5060,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Inner Temple East Hall",
-                        "node": "Dock to 1-Orb Hallway"
+                        "node": "Horizontal Dock to 1-Orb Hallway"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -5139,7 +5139,7 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Dock to Inner Temple West Hall": {
+                        "Horizontal Dock to Inner Temple West Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5151,7 +5151,7 @@
                                 ]
                             }
                         },
-                        "Dock to Inner Temple East Hall": {
+                        "Horizontal Dock to Inner Temple East Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5196,7 +5196,7 @@
                     "pickup_index": 103,
                     "location_category": "minor",
                     "connections": {
-                        "Dock to Inner Temple East Hall": {
+                        "Horizontal Dock to Inner Temple East Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5257,7 +5257,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Inner Temple East Hall": {
+                "Horizontal Dock to Inner Temple East Hall": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5271,13 +5271,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Inner Temple East Hall",
-                        "node": "Dock to Armory"
+                        "node": "Horizontal Dock to Armory"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -5593,7 +5593,7 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Dock to Inner Temple East Hall": {
+                        "Horizontal Dock to Inner Temple East Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5765,7 +5765,7 @@
                     "pickup_index": 104,
                     "location_category": "minor",
                     "connections": {
-                        "Dock to Inner Temple East Hall": {
+                        "Horizontal Dock to Inner Temple East Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5793,7 +5793,7 @@
                     "pickup_index": 105,
                     "location_category": "minor",
                     "connections": {
-                        "Dock to Inner Temple East Hall": {
+                        "Horizontal Dock to Inner Temple East Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5821,7 +5821,7 @@
                     "pickup_index": 106,
                     "location_category": "minor",
                     "connections": {
-                        "Dock to Inner Temple East Hall": {
+                        "Horizontal Dock to Inner Temple East Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5896,7 +5896,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Inner Temple East Hall": {
+                "Horizontal Dock to Inner Temple East Hall": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5910,13 +5910,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Inner Temple East Hall",
-                        "node": "Dock to Charge Beam Chamber Access"
+                        "node": "Horizontal Dock to Charge Beam Chamber Access"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -5969,7 +5969,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Inner Temple East Hall": {
+                        "Horizontal Dock to Inner Temple East Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6065,7 +6065,7 @@
             }
         },
         "Inner Temple Pipe": {
-            "default_node": "Dock to Inner Temple East Hall",
+            "default_node": "Horizontal Dock to Inner Temple East Hall",
             "extra": {
                 "map_name": "rm_a1a11",
                 "minimap_data": [
@@ -6084,7 +6084,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Inner Temple East Hall": {
+                "Horizontal Dock to Inner Temple East Hall": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6098,13 +6098,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Inner Temple East Hall",
-                        "node": "Dock to Inner Temple Pipe"
+                        "node": "Horizontal Dock to Inner Temple Pipe"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "3-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -6159,7 +6159,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Inner Temple East Hall": {
+                        "Horizontal Dock to Inner Temple East Hall": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6447,7 +6447,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Breeding Grounds Save Station": {
+                "Horizontal Dock to Breeding Grounds Save Station": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6461,13 +6461,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds Save Station",
-                        "node": "Dock to Breeding Grounds Entrance"
+                        "node": "Horizontal Dock to Breeding Grounds Entrance"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -6487,7 +6487,7 @@
                         }
                     }
                 },
-                "Dock to Breeding Grounds Hub": {
+                "Horizontal Dock to Breeding Grounds Hub": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6501,13 +6501,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds Hub",
-                        "node": "Dock to Breeding Grounds Entrance"
+                        "node": "Horizontal Dock to Breeding Grounds Entrance"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -6568,7 +6568,7 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Dock to Breeding Grounds Save Station": {
+                        "Horizontal Dock to Breeding Grounds Save Station": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6580,7 +6580,7 @@
                                 ]
                             }
                         },
-                        "Dock to Breeding Grounds Hub": {
+                        "Horizontal Dock to Breeding Grounds Hub": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6642,7 +6642,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Breeding Grounds South West": {
+                "Horizontal Dock to Breeding Grounds South West": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6656,26 +6656,26 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds South West",
-                        "node": "Dock to Breeding Grounds Hub"
+                        "node": "Horizontal Dock to Breeding Grounds Hub"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Breeding Grounds North East": {
+                        "Horizontal Dock to Breeding Grounds North East": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Dock to Breeding Grounds South East": {
+                        "Horizontal Dock to Breeding Grounds South East": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6684,7 +6684,7 @@
                         }
                     }
                 },
-                "Dock to Breeding Grounds Entrance": {
+                "Horizontal Dock to Breeding Grounds Entrance": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6698,19 +6698,19 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds Entrance",
-                        "node": "Dock to Breeding Grounds Hub"
+                        "node": "Horizontal Dock to Breeding Grounds Hub"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "5-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Breeding Grounds North East": {
+                        "Horizontal Dock to Breeding Grounds North East": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6719,7 +6719,7 @@
                         }
                     }
                 },
-                "Dock to Breeding Grounds North East": {
+                "Horizontal Dock to Breeding Grounds North East": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6733,26 +6733,26 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds North East",
-                        "node": "Dock to Breeding Grounds Hub"
+                        "node": "Horizontal Dock to Breeding Grounds Hub"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Breeding Grounds South West": {
+                        "Horizontal Dock to Breeding Grounds South West": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Dock to Breeding Grounds Entrance": {
+                        "Horizontal Dock to Breeding Grounds Entrance": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6761,7 +6761,7 @@
                         }
                     }
                 },
-                "Dock to Breeding Grounds South East": {
+                "Horizontal Dock to Breeding Grounds South East": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6775,19 +6775,19 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds South East",
-                        "node": "Dock to Breeding Grounds Hub"
+                        "node": "Horizontal Dock to Breeding Grounds Hub"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Breeding Grounds South West": {
+                        "Horizontal Dock to Breeding Grounds South West": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6826,7 +6826,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Breeding Grounds Hub": {
+                "Horizontal Dock to Breeding Grounds Hub": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6840,13 +6840,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds Hub",
-                        "node": "Dock to Breeding Grounds North East"
+                        "node": "Horizontal Dock to Breeding Grounds North East"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -6882,7 +6882,7 @@
                     "valid_starting_location": false,
                     "event_name": "Alpha3",
                     "connections": {
-                        "Dock to Breeding Grounds Hub": {
+                        "Horizontal Dock to Breeding Grounds Hub": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6952,7 +6952,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Breeding Grounds Hub": {
+                "Horizontal Dock to Breeding Grounds Hub": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6966,13 +6966,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds Hub",
-                        "node": "Dock to Breeding Grounds South West"
+                        "node": "Horizontal Dock to Breeding Grounds South West"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -7008,7 +7008,7 @@
                     "valid_starting_location": false,
                     "event_name": "Alpha5",
                     "connections": {
-                        "Dock to Breeding Grounds Hub": {
+                        "Horizontal Dock to Breeding Grounds Hub": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7070,7 +7070,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Breeding Grounds Hub": {
+                "Horizontal Dock to Breeding Grounds Hub": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -7084,13 +7084,13 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Golden Temple",
                         "area": "Breeding Grounds Hub",
-                        "node": "Dock to Breeding Grounds South East"
+                        "node": "Horizontal Dock to Breeding Grounds South East"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "4-Tiles High Dock",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -7126,7 +7126,7 @@
                     "valid_starting_location": false,
                     "event_name": "Alpha4",
                     "connections": {
-                        "Dock to Breeding Grounds Hub": {
+                        "Horizontal Dock to Breeding Grounds Hub": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/am2r/json_data/Golden Temple.txt
+++ b/randovania/games/am2r/json_data/Golden Temple.txt
@@ -5,12 +5,12 @@ Extra - minimap_data: [{'x': 51, 'y': 13}]
 > Area Transition to Main Caves; Heals? False
   * Layers: default
   * Open Passage to Mumbo Manor/Area Transition to Golden Temple
-  > Dock to Needler Shaft
+  > Horizontal Dock to Needler Shaft
       Trivial
 
-> Dock to Needler Shaft; Heals? False
+> Horizontal Dock to Needler Shaft; Heals? False
   * Layers: default
-  * Open Passage to Needler Shaft/Dock to Guardian Arena
+  * 5-Tiles High Dock to Needler Shaft/Horizontal Dock to Guardian Arena
   > Area Transition to Main Caves
       Before Area 1 - Golden Temple Visited or After Boss - Guardian Defeated
   > Dock to Guardian Storage
@@ -56,13 +56,13 @@ Extra - minimap_data: [{'x': 51, 'y': 13}]
 > Dock to Guardian Storage; Heals? False
   * Layers: default
   * Open Passage to Guardian Storage/Dock to Guardian Arena
-  > Dock to Needler Shaft
+  > Horizontal Dock to Needler Shaft
       Trivial
 
 > Event - Guardian; Heals? False
   * Layers: default
   * Event Boss - Guardian Defeated
-  > Dock to Needler Shaft
+  > Horizontal Dock to Needler Shaft
       Trivial
 
 ----------------
@@ -72,20 +72,20 @@ Extra - minimap_data: [{'x': 53, 'y': 14}]
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 3
-  > Dock to Needler Shaft
+  > Horizontal Dock to Needler Shaft
       Trivial
-  > Dock to Breeding Grounds Entrance
+  > Horizontal Dock to Breeding Grounds Entrance
       Trivial
 
-> Dock to Needler Shaft; Heals? False
+> Horizontal Dock to Needler Shaft; Heals? False
   * Layers: default
-  * Open Passage to Needler Shaft/Dock to Breeding Grounds Save Station
+  * 5-Tiles High Dock to Needler Shaft/Horizontal Dock to Breeding Grounds Save Station
   > Save Station
       Trivial
 
-> Dock to Breeding Grounds Entrance; Heals? False
+> Horizontal Dock to Breeding Grounds Entrance; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds Entrance/Dock to Breeding Grounds Save Station
+  * 5-Tiles High Dock to Breeding Grounds Entrance/Horizontal Dock to Breeding Grounds Save Station
   > Save Station
       Trivial
 
@@ -93,58 +93,58 @@ Extra - minimap_data: [{'x': 53, 'y': 14}]
 Needler Shaft
 Extra - map_name: rm_a1h03
 Extra - minimap_data: [{'x': 52, 'y': 11}, {'x': 52, 'y': 12}, {'x': 52, 'y': 13}, {'x': 52, 'y': 14}]
-> Dock to Guardian Arena; Heals? False
+> Horizontal Dock to Guardian Arena; Heals? False
   * Layers: default
-  * Open Passage to Guardian Arena/Dock to Needler Shaft
-  > Dock to Gawron Gangway
+  * 5-Tiles High Dock to Guardian Arena/Horizontal Dock to Needler Shaft
+  > Horizontal Dock to Gawron Gangway
       Trivial
-  > Dock to Breeding Grounds Save Station
-      Trivial
-
-> Dock to Gawron Gangway; Heals? False
-  * Layers: default
-  * Open Passage to Gawron Gangway/Dock to Needler Shaft
-  > Dock to Guardian Arena
+  > Horizontal Dock to Breeding Grounds Save Station
       Trivial
 
-> Dock to Breeding Grounds Save Station; Heals? False
+> Horizontal Dock to Gawron Gangway; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds Save Station/Dock to Needler Shaft
-  > Dock to Guardian Arena
+  * 5-Tiles High Dock to Gawron Gangway/Horizontal Dock to Needler Shaft
+  > Horizontal Dock to Guardian Arena
+      Trivial
+
+> Horizontal Dock to Breeding Grounds Save Station; Heals? False
+  * Layers: default
+  * 5-Tiles High Dock to Breeding Grounds Save Station/Horizontal Dock to Needler Shaft
+  > Horizontal Dock to Guardian Arena
       Trivial
 
 ----------------
 Gawron Gangway
 Extra - map_name: rm_a1h04
 Extra - minimap_data: [{'x': 53, 'y': 11}, {'x': 54, 'y': 11}, {'x': 55, 'y': 11}, {'x': 56, 'y': 11}, {'x': 57, 'y': 11}]
-> Dock to Needler Shaft; Heals? False
+> Horizontal Dock to Needler Shaft; Heals? False
   * Layers: default
-  * Open Passage to Needler Shaft/Dock to Gawron Gangway
-  > Dock to Golden Temple Exterior
+  * 5-Tiles High Dock to Needler Shaft/Horizontal Dock to Gawron Gangway
+  > Horizontal Dock to Golden Temple Exterior
       Trivial
 
-> Dock to Golden Temple Exterior; Heals? False
+> Horizontal Dock to Golden Temple Exterior; Heals? False
   * Layers: default
-  * Open Passage to Golden Temple Exterior/Dock to Gawron Gangway
-  > Dock to Needler Shaft
+  * 5-Tiles High Dock to Golden Temple Exterior/Horizontal Dock to Gawron Gangway
+  > Horizontal Dock to Needler Shaft
       Trivial
 
 ----------------
 Golden Temple Exterior
 Extra - map_name: rm_a1h05
 Extra - minimap_data: [{'x': 58, 'y': 7}, {'x': 58, 'y': 8}, {'x': 58, 'y': 9}, {'x': 58, 'y': 10}, {'x': 58, 'y': 11}, {'x': 59, 'y': 7}, {'x': 59, 'y': 8}, {'x': 59, 'y': 9}, {'x': 59, 'y': 10}, {'x': 59, 'y': 11}, {'x': 60, 'y': 7}, {'x': 60, 'y': 8}, {'x': 60, 'y': 9}, {'x': 60, 'y': 10}, {'x': 61, 'y': 7}, {'x': 61, 'y': 8}, {'x': 61, 'y': 9}, {'x': 61, 'y': 10}, {'x': 62, 'y': 7}, {'x': 62, 'y': 8}, {'x': 62, 'y': 9}, {'x': 63, 'y': 7}, {'x': 63, 'y': 8}, {'x': 63, 'y': 9}, {'x': 64, 'y': 7}, {'x': 64, 'y': 8}, {'x': 64, 'y': 9}, {'x': 65, 'y': 7}, {'x': 65, 'y': 8}, {'x': 65, 'y': 9}, {'x': 66, 'y': 7}, {'x': 66, 'y': 8}, {'x': 66, 'y': 9}, {'x': 66, 'y': 10}, {'x': 66, 'y': 11}, {'x': 67, 'y': 7}, {'x': 67, 'y': 8}, {'x': 67, 'y': 9}, {'x': 67, 'y': 10}, {'x': 67, 'y': 11}]
-> Dock to Gawron Gangway; Heals? False
+> Horizontal Dock to Gawron Gangway; Heals? False
   * Layers: default
-  * Open Passage to Gawron Gangway/Dock to Golden Temple Exterior
+  * 5-Tiles High Dock to Gawron Gangway/Horizontal Dock to Golden Temple Exterior
   > Event - Golden Temple Visited
       Trivial
 
-> Dock to Outer Temple Save Station; Heals? False
+> Horizontal Dock to Outer Temple Save Station; Heals? False
   * Layers: default
-  * Open Passage to Outer Temple Save Station/Dock to Golden Temple Exterior
+  * 5-Tiles High Dock to Outer Temple Save Station/Horizontal Dock to Golden Temple Exterior
   > Door to Inner Temple East Hall
       Trivial
-  > Dock to Exterior Alpha Nest
+  > Horizontal Dock to Exterior Alpha Nest
       Any of the following:
           Space Jump
           All of the following:
@@ -197,9 +197,9 @@ Extra - minimap_data: [{'x': 58, 'y': 7}, {'x': 58, 'y': 8}, {'x': 58, 'y': 9}, 
   > Event - Golden Temple Visited
       Trivial
 
-> Dock to 3-Orb Hallway; Heals? False
+> Horizontal Dock to 3-Orb Hallway; Heals? False
   * Layers: default
-  * Open Passage to 3-Orb Hallway/Dock to Golden Temple Exterior
+  * 3-Tiles High Dock to 3-Orb Hallway/Horizontal Dock to Golden Temple Exterior
   > Middle
       Can Use Any Bombs
 
@@ -207,7 +207,7 @@ Extra - minimap_data: [{'x': 58, 'y': 7}, {'x': 58, 'y': 8}, {'x': 58, 'y': 9}, 
   * Layers: default
   * Normal Door to Inner Temple East Hall/Door to Golden Temple Exterior
   * Extra - instance_id: 108040
-  > Dock to Outer Temple Save Station
+  > Horizontal Dock to Outer Temple Save Station
       Trivial
   > Door to Inner Temple Save Station
       Disabled Door Lock Rando and Zip From Destroyable Object
@@ -221,10 +221,10 @@ Extra - minimap_data: [{'x': 58, 'y': 7}, {'x': 58, 'y': 8}, {'x': 58, 'y': 9}, 
               # Shinespark up
               Speed Booster and Shinesparking Tricks (Beginner)
 
-> Dock to Exterior Alpha Nest; Heals? False
+> Horizontal Dock to Exterior Alpha Nest; Heals? False
   * Layers: default
-  * Open Passage to Exterior Alpha Nest/Dock to Golden Temple Exterior
-  > Dock to Outer Temple Save Station
+  * 3-Tiles High Dock to Exterior Alpha Nest/Horizontal Dock to Golden Temple Exterior
+  > Horizontal Dock to Outer Temple Save Station
       Trivial
   > Top
       Morph Ball and Morph Glide (Advanced)
@@ -239,7 +239,7 @@ Extra - minimap_data: [{'x': 58, 'y': 7}, {'x': 58, 'y': 8}, {'x': 58, 'y': 9}, 
   * Layers: default
   > Door to Inner Temple Save Station
       Trivial
-  > Dock to 3-Orb Hallway
+  > Horizontal Dock to 3-Orb Hallway
       Can Use Any Bombs
   > Top
       Any of the following:
@@ -266,7 +266,7 @@ Extra - minimap_data: [{'x': 58, 'y': 7}, {'x': 58, 'y': 8}, {'x': 58, 'y': 9}, 
   * Layers: default
   > Door to Inner Temple East Hall
       Trivial
-  > Dock to Exterior Alpha Nest
+  > Horizontal Dock to Exterior Alpha Nest
       Any of the following:
           All of the following:
               Hi-Jump Boots and Morph Ball and Morph Glide (Expert)
@@ -306,7 +306,7 @@ Extra - minimap_data: [{'x': 58, 'y': 7}, {'x': 58, 'y': 8}, {'x': 58, 'y': 9}, 
 > Event - Golden Temple Visited; Heals? False
   * Layers: default
   * Event Area 1 - Golden Temple Visited
-  > Dock to Gawron Gangway
+  > Horizontal Dock to Gawron Gangway
       Trivial
   > Door to Inner Temple Save Station
       Trivial
@@ -315,16 +315,16 @@ Extra - minimap_data: [{'x': 58, 'y': 7}, {'x': 58, 'y': 8}, {'x': 58, 'y': 9}, 
 Exterior Alpha Nest
 Extra - map_name: rm_a1h06
 Extra - minimap_data: [{'x': 68, 'y': 9}, {'x': 69, 'y': 9}]
-> Dock to Golden Temple Exterior; Heals? False
+> Horizontal Dock to Golden Temple Exterior; Heals? False
   * Layers: default
-  * Open Passage to Golden Temple Exterior/Dock to Exterior Alpha Nest
+  * 3-Tiles High Dock to Golden Temple Exterior/Horizontal Dock to Exterior Alpha Nest
   > Event - Alpha
       Defeat non-dodging Alpha
 
 > Event - Alpha; Heals? False
   * Layers: default
   * Event Metroids Area 1 - Exterior Alpha
-  > Dock to Golden Temple Exterior
+  > Horizontal Dock to Golden Temple Exterior
       Trivial
   > Pickup (Alpha)
       Trivial
@@ -343,14 +343,14 @@ Extra - minimap_data: [{'x': 68, 'y': 11}, {'x': 69, 'y': 11}]
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 5
-  > Dock to Golden Temple Exterior
+  > Horizontal Dock to Golden Temple Exterior
       Trivial
   > Dock to Spider Ball Chamber
       Morph Ball
 
-> Dock to Golden Temple Exterior; Heals? False
+> Horizontal Dock to Golden Temple Exterior; Heals? False
   * Layers: default
-  * Open Passage to Golden Temple Exterior/Dock to Outer Temple Save Station
+  * 5-Tiles High Dock to Golden Temple Exterior/Horizontal Dock to Outer Temple Save Station
   > Save Station
       Trivial
 
@@ -477,7 +477,7 @@ Extra - minimap_data: [{'x': 60, 'y': 11}]
   * Extra - save_room: 4
   > Door to Golden Temple Exterior
       Trivial
-  > Dock to Inner Temple West Hall
+  > Horizontal Dock to Inner Temple West Hall
       Trivial
 
 > Door to Golden Temple Exterior; Heals? False
@@ -487,9 +487,9 @@ Extra - minimap_data: [{'x': 60, 'y': 11}]
   > Save Station
       Trivial
 
-> Dock to Inner Temple West Hall; Heals? False
+> Horizontal Dock to Inner Temple West Hall; Heals? False
   * Layers: default
-  * Open Passage to Inner Temple West Hall/Dock to Inner Temple Save Station
+  * 4-Tiles High Dock to Inner Temple West Hall/Horizontal Dock to Inner Temple Save Station
   > Save Station
       Trivial
 
@@ -497,15 +497,15 @@ Extra - minimap_data: [{'x': 60, 'y': 11}]
 Inner Temple West Hall
 Extra - map_name: rm_a1a02
 Extra - minimap_data: [{'x': 61, 'y': 11}, {'x': 61, 'y': 12}, {'x': 61, 'y': 13}]
-> Dock to Inner Temple Save Station; Heals? False
+> Horizontal Dock to Inner Temple Save Station; Heals? False
   * Layers: default
-  * Open Passage to Inner Temple Save Station/Dock to Inner Temple West Hall
+  * 4-Tiles High Dock to Inner Temple Save Station/Horizontal Dock to Inner Temple West Hall
   > Middle
       Trivial
 
-> Dock to Bomb Chamber Access; Heals? False
+> Horizontal Dock to Bomb Chamber Access; Heals? False
   * Layers: default
-  * Open Passage to Bomb Chamber Access/Dock to Inner Temple West Hall
+  * 4-Tiles High Dock to Bomb Chamber Access/Horizontal Dock to Inner Temple West Hall
   > Middle
       Any of the following:
           Hi-Jump Boots or Space Jump or Can Use Any Bombs or Can Use Spider Ball
@@ -514,30 +514,30 @@ Extra - minimap_data: [{'x': 61, 'y': 11}, {'x': 61, 'y': 12}, {'x': 61, 'y': 13
               Walljump (Beginner)
               Power Grip or Walljump (Intermediate)
 
-> Dock to 1-Orb Hallway; Heals? False
+> Horizontal Dock to 1-Orb Hallway; Heals? False
   * Layers: default
-  * Open Passage to 1-Orb Hallway/Dock to Inner Temple West Hall
-  > Dock to Bomb Chamber Access
+  * 4-Tiles High Dock to 1-Orb Hallway/Horizontal Dock to Inner Temple West Hall
+  > Horizontal Dock to Bomb Chamber Access
       Trivial
   > Middle
       Movement (Beginner) or Power Grip Wall
 
 > Middle; Heals? False
   * Layers: default
-  > Dock to Inner Temple Save Station
+  > Horizontal Dock to Inner Temple Save Station
       Trivial
-  > Dock to Bomb Chamber Access
+  > Horizontal Dock to Bomb Chamber Access
       Trivial
-  > Dock to 1-Orb Hallway
+  > Horizontal Dock to 1-Orb Hallway
       Trivial
 
 ----------------
 Bomb Chamber Access
 Extra - map_name: rm_a1a03
 Extra - minimap_data: [{'x': 59, 'y': 13}, {'x': 60, 'y': 13}]
-> Dock to Inner Temple West Hall; Heals? False
+> Horizontal Dock to Inner Temple West Hall; Heals? False
   * Layers: default
-  * Open Passage to Inner Temple West Hall/Dock to Bomb Chamber Access
+  * 4-Tiles High Dock to Inner Temple West Hall/Horizontal Dock to Bomb Chamber Access
   > Door to Bomb Chamber
       Trivial
 
@@ -545,7 +545,7 @@ Extra - minimap_data: [{'x': 59, 'y': 13}, {'x': 60, 'y': 13}]
   * Layers: default
   * Missile Door to Bomb Chamber/Door to Bomb Chamber Access
   * Extra - instance_id: 108382
-  > Dock to Inner Temple West Hall
+  > Horizontal Dock to Inner Temple West Hall
       Trivial
 
 ----------------
@@ -579,20 +579,20 @@ Extra - minimap_data: [{'x': 58, 'y': 13}]
 3-Orb Hallway
 Extra - map_name: rm_a1a05
 Extra - minimap_data: [{'x': 62, 'y': 10}, {'x': 63, 'y': 10}, {'x': 64, 'y': 10}]
-> Dock to Inner Temple East Hall; Heals? False
+> Horizontal Dock to Inner Temple East Hall; Heals? False
   * Layers: default
-  * Open Passage to Inner Temple East Hall/Dock to 3-Orb Hallway
-  > Dock to Golden Temple Exterior
+  * 4-Tiles High Dock to Inner Temple East Hall/Horizontal Dock to 3-Orb Hallway
+  > Horizontal Dock to Golden Temple Exterior
       Morph Ball
   > Pickup (Right Missile Tank)
       Morph Ball
   > Pickup (Energy Tank)
       After Area 1 - Golden Temple 3 Orb Puzzle and Tunnel Climb
 
-> Dock to Golden Temple Exterior; Heals? False
+> Horizontal Dock to Golden Temple Exterior; Heals? False
   * Layers: default
-  * Open Passage to Golden Temple Exterior/Dock to 3-Orb Hallway
-  > Dock to Inner Temple East Hall
+  * 3-Tiles High Dock to Golden Temple Exterior/Horizontal Dock to 3-Orb Hallway
+  > Horizontal Dock to Inner Temple East Hall
       Morph Ball
   > Pickup (Left Missile Tank)
       Trivial
@@ -603,27 +603,27 @@ Extra - minimap_data: [{'x': 62, 'y': 10}, {'x': 63, 'y': 10}, {'x': 64, 'y': 10
   * Layers: default
   * Pickup 101; Category? Minor
   * Extra - object_name: oItemM_101
-  > Dock to Golden Temple Exterior
+  > Horizontal Dock to Golden Temple Exterior
       Trivial
 
 > Pickup (Right Missile Tank); Heals? False
   * Layers: default
   * Pickup 102; Category? Major
   * Extra - object_name: oItemM_102
-  > Dock to Inner Temple East Hall
+  > Horizontal Dock to Inner Temple East Hall
       Morph Ball
 
 > Pickup (Energy Tank); Heals? False
   * Layers: default
   * Pickup 108; Category? Minor
   * Extra - object_name: oItemETank_108
-  > Dock to Inner Temple East Hall
+  > Horizontal Dock to Inner Temple East Hall
       Morph Ball
 
 > Event - 3Orb; Heals? False
   * Layers: default
   * Event Area 1 - Golden Temple 3 Orb Puzzle
-  > Dock to Golden Temple Exterior
+  > Horizontal Dock to Golden Temple Exterior
       Trivial
 
 ----------------
@@ -637,33 +637,33 @@ Extra - minimap_data: [{'x': 65, 'y': 10}, {'x': 65, 'y': 11}, {'x': 65, 'y': 12
   > Middle
       Trivial
 
-> Dock to Charge Beam Chamber Access; Heals? False
+> Horizontal Dock to Charge Beam Chamber Access; Heals? False
   * Layers: default
-  * Open Passage to Charge Beam Chamber Access/Dock to Inner Temple East Hall
+  * 4-Tiles High Dock to Charge Beam Chamber Access/Horizontal Dock to Inner Temple East Hall
   > Middle
       Trivial
 
-> Dock to Armory; Heals? False
+> Horizontal Dock to Armory; Heals? False
   * Layers: default
-  * Open Passage to Armory/Dock to Inner Temple East Hall
+  * 4-Tiles High Dock to Armory/Horizontal Dock to Inner Temple East Hall
   > Middle
       Trivial
 
-> Dock to 3-Orb Hallway; Heals? False
+> Horizontal Dock to 3-Orb Hallway; Heals? False
   * Layers: default
-  * Open Passage to 3-Orb Hallway/Dock to Inner Temple East Hall
+  * 4-Tiles High Dock to 3-Orb Hallway/Horizontal Dock to Inner Temple East Hall
   > Middle
       Trivial
 
-> Dock to 1-Orb Hallway; Heals? False
+> Horizontal Dock to 1-Orb Hallway; Heals? False
   * Layers: default
-  * Open Passage to 1-Orb Hallway/Dock to Inner Temple East Hall
+  * 4-Tiles High Dock to 1-Orb Hallway/Horizontal Dock to Inner Temple East Hall
   > Middle
       Trivial
 
-> Dock to Inner Temple Pipe; Heals? False
+> Horizontal Dock to Inner Temple Pipe; Heals? False
   * Layers: default
-  * Open Passage to Inner Temple Pipe/Dock to Inner Temple East Hall
+  * 3-Tiles High Dock to Inner Temple Pipe/Horizontal Dock to Inner Temple East Hall
   > Middle
       Screw Attack or Disabled Screw Attack Pipe Blocks
 
@@ -678,15 +678,15 @@ Extra - minimap_data: [{'x': 65, 'y': 10}, {'x': 65, 'y': 11}, {'x': 65, 'y': 12
   * Layers: default
   > Door to Golden Temple Exterior
       Trivial
-  > Dock to Charge Beam Chamber Access
+  > Horizontal Dock to Charge Beam Chamber Access
       Trivial
-  > Dock to Armory
+  > Horizontal Dock to Armory
       Trivial
-  > Dock to 3-Orb Hallway
+  > Horizontal Dock to 3-Orb Hallway
       Trivial
-  > Dock to 1-Orb Hallway
+  > Horizontal Dock to 1-Orb Hallway
       Trivial
-  > Dock to Inner Temple Pipe
+  > Horizontal Dock to Inner Temple Pipe
       Screw Attack or Disabled Screw Attack Pipe Blocks
   > Door to Parkour Course
       Can Use Any Bombs
@@ -707,15 +707,15 @@ Extra - minimap_data: [{'x': 65, 'y': 10}, {'x': 65, 'y': 11}, {'x': 65, 'y': 12
 1-Orb Hallway
 Extra - map_name: rm_a1a07
 Extra - minimap_data: [{'x': 62, 'y': 12}, {'x': 63, 'y': 12}, {'x': 64, 'y': 12}]
-> Dock to Inner Temple West Hall; Heals? False
+> Horizontal Dock to Inner Temple West Hall; Heals? False
   * Layers: default
-  * Open Passage to Inner Temple West Hall/Dock to 1-Orb Hallway
+  * 4-Tiles High Dock to Inner Temple West Hall/Horizontal Dock to 1-Orb Hallway
   > Middle
       Can Use Any Bombs
 
-> Dock to Inner Temple East Hall; Heals? False
+> Horizontal Dock to Inner Temple East Hall; Heals? False
   * Layers: default
-  * Open Passage to Inner Temple East Hall/Dock to 1-Orb Hallway
+  * 4-Tiles High Dock to Inner Temple East Hall/Horizontal Dock to 1-Orb Hallway
   > Middle
       All of the following:
           Can Use Any Bombs
@@ -725,9 +725,9 @@ Extra - minimap_data: [{'x': 62, 'y': 12}, {'x': 63, 'y': 12}, {'x': 64, 'y': 12
 
 > Middle; Heals? False
   * Layers: default
-  > Dock to Inner Temple West Hall
+  > Horizontal Dock to Inner Temple West Hall
       Can Use Any Bombs
-  > Dock to Inner Temple East Hall
+  > Horizontal Dock to Inner Temple East Hall
       Can Use Any Bombs
   > Event - 1Orb
       Can Use Any Bombs
@@ -736,7 +736,7 @@ Extra - minimap_data: [{'x': 62, 'y': 12}, {'x': 63, 'y': 12}, {'x': 64, 'y': 12
   * Layers: default
   * Pickup 103; Category? Minor
   * Extra - object_name: oItemETank_103
-  > Dock to Inner Temple East Hall
+  > Horizontal Dock to Inner Temple East Hall
       Trivial
 
 > Event - 1Orb; Heals? False
@@ -749,9 +749,9 @@ Extra - minimap_data: [{'x': 62, 'y': 12}, {'x': 63, 'y': 12}, {'x': 64, 'y': 12
 Armory
 Extra - map_name: rm_a1a08
 Extra - minimap_data: [{'x': 66, 'y': 13}, {'x': 67, 'y': 13}, {'x': 68, 'y': 13}]
-> Dock to Inner Temple East Hall; Heals? False
+> Horizontal Dock to Inner Temple East Hall; Heals? False
   * Layers: default
-  * Open Passage to Inner Temple East Hall/Dock to Armory
+  * 4-Tiles High Dock to Inner Temple East Hall/Horizontal Dock to Armory
   > Inside Tunnel
       Any of the following:
           Tunnel Climb
@@ -795,7 +795,7 @@ Extra - minimap_data: [{'x': 66, 'y': 13}, {'x': 67, 'y': 13}, {'x': 68, 'y': 13
 
 > Inside Tunnel; Heals? False
   * Layers: default
-  > Dock to Inner Temple East Hall
+  > Horizontal Dock to Inner Temple East Hall
       Morph Ball
   > Tunnel to Spider Ball Chamber
       Morph Ball
@@ -817,21 +817,21 @@ Extra - minimap_data: [{'x': 66, 'y': 13}, {'x': 67, 'y': 13}, {'x': 68, 'y': 13
   * Layers: default
   * Pickup 104; Category? Minor
   * Extra - object_name: oItemM_104
-  > Dock to Inner Temple East Hall
+  > Horizontal Dock to Inner Temple East Hall
       Trivial
 
 > Pickup (Bottom Missile Tank); Heals? False
   * Layers: default
   * Pickup 105; Category? Minor
   * Extra - object_name: oItemM_105
-  > Dock to Inner Temple East Hall
+  > Horizontal Dock to Inner Temple East Hall
       Trivial
 
 > Pickup (Top Missile Tank); Heals? False
   * Layers: default
   * Pickup 106; Category? Minor
   * Extra - object_name: oItemM_106
-  > Dock to Inner Temple East Hall
+  > Horizontal Dock to Inner Temple East Hall
       Morph Ball
 
 > Pickup (Right Missile Tank); Heals? False
@@ -845,9 +845,9 @@ Extra - minimap_data: [{'x': 66, 'y': 13}, {'x': 67, 'y': 13}, {'x': 68, 'y': 13
 Charge Beam Chamber Access
 Extra - map_name: rm_a1a09
 Extra - minimap_data: [{'x': 63, 'y': 14}, {'x': 64, 'y': 14}]
-> Dock to Inner Temple East Hall; Heals? False
+> Horizontal Dock to Inner Temple East Hall; Heals? False
   * Layers: default
-  * Open Passage to Inner Temple East Hall/Dock to Charge Beam Chamber Access
+  * 4-Tiles High Dock to Inner Temple East Hall/Horizontal Dock to Charge Beam Chamber Access
   > Door to Charge Beam Chamber
       Morph Ball
 
@@ -855,7 +855,7 @@ Extra - minimap_data: [{'x': 63, 'y': 14}, {'x': 64, 'y': 14}]
   * Layers: default
   * Missile Door to Charge Beam Chamber/Door to Charge Beam Chamber Access
   * Extra - instance_id: 108658
-  > Dock to Inner Temple East Hall
+  > Horizontal Dock to Inner Temple East Hall
       High Mid-Air Morph Tunnel Climb
 
 ----------------
@@ -880,9 +880,9 @@ Extra - minimap_data: [{'x': 62, 'y': 14}]
 Inner Temple Pipe
 Extra - map_name: rm_a1a11
 Extra - minimap_data: [{'x': 62, 'y': 13}, {'x': 63, 'y': 13}, {'x': 64, 'y': 13}]
-> Dock to Inner Temple East Hall; Heals? False; Default Node
+> Horizontal Dock to Inner Temple East Hall; Heals? False; Default Node
   * Layers: default
-  * Open Passage to Inner Temple East Hall/Dock to Inner Temple Pipe
+  * 3-Tiles High Dock to Inner Temple East Hall/Horizontal Dock to Inner Temple Pipe
   > Pipe to Distribution Center
       Morph Ball
 
@@ -892,7 +892,7 @@ Extra - minimap_data: [{'x': 62, 'y': 13}, {'x': 63, 'y': 13}, {'x': 64, 'y': 13
   * Extra - instance_id: 108742
   * Extra - dest_x: 152
   * Extra - dest_y: 128
-  > Dock to Inner Temple East Hall
+  > Horizontal Dock to Inner Temple East Hall
       Morph Ball
 
 ----------------
@@ -922,15 +922,15 @@ Extra - minimap_data: [{'x': 66, 'y': 14}, {'x': 66, 'y': 15}, {'x': 66, 'y': 16
 Breeding Grounds Entrance
 Extra - map_name: rm_a1b01
 Extra - minimap_data: [{'x': 54, 'y': 14}, {'x': 55, 'y': 14}, {'x': 56, 'y': 14}, {'x': 57, 'y': 14}]
-> Dock to Breeding Grounds Save Station; Heals? False
+> Horizontal Dock to Breeding Grounds Save Station; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds Save Station/Dock to Breeding Grounds Entrance
+  * 5-Tiles High Dock to Breeding Grounds Save Station/Horizontal Dock to Breeding Grounds Entrance
   > Past Bombs
       Can Use Any Bombs
 
-> Dock to Breeding Grounds Hub; Heals? False
+> Horizontal Dock to Breeding Grounds Hub; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds Hub/Dock to Breeding Grounds Entrance
+  * 5-Tiles High Dock to Breeding Grounds Hub/Horizontal Dock to Breeding Grounds Entrance
   > Past Bombs
       All of the following:
           Morph Ball
@@ -938,9 +938,9 @@ Extra - minimap_data: [{'x': 54, 'y': 14}, {'x': 55, 'y': 14}, {'x': 56, 'y': 14
 
 > Past Bombs; Heals? False
   * Layers: default
-  > Dock to Breeding Grounds Save Station
+  > Horizontal Dock to Breeding Grounds Save Station
       Can Use Any Bombs
-  > Dock to Breeding Grounds Hub
+  > Horizontal Dock to Breeding Grounds Hub
       All of the following:
           Morph Ball
           Mid-Air Morph (Beginner) or Tunnel Climb
@@ -949,48 +949,48 @@ Extra - minimap_data: [{'x': 54, 'y': 14}, {'x': 55, 'y': 14}, {'x': 56, 'y': 14
 Breeding Grounds Hub
 Extra - map_name: rm_a1b02
 Extra - minimap_data: [{'x': 58, 'y': 14}, {'x': 58, 'y': 15}, {'x': 58, 'y': 16}]
-> Dock to Breeding Grounds South West; Heals? False
+> Horizontal Dock to Breeding Grounds South West; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds South West/Dock to Breeding Grounds Hub
-  > Dock to Breeding Grounds North East
+  * 4-Tiles High Dock to Breeding Grounds South West/Horizontal Dock to Breeding Grounds Hub
+  > Horizontal Dock to Breeding Grounds North East
       Trivial
-  > Dock to Breeding Grounds South East
+  > Horizontal Dock to Breeding Grounds South East
       Trivial
 
-> Dock to Breeding Grounds Entrance; Heals? False
+> Horizontal Dock to Breeding Grounds Entrance; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds Entrance/Dock to Breeding Grounds Hub
-  > Dock to Breeding Grounds North East
+  * 5-Tiles High Dock to Breeding Grounds Entrance/Horizontal Dock to Breeding Grounds Hub
+  > Horizontal Dock to Breeding Grounds North East
       Trivial
 
-> Dock to Breeding Grounds North East; Heals? False
+> Horizontal Dock to Breeding Grounds North East; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds North East/Dock to Breeding Grounds Hub
-  > Dock to Breeding Grounds South West
+  * 4-Tiles High Dock to Breeding Grounds North East/Horizontal Dock to Breeding Grounds Hub
+  > Horizontal Dock to Breeding Grounds South West
       Trivial
-  > Dock to Breeding Grounds Entrance
+  > Horizontal Dock to Breeding Grounds Entrance
       Trivial
 
-> Dock to Breeding Grounds South East; Heals? False
+> Horizontal Dock to Breeding Grounds South East; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds South East/Dock to Breeding Grounds Hub
-  > Dock to Breeding Grounds South West
+  * 4-Tiles High Dock to Breeding Grounds South East/Horizontal Dock to Breeding Grounds Hub
+  > Horizontal Dock to Breeding Grounds South West
       Trivial
 
 ----------------
 Breeding Grounds North East
 Extra - map_name: rm_a1b03
 Extra - minimap_data: [{'x': 59, 'y': 15}, {'x': 60, 'y': 15}, {'x': 61, 'y': 15}, {'x': 62, 'y': 15}, {'x': 63, 'y': 15}]
-> Dock to Breeding Grounds Hub; Heals? False
+> Horizontal Dock to Breeding Grounds Hub; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds Hub/Dock to Breeding Grounds North East
+  * 4-Tiles High Dock to Breeding Grounds Hub/Horizontal Dock to Breeding Grounds North East
   > Event - Alpha
       Defeat non-dodging Alpha
 
 > Event - Alpha; Heals? False
   * Layers: default
   * Event Metroids Area 1 - Breeding Grounds Upper Right Alpha
-  > Dock to Breeding Grounds Hub
+  > Horizontal Dock to Breeding Grounds Hub
       Trivial
   > Pickup (Alpha)
       Trivial
@@ -1006,16 +1006,16 @@ Extra - minimap_data: [{'x': 59, 'y': 15}, {'x': 60, 'y': 15}, {'x': 61, 'y': 15
 Breeding Grounds South West
 Extra - map_name: rm_a1b04
 Extra - minimap_data: [{'x': 54, 'y': 16}, {'x': 55, 'y': 16}, {'x': 56, 'y': 16}, {'x': 57, 'y': 16}]
-> Dock to Breeding Grounds Hub; Heals? False
+> Horizontal Dock to Breeding Grounds Hub; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds Hub/Dock to Breeding Grounds South West
+  * 4-Tiles High Dock to Breeding Grounds Hub/Horizontal Dock to Breeding Grounds South West
   > Event - Alpha
       Defeat dodging Alpha
 
 > Event - Alpha; Heals? False
   * Layers: default
   * Event Metroids Area 1 - Breeding Grounds Lower Left Alpha
-  > Dock to Breeding Grounds Hub
+  > Horizontal Dock to Breeding Grounds Hub
       Trivial
   > Pickup (Alpha)
       Trivial
@@ -1031,16 +1031,16 @@ Extra - minimap_data: [{'x': 54, 'y': 16}, {'x': 55, 'y': 16}, {'x': 56, 'y': 16
 Breeding Grounds South East
 Extra - map_name: rm_a1b05
 Extra - minimap_data: [{'x': 59, 'y': 16}, {'x': 60, 'y': 16}]
-> Dock to Breeding Grounds Hub; Heals? False
+> Horizontal Dock to Breeding Grounds Hub; Heals? False
   * Layers: default
-  * Open Passage to Breeding Grounds Hub/Dock to Breeding Grounds South East
+  * 4-Tiles High Dock to Breeding Grounds Hub/Horizontal Dock to Breeding Grounds South East
   > Event - Alpha
       Defeat non-dodging Alpha
 
 > Event - Alpha; Heals? False
   * Layers: default
   * Event Metroids Area 1 - Breeding Grounds Lower Right Alpha
-  > Dock to Breeding Grounds Hub
+  > Horizontal Dock to Breeding Grounds Hub
       Trivial
   > Pickup (Alpha)
       Trivial

--- a/randovania/games/am2r/json_data/header.json
+++ b/randovania/games/am2r/json_data/header.json
@@ -4338,6 +4338,46 @@
                     ]
                 }
             },
+            "horizontal_dock": {
+                "name": "Horizontal Dock",
+                "extra": {},
+                "items": {
+                    "4-Tiles High Dock": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "lock": null
+                    },
+                    "5-Tiles High Dock": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "lock": null
+                    },
+                    "3-Tiles High Dock": {
+                        "extra": {},
+                        "requirement": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "lock": null
+                    }
+                },
+                "dock_rando": null
+            },
             "tunnel": {
                 "name": "Tunnel",
                 "extra": {},

--- a/randovania/games/am2r/json_data/header.txt
+++ b/randovania/games/am2r/json_data/header.txt
@@ -546,6 +546,27 @@ Dock Weaknesses
           Wave Beam Door
 
 
+> Horizontal Dock
+  * 4-Tiles High Dock
+      Open:
+          Trivial
+      No lock
+
+
+  * 5-Tiles High Dock
+      Open:
+          Trivial
+      No lock
+
+
+  * 3-Tiles High Dock
+      Open:
+          Trivial
+      No lock
+
+  > Dock Rando: Disabled
+
+
 > Tunnel
   * Morph Ball Tunnel
       Open:


### PR DESCRIPTION
This is part one of many, which refactors the docks in AM2R's DB.
Currently, **all** of AM2R's docks are classified as "Open Access Docks". This is fine for the current feature set, but for future features (mainly Room Rando and "Replace docks with doors") it will be required to know how high/wide docks are.
This PR adds Horizontal docks, and goes through all of them in Golden Temple.
Doing the Vertical docks will come in later PRs, as this feature is not too important right now, and i'd like to split this as much as possible for reviewability

It's worth noting, that the "dock order" is currently intentional like this, as they're approximately sorted by how often they're used.