### PR TITLE
Fix am2r and prime getting invalid ETM model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: Comments no longer prevent And/Or requirements from being displayed as short form.
 - Fixed: Auto Tracker icons that were supposed to be always visible no longer show as disabled.
 - Fixed: Opening race rdvgame files from older Randovania versions now works properly. 
+- Fixed: Exporting games with hidden Nothing models don't crash during the exporting process anymore.
 
 ### Metroid Dread
 

--- a/randovania/exporter/pickup_exporter.py
+++ b/randovania/exporter/pickup_exporter.py
@@ -267,10 +267,10 @@ class PickupExporterMulti(PickupExporter):
 def _get_visual_model(original_index: int,
                       pickup_list: list[PickupTarget],
                       data_source: PickupModelDataSource,
-                      visual_etm: PickupEntry,
+                      visual_nothing: PickupEntry,
                       ) -> PickupEntry:
     if data_source == PickupModelDataSource.ETM:
-        return visual_etm
+        return visual_nothing
     elif data_source == PickupModelDataSource.RANDOM:
         return pickup_list[original_index % len(pickup_list)].pickup
     elif data_source == PickupModelDataSource.LOCATION:
@@ -286,7 +286,7 @@ def export_all_indices(patches: GamePatches,
                        model_style: PickupModelStyle,
                        data_source: PickupModelDataSource,
                        exporter: PickupExporter,
-                       visual_etm: PickupEntry,
+                       visual_nothing: PickupEntry,
                        ) -> list[ExportedPickupDetails]:
     """
     Creates the patcher data for all pickups in the game
@@ -297,7 +297,7 @@ def export_all_indices(patches: GamePatches,
     :param model_style:
     :param data_source:
     :param exporter:
-    :param visual_etm:
+    :param visual_nothing:
     :return:
     """
     pickup_assignment = patches.pickup_assignment
@@ -314,7 +314,7 @@ def export_all_indices(patches: GamePatches,
     pickups = [
         exporter.export(index,
                         pickup_assignment.get(index, useless_target),
-                        _get_visual_model(i, pickup_list, data_source, visual_etm),
+                        _get_visual_model(i, pickup_list, data_source, visual_nothing),
                         model_style,
                         )
         for i, index in enumerate(indices)

--- a/randovania/game_description/default_database.py
+++ b/randovania/game_description/default_database.py
@@ -50,6 +50,7 @@ def write_pickup_database_for_game(pickup_db: pickup_database.PickupDatabase, ga
 
 
 @functools.lru_cache
+# TODO: this game specific function should be removed from here.
 def default_prime2_memo_data() -> dict:
     memo_data = json_lib.read_path(
         RandovaniaGame.METROID_PRIME_ECHOES.data_path.joinpath("pickup_database", "memo_data.json")

--- a/randovania/games/am2r/exporter/patch_data_factory.py
+++ b/randovania/games/am2r/exporter/patch_data_factory.py
@@ -270,7 +270,7 @@ class AM2RPatchDataFactory(BasePatchDataFactory):
             self.configuration.pickup_model_style,
             self.configuration.pickup_model_data_source,
             exporter=pickup_exporter.create_pickup_exporter(memo_data, self.players_config, self.game_enum()),
-            visual_etm=pickup_creator.create_visual_nothing(self.game_enum(), "sItemNothing"),
+            visual_nothing=pickup_creator.create_visual_nothing(self.game_enum(), "sItemNothing"),
         )
 
         return {

--- a/randovania/games/am2r/exporter/patch_data_factory.py
+++ b/randovania/games/am2r/exporter/patch_data_factory.py
@@ -270,7 +270,7 @@ class AM2RPatchDataFactory(BasePatchDataFactory):
             self.configuration.pickup_model_style,
             self.configuration.pickup_model_data_source,
             exporter=pickup_exporter.create_pickup_exporter(memo_data, self.players_config, self.game_enum()),
-            visual_etm=pickup_creator.create_visual_etm(),
+            visual_etm=pickup_creator.create_visual_etm(self.game_enum(), "sItemNothing"),
         )
 
         return {

--- a/randovania/games/am2r/exporter/patch_data_factory.py
+++ b/randovania/games/am2r/exporter/patch_data_factory.py
@@ -270,7 +270,7 @@ class AM2RPatchDataFactory(BasePatchDataFactory):
             self.configuration.pickup_model_style,
             self.configuration.pickup_model_data_source,
             exporter=pickup_exporter.create_pickup_exporter(memo_data, self.players_config, self.game_enum()),
-            visual_etm=pickup_creator.create_visual_etm(self.game_enum(), "sItemNothing"),
+            visual_etm=pickup_creator.create_visual_nothing(self.game_enum(), "sItemNothing"),
         )
 
         return {

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -485,7 +485,7 @@ class DreadPatchDataFactory(BasePatchDataFactory):
             self.configuration.pickup_model_style,
             self.configuration.pickup_model_data_source,
             exporter=pickup_exporter.create_pickup_exporter(self.memo_data, self.players_config, self.game_enum()),
-            visual_etm=pickup_creator.create_visual_nothing(),
+            visual_nothing=pickup_creator.create_visual_nothing(),
         )
 
         energy_per_tank = self.configuration.energy_per_tank if self.configuration.immediate_energy_parts else 100.0

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -485,7 +485,7 @@ class DreadPatchDataFactory(BasePatchDataFactory):
             self.configuration.pickup_model_style,
             self.configuration.pickup_model_data_source,
             exporter=pickup_exporter.create_pickup_exporter(self.memo_data, self.players_config, self.game_enum()),
-            visual_etm=pickup_creator.create_visual_etm(),
+            visual_etm=pickup_creator.create_visual_nothing(),
         )
 
         energy_per_tank = self.configuration.energy_per_tank if self.configuration.immediate_energy_parts else 100.0

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -485,7 +485,7 @@ class DreadPatchDataFactory(BasePatchDataFactory):
             self.configuration.pickup_model_style,
             self.configuration.pickup_model_data_source,
             exporter=pickup_exporter.create_pickup_exporter(self.memo_data, self.players_config, self.game_enum()),
-            visual_nothing=pickup_creator.create_visual_nothing(),
+            visual_nothing=pickup_creator.create_visual_nothing(self.game_enum(), "Nothing"),
         )
 
         energy_per_tank = self.configuration.energy_per_tank if self.configuration.immediate_energy_parts else 100.0

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -629,7 +629,7 @@ class PrimePatchDataFactory(BasePatchDataFactory):
                 self.players_config,
                 self.game_enum()
             ),
-            visual_etm=pickup_creator.create_visual_nothing(self.game_enum(), "Nothing"),
+            visual_nothing=pickup_creator.create_visual_nothing(self.game_enum(), "Nothing"),
         )
         modal_hud_override = _create_locations_with_modal_hud_memo(pickup_list)
         regions = [region for region in db.region_list.regions if region.name != "End of Game"]

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -629,7 +629,7 @@ class PrimePatchDataFactory(BasePatchDataFactory):
                 self.players_config,
                 self.game_enum()
             ),
-            visual_etm=pickup_creator.create_visual_etm(),
+            visual_etm=pickup_creator.create_visual_etm(self.game_enum(), "Nothing"),
         )
         modal_hud_override = _create_locations_with_modal_hud_memo(pickup_list)
         regions = [region for region in db.region_list.regions if region.name != "End of Game"]

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -629,7 +629,7 @@ class PrimePatchDataFactory(BasePatchDataFactory):
                 self.players_config,
                 self.game_enum()
             ),
-            visual_etm=pickup_creator.create_visual_etm(self.game_enum(), "Nothing"),
+            visual_etm=pickup_creator.create_visual_nothing(self.game_enum(), "Nothing"),
         )
         modal_hud_override = _create_locations_with_modal_hud_memo(pickup_list)
         regions = [region for region in db.region_list.regions if region.name != "End of Game"]

--- a/randovania/games/prime2/exporter/patch_data_factory.py
+++ b/randovania/games/prime2/exporter/patch_data_factory.py
@@ -827,7 +827,7 @@ def _create_pickup_list(cosmetic_patches: EchoesCosmeticPatches, configuration: 
         configuration.pickup_model_style,
         configuration.pickup_model_data_source,
         exporter=pickup_exporter.create_pickup_exporter(memo_data, players_config, RandovaniaGame.METROID_PRIME_ECHOES),
-        visual_etm=pickup_creator.create_visual_etm(),
+        visual_etm=pickup_creator.create_visual_nothing(),
     )
     multiworld_item = game.resource_database.get_item(echoes_items.MULTIWORLD_ITEM)
 

--- a/randovania/games/prime2/exporter/patch_data_factory.py
+++ b/randovania/games/prime2/exporter/patch_data_factory.py
@@ -819,6 +819,7 @@ def _create_pickup_list(cosmetic_patches: EchoesCosmeticPatches, configuration: 
     else:
         memo_data = default_prime2_memo_data()
 
+    echoes_game = RandovaniaGame.METROID_PRIME_ECHOES
     pickup_list = pickup_exporter.export_all_indices(
         patches,
         useless_target,
@@ -826,8 +827,8 @@ def _create_pickup_list(cosmetic_patches: EchoesCosmeticPatches, configuration: 
         rng,
         configuration.pickup_model_style,
         configuration.pickup_model_data_source,
-        exporter=pickup_exporter.create_pickup_exporter(memo_data, players_config, RandovaniaGame.METROID_PRIME_ECHOES),
-        visual_nothing=pickup_creator.create_visual_nothing(),
+        exporter=pickup_exporter.create_pickup_exporter(memo_data, players_config, echoes_game),
+        visual_nothing=pickup_creator.create_visual_nothing(echoes_game, "EnergyTransferModule"),
     )
     multiworld_item = game.resource_database.get_item(echoes_items.MULTIWORLD_ITEM)
 

--- a/randovania/games/prime2/exporter/patch_data_factory.py
+++ b/randovania/games/prime2/exporter/patch_data_factory.py
@@ -827,7 +827,7 @@ def _create_pickup_list(cosmetic_patches: EchoesCosmeticPatches, configuration: 
         configuration.pickup_model_style,
         configuration.pickup_model_data_source,
         exporter=pickup_exporter.create_pickup_exporter(memo_data, players_config, RandovaniaGame.METROID_PRIME_ECHOES),
-        visual_etm=pickup_creator.create_visual_nothing(),
+        visual_nothing=pickup_creator.create_visual_nothing(),
     )
     multiworld_item = game.resource_database.get_item(echoes_items.MULTIWORLD_ITEM)
 

--- a/randovania/games/prime2/pickup_database/memo_data.json
+++ b/randovania/games/prime2/pickup_database/memo_data.json
@@ -47,5 +47,6 @@
   "Sky Temple Key": "Sky Temple Key acquired!\nThis is one of nine keys needed to open the Sky Temple.\nAdditional data downloaded to Inventory Screen. Press START to access the Inventory Screen.",
   "Double Damage": "Double Damage acquired!\nThis doubles all damage you deal and makes you flash red.",
   "Unlimited Beam Ammo": "Unlimited Beam Ammo acquired!\nDark and Light Beam Ammo are now always at maximum.",
-  "Unlimited Missiles": "Unlimited Missiles acquired!\nMissile Ammo is now always at maximum."
+  "Unlimited Missiles": "Unlimited Missiles acquired!\nMissile Ammo is now always at maximum.",
+  "Unknown item": "Unknown item acquired!"
 }

--- a/randovania/games/samus_returns/exporter/patch_data_factory.py
+++ b/randovania/games/samus_returns/exporter/patch_data_factory.py
@@ -92,7 +92,7 @@ class MSRPatchDataFactory(BasePatchDataFactory):
             self.configuration.pickup_model_style,
             self.configuration.pickup_model_data_source,
             exporter=pickup_exporter.create_pickup_exporter(self.memo_data, self.players_config, self.game_enum()),
-            visual_etm=pickup_creator.create_visual_etm(),
+            visual_etm=pickup_creator.create_visual_nothing(),
         )
 
         energy_per_tank = self.configuration.energy_per_tank

--- a/randovania/games/samus_returns/exporter/patch_data_factory.py
+++ b/randovania/games/samus_returns/exporter/patch_data_factory.py
@@ -92,7 +92,7 @@ class MSRPatchDataFactory(BasePatchDataFactory):
             self.configuration.pickup_model_style,
             self.configuration.pickup_model_data_source,
             exporter=pickup_exporter.create_pickup_exporter(self.memo_data, self.players_config, self.game_enum()),
-            visual_etm=pickup_creator.create_visual_nothing(),
+            visual_nothing=pickup_creator.create_visual_nothing(),
         )
 
         energy_per_tank = self.configuration.energy_per_tank

--- a/randovania/games/samus_returns/exporter/patch_data_factory.py
+++ b/randovania/games/samus_returns/exporter/patch_data_factory.py
@@ -92,7 +92,7 @@ class MSRPatchDataFactory(BasePatchDataFactory):
             self.configuration.pickup_model_style,
             self.configuration.pickup_model_data_source,
             exporter=pickup_exporter.create_pickup_exporter(self.memo_data, self.players_config, self.game_enum()),
-            visual_nothing=pickup_creator.create_visual_nothing(),
+            visual_nothing=pickup_creator.create_visual_nothing(self.game_enum(), "Nothing"),
         )
 
         energy_per_tank = self.configuration.energy_per_tank

--- a/randovania/games/super_metroid/exporter/patch_data_factory.py
+++ b/randovania/games/super_metroid/exporter/patch_data_factory.py
@@ -116,7 +116,7 @@ class SuperMetroidPatchDataFactory(BasePatchDataFactory):
                 self.players_config,
                 self.game_enum()
             ),
-            visual_nothing=pickup_creator.create_visual_nothing(),
+            visual_nothing=pickup_creator.create_visual_nothing(self.game_enum(), "Nothing"),
         )
 
         gameplay_patch_list = [field.name for field in dataclasses.fields(self.configuration.patches)]

--- a/randovania/games/super_metroid/exporter/patch_data_factory.py
+++ b/randovania/games/super_metroid/exporter/patch_data_factory.py
@@ -116,7 +116,7 @@ class SuperMetroidPatchDataFactory(BasePatchDataFactory):
                 self.players_config,
                 self.game_enum()
             ),
-            visual_etm=pickup_creator.create_visual_etm(),
+            visual_etm=pickup_creator.create_visual_nothing(),
         )
 
         gameplay_patch_list = [field.name for field in dataclasses.fields(self.configuration.patches)]

--- a/randovania/games/super_metroid/exporter/patch_data_factory.py
+++ b/randovania/games/super_metroid/exporter/patch_data_factory.py
@@ -116,7 +116,7 @@ class SuperMetroidPatchDataFactory(BasePatchDataFactory):
                 self.players_config,
                 self.game_enum()
             ),
-            visual_etm=pickup_creator.create_visual_nothing(),
+            visual_nothing=pickup_creator.create_visual_nothing(),
         )
 
         gameplay_patch_list = [field.name for field in dataclasses.fields(self.configuration.patches)]

--- a/randovania/generator/pickup_pool/pickup_creator.py
+++ b/randovania/generator/pickup_pool/pickup_creator.py
@@ -137,17 +137,19 @@ def create_nothing_pickup(resource_database: ResourceDatabase, model_name: str =
     )
 
 
-def create_visual_etm() -> PickupEntry:
+def create_visual_etm(game: RandovaniaGame = RandovaniaGame.METROID_PRIME_ECHOES,
+                      model_name: str = echoes_items.USELESS_PICKUP_MODEL,
+                      pickup_name: str = "Unknown item") -> PickupEntry:
     """
     Creates an ETM that should only be used as a visual pickup.
     :return:
     """
     return PickupEntry(
-        name="Unknown item",
+        name=pickup_name,
         progression=(),
         model=PickupModel(
-            game=RandovaniaGame.METROID_PRIME_ECHOES,
-            name=echoes_items.USELESS_PICKUP_MODEL,
+            game=game,
+            name=model_name,
         ),
         pickup_category=pickup_category.USELESS_PICKUP_CATEGORY,
         broad_category=pickup_category.USELESS_PICKUP_CATEGORY,

--- a/randovania/generator/pickup_pool/pickup_creator.py
+++ b/randovania/generator/pickup_pool/pickup_creator.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING
 from randovania.game_description.pickup import pickup_category
 from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
 from randovania.game_description.resources.location_category import LocationCategory
-from randovania.games.game import RandovaniaGame
-from randovania.games.prime2.patcher import echoes_items
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -16,6 +14,7 @@ if TYPE_CHECKING:
     from randovania.game_description.resources.item_resource_info import ItemResourceInfo
     from randovania.game_description.resources.resource_database import ResourceDatabase
     from randovania.game_description.resources.resource_info import ResourceQuantity
+    from randovania.games.game import RandovaniaGame
     from randovania.layout.base.standard_pickup_state import StandardPickupState
 
 
@@ -137,13 +136,13 @@ def create_nothing_pickup(resource_database: ResourceDatabase, model_name: str =
     )
 
 
-def create_visual_nothing(game: RandovaniaGame = RandovaniaGame.METROID_PRIME_ECHOES,
-                          model_name: str = echoes_items.USELESS_PICKUP_MODEL,
+def create_visual_nothing(game: RandovaniaGame,
+                          model_name: str,
                           pickup_name: str = "Unknown item") -> PickupEntry:
     """
     Creates a Nothing pickup that should only be used for visual purposes.
-    :param game: The game from where the model comes from. Defaults to Echoes.
-    :param model_name: The model name for the Nothing pickup. Defaults to "EnergyTransferModule".
+    :param game: The game from where the model comes from.
+    :param model_name: The model name for the Nothing pickup.
     :param pickup_name: The name of the Nothing pickup. Defaults to "Unknown item".
     :return:
     """

--- a/randovania/generator/pickup_pool/pickup_creator.py
+++ b/randovania/generator/pickup_pool/pickup_creator.py
@@ -137,11 +137,14 @@ def create_nothing_pickup(resource_database: ResourceDatabase, model_name: str =
     )
 
 
-def create_visual_etm(game: RandovaniaGame = RandovaniaGame.METROID_PRIME_ECHOES,
-                      model_name: str = echoes_items.USELESS_PICKUP_MODEL,
-                      pickup_name: str = "Unknown item") -> PickupEntry:
+def create_visual_nothing(game: RandovaniaGame = RandovaniaGame.METROID_PRIME_ECHOES,
+                          model_name: str = echoes_items.USELESS_PICKUP_MODEL,
+                          pickup_name: str = "Unknown item") -> PickupEntry:
     """
-    Creates an ETM that should only be used as a visual pickup.
+    Creates a Nothing pickup that should only be used for visual purposes.
+    :param game: The game from where the model comes from. Defaults to Echoes.
+    :param model_name: The model name for the Nothing pickup. Defaults to "EnergyTransferModule".
+    :param pickup_name: The name of the Nothing pickup. Defaults to "Unknown item".
     :return:
     """
     return PickupEntry(

--- a/test/game_description/test_game_patches.py
+++ b/test/game_description/test_game_patches.py
@@ -5,7 +5,7 @@ from randovania.generator.pickup_pool import pickup_creator
 
 def test_assign_extra_pickups(empty_patches):
     # Setup
-    sample_pickup = pickup_creator.create_visual_nothing()
+    sample_pickup = pickup_creator.create_visual_nothing("Test Game", "Visual Nothing")
 
     # Run
     new_patches = empty_patches.assign_extra_starting_pickups([

--- a/test/game_description/test_game_patches.py
+++ b/test/game_description/test_game_patches.py
@@ -5,7 +5,7 @@ from randovania.generator.pickup_pool import pickup_creator
 
 def test_assign_extra_pickups(empty_patches):
     # Setup
-    sample_pickup = pickup_creator.create_visual_etm()
+    sample_pickup = pickup_creator.create_visual_nothing()
 
     # Run
     new_patches = empty_patches.assign_extra_starting_pickups([

--- a/test/games/am2r/exporter/test_am2r_patch_data_factory.py
+++ b/test/games/am2r/exporter/test_am2r_patch_data_factory.py
@@ -86,7 +86,7 @@ def test_create_pickups_dict_shiny(test_files_dir, rdvgame_filename,
         data.configuration.pickup_model_style,
         data.configuration.pickup_model_data_source,
         exporter=pickup_exporter.create_pickup_exporter(memo_data, data.players_config, data.game),
-        visual_etm=pickup_creator.create_visual_etm(),
+        visual_etm=pickup_creator.create_visual_nothing(data.game_enum(), "sItemNothing"),
     )
 
     # Run

--- a/test/games/am2r/exporter/test_am2r_patch_data_factory.py
+++ b/test/games/am2r/exporter/test_am2r_patch_data_factory.py
@@ -86,7 +86,7 @@ def test_create_pickups_dict_shiny(test_files_dir, rdvgame_filename,
         data.configuration.pickup_model_style,
         data.configuration.pickup_model_data_source,
         exporter=pickup_exporter.create_pickup_exporter(memo_data, data.players_config, data.game),
-        visual_etm=pickup_creator.create_visual_nothing(data.game_enum(), "sItemNothing"),
+        visual_nothing=pickup_creator.create_visual_nothing(data.game_enum(), "sItemNothing"),
     )
 
     # Run

--- a/test/games/prime/patcher_file_lib/test_pickup_exporter.py
+++ b/test/games/prime/patcher_file_lib/test_pickup_exporter.py
@@ -164,7 +164,7 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
         model_style,
         PickupModelDataSource.ETM,
         creator,
-        pickup_creator.create_visual_nothing(),
+        pickup_creator.create_visual_nothing(RandovaniaGame.METROID_PRIME_ECHOES, "EnergyTransferModule"),
     )
 
     # Assert
@@ -301,7 +301,7 @@ def test_create_pickup_list_random_data_source(has_memo_data: bool, empty_patche
         PickupModelStyle.HIDE_ALL,
         PickupModelDataSource.RANDOM,
         creator,
-        pickup_creator.create_visual_nothing(),
+        pickup_creator.create_visual_nothing(RandovaniaGame.METROID_PRIME_ECHOES, "EnergyTransferModule"),
     )
 
     # Assert

--- a/test/games/prime/patcher_file_lib/test_pickup_exporter.py
+++ b/test/games/prime/patcher_file_lib/test_pickup_exporter.py
@@ -164,7 +164,7 @@ def test_create_pickup_list(model_style: PickupModelStyle, empty_patches, generi
         model_style,
         PickupModelDataSource.ETM,
         creator,
-        pickup_creator.create_visual_etm(),
+        pickup_creator.create_visual_nothing(),
     )
 
     # Assert
@@ -301,7 +301,7 @@ def test_create_pickup_list_random_data_source(has_memo_data: bool, empty_patche
         PickupModelStyle.HIDE_ALL,
         PickupModelDataSource.RANDOM,
         creator,
-        pickup_creator.create_visual_etm(),
+        pickup_creator.create_visual_nothing(),
     )
 
     # Assert


### PR DESCRIPTION
This changes the `create_visual_etm` function to accept optional model_name, game and pickup_name parameters.
While I'd usually put pickup_name as the first param, AFAIK that'd mean that if one only wants to change the model name (which is much more likely), that one always has to provide `Unknown item` as the first argument.

One step forwards to seperating ETM from nothing I suppose.

Fixes #5146 