### PR TITLE
Dread: Fix conditions for fighting Kraid from behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: A typo in the room name Ferenia - East Transport to Dairon has been changed from East Transport to Darion.
 - Fixed: In Burenia - Teleport to Ghavoran, to open the Plasma Beam door from below, add requirement to have Plasma Beam. This becomes relevant with Separate Beam Behavior.
 - Fixed: In Artaria - Teleport to Dairon, to enter the teleport itself using Wave Beam, add requirements to have Wide Beam and Door Lock Rando being disabled. The former becomes relevant with Separate Beam Behavior.
+- Fixed: In Cataris - Kraid Area, when using Wave Beam to fight Kraid from behind, you now also need the rest of the rest of the requirements to fight Kraid.
 
 ### Metroid Prime
 

--- a/randovania/games/dread/json_data/Cataris.json
+++ b/randovania/games/dread/json_data/Cataris.json
@@ -10543,7 +10543,7 @@
                     "default_connection": {
                         "region": "Cataris",
                         "area": "Kraid Arena",
-                        "node": "Dock to Above Kraid"
+                        "node": "Dock from Above Kraid"
                     },
                     "default_dock_weakness": "Open Passage",
                     "exclude_from_dock_rando": false,
@@ -26680,7 +26680,7 @@
                         }
                     }
                 },
-                "Dock to Above Kraid": {
+                "Dock from Above Kraid": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -26700,7 +26700,7 @@
                         "area": "Above Kraid",
                         "node": "Dock to Kraid Arena"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "Blocked Passage",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -26910,15 +26910,11 @@
                                 "items": []
                             }
                         },
-                        "Event - Kraid": {
+                        "Dock from Above Kraid": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Shoot Charge Beam"
-                                    },
                                     {
                                         "type": "resource",
                                         "data": {
@@ -26936,6 +26932,10 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Shoot Charge Beam"
                                     }
                                 ]
                             }

--- a/randovania/games/dread/json_data/Cataris.txt
+++ b/randovania/games/dread/json_data/Cataris.txt
@@ -1674,7 +1674,7 @@ Extra - asset_id: collision_camera_024
 
 > Dock to Kraid Arena; Heals? False
   * Layers: default
-  * Open Passage to Kraid Arena/Dock to Above Kraid
+  * Open Passage to Kraid Arena/Dock from Above Kraid
   > Door to Kraid Eyedoor Room
       Trivial
 
@@ -4233,9 +4233,9 @@ Extra - asset_id: collision_camera_063
               Gravity Suit
               Heat/Cold Runs (Intermediate) and Lava Damage ≥ 1000
 
-> Dock to Above Kraid; Heals? False
+> Dock from Above Kraid; Heals? False
   * Layers: default
-  * Open Passage to Above Kraid/Dock to Kraid Arena
+  * Blocked Passage to Above Kraid/Dock to Kraid Arena
   > Event - Kraid
       All of the following:
           Any of the following:
@@ -4263,7 +4263,7 @@ Extra - asset_id: collision_camera_063
   * Morph Ball Tunnel to Diffusion Beam Room/Tunnel to Kraid Arena (top)
   > Right Ledge
       Trivial
-  > Event - Kraid
+  > Dock from Above Kraid
       Wave Beam and Combat (Beginner) and Shoot Charge Beam
 
 > Tunnel to Diffusion Beam Room (Bottom); Heals? False


### PR DESCRIPTION
Fixed: In Cataris - Kraid Area, when using Wave Beam to fight Kraid from behind, you now also need the rest of the rest of the requirements to fight Kraid.