### PR TITLE
AM2R: Add seperate option to skip save cutscenes

### DIFF
--- a/randovania/games/am2r/exporter/patch_data_factory.py
+++ b/randovania/games/am2r/exporter/patch_data_factory.py
@@ -112,6 +112,7 @@ class AM2RPatchDataFactory(PatchDataFactory):
             "septogg_helpers": self.patches.configuration.septogg_helpers,
             "respawn_bomb_blocks": self.patches.configuration.respawn_bomb_blocks,
             "skip_cutscenes": self.patches.configuration.skip_cutscenes,
+            "skip_save_cutscene": self.patches.configuration.skip_save_cutscene,
             "skip_item_cutscenes": self.patches.configuration.skip_item_cutscenes,
             "energy_per_tank": self.patches.configuration.energy_per_tank,
             "grave_grotto_blocks": self.patches.configuration.grave_grotto_blocks,

--- a/randovania/games/am2r/gui/preset_settings/am2r_patches_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_patches_tab.py
@@ -19,6 +19,7 @@ _FIELDS = [
     "septogg_helpers",
     "respawn_bomb_blocks",
     "skip_cutscenes",
+    "skip_save_cutscene",
     "skip_item_cutscenes",
     "grave_grotto_blocks",
     "fusion_mode",

--- a/randovania/games/am2r/layout/am2r_configuration.py
+++ b/randovania/games/am2r/layout/am2r_configuration.py
@@ -22,6 +22,7 @@ class AM2RConfiguration(BaseConfiguration):
     softlock_prevention_blocks: bool
     septogg_helpers: bool
     skip_cutscenes: bool
+    skip_save_cutscene: bool
     skip_item_cutscenes: bool
     respawn_bomb_blocks: bool
     screw_blocks: bool

--- a/randovania/games/am2r/presets/starter_preset.rdvpreset
+++ b/randovania/games/am2r/presets/starter_preset.rdvpreset
@@ -159,6 +159,7 @@
         "softlock_prevention_blocks": true,
         "septogg_helpers": true,
         "skip_cutscenes": true,
+        "skip_save_cutscene": false,
         "skip_item_cutscenes": false,
         "respawn_bomb_blocks": false,
         "screw_blocks": true,

--- a/randovania/gui/ui_files/preset_am2r_patches.ui
+++ b/randovania/gui/ui_files/preset_am2r_patches.ui
@@ -44,7 +44,7 @@
          <x>0</x>
          <y>0</y>
          <width>745</width>
-         <height>892</height>
+         <height>944</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="scroll_layout">
@@ -221,6 +221,23 @@
             <widget class="QLabel" name="skip_cutscenes_label">
              <property name="text">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enabling this will skip most gameplay related cutscenes, such as the Drill Sequence, the cutscenes you'll see when viewing a Metroid for the first time and similar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="skip_save_cutscene_check">
+             <property name="text">
+              <string>Skip Save Station cutscene</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="skip_save_cutscene_label">
+             <property name="text">
+              <string>Enabling this will skip the short cutscene that appears when saving at a Save Station.</string>
              </property>
              <property name="wordWrap">
               <bool>true</bool>

--- a/test/test_files/log_files/am2r/door_lock.rdvgame
+++ b/test/test_files/log_files/am2r/door_lock.rdvgame
@@ -167,6 +167,7 @@
                     "softlock_prevention_blocks": true,
                     "septogg_helpers": true,
                     "skip_cutscenes": true,
+                    "skip_save_cutscene": false,
                     "skip_item_cutscenes": false,
                     "respawn_bomb_blocks": false,
                     "screw_blocks": false,

--- a/test/test_files/log_files/am2r/no_ammo.rdvgame
+++ b/test/test_files/log_files/am2r/no_ammo.rdvgame
@@ -169,6 +169,7 @@
                     "softlock_prevention_blocks": true,
                     "septogg_helpers": true,
                     "skip_cutscenes": true,
+                    "skip_save_cutscene": false,
                     "skip_item_cutscenes": false,
                     "respawn_bomb_blocks": false,
                     "screw_blocks": true,

--- a/test/test_files/log_files/am2r/starter_preset.rdvgame
+++ b/test/test_files/log_files/am2r/starter_preset.rdvgame
@@ -168,6 +168,7 @@
                     "softlock_prevention_blocks": true,
                     "septogg_helpers": true,
                     "skip_cutscenes": true,
+                    "skip_save_cutscene": false,
                     "skip_item_cutscenes": false,
                     "respawn_bomb_blocks": false,
                     "screw_blocks": false,

--- a/test/test_files/patcher_data/am2r/door_lock.json
+++ b/test/test_files/patcher_data/am2r/door_lock.json
@@ -10087,6 +10087,7 @@
         "septogg_helpers": true,
         "respawn_bomb_blocks": false,
         "skip_cutscenes": true,
+        "skip_save_cutscene": false,
         "skip_item_cutscenes": false,
         "energy_per_tank": 100,
         "grave_grotto_blocks": false,

--- a/test/test_files/patcher_data/am2r/starter_preset.json
+++ b/test/test_files/patcher_data/am2r/starter_preset.json
@@ -10087,6 +10087,7 @@
         "septogg_helpers": true,
         "respawn_bomb_blocks": false,
         "skip_cutscenes": true,
+        "skip_save_cutscene": false,
         "skip_item_cutscenes": false,
         "energy_per_tank": 100,
         "grave_grotto_blocks": false,


### PR DESCRIPTION
Community wished for it to be a seperate option instead of being encompassed by skip gameplay cutscenes