### PR TITLE
Dread: Fix a Dock Type in Ghavoran

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: During generation, if no alternatives have a non-zero weight, try weighting by how many additional Nodes are reachable.
 
+### Metroid Dread
+
+#### Logic Database
+
+##### Ghavoran
+
+- Changed: The connection of EMMI Zone Exit Southeast and EMMI Zone Exit West is now a proper door. This enables it to now be shuffled in door lock rando.
+
 ## [6.2.1] - 2023-09-??
 
 - Nothing.

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -4323,7 +4323,7 @@
                                 "items": []
                             }
                         },
-                        "Dock to EMMI Zone Exit West": {
+                        "Door to EMMI Zone Exit West": {
                             "type": "and",
                             "data": {
                                 "comment": "If you start in the room direclty below this one, you can carry a speed boost all the way to here",
@@ -4648,7 +4648,7 @@
                                 "items": []
                             }
                         },
-                        "Dock to EMMI Zone Exit West": {
+                        "Door to EMMI Zone Exit West": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -4748,7 +4748,7 @@
                         }
                     }
                 },
-                "Dock to EMMI Zone Exit West": {
+                "Door to EMMI Zone Exit West": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4769,13 +4769,13 @@
                         "right_shield_def": null
                     },
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "door",
                     "default_connection": {
                         "region": "Ghavoran",
                         "area": "EMMI Zone Exit West",
-                        "node": "Dock to EMMI Zone Exit Southeast"
+                        "node": "Door to EMMI Zone Exit Southeast"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "Access Open",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -4881,7 +4881,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to EMMI Zone Exit West": {
+                        "Door to EMMI Zone Exit West": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5611,7 +5611,7 @@
                         }
                     }
                 },
-                "Dock to EMMI Zone Exit Southeast": {
+                "Door to EMMI Zone Exit Southeast": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5632,13 +5632,13 @@
                         "right_shield_def": null
                     },
                     "valid_starting_location": false,
-                    "dock_type": "other",
+                    "dock_type": "door",
                     "default_connection": {
                         "region": "Ghavoran",
                         "area": "EMMI Zone Exit Southeast",
-                        "node": "Dock to EMMI Zone Exit West"
+                        "node": "Door to EMMI Zone Exit West"
                     },
-                    "default_dock_weakness": "Open Passage",
+                    "default_dock_weakness": "Access Open",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
@@ -5823,7 +5823,7 @@
                                 "items": []
                             }
                         },
-                        "Dock to EMMI Zone Exit Southeast": {
+                        "Door to EMMI Zone Exit Southeast": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -776,7 +776,7 @@ Extra - asset_id: collision_camera_011
   * Extra - right_shield_def: None
   > Dock to Map Station Access (Lower)
       Trivial
-  > Dock to EMMI Zone Exit West
+  > Door to EMMI Zone Exit West
       # If you start in the room direclty below this one, you can carry a speed boost all the way to here
       Morph Ball and Speed Booster and Speed Booster Conservation (Advanced) and Disabled Door Lock Randomizer and Shoot Plasma Beam
 
@@ -808,7 +808,7 @@ Extra - asset_id: collision_camera_011
   * Extra - actor_def: actordef:actors/props/dooremmy/charclasses/dooremmy.bmsad
   > Dock to Map Station Access (Lower)
       Trivial
-  > Dock to EMMI Zone Exit West
+  > Door to EMMI Zone Exit West
       Any of the following:
           Flash Shift or Grapple Beam or Spider Magnet or Use Spin Boost
           Slide and Slide Jump (Beginner)
@@ -817,9 +817,9 @@ Extra - asset_id: collision_camera_011
               Speed Booster
               Lay Bomb or Lay Power Bomb
 
-> Dock to EMMI Zone Exit West; Heals? False
+> Door to EMMI Zone Exit West; Heals? False
   * Layers: default
-  * Open Passage to EMMI Zone Exit West/Dock to EMMI Zone Exit Southeast
+  * Access Open to EMMI Zone Exit West/Door to EMMI Zone Exit Southeast
   * Extra - actor_name: doorframe_000
   * Extra - actor_def: actordef:actors/props/doorframe/charclasses/doorframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -836,7 +836,7 @@ Extra - asset_id: collision_camera_011
 > Tunnel to Blue EMMI Introduction; Heals? False
   * Layers: default
   * Ghavoran EMMI Tunnel to Blue EMMI Introduction/Tunnel to EMMI Zone Exit Southeast
-  > Dock to EMMI Zone Exit West
+  > Door to EMMI Zone Exit West
       Trivial
 
 ----------------
@@ -964,9 +964,9 @@ Extra - asset_id: collision_camera_014
   > Dock to Early Ice Room (Upper)
       Trivial
 
-> Dock to EMMI Zone Exit Southeast; Heals? False
+> Door to EMMI Zone Exit Southeast; Heals? False
   * Layers: default
-  * Open Passage to EMMI Zone Exit Southeast/Dock to EMMI Zone Exit West
+  * Access Open to EMMI Zone Exit Southeast/Door to EMMI Zone Exit West
   * Extra - actor_name: doorframe_000
   * Extra - actor_def: actordef:actors/props/doorframe/charclasses/doorframe.bmsad
   * Extra - left_shield_entity: {EMPTY}
@@ -992,7 +992,7 @@ Extra - asset_id: collision_camera_014
   * Layers: default
   > Dock to Early Ice Room (Lower)
       Trivial
-  > Dock to EMMI Zone Exit Southeast
+  > Door to EMMI Zone Exit Southeast
       Trivial
   > Tunnel to EMMI Zone Middle Path
       Trivial


### PR DESCRIPTION
- Changed: The connection of EMMI Zone Exit Southeast and EMMI Zone Exit West is now a proper door. This enables it to now be shuffled in door lock rando.