### PR TITLE
AM2R: Fix possible crash for MW patch data factory

### DIFF
--- a/randovania/games/am2r/exporter/patch_data_factory.py
+++ b/randovania/games/am2r/exporter/patch_data_factory.py
@@ -48,10 +48,12 @@ class AM2RPatchDataFactory(PatchDataFactory):
                                "Locked" in res_lock.temporary_item.long_name and
                                len(pickup.collection_text) > 1) else 0
 
+            # TODO: figure out later on how to get proper sprite names and sprite animation speed for offworld items
             pickup_map_dict[object_name] = {
                 "sprite_details": {
                     "name": pickup.model.name,
                     "speed": item_info[pickup.original_pickup.name]["sprite_speed"]
+                    if not self.players_config.is_multiworld else 0.2
                 },
                 "item_effect": pickup.original_pickup.name if not pickup.other_player else "Nothing",
                 "quantity": quantity,


### PR DESCRIPTION
Currently hardcoded, because I havent implemented a real system for custom models. Will fix this properly later such a system was implemented, just wanna get rid of the crash for now.