### PR TITLE
Generator: Fix not wanting to place etanks, when damage req would be just high enough to kill player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.3.0] - 2023-10-??
 
 - Added: During generation, if no alternatives have a non-zero weight, try weighting by how many additional Nodes are reachable.
+- Changed: The generator will now consider placing Energy Tanks, if there's a damage requirement that's exactly high enough to kill the player.
 - Fixed: The menu option for viewing all Randovania dependencies and their licenses has been restored.
 
 ### Metroid Dread

--- a/randovania/generator/filler/pickup_list.py
+++ b/randovania/generator/filler/pickup_list.py
@@ -68,7 +68,7 @@ def _unsatisfied_item_requirements_in_list(
         return
 
     sum_damage = sum(req.damage(state.resources, state.resource_database) for req in damage)
-    if state.energy < sum_damage:
+    if state.energy <= sum_damage:
         # A requirement for many "Energy Tanks" is added,
         # which is then decreased by how many tanks is in the state by pickups_to_solve_list
         tank_count = sum_damage // state.game_data.energy_per_tank


### PR DESCRIPTION
I only tested this with ~2k seeds with am2r

Should *probably* be tested for other games, can imagine that echoes could not like this much.