### PR TITLE
SM: exclude beginner shinespark instead of specific items.

### DIFF
--- a/randovania/games/super_metroid/json_data/Crateria.json
+++ b/randovania/games/super_metroid/json_data/Crateria.json
@@ -289,8 +289,8 @@
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 1979.492957746479,
-                        "y": 339.53051643192475,
+                        "x": 1979.49,
+                        "y": 339.53,
                         "z": 0.0
                     },
                     "description": "",
@@ -299,7 +299,7 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "event_name": "Event7",
+                    "event_name": "Event8",
                     "connections": {
                         "Landing Site Save Station": {
                             "type": "and",
@@ -615,7 +615,7 @@
                             "type": "resource",
                             "data": {
                                 "type": "events",
-                                "name": "Event8",
+                                "name": "Event7",
                                 "amount": 1,
                                 "negate": false
                             }

--- a/randovania/games/super_metroid/json_data/Crateria.json
+++ b/randovania/games/super_metroid/json_data/Crateria.json
@@ -2513,7 +2513,15 @@
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
-                    "connections": {}
+                    "connections": {
+                        "Pickup (Power Bomb Expansion)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 },
                 "Pickup (Power Bomb Expansion)": {
                     "node_type": "pickup",
@@ -2531,7 +2539,15 @@
                     "valid_starting_location": false,
                     "pickup_index": 0,
                     "location_category": "minor",
-                    "connections": {}
+                    "connections": {
+                        "Door to Landing Site": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/randovania/games/super_metroid/json_data/Crateria.txt
+++ b/randovania/games/super_metroid/json_data/Crateria.txt
@@ -344,10 +344,14 @@ Extra - asset_id: 10
 > Door to Landing Site; Heals? False; Default Node
   * Layers: default
   * Normal Door to Landing Site/Door to Crateria Power Bomb Room
+  > Pickup (Power Bomb Expansion)
+      Trivial
 
 > Pickup (Power Bomb Expansion); Heals? False
   * Layers: default
   * Pickup 0; Category? Minor
+  > Door to Landing Site
+      Trivial
 
 ----------------
 Gauntlet

--- a/randovania/games/super_metroid/json_data/Crateria.txt
+++ b/randovania/games/super_metroid/json_data/Crateria.txt
@@ -37,7 +37,7 @@ Extra - save_index: 0
 
 > Event - Win Game; Heals? False
   * Layers: default
-  * Event Defeat Mother Brain
+  * Event Win Game
   > Landing Site Save Station
       Trivial
 
@@ -71,7 +71,7 @@ Extra - save_index: 0
               Morph Ball
               Morph Ball Bombs or Power Bombs
   > Event - Win Game
-      After Win Game
+      After Defeat Mother Brain
 
 ----------------
 Crateria Tube

--- a/randovania/games/super_metroid/json_data/Norfair.json
+++ b/randovania/games/super_metroid/json_data/Norfair.json
@@ -9398,8 +9398,8 @@
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 777.5880149812733,
-                        "y": 201.66791510611733,
+                        "x": 777.59,
+                        "y": 201.67,
                         "z": 0.0
                     },
                     "description": "",
@@ -9408,7 +9408,7 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "event_name": "Event11",
+                    "event_name": "Event13",
                     "connections": {
                         "Door to Wasteland": {
                             "type": "resource",

--- a/randovania/games/super_metroid/json_data/Norfair.txt
+++ b/randovania/games/super_metroid/json_data/Norfair.txt
@@ -1488,7 +1488,7 @@ Extra - asset_id: 237
 
 > Event - Defeat Metal Pirates; Heals? False
   * Layers: default
-  * Event Botwoon Defeated
+  * Event Metal Pirates Defeated
   > Door to Wasteland
       Varia Suit
 

--- a/randovania/games/super_metroid/json_data/header.json
+++ b/randovania/games/super_metroid/json_data/header.json
@@ -624,7 +624,7 @@
                     "type": "resource",
                     "data": {
                         "type": "events",
-                        "name": "Event10",
+                        "name": "Event8",
                         "amount": 1,
                         "negate": false
                     }

--- a/test/generator/test_generator_reach.py
+++ b/test/generator/test_generator_reach.py
@@ -131,13 +131,14 @@ _ignore_pickups_for_game = {
     # These 3 indices are in Olympus and are unreachable given the default preset
     RandovaniaGame.METROID_PRIME_CORRUPTION: {0, 1, 2},
     # Unknown reason why
-    RandovaniaGame.SUPER_METROID: {0, 11, 78, 129},
     RandovaniaGame.CAVE_STORY: {30, 31, 41, 45},
 }
 
 _include_tricks_for_game = {
     # Some items require shinesparking to reach in vanilla, which due to varying difficulty has been made into a trick
-    RandovaniaGame.AM2R: {("Shinesparking", LayoutTrickLevel.ADVANCED)}
+    RandovaniaGame.AM2R: {("Shinesparking", LayoutTrickLevel.ADVANCED)},
+    # Same reasons as above
+    RandovaniaGame.SUPER_METROID: {("Shinespark", LayoutTrickLevel.BEGINNER)},
 }
 
 

--- a/test/generator/test_generator_reach.py
+++ b/test/generator/test_generator_reach.py
@@ -102,17 +102,7 @@ _ignore_events_for_game = {
     RandovaniaGame.METROID_PRIME: {"Event33"},
     RandovaniaGame.METROID_PRIME_ECHOES: {"Event91", "Event92", "Event97"},
     RandovaniaGame.METROID_PRIME_CORRUPTION: {"Event1", "Event146", "Event147", "Event148", "Event154"},
-    RandovaniaGame.SUPER_METROID: {
-        "Event4",
-        "Event6",
-        "Event7",
-        "Event8",
-        "Event13",
-        "Event14",
-        "Event15",
-        "Event16",
-        "Event17",
-    },
+    RandovaniaGame.SUPER_METROID: {"Event6"},
     RandovaniaGame.METROID_DREAD: {},
     RandovaniaGame.CAVE_STORY: {
         "camp",


### PR DESCRIPTION
This is nicer than listing every single pickup.

Noticed this while investigating why tests failed for #5264 