### PR TITLE
MSR: Update grapple block names in header + add new grapple event in area 6

### DIFF
--- a/randovania/games/samus_returns/json_data/Area 4 - West.json
+++ b/randovania/games/samus_returns/json_data/Area 4 - West.json
@@ -5567,7 +5567,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 4 (West) -Transport to Area 5 Entrance Grapple Block",
+                                            "name": "Area 4 (West) - Transport to Area 5 Entrance Grapple Block",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -5695,7 +5695,7 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "event_name": "Area 4 (West) -Transport to Area 5 Entrance Grapple Block",
+                    "event_name": "Area 4 (West) - Transport to Area 5 Entrance Grapple Block",
                     "connections": {
                         "Next to Grapple Block": {
                             "type": "and",
@@ -5800,7 +5800,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 4 (West) -Transport to Area 5 Entrance Grapple Block",
+                                            "name": "Area 4 (West) - Transport to Area 5 Entrance Grapple Block",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -5830,7 +5830,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 4 (West) -Transport to Area 5 Entrance Grapple Block",
+                                            "name": "Area 4 (West) - Transport to Area 5 Entrance Grapple Block",
                                             "amount": 1,
                                             "negate": false
                                         }

--- a/randovania/games/samus_returns/json_data/Area 4 - West.txt
+++ b/randovania/games/samus_returns/json_data/Area 4 - West.txt
@@ -868,7 +868,7 @@ Extra - asset_id: collision_camera_023
   * Extra - actor_name: Door013
   * Extra - actor_type: doorchargecharge
   > Next to Grapple Block
-      Morph Ball and After Area 4 (West) -Transport to Area 5 Entrance Grapple Block
+      Morph Ball and After Area 4 (West) - Transport to Area 5 Entrance Grapple Block
 
 > Door to The Big Gap; Heals? False
   * Layers: default
@@ -894,7 +894,7 @@ Extra - asset_id: collision_camera_023
 
 > Event - Grapple Block; Heals? False
   * Layers: default
-  * Event Area 4 (West) -Transport to Area 5 Entrance Grapple Block
+  * Event Area 4 (West) - Transport to Area 5 Entrance Grapple Block
   > Next to Grapple Block
       Trivial
 
@@ -905,9 +905,9 @@ Extra - asset_id: collision_camera_023
           Screw Attack
           Ice Beam and Morph Ball and Stand on Frozen Enemy (Beginner) and Melee Clip (Advanced)
   > Door to Chozo Seals
-      Morph Ball and After Area 4 (West) -Transport to Area 5 Entrance Grapple Block
+      Morph Ball and After Area 4 (West) - Transport to Area 5 Entrance Grapple Block
   > Pickup (Super Missile Tank)
-      Morph Ball and After Area 4 (West) -Transport to Area 5 Entrance Grapple Block and Shoot Super Missile
+      Morph Ball and After Area 4 (West) - Transport to Area 5 Entrance Grapple Block and Shoot Super Missile
   > Tunnel to Chozo Seals
       Morph Ball
   > Event - Grapple Block

--- a/randovania/games/samus_returns/json_data/Area 5 - Entrance.json
+++ b/randovania/games/samus_returns/json_data/Area 5 - Entrance.json
@@ -1140,7 +1140,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 5 (Entrance) - Transport Hub Grapple Block Middle",
+                                            "name": "Area 5 (Entrance) - Chozo Seal Grapple Block Middle",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -1432,7 +1432,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 5 (Entrance) - Transport Hub Grapple Block Bottom",
+                                            "name": "Area 5 (Entrance) - Chozo Seal Grapple Block Bottom",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -1777,7 +1777,7 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "event_name": "Area 5 (Entrance) - Transport Hub Grapple Block Middle",
+                    "event_name": "Area 5 (Entrance) - Chozo Seal Grapple Block Middle",
                     "connections": {
                         "Below Center Tunnel": {
                             "type": "and",
@@ -1802,7 +1802,7 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "event_name": "Area 5 (Entrance) - Transport Hub Grapple Block Top",
+                    "event_name": "Area 5 (Entrance) - Chozo Seal Grapple Block Top",
                     "connections": {
                         "Next to Top Grapple Block": {
                             "type": "and",
@@ -1827,7 +1827,7 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "event_name": "Area 5 (Entrance) - Transport Hub Grapple Block Bottom",
+                    "event_name": "Area 5 (Entrance) - Chozo Seal Grapple Block Bottom",
                     "connections": {
                         "Elevator to Area 6": {
                             "type": "and",
@@ -1871,7 +1871,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 5 (Entrance) - Transport Hub Grapple Block Middle",
+                                            "name": "Area 5 (Entrance) - Chozo Seal Grapple Block Middle",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -1905,7 +1905,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 5 (Entrance) - Transport Hub Grapple Block Bottom",
+                                            "name": "Area 5 (Entrance) - Chozo Seal Grapple Block Bottom",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -2050,7 +2050,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 5 (Entrance) - Transport Hub Grapple Block Top",
+                                            "name": "Area 5 (Entrance) - Chozo Seal Grapple Block Top",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -2139,7 +2139,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 5 (Entrance) - Transport Hub Grapple Block Top",
+                                            "name": "Area 5 (Entrance) - Chozo Seal Grapple Block Top",
                                             "amount": 1,
                                             "negate": true
                                         }
@@ -2204,7 +2204,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 5 (Entrance) - Transport Hub Grapple Block Top",
+                                            "name": "Area 5 (Entrance) - Chozo Seal Grapple Block Top",
                                             "amount": 1,
                                             "negate": false
                                         }

--- a/randovania/games/samus_returns/json_data/Area 6.json
+++ b/randovania/games/samus_returns/json_data/Area 6.json
@@ -152,7 +152,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 6 - Transport to Area 7 Grapple Block",
+                                            "name": "Area 6 - Transport to Area 7 Grapple Block Top",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -266,7 +266,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - Grapple Blocks Top": {
+                        "Event - Grapple Block Top": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -300,12 +300,21 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 6 - Transport to Area 7 Grapple Block",
+                                            "name": "Area 6 - Transport to Area 7 Grapple Block Top",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Event - Grapple Block Pull": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Grapple",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -352,12 +361,12 @@
                         }
                     }
                 },
-                "Event - Grapple Blocks Top": {
+                "Event - Grapple Block Top": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": -15825.100908173563,
-                        "y": -5734.7965018499835,
+                        "x": -15825.1,
+                        "y": -5734.8,
                         "z": 0.0
                     },
                     "description": "",
@@ -366,7 +375,7 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "event_name": "Area 6 - Transport to Area 7 Grapple Block",
+                    "event_name": "Area 6 - Transport to Area 7 Grapple Block Top",
                     "connections": {
                         "Door to Diggernaut Hallway": {
                             "type": "template",
@@ -407,7 +416,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 6 - Transport to Area 7 Grapple Block",
+                                            "name": "Area 6 - Transport to Area 7 Grapple Block Pull",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -437,7 +446,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 6 - Transport to Area 7 Grapple Block",
+                                            "name": "Area 6 - Transport to Area 7 Grapple Block Top",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -935,6 +944,31 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Door to Diggernaut Arena": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Grapple Block Pull": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -15566.07,
+                        "y": -5143.13,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "Area 6 - Transport to Area 7 Grapple Block Pull",
+                    "connections": {
+                        "Door to Diggernaut Hallway": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/samus_returns/json_data/Area 6.txt
+++ b/randovania/games/samus_returns/json_data/Area 6.txt
@@ -18,7 +18,7 @@ Extra - asset_id: collision_camera_034
   * Extra - actor_type: weightactivatedplatform
   * Extra - start_point_actor_name: ST_FromArea09
   > Before Diggernaut Area
-      Morph Ball and After Area 6 - Transport to Area 7 Grapple Blocks Top
+      Morph Ball and After Area 6 - Transport to Area 7 Grapple Block Top
 
 > Save Station; Heals? False; Spawn Point; Default Node
   * Layers: default
@@ -43,10 +43,12 @@ Extra - asset_id: collision_camera_034
   * Power Beam Door to Diggernaut Hallway/Door to Transport to Area 7
   * Extra - actor_name: Door016
   * Extra - actor_type: doorpowerpower
-  > Event - Grapple Blocks Top
+  > Event - Grapple Block Top
       Grapple Beam and Lay Any Bomb
   > Before Diggernaut Area
-      After Area 6 - Transport to Area 7 Grapple Blocks Top and Lay Any Bomb
+      After Area 6 - Transport to Area 7 Grapple Block Top and Lay Any Bomb
+  > Event - Grapple Block Pull
+      Grapple Beam
 
 > Door to Diggernaut Arena; Heals? False
   * Layers: default
@@ -58,20 +60,20 @@ Extra - asset_id: collision_camera_034
   > Start Point
       Trivial
 
-> Event - Grapple Blocks Top; Heals? False
+> Event - Grapple Block Top; Heals? False
   * Layers: default
-  * Event Area 6 - Transport to Area 7 Grapple Blocks Top
+  * Event Area 6 - Transport to Area 7 Grapple Block Top
   > Door to Diggernaut Hallway
       Lay Any Bomb
 
 > Before Diggernaut Area; Heals? False
   * Layers: default
   > Elevator to Area 7
-      Morph Ball and After Area 6 - Transport to Area 7 Grapple Blocks Top
+      Morph Ball and After Area 6 - Transport to Area 7 Grapple Block Pull
   > Save Station
       Morph Ball
   > Door to Diggernaut Hallway
-      After Area 6 - Transport to Area 7 Grapple Blocks Top and Lay Any Bomb
+      After Area 6 - Transport to Area 7 Grapple Block Top and Lay Any Bomb
   > Door to Diggernaut Arena
       Lay Any Bomb
   > Above Pickup
@@ -125,6 +127,12 @@ Extra - asset_id: collision_camera_034
   * Layers: default
   * Extra - start_point_actor_name: ST_SG_ManicMiner
   > Door to Diggernaut Arena
+      Trivial
+
+> Event - Grapple Block Pull; Heals? False
+  * Layers: default
+  * Event Area 6 - Transport to Area 7 Grapple Block Pull
+  > Door to Diggernaut Hallway
       Trivial
 
 ----------------

--- a/randovania/games/samus_returns/json_data/Area 7.json
+++ b/randovania/games/samus_returns/json_data/Area 7.json
@@ -7363,7 +7363,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "events",
-                                                        "name": "Area 7 - Transport to Area 8",
+                                                        "name": "Area 7 - Transport to Area 8 Grapple Block",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -7458,7 +7458,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 7 - Transport to Area 8",
+                                            "name": "Area 7 - Transport to Area 8 Grapple Block",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -7512,7 +7512,7 @@
                     ],
                     "extra": {},
                     "valid_starting_location": false,
-                    "event_name": "Area 7 - Transport to Area 8",
+                    "event_name": "Area 7 - Transport to Area 8 Grapple Block",
                     "connections": {
                         "Door to Exit Puzzle Room 2": {
                             "type": "and",

--- a/randovania/games/samus_returns/json_data/header.json
+++ b/randovania/games/samus_returns/json_data/header.json
@@ -640,8 +640,8 @@
                 "long_name": "Area 4 (West) - Chozo Seals Grapple Block Pull Right",
                 "extra": {}
             },
-            "Area 4 (West) -Transport to Area 5 Entrance Grapple Block": {
-                "long_name": "Area 4 (West) -Transport to Area 5 Entrance Grapple Block",
+            "Area 4 (West) - Transport to Area 5 Entrance Grapple Block": {
+                "long_name": "Area 4 (West) - Transport to Area 5 Entrance Grapple Block",
                 "extra": {}
             },
             "Area 5 (Entrance) - Phase Drift Tutorial Grapple Block": {
@@ -656,15 +656,15 @@
                 "long_name": "Area 5 (Entrance) - Pool West Grapple Block",
                 "extra": {}
             },
-            "Area 5 (Entrance) - Transport Hub Grapple Block Top": {
+            "Area 5 (Entrance) - Chozo Seal Grapple Block Top": {
                 "long_name": "Area 5 (Entrance) - Chozo Seal Grapple Block Top",
                 "extra": {}
             },
-            "Area 5 (Entrance) - Transport Hub Grapple Block Middle": {
+            "Area 5 (Entrance) - Chozo Seal Grapple Block Middle": {
                 "long_name": "Area 5 (Entrance) - Chozo Seal Grapple Block Middle",
                 "extra": {}
             },
-            "Area 5 (Entrance) - Transport Hub Grapple Block Bottom": {
+            "Area 5 (Entrance) - Chozo Seal Grapple Block Bottom": {
                 "long_name": "Area 5 (Entrance) - Chozo Seal Grapple Block Bottom",
                 "extra": {}
             },
@@ -696,8 +696,12 @@
                 "long_name": "Area 6 - Stolen Power Bomb Room Grapple Block",
                 "extra": {}
             },
-            "Area 6 - Transport to Area 7 Grapple Block": {
-                "long_name": "Area 6 - Transport to Area 7 Grapple Blocks Top",
+            "Area 6 - Transport to Area 7 Grapple Block Top": {
+                "long_name": "Area 6 - Transport to Area 7 Grapple Block Top",
+                "extra": {}
+            },
+            "Area 6 - Transport to Area 7 Grapple Block Pull": {
+                "long_name": "Area 6 - Transport to Area 7 Grapple Block Pull",
                 "extra": {}
             },
             "Area 6 - Transport to Area 7 Grapple Block Bottom": {
@@ -724,7 +728,7 @@
                 "long_name": "Area 7 - Launch Tunnel South Grapple Block Top",
                 "extra": {}
             },
-            "Area 7 - Transport to Area 8": {
+            "Area 7 - Transport to Area 8 Grapple Block": {
                 "long_name": "Area 7 - Transport to Area 8 Grapple Block",
                 "extra": {}
             },


### PR DESCRIPTION
Some of the events were using the old room names, so I updated those. There are probably more that I missed (and likely more will exist once most of the rooms get renamed, if we even bother making them match), but these are most important right now.

I also added a separate event for the other grapple block leaving Area 6 because of the soon-to-be-supported option that removes grapple blocks, which needs to properly check for an event to remove. Not splitting the events would mean that the smaller block is also being removed which is not the case.