### PR TITLE
Run black after ruff, use mirror for faster black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,14 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 repos:
--   repo: https://github.com/psf/black
-    rev: 23.9.1
-    hooks:
-      - id: black
-
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.0.288
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
+
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
+    hooks:
+      - id: black


### PR DESCRIPTION
Ruff can generate code that black would then be not happy with.