### PR TITLE
Dread: Ghavoran Eyedoor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ##### Ghavoran
 
 - Changed: The connection of EMMI Zone Exit Southeast and EMMI Zone Exit West is now a proper door. This enables it to now be shuffled in door lock rando.
+- Changed: Going backwards through the Eyedoor now requires having first destroyed it, Flash Shift and Intermediate Movement, or being able to tank the damage.
 
 ### Metroid Prime
 

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -10420,10 +10420,12 @@
                             }
                         },
                         "Door to Above Golzuna": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "events",
+                                "name": "GhavoranEyedoor",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Pickup (Energy Part)": {

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -9475,112 +9475,6 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Above Golzuna": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Speed",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Space",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spin Boost"
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "template",
-                                                                            "data": "Shoot Ice Missile"
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "FrozenEnemy",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "events",
-                                                                                "name": "ElunReleaseX",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Flash",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "Walljump",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Simple IBJ"
-                                    }
-                                ]
-                            }
-                        },
                         "Door to Energy Recharge Station": {
                             "type": "and",
                             "data": {
@@ -9664,6 +9558,112 @@
                                     }
                                 ]
                             }
+                        },
+                        "Next to Eyedoor": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Use Spin Boost"
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "events",
+                                                                                "name": "ElunReleaseX",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "FrozenEnemy",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Shoot Ice Missile"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Flash",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Walljump",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -9700,29 +9700,53 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Save Station East": {
-                            "type": "and",
+                        "Next to Eyedoor": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Pickup (Energy Part)": {
-                            "type": "and",
-                            "data": {
-                                "comment": "Eye doors are exluded from door lock shuffe",
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Ballspark"
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "GhavoranEyedoor",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Spin",
-                                            "amount": 1,
+                                            "type": "damage",
+                                            "name": "Damage",
+                                            "amount": 182,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Flash",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -10344,6 +10368,108 @@
                                         }
                                     }
                                 ]
+                            }
+                        }
+                    }
+                },
+                "Event - Golzuna Eyedoor": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 6550.0,
+                        "y": 6100.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "GhavoranEyedoor",
+                    "connections": {
+                        "Next to Eyedoor": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Next to Eyedoor": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 6250.0,
+                        "y": 6100.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "connections": {
+                        "Door to Save Station East": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Door to Above Golzuna": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Pickup (Energy Part)": {
+                            "type": "and",
+                            "data": {
+                                "comment": "Eyedoors are excluded from door lock randomizer.",
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spin Boost"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Speedbooster",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Pickup (Missile Tank)": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Event - Golzuna Eyedoor": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }

--- a/randovania/games/dread/json_data/Ghavoran.json
+++ b/randovania/games/dread/json_data/Ghavoran.json
@@ -10431,7 +10431,7 @@
                         "Pickup (Energy Part)": {
                             "type": "and",
                             "data": {
-                                "comment": "Eyedoors are excluded from door lock randomizer.",
+                                "comment": "Eyedoors are excluded from door lock randomizer",
                                 "items": [
                                     {
                                         "type": "template",

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -1770,7 +1770,7 @@ Extra - asset_id: collision_camera_024
   > Door to Above Golzuna
       After Ghavoran - Destroy Golzuna Eyedoor
   > Pickup (Energy Part)
-      # Eyedoors are excluded from door lock randomizer.
+      # Eyedoors are excluded from door lock randomizer
       Speed Booster and Speed Booster Conservation (Beginner) and Use Spin Boost
   > Pickup (Missile Tank)
       Morph Ball

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -1627,14 +1627,6 @@ Extra - asset_id: collision_camera_024
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Above Golzuna
-      Any of the following:
-          Space Jump or Speed Booster or Simple IBJ
-          All of the following:
-              Use Spin Boost
-              Any of the following:
-                  After Elun - Release X Parasites and Stand on Frozen Enemy (Intermediate) and Shoot Ice Missile
-                  Flash Shift and Wall Jump (Intermediate)
   > Door to Energy Recharge Station
       Trivial
   > Pickup (Missile Tank)
@@ -1643,6 +1635,14 @@ Extra - asset_id: collision_camera_024
           Any of the following:
               Space Jump or Speed Booster or Simple IBJ
               Flash Shift and Wall Jump (Beginner) and Use Spin Boost
+  > Next to Eyedoor
+      Any of the following:
+          Space Jump or Speed Booster or Simple IBJ
+          All of the following:
+              Use Spin Boost
+              Any of the following:
+                  After Elun - Release X Parasites and Stand on Frozen Enemy (Intermediate) and Shoot Ice Missile
+                  Flash Shift and Wall Jump (Intermediate)
 
 > Door to Above Golzuna; Heals? False
   * Layers: default
@@ -1653,11 +1653,10 @@ Extra - asset_id: collision_camera_024
   * Extra - left_shield_def: None
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
-  > Door to Save Station East
-      Trivial
-  > Pickup (Energy Part)
-      # Eye doors are exluded from door lock shuffe
-      Spin Boost and Ballspark
+  > Next to Eyedoor
+      Any of the following:
+          After Ghavoran - Destroy Golzuna Eyedoor or Normal Damage ≥ 182
+          Flash Shift and Movement (Intermediate)
 
 > Door to Energy Recharge Station; Heals? False
   * Layers: default
@@ -1757,6 +1756,26 @@ Extra - asset_id: collision_camera_024
       Any of the following:
           Lay Bomb
           Power Bombs ≥ 2 and Lay Power Bomb
+
+> Event - Golzuna Eyedoor; Heals? False
+  * Layers: default
+  * Event Ghavoran - Destroy Golzuna Eyedoor
+  > Next to Eyedoor
+      Trivial
+
+> Next to Eyedoor; Heals? False
+  * Layers: default
+  > Door to Save Station East
+      Trivial
+  > Door to Above Golzuna
+      Trivial
+  > Pickup (Energy Part)
+      # Eyedoors are excluded from door lock randomizer.
+      Speed Booster and Speed Booster Conservation (Beginner) and Use Spin Boost
+  > Pickup (Missile Tank)
+      Morph Ball
+  > Event - Golzuna Eyedoor
+      Trivial
 
 ----------------
 Teleport to Burenia

--- a/randovania/games/dread/json_data/Ghavoran.txt
+++ b/randovania/games/dread/json_data/Ghavoran.txt
@@ -1768,7 +1768,7 @@ Extra - asset_id: collision_camera_024
   > Door to Save Station East
       Trivial
   > Door to Above Golzuna
-      Trivial
+      After Ghavoran - Destroy Golzuna Eyedoor
   > Pickup (Energy Part)
       # Eyedoors are excluded from door lock randomizer.
       Speed Booster and Speed Booster Conservation (Beginner) and Use Spin Boost

--- a/randovania/games/dread/json_data/header.json
+++ b/randovania/games/dread/json_data/header.json
@@ -1067,6 +1067,10 @@
             "BureniaGravitySuitRoomStoreSpeed": {
                 "long_name": "Burenia - Gravity Suit Room Store Shinespark",
                 "extra": {}
+            },
+            "GhavoranEyedoor": {
+                "long_name": "Ghavoran - Destroy Golzuna Eyedoor",
+                "extra": {}
             }
         },
         "tricks": {


### PR DESCRIPTION
- Changed: Going backwards through the Eyedoor now requires having first destroyed it, Flash Shift and Intermediate Movement, or being able to tank the damage.

This one is the only relevant Eyedoor these changes can apply to. The other ones would require starting in Corpius Arena, Escue Arena, and that alcove above Drogyga. The Kraid one can be bypassed completely just by going above. which you would be guaranteed to be able to do if you can get to it from reverse.