### PR TITLE
AM2R: Fix incorrect major/minor locations

### DIFF
--- a/randovania/games/am2r/json_data/Golden Temple.json
+++ b/randovania/games/am2r/json_data/Golden Temple.json
@@ -4487,7 +4487,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 102,
-                    "location_category": "major",
+                    "location_category": "minor",
                     "connections": {
                         "Horizontal Dock to Inner Temple East Hall": {
                             "type": "and",

--- a/randovania/games/am2r/json_data/Golden Temple.txt
+++ b/randovania/games/am2r/json_data/Golden Temple.txt
@@ -593,7 +593,7 @@ Extra - minimap_data: [{'x': 62, 'y': 10}, {'x': 63, 'y': 10}, {'x': 64, 'y': 10
 
 > Pickup (Right Missile Tank); Heals? False
   * Layers: default
-  * Pickup 102; Category? Major
+  * Pickup 102; Category? Minor
   * Extra - object_name: oItemM_102
   > Horizontal Dock to Inner Temple East Hall
       Morph Ball

--- a/randovania/games/am2r/json_data/Industrial Complex.json
+++ b/randovania/games/am2r/json_data/Industrial Complex.json
@@ -8578,7 +8578,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 206,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "In Front Of Super": {
                             "type": "and",
@@ -11038,7 +11038,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 380,
-                    "location_category": "major",
+                    "location_category": "minor",
                     "connections": {
                         "Event - Gamma": {
                             "type": "and",

--- a/randovania/games/am2r/json_data/Industrial Complex.txt
+++ b/randovania/games/am2r/json_data/Industrial Complex.txt
@@ -1203,7 +1203,7 @@ Extra - minimap_data: [{'x': 72, 'y': 32}, {'x': 73, 'y': 32}]
 
 > Pickup (Super Missile Tank); Heals? False
   * Layers: default
-  * Pickup 206; Category? Minor
+  * Pickup 206; Category? Major
   * Extra - object_name: oItemSM_206
   > In Front Of Super
       Trivial
@@ -1574,7 +1574,7 @@ Extra - minimap_data: [{'x': 57, 'y': 30}, {'x': 57, 'y': 31}, {'x': 58, 'y': 30
 
 > Pickup (Gamma); Heals? False
   * Layers: default
-  * Pickup 380; Category? Major
+  * Pickup 380; Category? Minor
   * Extra - object_name: oItemDNA_380
   > Event - Gamma
       Trivial

--- a/randovania/games/am2r/json_data/Main Caves.json
+++ b/randovania/games/am2r/json_data/Main Caves.json
@@ -6220,7 +6220,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 55,
-                    "location_category": "major",
+                    "location_category": "minor",
                     "connections": {
                         "Dock to Skreek Street": {
                             "type": "and",

--- a/randovania/games/am2r/json_data/Main Caves.txt
+++ b/randovania/games/am2r/json_data/Main Caves.txt
@@ -873,7 +873,7 @@ Extra - minimap_data: [{'x': 44, 'y': 40}, {'x': 44, 'y': 41}, {'x': 45, 'y': 40
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
-  * Pickup 55; Category? Major
+  * Pickup 55; Category? Minor
   * Extra - object_name: oItemM_55
   > Dock to Skreek Street
       Trivial

--- a/randovania/games/am2r/json_data/The Tower.json
+++ b/randovania/games/am2r/json_data/The Tower.json
@@ -9826,7 +9826,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 254,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Bottom": {
                             "type": "and",

--- a/randovania/games/am2r/json_data/The Tower.json
+++ b/randovania/games/am2r/json_data/The Tower.json
@@ -9735,7 +9735,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 253,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Horizontal Dock to Power Plant Entrance": {
                             "type": "or",
@@ -9826,7 +9826,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 254,
-                    "location_category": "major",
+                    "location_category": "minor",
                     "connections": {
                         "Bottom": {
                             "type": "and",

--- a/randovania/games/am2r/json_data/The Tower.txt
+++ b/randovania/games/am2r/json_data/The Tower.txt
@@ -1277,7 +1277,7 @@ Extra - minimap_data: [{'x': 35, 'y': 42}, {'x': 35, 'y': 43}, {'x': 35, 'y': 44
 
 > Pickup (Power Bomb Tank); Heals? False
   * Layers: default
-  * Pickup 253; Category? Minor
+  * Pickup 253; Category? Major
   * Extra - object_name: oItemPB_253
   > Horizontal Dock to Power Plant Entrance
       Space Jump Wall
@@ -1294,7 +1294,7 @@ Extra - minimap_data: [{'x': 33, 'y': 46}, {'x': 34, 'y': 46}]
 
 > Pickup (Energy Tank); Heals? False
   * Layers: default
-  * Pickup 254; Category? Major
+  * Pickup 254; Category? Minor
   * Extra - object_name: oItemETank_254
   > Bottom
       Trivial

--- a/randovania/games/am2r/json_data/The Tower.txt
+++ b/randovania/games/am2r/json_data/The Tower.txt
@@ -1294,7 +1294,7 @@ Extra - minimap_data: [{'x': 33, 'y': 46}, {'x': 34, 'y': 46}]
 
 > Pickup (Energy Tank); Heals? False
   * Layers: default
-  * Pickup 254; Category? Minor
+  * Pickup 254; Category? Major
   * Extra - object_name: oItemETank_254
   > Bottom
       Trivial


### PR DESCRIPTION
- 3-Orb Hallway Missile -> Minor
- Gamma in BG3 -> Minor
- Vanilla Supers -> Major
- Fat Crocomire Room Missile -> Minor
- Vanilla PBs -> Major