### PR TITLE
Dread: Add warning about custom text in FAQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Metroid Dread
 
 - Added: Enky and Charge Beam Doors can be made immune to Power Bombs. This is enabled in the Starter Preset, and can be toggled in Preset -> Game Modifications -> Other -> Miscellaneous -> Power Bomb Limitations.
+- Added: Warning in the FAQ section about custom text only properly displaying when running the game in English.
 - Changed: Exporting games is now significantly faster.
 
 #### Logic Database

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Metroid Dread
 
 - Added: Enky and Charge Beam Doors can be made immune to Power Bombs. This is enabled in the Starter Preset, and can be toggled in Preset -> Game Modifications -> Other -> Miscellaneous -> Power Bomb Limitations.
-- Added: Warning in the FAQ section about custom text only fully displayed when running the game in English.
+- Added: Warning in the FAQ about custom text not displaying if the game is played in languages other than English.
 - Changed: Exporting games is now significantly faster.
 
 #### Logic Database

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Metroid Dread
 
 - Added: Enky and Charge Beam Doors can be made immune to Power Bombs. This is enabled in the Starter Preset, and can be toggled in Preset -> Game Modifications -> Other -> Miscellaneous -> Power Bomb Limitations.
-- Added: Warning in the FAQ section about custom text only properly displaying when running the game in English.
+- Added: Warning in the FAQ section about custom text only fully displayed when running the game in English.
 - Changed: Exporting games is now significantly faster.
 
 #### Logic Database

--- a/randovania/games/dread/game_data.py
+++ b/randovania/games/dread/game_data.py
@@ -112,9 +112,9 @@ game_data: game.GameData = game.GameData(
             "Your checkpoint was saved after killing the E.M.M.I., so you will not lose progress.",
         ),
         (
-            "Custom text like seed hash, item hints and items collected from bosses aren't displaying!",
-            "Currently the English language is the only officially supported one for Dread due to custom text.\n\n"
-            "If you are using another language, switch to English when playing randomized Metroid Dread.",
+            "Why are items, hints, and the seed hash not displaying properly in my game?",
+            "Currently, English is the only officially supported language.\n\n"
+            "You must set your language to English to see all the text the randomizer changes.",
         ),
     ],
     layout=game.GameLayout(

--- a/randovania/games/dread/game_data.py
+++ b/randovania/games/dread/game_data.py
@@ -111,6 +111,11 @@ game_data: game.GameData = game.GameData(
             "Reload from checkpoint immediately to fix the issue. "
             "Your checkpoint was saved after killing the E.M.M.I., so you will not lose progress.",
         ),
+        (
+            "Custom text like seed hash, item hints and items collected from bosses aren't displaying!",
+            "Currently the English language is the only officially supported one for Dread due to custom text.\n\n"
+            "If you are using another language, switch to English when playing randomized Metroid Dread.",
+        ),
     ],
     layout=game.GameLayout(
         configuration=DreadConfiguration, cosmetic_patches=DreadCosmeticPatches, preset_describer=DreadPresetDescriber()


### PR DESCRIPTION
This PR intends to address the confusion reported in #5248.
It introduces a new entry in the Dread FAQ addressing this issue and advising to switch the language to English when playing randomized Dread.
This PR was tested by running a new GUI instance from source and assessing the changes were present.
![Working change](https://github.com/randovania/randovania/assets/9999909/596f320a-75e2-49e0-9bc8-de913a51af9c)

A next but much more complex task would be ensuring the vanilla text is replaced regardless of console language