### PR TITLE
AM2R: Rename event nodes

### DIFF
--- a/randovania/games/am2r/json_data/Distribution Center.json
+++ b/randovania/games/am2r/json_data/Distribution Center.json
@@ -2437,7 +2437,7 @@
                                 ]
                             }
                         },
-                        "Event - EMPPuzzle": {
+                        "Event - EMP Slot": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2493,7 +2493,7 @@
                         }
                     }
                 },
-                "Event - EMPPuzzle": {
+                "Event - EMP Slot": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -2608,7 +2608,7 @@
                                 "items": []
                             }
                         },
-                        "Event - EMPPuzzle": {
+                        "Event - EMP Slot": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -2640,7 +2640,7 @@
                         }
                     }
                 },
-                "Event - EMPPuzzle": {
+                "Event - EMP Slot": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -2752,7 +2752,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - EMP Puzzle": {
+                        "Event - EMP Slot": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -2853,12 +2853,12 @@
                         }
                     }
                 },
-                "Event - EMP Puzzle": {
+                "Event - EMP Slot": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 151.89318073438244,
-                        "y": 132.0553171196948,
+                        "x": 151.89,
+                        "y": 132.06,
                         "z": 0.0
                     },
                     "description": "",
@@ -4701,7 +4701,7 @@
                                 "items": []
                             }
                         },
-                        "Event - NearLeftOutsideEMP": {
+                        "Event - EMP Slot": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -4770,7 +4770,7 @@
                         }
                     }
                 },
-                "Event - NearLeftOutsideEMP": {
+                "Event - EMP Slot": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -6790,7 +6790,7 @@
                         }
                     }
                 },
-                "Event - EMP": {
+                "Event - EMP Slot": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -6947,7 +6947,7 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Event - EMP": {
+                        "Event - EMP Slot": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -8966,7 +8966,7 @@
                                 ]
                             }
                         },
-                        "Event - NearRightOutsideEMP": {
+                        "Event - EMP Slot": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9052,7 +9052,7 @@
                         }
                     }
                 },
-                "Event - NearRightOutsideEMP": {
+                "Event - EMP Slot": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/am2r/json_data/Distribution Center.txt
+++ b/randovania/games/am2r/json_data/Distribution Center.txt
@@ -343,7 +343,7 @@ Extra - minimap_data: [{'x': 65, 'y': 43}, {'x': 65, 'y': 44}, {'x': 65, 'y': 45
   * Extra - instance_id: 133836
   > Door to Energy Distribution Emergency Exit
       Can Use Any Bombs and Space Jump Tunnel Climb
-  > Event - EMPPuzzle
+  > Event - EMP Slot
       Can Use Any Bombs
 
 > Door to Energy Distribution Emergency Exit; Heals? False
@@ -353,7 +353,7 @@ Extra - minimap_data: [{'x': 65, 'y': 43}, {'x': 65, 'y': 44}, {'x': 65, 'y': 45
   > Door to Energy Distribution Robot Home
       Can Use Any Bombs
 
-> Event - EMPPuzzle; Heals? False
+> Event - EMP Slot; Heals? False
   * Layers: default
   * Event EMP - Area 5 EMP Ball Introduction
   > Door to Energy Distribution Robot Home
@@ -376,10 +376,10 @@ Extra - minimap_data: [{'x': 63, 'y': 45}, {'x': 64, 'y': 45}]
   * Extra - instance_id: 133904
   > Door to Energy Distribution Tower East
       Trivial
-  > Event - EMPPuzzle
+  > Event - EMP Slot
       Missiles ≥ 2 or Super Missiles or Can Use Bombs
 
-> Event - EMPPuzzle; Heals? False
+> Event - EMP Slot; Heals? False
   * Layers: default
   * Event EMP - Area 5 Robot Home
   > Door to EMP Ball Introduction
@@ -400,7 +400,7 @@ Extra - minimap_data: [{'x': 62, 'y': 45}, {'x': 62, 'y': 46}, {'x': 62, 'y': 47
   * Layers: default
   * Normal Door to Energy Distribution Robot Home/Door to Energy Distribution Tower East
   * Extra - instance_id: 133917
-  > Event - EMP Puzzle
+  > Event - EMP Slot
       Any of the following:
           Can Use Bombs
           All of the following:
@@ -416,7 +416,7 @@ Extra - minimap_data: [{'x': 62, 'y': 45}, {'x': 62, 'y': 46}, {'x': 62, 'y': 47
   > Bottom
       Trivial
 
-> Event - EMP Puzzle; Heals? False
+> Event - EMP Slot; Heals? False
   * Layers: default
   * Event EMP - Area 5 Energy Distribution Tower East
   > Bottom
@@ -674,7 +674,7 @@ Extra - minimap_data: [{'x': 59, 'y': 42}, {'x': 60, 'y': 42}]
   * Extra - instance_id: 134427
   > Door to Distribution Center Exterior West
       Trivial
-  > Event - NearLeftOutsideEMP
+  > Event - EMP Slot
       Missiles ≥ 10 or Super Missiles ≥ 5 or Can Use Any Bombs
 
 > Door to Distribution Center Exterior West; Heals? False
@@ -684,7 +684,7 @@ Extra - minimap_data: [{'x': 59, 'y': 42}, {'x': 60, 'y': 42}]
   > Door to Pipe Hub
       Trivial
 
-> Event - NearLeftOutsideEMP; Heals? False
+> Event - EMP Slot; Heals? False
   * Layers: default
   * Event EMP - Area 5 Pipe Hub Access
   > Door to Pipe Hub
@@ -994,7 +994,7 @@ Extra - minimap_data: [{'x': 70, 'y': 44}, {'x': 70, 'y': 45}, {'x': 70, 'y': 46
           # HJ + CBJ
           Hi-Jump Boots and Charged Bomb Jump (Advanced) and Walljump (Intermediate) and Can Use Charged Bomb Jump
 
-> Event - EMP; Heals? False
+> Event - EMP Slot; Heals? False
   * Layers: default
   * Event EMP - Area 5 Bullet Hell Room Access
   > Door to Bullet Hell Room
@@ -1010,7 +1010,7 @@ Extra - minimap_data: [{'x': 70, 'y': 44}, {'x': 70, 'y': 45}, {'x': 70, 'y': 46
 
 > EMP Ball; Heals? False
   * Layers: default
-  > Event - EMP
+  > Event - EMP Slot
       Missiles ≥ 20 or Super Missiles ≥ 10 or Can Use Bombs
 
 > Center; Heals? False
@@ -1344,7 +1344,7 @@ Extra - minimap_data: [{'x': 72, 'y': 44}, {'x': 73, 'y': 44}]
   * Extra - instance_id: 135329
   > Door to Distribution Facility Intersection
       Can Use Any Bombs
-  > Event - NearRightOutsideEMP
+  > Event - EMP Slot
       All of the following:
           Can Use Any Bombs
           Missiles ≥ 2 or Super Missiles or Can Use Bombs
@@ -1356,7 +1356,7 @@ Extra - minimap_data: [{'x': 72, 'y': 44}, {'x': 73, 'y': 44}]
   > Door to Distribution Center Exterior East
       Can Use Any Bombs
 
-> Event - NearRightOutsideEMP; Heals? False
+> Event - EMP Slot; Heals? False
   * Layers: default
   * Event EMP - Area 5 Exterior East Access
   > Door to Distribution Center Exterior East

--- a/randovania/games/am2r/json_data/GFS Thoth.json
+++ b/randovania/games/am2r/json_data/GFS Thoth.json
@@ -60,7 +60,7 @@
                 ]
             },
             "nodes": {
-                "Dock to Research Site Access": {
+                "Dock to Research Site Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -77,7 +77,7 @@
                     "dock_type": "other",
                     "default_connection": {
                         "region": "Main Caves",
-                        "area": "Research Site Access",
+                        "area": "Research Site Elevator",
                         "node": "Dock to Elevator Shaft"
                     },
                     "default_dock_weakness": "Open Passage",
@@ -170,7 +170,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Research Site Access": {
+                        "Dock to Research Site Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/am2r/json_data/GFS Thoth.txt
+++ b/randovania/games/am2r/json_data/GFS Thoth.txt
@@ -2,9 +2,9 @@
 Elevator Shaft
 Extra - map_name: rm_a8h00
 Extra - minimap_data: [{'x': 41, 'y': 8}, {'x': 41, 'y': 9}, {'x': 41, 'y': 10}, {'x': 41, 'y': 11}, {'x': 41, 'y': 12}, {'x': 41, 'y': 16}, {'x': 41, 'y': 17}, {'x': 41, 'y': 18}, {'x': 41, 'y': 19}, {'x': 41, 'y': 20}, {'x': 41, 'y': 22}, {'x': 41, 'y': 23}]
-> Dock to Research Site Access; Heals? False
+> Dock to Research Site Elevator; Heals? False
   * Layers: default
-  * Open Passage to Research Site Access/Dock to Elevator Shaft
+  * Open Passage to Research Site Elevator/Dock to Elevator Shaft
   > Dock to GFS Thoth Exterior
       Any of the following:
           Space Jump or Walljump (Expert) or Disabled Entrance Rando
@@ -13,7 +13,7 @@ Extra - minimap_data: [{'x': 41, 'y': 8}, {'x': 41, 'y': 9}, {'x': 41, 'y': 10},
 > Dock to GFS Thoth Exterior; Heals? False
   * Layers: default
   * Open Passage to GFS Thoth Exterior/Dock to Elevator Shaft
-  > Dock to Research Site Access
+  > Dock to Research Site Elevator
       Trivial
 
 ----------------

--- a/randovania/games/am2r/json_data/Golden Temple.json
+++ b/randovania/games/am2r/json_data/Golden Temple.json
@@ -4433,7 +4433,7 @@
                                 "items": []
                             }
                         },
-                        "Event - 3Orb": {
+                        "Event - 3-Orbs": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4546,12 +4546,12 @@
                         }
                     }
                 },
-                "Event - 3Orb": {
+                "Event - 3-Orbs": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 167.49811035525326,
-                        "y": 179.01738473167046,
+                        "x": 167.5,
+                        "y": 179.02,
                         "z": 0.0
                     },
                     "description": "",
@@ -4962,7 +4962,7 @@
                                 ]
                             }
                         },
-                        "Event - GTEMP": {
+                        "Event - EMP Slot": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5002,7 +5002,7 @@
                         }
                     }
                 },
-                "Event - GTEMP": {
+                "Event - EMP Slot": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -5165,7 +5165,7 @@
                                 ]
                             }
                         },
-                        "Event - 1Orb": {
+                        "Event - 1-Orb": {
                             "type": "and",
                             "data": {
                                 "comment": "Shoot orb through wall",
@@ -5232,7 +5232,7 @@
                                 ]
                             }
                         },
-                        "Event - 1Orb": {
+                        "Event - 1-Orb": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5274,7 +5274,7 @@
                         }
                     }
                 },
-                "Event - 1Orb": {
+                "Event - 1-Orb": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/am2r/json_data/Golden Temple.txt
+++ b/randovania/games/am2r/json_data/Golden Temple.txt
@@ -581,7 +581,7 @@ Extra - minimap_data: [{'x': 62, 'y': 10}, {'x': 63, 'y': 10}, {'x': 64, 'y': 10
       Morph Ball
   > Pickup (Left Missile Tank)
       Trivial
-  > Event - 3Orb
+  > Event - 3-Orbs
       Trivial
 
 > Pickup (Left Missile Tank); Heals? False
@@ -605,7 +605,7 @@ Extra - minimap_data: [{'x': 62, 'y': 10}, {'x': 63, 'y': 10}, {'x': 64, 'y': 10
   > Horizontal Dock to Inner Temple East Hall
       Morph Ball
 
-> Event - 3Orb; Heals? False
+> Event - 3-Orbs; Heals? False
   * Layers: default
   * Event Area 1 - Golden Temple 3 Orb Puzzle
   > Horizontal Dock to Golden Temple Exterior
@@ -675,13 +675,13 @@ Extra - minimap_data: [{'x': 65, 'y': 10}, {'x': 65, 'y': 11}, {'x': 65, 'y': 12
       Screw Attack or Disabled Screw Attack Pipe Blocks
   > Door to Parkour Course
       Can Use Any Bombs
-  > Event - GTEMP
+  > Event - EMP Slot
       All of the following:
           After Area 5 - Distribution Center Energy Activated
           # Transport EMP Ball
           Missiles ≥ 5 or Can Use Bombs
 
-> Event - GTEMP; Heals? False
+> Event - EMP Slot; Heals? False
   * Layers: default
   * Event EMP - Golden Temple
   > Middle
@@ -706,7 +706,7 @@ Extra - minimap_data: [{'x': 62, 'y': 12}, {'x': 63, 'y': 12}, {'x': 64, 'y': 12
           Mid-Air Morph (Beginner) or Tunnel Climb
   > Pickup (Energy Tank)
       After Area 1 - Golden Temple 1 Orb Puzzle
-  > Event - 1Orb
+  > Event - 1-Orb
       # Shoot orb through wall
       Wave Beam and Knowledge (Intermediate)
 
@@ -716,7 +716,7 @@ Extra - minimap_data: [{'x': 62, 'y': 12}, {'x': 63, 'y': 12}, {'x': 64, 'y': 12
       Can Use Any Bombs
   > Horizontal Dock to Inner Temple East Hall
       Can Use Any Bombs
-  > Event - 1Orb
+  > Event - 1-Orb
       Can Use Any Bombs
 
 > Pickup (Energy Tank); Heals? False
@@ -726,7 +726,7 @@ Extra - minimap_data: [{'x': 62, 'y': 12}, {'x': 63, 'y': 12}, {'x': 64, 'y': 12
   > Horizontal Dock to Inner Temple East Hall
       Trivial
 
-> Event - 1Orb; Heals? False
+> Event - 1-Orb; Heals? False
   * Layers: default
   * Event Area 1 - Golden Temple 1 Orb Puzzle
   > Horizontal Dock to Inner Temple East Hall

--- a/randovania/games/am2r/json_data/Hydro Station.json
+++ b/randovania/games/am2r/json_data/Hydro Station.json
@@ -532,7 +532,7 @@
                                 "items": []
                             }
                         },
-                        "Horizontal Dock to Breeding Grounds Access (Bottom)": {
+                        "Horizontal Dock to Breeding Grounds Entrance (Bottom)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1048,7 +1048,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Horizontal Dock to Breeding Grounds Access (Top)": {
+                        "Horizontal Dock to Breeding Grounds Entrance (Top)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1069,7 +1069,7 @@
                         }
                     }
                 },
-                "Horizontal Dock to Breeding Grounds Access (Top)": {
+                "Horizontal Dock to Breeding Grounds Entrance (Top)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1086,7 +1086,7 @@
                     "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Hydro Station",
-                        "area": "Breeding Grounds Access",
+                        "area": "Breeding Grounds Entrance",
                         "node": "Horizontal Dock to Hydro Station Exterior (Top)"
                     },
                     "default_dock_weakness": "3-Tiles High Dock",
@@ -1095,7 +1095,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Horizontal Dock to Breeding Grounds Access (Bottom)": {
+                        "Horizontal Dock to Breeding Grounds Entrance (Bottom)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1104,7 +1104,7 @@
                         }
                     }
                 },
-                "Horizontal Dock to Breeding Grounds Access (Bottom)": {
+                "Horizontal Dock to Breeding Grounds Entrance (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1121,7 +1121,7 @@
                     "dock_type": "horizontal_dock",
                     "default_connection": {
                         "region": "Hydro Station",
-                        "area": "Breeding Grounds Access",
+                        "area": "Breeding Grounds Entrance",
                         "node": "Horizontal Dock to Hydro Station Exterior (Bottom)"
                     },
                     "default_dock_weakness": "3-Tiles High Dock",
@@ -1137,7 +1137,7 @@
                                 "items": []
                             }
                         },
-                        "Horizontal Dock to Breeding Grounds Access (Top)": {
+                        "Horizontal Dock to Breeding Grounds Entrance (Top)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -1439,7 +1439,7 @@
                                 ]
                             }
                         },
-                        "Horizontal Dock to Breeding Grounds Access (Top)": {
+                        "Horizontal Dock to Breeding Grounds Entrance (Top)": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -3737,7 +3737,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - A2WaterLowered": {
+                        "Event - Water Lowered": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3772,7 +3772,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - A2BottomWaterTurbine": {
+                        "Event - Bottom Water Turbine": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3807,7 +3807,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - A2BottomWaterTurbine": {
+                        "Event - Bottom Water Turbine": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -3835,12 +3835,12 @@
                         }
                     }
                 },
-                "Event - A2WaterLowered": {
+                "Event - Water Lowered": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 49.56796628029507,
-                        "y": 358.8619599578504,
+                        "x": 49.57,
+                        "y": 358.86,
                         "z": 0.0
                     },
                     "description": "",
@@ -3858,7 +3858,7 @@
                                 "items": []
                             }
                         },
-                        "Event - A2TopWaterTurbine": {
+                        "Event - Top Water Turbine": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -3897,7 +3897,7 @@
                         }
                     }
                 },
-                "Event - A2TopWaterTurbine": {
+                "Event - Top Water Turbine": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -3913,7 +3913,7 @@
                     "valid_starting_location": false,
                     "event_name": "A2TopWaterTurbine",
                     "connections": {
-                        "Event - A2WaterLowered": {
+                        "Event - Water Lowered": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3925,7 +3925,7 @@
                                 ]
                             }
                         },
-                        "Event - A2MiddleWaterTurbine": {
+                        "Event - Middle Water Turbine": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -3948,12 +3948,12 @@
                         }
                     }
                 },
-                "Event - A2MiddleWaterTurbine": {
+                "Event - Middle Water Turbine": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 154.66104671584125,
-                        "y": 166.0976466455919,
+                        "x": 154.66,
+                        "y": 166.1,
                         "z": 0.0
                     },
                     "description": "",
@@ -3964,7 +3964,7 @@
                     "valid_starting_location": false,
                     "event_name": "A2MiddleWaterTurbine",
                     "connections": {
-                        "Event - A2TopWaterTurbine": {
+                        "Event - Top Water Turbine": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3976,7 +3976,7 @@
                                 ]
                             }
                         },
-                        "Event - A2BottomWaterTurbine": {
+                        "Event - Bottom Water Turbine": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -3999,12 +3999,12 @@
                         }
                     }
                 },
-                "Event - A2BottomWaterTurbine": {
+                "Event - Bottom Water Turbine": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 177.70284510010538,
-                        "y": 47.51668422901304,
+                        "x": 177.7,
+                        "y": 47.52,
                         "z": 0.0
                     },
                     "description": "",
@@ -4048,7 +4048,7 @@
                                 ]
                             }
                         },
-                        "Event - A2MiddleWaterTurbine": {
+                        "Event - Middle Water Turbine": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4081,7 +4081,7 @@
                     "pickup_index": 150,
                     "location_category": "minor",
                     "connections": {
-                        "Event - A2WaterLowered": {
+                        "Event - Water Lowered": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -6832,7 +6832,7 @@
                 }
             }
         },
-        "Breeding Grounds Access": {
+        "Breeding Grounds Entrance": {
             "default_node": null,
             "extra": {
                 "map_name": "rm_a2c01",
@@ -6874,7 +6874,7 @@
                     "default_connection": {
                         "region": "Hydro Station",
                         "area": "Hydro Station Exterior",
-                        "node": "Horizontal Dock to Breeding Grounds Access (Top)"
+                        "node": "Horizontal Dock to Breeding Grounds Entrance (Top)"
                     },
                     "default_dock_weakness": "3-Tiles High Dock",
                     "exclude_from_dock_rando": false,
@@ -6940,7 +6940,7 @@
                     "default_connection": {
                         "region": "Hydro Station",
                         "area": "Hydro Station Exterior",
-                        "node": "Horizontal Dock to Breeding Grounds Access (Bottom)"
+                        "node": "Horizontal Dock to Breeding Grounds Entrance (Bottom)"
                     },
                     "default_dock_weakness": "3-Tiles High Dock",
                     "exclude_from_dock_rando": false,
@@ -7481,7 +7481,7 @@
                     "default_connection": {
                         "region": "Hydro Station",
                         "area": "Breeding Grounds Save Station",
-                        "node": "Tunnel to Breeding Grounds Access"
+                        "node": "Tunnel to Breeding Grounds Entrance"
                     },
                     "default_dock_weakness": "Morph Ball Tunnel",
                     "exclude_from_dock_rando": false,
@@ -7528,7 +7528,7 @@
                     "default_connection": {
                         "region": "Hydro Station",
                         "area": "Speedboosting Challenge",
-                        "node": "Door to Breeding Grounds Access"
+                        "node": "Door to Breeding Grounds Entrance"
                     },
                     "default_dock_weakness": "Hydro Station EMP Door",
                     "exclude_from_dock_rando": false,
@@ -7545,7 +7545,7 @@
                         }
                     }
                 },
-                "Event - A2EMP": {
+                "Event - EMP Slot": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -7609,7 +7609,7 @@
                                 "items": []
                             }
                         },
-                        "Event - A2EMP": {
+                        "Event - EMP Slot": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7680,7 +7680,7 @@
                     },
                     "valid_starting_location": true,
                     "connections": {
-                        "Tunnel to Breeding Grounds Access": {
+                        "Tunnel to Breeding Grounds Entrance": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7701,7 +7701,7 @@
                         }
                     }
                 },
-                "Tunnel to Breeding Grounds Access": {
+                "Tunnel to Breeding Grounds Entrance": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -7718,7 +7718,7 @@
                     "dock_type": "tunnel",
                     "default_connection": {
                         "region": "Hydro Station",
-                        "area": "Breeding Grounds Access",
+                        "area": "Breeding Grounds Entrance",
                         "node": "Tunnel to Breeding Grounds Save Station"
                     },
                     "default_dock_weakness": "Morph Ball Tunnel",
@@ -10236,7 +10236,7 @@
                 ]
             },
             "nodes": {
-                "Door to Breeding Grounds Access": {
+                "Door to Breeding Grounds Entrance": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -10255,7 +10255,7 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Hydro Station",
-                        "area": "Breeding Grounds Access",
+                        "area": "Breeding Grounds Entrance",
                         "node": "Door to Speedboosting Challenge"
                     },
                     "default_dock_weakness": "Normal Door",
@@ -10354,7 +10354,7 @@
                     "pickup_index": 162,
                     "location_category": "minor",
                     "connections": {
-                        "Door to Breeding Grounds Access": {
+                        "Door to Breeding Grounds Entrance": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/am2r/json_data/Hydro Station.txt
+++ b/randovania/games/am2r/json_data/Hydro Station.txt
@@ -61,7 +61,7 @@ Extra - minimap_data: [{'x': 29, 'y': 18}, {'x': 29, 'y': 19}, {'x': 29, 'y': 20
   * 4-Tiles High Dock to Inner Save Station/Horizontal Dock to Hydro Station Exterior
   > Door to Water Turbine Station
       Trivial
-  > Horizontal Dock to Breeding Grounds Access (Bottom)
+  > Horizontal Dock to Breeding Grounds Entrance (Bottom)
       Trivial
   > Middle Left
       Power Grip or Hijump Wall
@@ -126,23 +126,23 @@ Extra - minimap_data: [{'x': 29, 'y': 18}, {'x': 29, 'y': 19}, {'x': 29, 'y': 20
 > Horizontal Dock to Exterior Alpha Nest; Heals? False
   * Layers: default
   * 3-Tiles High Dock to Exterior Alpha Nest/Horizontal Dock to Hydro Station Exterior
-  > Horizontal Dock to Breeding Grounds Access (Top)
+  > Horizontal Dock to Breeding Grounds Entrance (Top)
       Can Use Spider Ball
   > Middle Left
       Trivial
 
-> Horizontal Dock to Breeding Grounds Access (Top); Heals? False
+> Horizontal Dock to Breeding Grounds Entrance (Top); Heals? False
   * Layers: default
-  * 3-Tiles High Dock to Breeding Grounds Access/Horizontal Dock to Hydro Station Exterior (Top)
-  > Horizontal Dock to Breeding Grounds Access (Bottom)
+  * 3-Tiles High Dock to Breeding Grounds Entrance/Horizontal Dock to Hydro Station Exterior (Top)
+  > Horizontal Dock to Breeding Grounds Entrance (Bottom)
       Trivial
 
-> Horizontal Dock to Breeding Grounds Access (Bottom); Heals? False
+> Horizontal Dock to Breeding Grounds Entrance (Bottom); Heals? False
   * Layers: default
-  * 3-Tiles High Dock to Breeding Grounds Access/Horizontal Dock to Hydro Station Exterior (Bottom)
+  * 3-Tiles High Dock to Breeding Grounds Entrance/Horizontal Dock to Hydro Station Exterior (Bottom)
   > Horizontal Dock to Inner Save Station
       Trivial
-  > Horizontal Dock to Breeding Grounds Access (Top)
+  > Horizontal Dock to Breeding Grounds Entrance (Top)
       Any of the following:
           Space Jump
           # IBJ
@@ -172,7 +172,7 @@ Extra - minimap_data: [{'x': 29, 'y': 18}, {'x': 29, 'y': 19}, {'x': 29, 'y': 20
                   After Metroids Area 2 - Interior Upper Alpha and Disabled Entrance Rando
           # IBJ
           Infinite Bomb Jumping (Intermediate) and Can Use Bombs
-  > Horizontal Dock to Breeding Grounds Access (Top)
+  > Horizontal Dock to Breeding Grounds Entrance (Top)
       # Shinespark from the room on the right
       Morph Ball and Speed Booster and Shinesparking Tricks (Beginner) and Disabled Entrance Rando
 
@@ -524,62 +524,62 @@ Extra - minimap_data: [{'x': 32, 'y': 22}, {'x': 32, 'y': 23}]
   * Layers: default
   * Normal Door to Hydro Station Exterior/Door to Water Turbine Station
   * Extra - instance_id: 400002
-  > Event - A2WaterLowered
+  > Event - Water Lowered
       Trivial
 
 > Horizontal Dock to Inner Alpha Nest South; Heals? False
   * Layers: default
   * 4-Tiles High Dock to Inner Alpha Nest South/Horizontal Dock to Water Turbine Station
-  > Event - A2BottomWaterTurbine
+  > Event - Bottom Water Turbine
       Trivial
 
 > Horizontal Dock to Water Turbine Station Pipe; Heals? False
   * Layers: default
   * 3-Tiles High Dock to Water Turbine Station Pipe/Horizontal Dock to Water Turbine Station
-  > Event - A2BottomWaterTurbine
+  > Event - Bottom Water Turbine
       Screw Attack or Disabled Screw Attack Pipe Blocks
 
-> Event - A2WaterLowered; Heals? False
+> Event - Water Lowered; Heals? False
   * Layers: default
   * Event Area 2 - Hydro Station Exterior Water Lowered
   > Door to Hydro Station Exterior
       Trivial
-  > Event - A2TopWaterTurbine
+  > Event - Top Water Turbine
       After Area 2 - Hydro Station Top Water Turbine Destroyed or Destroy Turbine
   > Pickup (Missile Tank)
       Can Use Any Bombs and Power Grip Wall
 
-> Event - A2TopWaterTurbine; Heals? False
+> Event - Top Water Turbine; Heals? False
   * Layers: default
   * Event Area 2 - Hydro Station Top Water Turbine Destroyed
-  > Event - A2WaterLowered
+  > Event - Water Lowered
       Power Grip Wall
-  > Event - A2MiddleWaterTurbine
+  > Event - Middle Water Turbine
       After Area 2 - Hydro Station Middle Water Turbine Destroyed or Destroy Turbine
 
-> Event - A2MiddleWaterTurbine; Heals? False
+> Event - Middle Water Turbine; Heals? False
   * Layers: default
   * Event Area 2 - Hydro Station Middle Water Turbine Destroyed
-  > Event - A2TopWaterTurbine
+  > Event - Top Water Turbine
       Power Grip Wall
-  > Event - A2BottomWaterTurbine
+  > Event - Bottom Water Turbine
       After Area 2 - Hydro Station Bottom Water Turbine Destroyed or Destroy Turbine
 
-> Event - A2BottomWaterTurbine; Heals? False
+> Event - Bottom Water Turbine; Heals? False
   * Layers: default
   * Event Area 2 - Hydro Station Bottom Water Turbine Destroyed
   > Horizontal Dock to Inner Alpha Nest South
       Trivial
   > Horizontal Dock to Water Turbine Station Pipe
       Screw Attack or Disabled Screw Attack Pipe Blocks
-  > Event - A2MiddleWaterTurbine
+  > Event - Middle Water Turbine
       Power Grip Wall
 
 > Pickup (Missile Tank); Heals? False
   * Layers: default
   * Pickup 150; Category? Minor
   * Extra - object_name: oItemM_150
-  > Event - A2WaterLowered
+  > Event - Water Lowered
       Can Use Any Bombs
 
 ----------------
@@ -985,12 +985,12 @@ Extra - minimap_data: [{'x': 30, 'y': 23}, {'x': 31, 'y': 23}]
       Morph Ball
 
 ----------------
-Breeding Grounds Access
+Breeding Grounds Entrance
 Extra - map_name: rm_a2c01
 Extra - minimap_data: [{'x': 28, 'y': 19}, {'x': 28, 'y': 20}, {'x': 28, 'y': 21}, {'x': 28, 'y': 22}]
 > Horizontal Dock to Hydro Station Exterior (Top); Heals? False
   * Layers: default
-  * 3-Tiles High Dock to Hydro Station Exterior/Horizontal Dock to Breeding Grounds Access (Top)
+  * 3-Tiles High Dock to Hydro Station Exterior/Horizontal Dock to Breeding Grounds Entrance (Top)
   > EMPBall
       Any of the following:
           Tunnel Climb
@@ -998,7 +998,7 @@ Extra - minimap_data: [{'x': 28, 'y': 19}, {'x': 28, 'y': 20}, {'x': 28, 'y': 21
 
 > Horizontal Dock to Hydro Station Exterior (Bottom); Heals? False
   * Layers: default
-  * 3-Tiles High Dock to Hydro Station Exterior/Horizontal Dock to Breeding Grounds Access (Bottom)
+  * 3-Tiles High Dock to Hydro Station Exterior/Horizontal Dock to Breeding Grounds Entrance (Bottom)
   > Tunnel to Breeding Grounds Save Station
       All of the following:
           Morph Ball
@@ -1045,18 +1045,18 @@ Extra - minimap_data: [{'x': 28, 'y': 19}, {'x': 28, 'y': 20}, {'x': 28, 'y': 21
 
 > Tunnel to Breeding Grounds Save Station; Heals? False
   * Layers: default
-  * Morph Ball Tunnel to Breeding Grounds Save Station/Tunnel to Breeding Grounds Access
+  * Morph Ball Tunnel to Breeding Grounds Save Station/Tunnel to Breeding Grounds Entrance
   > Horizontal Dock to Hydro Station Exterior (Bottom)
       Morph Ball
 
 > Door to Speedboosting Challenge; Heals? False
   * Layers: default
-  * Hydro Station EMP Door to Speedboosting Challenge/Door to Breeding Grounds Access
+  * Hydro Station EMP Door to Speedboosting Challenge/Door to Breeding Grounds Entrance
   * Extra - instance_id: 111778
   > Horizontal Dock to Hydro Station Exterior (Bottom)
       Trivial
 
-> Event - A2EMP; Heals? False
+> Event - EMP Slot; Heals? False
   * Layers: default
   * Event EMP - Hydro Station
   > Horizontal Dock to Hydro Station Exterior (Bottom)
@@ -1068,7 +1068,7 @@ Extra - minimap_data: [{'x': 28, 'y': 19}, {'x': 28, 'y': 20}, {'x': 28, 'y': 21
       Morph Ball
   > Horizontal Dock to Hydro Station Exterior (Bottom)
       Trivial
-  > Event - A2EMP
+  > Event - EMP Slot
       All of the following:
           After Area 5 - Distribution Center Energy Activated
           Missile Launcher ≥ 20 or Can Use Bombs
@@ -1080,14 +1080,14 @@ Extra - minimap_data: [{'x': 27, 'y': 22}]
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 7
-  > Tunnel to Breeding Grounds Access
+  > Tunnel to Breeding Grounds Entrance
       Low Mid-Air Morph Tunnel Climb
   > Horizontal Dock to Breeding Grounds Shaft
       Trivial
 
-> Tunnel to Breeding Grounds Access; Heals? False
+> Tunnel to Breeding Grounds Entrance; Heals? False
   * Layers: default
-  * Morph Ball Tunnel to Breeding Grounds Access/Tunnel to Breeding Grounds Save Station
+  * Morph Ball Tunnel to Breeding Grounds Entrance/Tunnel to Breeding Grounds Save Station
   > Save Station
       Morph Ball
 
@@ -1434,9 +1434,9 @@ Extra - minimap_data: [{'x': 20, 'y': 22}, {'x': 21, 'y': 22}, {'x': 22, 'y': 22
 Speedboosting Challenge
 Extra - map_name: rm_a2c10
 Extra - minimap_data: [{'x': 25, 'y': 21}, {'x': 26, 'y': 21}, {'x': 27, 'y': 21}]
-> Door to Breeding Grounds Access; Heals? False
+> Door to Breeding Grounds Entrance; Heals? False
   * Layers: default
-  * Normal Door to Breeding Grounds Access/Door to Speedboosting Challenge
+  * Normal Door to Breeding Grounds Entrance/Door to Speedboosting Challenge
   * Extra - instance_id: 113636
   > Pickup (Super Missile Tank)
       All of the following:
@@ -1450,6 +1450,6 @@ Extra - minimap_data: [{'x': 25, 'y': 21}, {'x': 26, 'y': 21}, {'x': 27, 'y': 21
   * Layers: default
   * Pickup 162; Category? Minor
   * Extra - object_name: oItemSM_162
-  > Door to Breeding Grounds Access
+  > Door to Breeding Grounds Entrance
       Can Use Any Bombs
 

--- a/randovania/games/am2r/json_data/Industrial Complex.json
+++ b/randovania/games/am2r/json_data/Industrial Complex.json
@@ -2569,7 +2569,7 @@
                                 ]
                             }
                         },
-                        "Event - A3EMP": {
+                        "Event - EMP Slot": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2618,7 +2618,7 @@
                         }
                     }
                 },
-                "Event - A3EMP": {
+                "Event - EMP Slot": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -8443,7 +8443,7 @@
                                 ]
                             }
                         },
-                        "Event - MakeSkippyBeCleared": {
+                        "Event - Make Skippy Be Cleared": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8452,7 +8452,7 @@
                         }
                     }
                 },
-                "Event - MakeSkippyBeCleared": {
+                "Event - Make Skippy Be Cleared": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -8542,7 +8542,7 @@
                                 ]
                             }
                         },
-                        "Event - SuperCrystal": {
+                        "Event - Crystal": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8628,7 +8628,7 @@
                                 "items": []
                             }
                         },
-                        "Event - SuperCrystal": {
+                        "Event - Crystal": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8647,7 +8647,7 @@
                         }
                     }
                 },
-                "Event - SuperCrystal": {
+                "Event - Crystal": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/am2r/json_data/Industrial Complex.txt
+++ b/randovania/games/am2r/json_data/Industrial Complex.txt
@@ -351,12 +351,12 @@ Extra - minimap_data: [{'x': 51, 'y': 23}, {'x': 52, 'y': 22}, {'x': 52, 'y': 23
       Trivial
   > Dock to Eastern Cave Save Station
       Can Use Any Bombs
-  > Event - A3EMP
+  > Event - EMP Slot
       All of the following:
           After Area 5 - Distribution Center Energy Activated and Can Use Power Bombs
           Missiles ≥ 5 or Super Missiles ≥ 2
 
-> Event - A3EMP; Heals? False
+> Event - EMP Slot; Heals? False
   * Layers: default
   * Event EMP - Industrial Complex
   > Bottom
@@ -1180,10 +1180,10 @@ Extra - minimap_data: [{'x': 74, 'y': 31}, {'x': 74, 'y': 32}]
       Any of the following:
           Space Jump or Walljump (Intermediate) or Can Use Spider Ball
           Hi-Jump Boots and Power Grip
-  > Event - MakeSkippyBeCleared
+  > Event - Make Skippy Be Cleared
       Trivial
 
-> Event - MakeSkippyBeCleared; Heals? False
+> Event - Make Skippy Be Cleared; Heals? False
   * Layers: default
   * Event Area 3 - Industrial Complex Skippy Minigame Cleared
   > Horizontal Dock to Super Missile Chamber
@@ -1198,7 +1198,7 @@ Extra - minimap_data: [{'x': 72, 'y': 32}, {'x': 73, 'y': 32}]
   * 4-Tiles High Dock to Super Missile Chamber Access/Horizontal Dock to Super Missile Chamber
   > In Front Of Super
       After Area 3 - Super Missile Crystal Destroyed or Power Grip Wall
-  > Event - SuperCrystal
+  > Event - Crystal
       Super Missiles
 
 > Pickup (Super Missile Tank); Heals? False
@@ -1214,10 +1214,10 @@ Extra - minimap_data: [{'x': 72, 'y': 32}, {'x': 73, 'y': 32}]
       After Area 3 - Super Missile Crystal Destroyed
   > Pickup (Super Missile Tank)
       Trivial
-  > Event - SuperCrystal
+  > Event - Crystal
       Super Missiles
 
-> Event - SuperCrystal; Heals? False
+> Event - Crystal; Heals? False
   * Layers: default
   * Event Area 3 - Super Missile Crystal Destroyed
   > Horizontal Dock to Super Missile Chamber Access

--- a/randovania/games/am2r/json_data/Main Caves.json
+++ b/randovania/games/am2r/json_data/Main Caves.json
@@ -6601,7 +6601,7 @@
                                 ]
                             }
                         },
-                        "Event - A4RockEntrance": {
+                        "Event - Rocks": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -6685,7 +6685,7 @@
                                 ]
                             }
                         },
-                        "Event - A4RockEntrance": {
+                        "Event - Rocks": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -6726,12 +6726,12 @@
                         }
                     }
                 },
-                "Event - A4RockEntrance": {
+                "Event - Rocks": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 293.52378722241735,
-                        "y": 210.41876439136712,
+                        "x": 293.52,
+                        "y": 210.42,
                         "z": 0.0
                     },
                     "description": "",
@@ -7917,7 +7917,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Area Transition to Research Site Access": {
+                        "Area Transition to Research Site Elevator": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -8038,7 +8038,7 @@
                         }
                     }
                 },
-                "Area Transition to Research Site Access": {
+                "Area Transition to Research Site Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8059,7 +8059,7 @@
                     "dock_type": "area_transition",
                     "default_connection": {
                         "region": "Main Caves",
-                        "area": "Research Site Access",
+                        "area": "Research Site Elevator",
                         "node": "Area Transition to Octroll Lava Pool"
                     },
                     "default_dock_weakness": "Open Passage",
@@ -8191,7 +8191,7 @@
                 }
             }
         },
-        "Research Site Access": {
+        "Research Site Elevator": {
             "default_node": null,
             "extra": {
                 "map_name": "rm_a0h13",
@@ -8233,7 +8233,7 @@
                     "default_connection": {
                         "region": "Main Caves",
                         "area": "Octroll Lava Pool",
-                        "node": "Area Transition to Research Site Access"
+                        "node": "Area Transition to Research Site Elevator"
                     },
                     "default_dock_weakness": "Open Passage",
                     "exclude_from_dock_rando": false,
@@ -8273,7 +8273,7 @@
                     "default_connection": {
                         "region": "Main Caves",
                         "area": "Research Site",
-                        "node": "Dock to Research Site Access"
+                        "node": "Dock to Research Site Elevator"
                     },
                     "default_dock_weakness": "Open Passage",
                     "exclude_from_dock_rando": false,
@@ -8305,7 +8305,7 @@
                                 ]
                             }
                         },
-                        "Event - ThothPBEntrance": {
+                        "Event - Power Bomb Blocks": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8337,7 +8337,7 @@
                     "default_connection": {
                         "region": "GFS Thoth",
                         "area": "Elevator Shaft",
-                        "node": "Dock to Research Site Access"
+                        "node": "Dock to Research Site Elevator"
                     },
                     "default_dock_weakness": "Open Passage",
                     "exclude_from_dock_rando": false,
@@ -8345,7 +8345,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Event - ThothPBEntrance": {
+                        "Event - Power Bomb Blocks": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8354,12 +8354,12 @@
                         }
                     }
                 },
-                "Event - ThothPBEntrance": {
+                "Event - Power Bomb Blocks": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 162.99465240641712,
-                        "y": 546.951871657754,
+                        "x": 162.99,
+                        "y": 546.95,
                         "z": 0.0
                     },
                     "description": "",
@@ -8427,14 +8427,14 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Research Site Access": {
+                        "Dock to Research Site Elevator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Event - LeftDualAlpha": {
+                        "Event - Left Alpha": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8455,7 +8455,7 @@
                                 ]
                             }
                         },
-                        "Event - RightDualAlpha": {
+                        "Event - Right Alpha": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8478,7 +8478,7 @@
                         }
                     }
                 },
-                "Dock to Research Site Access": {
+                "Dock to Research Site Elevator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8495,7 +8495,7 @@
                     "dock_type": "other",
                     "default_connection": {
                         "region": "Main Caves",
-                        "area": "Research Site Access",
+                        "area": "Research Site Elevator",
                         "node": "Dock to Research Site"
                     },
                     "default_dock_weakness": "Open Passage",
@@ -8513,12 +8513,12 @@
                         }
                     }
                 },
-                "Event - LeftDualAlpha": {
+                "Event - Left Alpha": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 490.11250158007834,
-                        "y": 135.1687523701176,
+                        "x": 490.11,
+                        "y": 135.17,
                         "z": 0.0
                     },
                     "description": "",
@@ -8545,7 +8545,7 @@
                         }
                     }
                 },
-                "Event - RightDualAlpha": {
+                "Event - Right Alpha": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -8596,7 +8596,7 @@
                     "pickup_index": 364,
                     "location_category": "minor",
                     "connections": {
-                        "Event - LeftDualAlpha": {
+                        "Event - Left Alpha": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -8624,7 +8624,7 @@
                     "pickup_index": 365,
                     "location_category": "minor",
                     "connections": {
-                        "Event - RightDualAlpha": {
+                        "Event - Right Alpha": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9577,7 +9577,7 @@
                                 ]
                             }
                         },
-                        "Event - DrillCrystal from left": {
+                        "Event - Drill Crystal from Left": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9708,7 +9708,7 @@
                                 ]
                             }
                         },
-                        "Event - DrillCrystal from right": {
+                        "Event - Drill Crystal from Right": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -9727,7 +9727,7 @@
                         }
                     }
                 },
-                "Event - DrillCrystal from left": {
+                "Event - Drill Crystal from Left": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -9761,7 +9761,7 @@
                         }
                     }
                 },
-                "Event - DrillCrystal from right": {
+                "Event - Drill Crystal from Right": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {

--- a/randovania/games/am2r/json_data/Main Caves.txt
+++ b/randovania/games/am2r/json_data/Main Caves.txt
@@ -925,7 +925,7 @@ Extra - minimap_data: [{'x': 38, 'y': 41}, {'x': 39, 'y': 41}]
   * Extra - source_y: 128
   > Dock to Skreek Street
       After Surface - Rock Entrance To The Tower and Power Grip Wall
-  > Event - A4RockEntrance
+  > Event - Rocks
       Missiles or Speed Booster or Super Missiles or Can Use Any Bombs
 
 > Dock to Skreek Street; Heals? False
@@ -933,10 +933,10 @@ Extra - minimap_data: [{'x': 38, 'y': 41}, {'x': 39, 'y': 41}]
   * Open Passage to Skreek Street/Dock to Tower East Exterior Access
   > Area Transition to The Tower
       After Surface - Rock Entrance To The Tower
-  > Event - A4RockEntrance
+  > Event - Rocks
       Missiles or Speed Booster or Super Missiles or Can Use Any Bombs
 
-> Event - A4RockEntrance; Heals? False
+> Event - Rocks; Heals? False
   * Layers: default
   * Event Surface - Rock Entrance To The Tower
   > Area Transition to The Tower
@@ -1113,7 +1113,7 @@ Extra - minimap_data: [{'x': 42, 'y': 26}, {'x': 43, 'y': 26}, {'x': 44, 'y': 26
 > Dock to Bend Chasm; Heals? False
   * Layers: default
   * Open Passage to Bend Chasm/Dock to Octroll Lava Pool
-  > Area Transition to Research Site Access
+  > Area Transition to Research Site Elevator
       Any of the following:
           Space Jump or Can Use Spider Ball
           All of the following:
@@ -1125,9 +1125,9 @@ Extra - minimap_data: [{'x': 42, 'y': 26}, {'x': 43, 'y': 26}, {'x': 44, 'y': 26
           # Hang off first platform
           Power Grip and Movement (Beginner)
 
-> Area Transition to Research Site Access; Heals? False
+> Area Transition to Research Site Elevator; Heals? False
   * Layers: default
-  * Open Passage to Research Site Access/Area Transition to Octroll Lava Pool
+  * Open Passage to Research Site Elevator/Area Transition to Octroll Lava Pool
   * Extra - instance_id: 122611
   * Extra - source_x: 0
   * Extra - source_y: 112
@@ -1146,12 +1146,12 @@ Extra - minimap_data: [{'x': 42, 'y': 26}, {'x': 43, 'y': 26}, {'x': 44, 'y': 26
               Power Grip and Movement (Beginner)
 
 ----------------
-Research Site Access
+Research Site Elevator
 Extra - map_name: rm_a0h13
 Extra - minimap_data: [{'x': 41, 'y': 24}, {'x': 41, 'y': 25}, {'x': 41, 'y': 26}]
 > Area Transition to Octroll Lava Pool; Heals? False
   * Layers: default
-  * Open Passage to Octroll Lava Pool/Area Transition to Research Site Access
+  * Open Passage to Octroll Lava Pool/Area Transition to Research Site Elevator
   * Extra - instance_id: 122751
   * Extra - source_x: 320
   * Extra - source_y: 592
@@ -1160,21 +1160,21 @@ Extra - minimap_data: [{'x': 41, 'y': 24}, {'x': 41, 'y': 25}, {'x': 41, 'y': 26
 
 > Dock to Research Site; Heals? False
   * Layers: default
-  * Open Passage to Research Site/Dock to Research Site Access
+  * Open Passage to Research Site/Dock to Research Site Elevator
   > Area Transition to Octroll Lava Pool
       Trivial
   > Dock to Elevator Shaft
       After Surface - Thoth Power Bomb Blocks Entrance Destroyed
-  > Event - ThothPBEntrance
+  > Event - Power Bomb Blocks
       Can Use Power Bombs
 
 > Dock to Elevator Shaft; Heals? False
   * Layers: default
-  * Open Passage to Elevator Shaft/Dock to Research Site Access
-  > Event - ThothPBEntrance
+  * Open Passage to Elevator Shaft/Dock to Research Site Elevator
+  > Event - Power Bomb Blocks
       Trivial
 
-> Event - ThothPBEntrance; Heals? False
+> Event - Power Bomb Blocks; Heals? False
   * Layers: default
   * Event Surface - Thoth Power Bomb Blocks Entrance Destroyed
   > Dock to Research Site
@@ -1187,20 +1187,20 @@ Extra - minimap_data: [{'x': 42, 'y': 24}, {'x': 43, 'y': 24}, {'x': 44, 'y': 24
 > Dock to Research Site Storage; Heals? False
   * Layers: default
   * Open Passage to Research Site Storage/Dock to Research Site
-  > Dock to Research Site Access
+  > Dock to Research Site Elevator
       Trivial
-  > Event - LeftDualAlpha
+  > Event - Left Alpha
       After Surface - Research Site Dual Alphas Trigger Activated and Defeat Dual Alphas
-  > Event - RightDualAlpha
+  > Event - Right Alpha
       After Surface - Research Site Dual Alphas Trigger Activated and Defeat Dual Alphas
 
-> Dock to Research Site Access; Heals? False
+> Dock to Research Site Elevator; Heals? False
   * Layers: default
-  * Open Passage to Research Site Access/Dock to Research Site
+  * Open Passage to Research Site Elevator/Dock to Research Site
   > Dock to Research Site Storage
       Trivial
 
-> Event - LeftDualAlpha; Heals? False
+> Event - Left Alpha; Heals? False
   * Layers: default
   * Event Metroids Surface - Dual Alphas Left
   > Dock to Research Site Storage
@@ -1208,7 +1208,7 @@ Extra - minimap_data: [{'x': 42, 'y': 24}, {'x': 43, 'y': 24}, {'x': 44, 'y': 24
   > Pickup (Left Alpha)
       Trivial
 
-> Event - RightDualAlpha; Heals? False
+> Event - Right Alpha; Heals? False
   * Layers: default
   * Event Metroids Surface - Dual Alphas Right
   > Dock to Research Site Storage
@@ -1220,14 +1220,14 @@ Extra - minimap_data: [{'x': 42, 'y': 24}, {'x': 43, 'y': 24}, {'x': 44, 'y': 24
   * Layers: default
   * Pickup 364; Category? Minor
   * Extra - object_name: oItemDNA_364
-  > Event - LeftDualAlpha
+  > Event - Left Alpha
       Trivial
 
 > Pickup (Right Alpha); Heals? False
   * Layers: default
   * Pickup 365; Category? Minor
   * Extra - object_name: oItemDNA_365
-  > Event - RightDualAlpha
+  > Event - Right Alpha
       Trivial
 
 ----------------
@@ -1384,7 +1384,7 @@ Extra - minimap_data: [{'x': 49, 'y': 35}, {'x': 50, 'y': 35}, {'x': 51, 'y': 35
   * Open Passage to Drill Excavation Access/Dock to Drill Excavation
   > After Drill Sequence
       After Surface - Mines Drill Crystal Destroyed
-  > Event - DrillCrystal from left
+  > Event - Drill Crystal from Left
       All of the following:
           Super Missiles
           Any of the following:
@@ -1400,16 +1400,16 @@ Extra - minimap_data: [{'x': 49, 'y': 35}, {'x': 50, 'y': 35}, {'x': 51, 'y': 35
           Speed Booster and After Surface - Mines Drill Crystal Destroyed and Shinesparking Tricks (Beginner)
   > Dock to Drill Excavation Access
       After Surface - Mines Drill Crystal Destroyed
-  > Event - DrillCrystal from right
+  > Event - Drill Crystal from Right
       Super Missiles
 
-> Event - DrillCrystal from left; Heals? False
+> Event - Drill Crystal from Left; Heals? False
   * Layers: default
   * Event Surface - Mines Drill Crystal Destroyed
   > Dock to Drill Excavation Access
       Can Use Any Bombs and Tunnel Climb
 
-> Event - DrillCrystal from right; Heals? False
+> Event - Drill Crystal from Right; Heals? False
   * Layers: default
   * Event Surface - Mines Drill Crystal Destroyed
   > After Drill Sequence

--- a/randovania/games/am2r/json_data/The Tower.json
+++ b/randovania/games/am2r/json_data/The Tower.json
@@ -6518,7 +6518,7 @@
                         }
                     }
                 },
-                "Event - ActivateTower": {
+                "Event - Activate Tower": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
@@ -6572,7 +6572,7 @@
                                 "items": []
                             }
                         },
-                        "Event - ActivateTower": {
+                        "Event - Activate Tower": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/am2r/json_data/The Tower.txt
+++ b/randovania/games/am2r/json_data/The Tower.txt
@@ -825,7 +825,7 @@ Extra - minimap_data: [{'x': 33, 'y': 38}, {'x': 34, 'y': 38}]
   > Ground
       Trivial
 
-> Event - ActivateTower; Heals? False
+> Event - Activate Tower; Heals? False
   * Layers: default
   * Event Area 4 - Tower Energy Activated
   > Ground
@@ -837,7 +837,7 @@ Extra - minimap_data: [{'x': 33, 'y': 38}, {'x': 34, 'y': 38}]
       Trivial
   > Door to Tower Exterior West
       Trivial
-  > Event - ActivateTower
+  > Event - Activate Tower
       Morph Ball
 
 ----------------

--- a/test/test_files/patcher_data/am2r/door_lock.json
+++ b/test/test_files/patcher_data/am2r/door_lock.json
@@ -2781,7 +2781,7 @@
             ]
         },
         "rm_a0h13": {
-            "display_name": "Research Site Access",
+            "display_name": "Research Site Elevator",
             "region_name": "Main Caves",
             "minimap_data": [
                 {
@@ -4305,7 +4305,7 @@
             ]
         },
         "rm_a2c01": {
-            "display_name": "Breeding Grounds Access",
+            "display_name": "Breeding Grounds Entrance",
             "region_name": "Hydro Station",
             "minimap_data": [
                 {

--- a/test/test_files/patcher_data/am2r/starter_preset.json
+++ b/test/test_files/patcher_data/am2r/starter_preset.json
@@ -2781,7 +2781,7 @@
             ]
         },
         "rm_a0h13": {
-            "display_name": "Research Site Access",
+            "display_name": "Research Site Elevator",
             "region_name": "Main Caves",
             "minimap_data": [
                 {
@@ -4305,7 +4305,7 @@
             ]
         },
         "rm_a2c01": {
-            "display_name": "Breeding Grounds Access",
+            "display_name": "Breeding Grounds Entrance",
             "region_name": "Hydro Station",
             "minimap_data": [
                 {


### PR DESCRIPTION
Event nodes are visible by end users in the data visualizer, and thus should be more readable instead of just throwing something together to have one word.