### PR TITLE
AM2R: Workaround for a5 zeta

### DIFF
--- a/randovania/games/am2r/json_data/Distribution Center.json
+++ b/randovania/games/am2r/json_data/Distribution Center.json
@@ -3216,8 +3216,37 @@
                                         "data": "Power Grip Wall"
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Can Use Any Bombs"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Destroy Bomb Blocks",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Bombs"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "HACK: 2 PBs to circumvent some resolver issues",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Power Bombs"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Power Bombs",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "or",
@@ -3323,8 +3352,37 @@
                                         "data": "Power Grip Wall"
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Can Use Any Bombs"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Destroy Bomb Blocks",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Bombs"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "HACK: 2 PBs to circumvent some resolver issues",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Power Bombs"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Power Bombs",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "or",

--- a/randovania/games/am2r/json_data/Distribution Center.txt
+++ b/randovania/games/am2r/json_data/Distribution Center.txt
@@ -472,7 +472,12 @@ Extra - minimap_data: [{'x': 63, 'y': 47}, {'x': 64, 'y': 47}, {'x': 65, 'y': 47
   * Layers: default
   > Door to Distribution Facility Tower West
       All of the following:
-          Can Use Any Bombs and Power Grip Wall
+          Power Grip Wall
+          Any of the following:
+              # Destroy Bomb Blocks
+              Can Use Bombs
+              # HACK: 2 PBs to circumvent some resolver issues
+              Power Bombs ≥ 2 and Can Use Power Bombs
           Any of the following:
               # Pass by the Zeta
               Hi-Jump Boots or Space Jump or After Metroids Area 5 - Interior Zeta or Can Use Spider Ball
@@ -482,7 +487,12 @@ Extra - minimap_data: [{'x': 63, 'y': 47}, {'x': 64, 'y': 47}, {'x': 65, 'y': 47
               Damage Boost (Beginner) and Normal Damage ≥ 51
   > Door to Energy Distribution Tower East
       All of the following:
-          Can Use Any Bombs and Power Grip Wall
+          Power Grip Wall
+          Any of the following:
+              # Destroy Bomb Blocks
+              Can Use Bombs
+              # HACK: 2 PBs to circumvent some resolver issues
+              Power Bombs ≥ 2 and Can Use Power Bombs
           Any of the following:
               # Pass by the Zeta
               Hi-Jump Boots or Space Jump or After Metroids Area 5 - Interior Zeta or Can Use Spider Ball


### PR DESCRIPTION
Neither resolver nor generator stacks ammo, which makes them think that you can go through the passage with only 1 Bomb. Which is not possible