### PR TITLE
AM2R: Make *both* ways for first omega behind a trick for traversal

### DIFF
--- a/randovania/games/am2r/json_data/The Depths.json
+++ b/randovania/games/am2r/json_data/The Depths.json
@@ -1574,6 +1574,32 @@
                                                                         }
                                                                     ]
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "Heavy RNG until Omega hops over you in a desired way",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Morph Ball",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Movement",
+                                                                                "amount": 5,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
                                                             }
                                                         ]
                                                     }
@@ -1618,34 +1644,89 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Use Spider Ball"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Space Jump",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "and",
                                         "data": {
-                                            "comment": "IBJ over them https://www.youtube.com/watch?v=I7IayKDp2ss",
+                                            "comment": "Traverse around Omega while it is still alive",
                                             "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can Use Bombs"
-                                                },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "IBJ",
+                                                        "name": "Movement",
                                                         "amount": 4,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Space Jump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Spider Ball"
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "IBJ over it https://www.youtube.com/watch?v=I7IayKDp2ss",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Use Bombs"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "IBJ",
+                                                                                "amount": 4,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "Heavy RNG until Omega hops over you in a desired way",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Morph Ball",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Movement",
+                                                                                "amount": 5,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Power Grip Wall"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -1654,7 +1735,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "After Omega is dead",
                                             "items": [
                                                 {
                                                     "type": "resource",

--- a/randovania/games/am2r/json_data/The Depths.txt
+++ b/randovania/games/am2r/json_data/The Depths.txt
@@ -250,16 +250,25 @@ Extra - minimap_data: [{'x': 24, 'y': 47}, {'x': 25, 'y': 47}, {'x': 26, 'y': 47
                   Space Jump or Can Use Spider Ball
                   # IBJ over them https://www.youtube.com/watch?v=I7IayKDp2ss
                   Infinite Bomb Jumping (Expert) and Can Use Bombs
+                  # Heavy RNG until Omega hops over you in a desired way
+                  Morph Ball and Movement (Hypermode)
 
 > Horizontal Dock to Hideout Omega Nest Access; Heals? False
   * Layers: default
   * 3-Tiles High Dock to Hideout Omega Nest Access/Horizontal Dock to Hideout Omega Nest
   > Dock to Hideout Storage
       Any of the following:
-          Space Jump or Can Use Spider Ball
-          # IBJ over them https://www.youtube.com/watch?v=I7IayKDp2ss
-          Infinite Bomb Jumping (Expert) and Can Use Bombs
           All of the following:
+              # Traverse around Omega while it is still alive
+              Movement (Expert)
+              Any of the following:
+                  Space Jump or Can Use Spider Ball
+                  # IBJ over it https://www.youtube.com/watch?v=I7IayKDp2ss
+                  Infinite Bomb Jumping (Expert) and Can Use Bombs
+                  # Heavy RNG until Omega hops over you in a desired way
+                  Morph Ball and Movement (Hypermode) and Power Grip Wall
+          All of the following:
+              # After Omega is dead
               After Metroids Area 6 - First Omega
               Any of the following:
                   Power Grip Wall


### PR DESCRIPTION
Previously, only the way *back* was behind a trick. which lead to logic going there, and then being stuck.

Also adds some hypermode morph stuff too ig.