### PR TITLE
CI: Cache more pip stuff

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -75,6 +75,9 @@ jobs:
         with:
           python-version: "${{ matrix.python }}"
           cache: "pip"
+          cache-dependency-path: |
+            **/setup.cfg
+            **/requirements*.txt
 
       - name: Apt
         run: sudo apt-get -q update && sudo apt-get -y install xvfb xserver-xephyr tigervnc-standalone-server x11-utils gnumeric libxcb-cursor0 libxkbcommon-x11-0


### PR DESCRIPTION
I have no clue if this works.
From the documentation:
> The action defaults to searching for **a dependency file** (`requirements.txt` or `pyproject.toml` for pip, `Pipfile.lock` for pipenv or `poetry.lock` for poetry) in the repository, and uses its hash as a part of the cache key. Input cache-dependency-path is used for cases when **multiple dependency files** are used, they are located in different subdirectories or different files for the hash that want to be used.

Emphasis mine. Since we don't provide the `cache-dependency-path` path, it seems that it would only cache `requirements.txt`.

Looking at further documentation shows us this:
```yaml
# Using a list of wildcard patterns to cache dependencies

steps:
- uses: actions/checkout@v3
- uses: actions/setup-python@v4
  with:
    python-version: '3.10'
    cache: 'pip'
    cache-dependency-path: |
      **/setup.cfg
      **/requirements*.txt
- run: pip install -e . -r subdirectory/requirements-dev.txt
```

So I essentially just copied that.