### PR TITLE
Samus Returns - Support Crumble Block Removal Misc Resources

### DIFF
--- a/randovania/games/samus_returns/exporter/patch_data_factory.py
+++ b/randovania/games/samus_returns/exporter/patch_data_factory.py
@@ -194,6 +194,8 @@ class MSRPatchDataFactory(PatchDataFactory):
                 "nerf_super_missiles": self.configuration.nerf_super_missiles,
                 "remove_elevator_grapple_blocks": self.configuration.elevator_grapple_blocks,
                 "remove_grapple_block_area3_interior_shortcut": self.configuration.area3_interior_shortcut_no_grapple,
+                "patch_surface_crumbles": self.configuration.surface_crumbles,
+                "patch_area1_crumbles": self.configuration.area1_crumbles,
             },
         }
 

--- a/randovania/games/samus_returns/generator/bootstrap.py
+++ b/randovania/games/samus_returns/generator/bootstrap.py
@@ -19,9 +19,11 @@ class MSRBootstrap(MetroidBootstrap):
         assert isinstance(configuration, MSRConfiguration)
 
         logical_patches = {
+            "allow_highly_dangerous_logic": "HighDanger",
             "nerf_power_bombs": "NerfPBs",
             "nerf_super_missiles": "NerfSupers",
-            "allow_highly_dangerous_logic": "HighDanger",
+            "remove_surface_crumbles": "SurfaceCrumbles",
+            "remove_area1_crumbles": "Area1Crumbles",
         }
         for name, index in logical_patches.items():
             if getattr(configuration, name):

--- a/randovania/games/samus_returns/generator/bootstrap.py
+++ b/randovania/games/samus_returns/generator/bootstrap.py
@@ -22,8 +22,8 @@ class MSRBootstrap(MetroidBootstrap):
             "allow_highly_dangerous_logic": "HighDanger",
             "nerf_power_bombs": "NerfPBs",
             "nerf_super_missiles": "NerfSupers",
-            "remove_surface_crumbles": "SurfaceCrumbles",
-            "remove_area1_crumbles": "Area1Crumbles",
+            "surface_crumbles": "SurfaceCrumbles",
+            "area1_crumbles": "Area1Crumbles",
         }
         for name, index in logical_patches.items():
             if getattr(configuration, name):

--- a/randovania/games/samus_returns/gui/preset_settings/msr_patches_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_patches_tab.py
@@ -19,6 +19,8 @@ _FIELDS = [
     "area3_interior_shortcut_no_grapple",
     "nerf_power_bombs",
     "nerf_super_missiles",
+    "surface_crumbles",
+    "area1_crumbles",
 ]
 
 

--- a/randovania/games/samus_returns/json_data/Area 1.json
+++ b/randovania/games/samus_returns/json_data/Area 1.json
@@ -213,6 +213,15 @@
                                                                         }
                                                                     ]
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "misc",
+                                                                    "name": "Area1Crumbles",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             }
                                                         ]
                                                     }

--- a/randovania/games/samus_returns/json_data/Area 1.txt
+++ b/randovania/games/samus_returns/json_data/Area 1.txt
@@ -17,7 +17,7 @@ Extra - asset_id: collision_camera_000
           All of the following:
               Morph Ball
               Any of the following:
-                  Spider Ball or Phase Drift Skip (Advanced)
+                  Spider Ball or Phase Drift Skip (Advanced) or Enabled Remove Area 1 Crumble Blocks
                   All of the following:
                       Phase Drift
                       Any of the following:

--- a/randovania/games/samus_returns/json_data/Surface - East.json
+++ b/randovania/games/samus_returns/json_data/Surface - East.json
@@ -2987,6 +2987,53 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Dock to Scan Pulse Room": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "SurfaceCrumbles",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Climb Rooms Vertically (High Jump)"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SWJ",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
                         "Tunnel to Upper Storage": {
                             "type": "and",
                             "data": {

--- a/randovania/games/samus_returns/json_data/Surface - East.txt
+++ b/randovania/games/samus_returns/json_data/Surface - East.txt
@@ -557,6 +557,10 @@ Extra - asset_id: collision_camera_014
   * Power Beam Door to Alpha Arena Access/Door to One-Way Drop
   * Extra - actor_name: Door009
   * Extra - actor_type: doorpowerpower
+  > Dock to Scan Pulse Room
+      All of the following:
+          Enabled Remove Surface Crumble Blocks
+          Single-wall Wall Jump (Beginner) or Walljump (Beginner) or Climb Rooms Vertically (High Jump)
   > Tunnel to Upper Storage
       All of the following:
           Morph Ball

--- a/randovania/games/samus_returns/json_data/header.json
+++ b/randovania/games/samus_returns/json_data/header.json
@@ -917,6 +917,14 @@
             "HighDanger": {
                 "long_name": "Highly Dangerous Logic",
                 "extra": {}
+            },
+            "SurfaceCrumbles": {
+                "long_name": "Remove Surface Crumble Blocks",
+                "extra": {}
+            },
+            "Area1Crumbles": {
+                "long_name": "Remove Area 1 Crumble Blocks",
+                "extra": {}
             }
         },
         "requirement_template": {

--- a/randovania/games/samus_returns/layout/msr_configuration.py
+++ b/randovania/games/samus_returns/layout/msr_configuration.py
@@ -13,6 +13,8 @@ class MSRConfiguration(BaseConfiguration):
     area3_interior_shortcut_no_grapple: bool
     nerf_power_bombs: bool
     nerf_super_missiles: bool
+    surface_crumbles: bool
+    area1_crumbles: bool
     allow_highly_dangerous_logic: bool
 
     @classmethod

--- a/randovania/games/samus_returns/layout/preset_describer.py
+++ b/randovania/games/samus_returns/layout/preset_describer.py
@@ -52,10 +52,12 @@ class MSRPresetDescriber(GamePresetDescriber):
                     },
                 ),
                 {
-                    "Open Area 3 Interior East Shortcut": configuration.area3_interior_shortcut_no_grapple,
-                    "Remove Area Exit Path Grapple Blocks": configuration.elevator_grapple_blocks,
                     "Nerfed Power Bombs": configuration.nerf_power_bombs,
                     "Nerfed Super Missiles": configuration.nerf_super_missiles,
+                    "Open Area 3 Interior East Shortcut": configuration.area3_interior_shortcut_no_grapple,
+                    "Remove Area Exit Path Grapple Blocks": configuration.elevator_grapple_blocks,
+                    "Remove Surface Scan Pulse Crumble Blocks": configuration.surface_crumbles,
+                    "Remove Area 1 Chozo Seal Crumble Blocks": configuration.area1_crumbles,
                 },
             ],
         }

--- a/randovania/games/samus_returns/presets/starter_preset.rdvpreset
+++ b/randovania/games/samus_returns/presets/starter_preset.rdvpreset
@@ -167,6 +167,8 @@
         "nerf_super_missiles": false,
         "elevator_grapple_blocks": true,
         "area3_interior_shortcut_no_grapple": true,
-        "allow_highly_dangerous_logic": false
+        "allow_highly_dangerous_logic": false,
+        "surface_crumbles": true,
+        "area1_crumbles": true
     }
 }

--- a/randovania/gui/ui_files/preset_msr_patches.ui
+++ b/randovania/gui/ui_files/preset_msr_patches.ui
@@ -2,12 +2,15 @@
 <ui version="4.0">
  <class>PresetMSRPatches</class>
  <widget class="QMainWindow" name="PresetMSRPatches">
+  <property name="enabled">
+   <bool>true</bool>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>456</width>
-    <height>324</height>
+    <width>642</width>
+    <height>535</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,6 +27,9 @@
     <property name="spacing">
      <number>6</number>
     </property>
+    <property name="sizeConstraint">
+     <enum>QLayout::SetDefaultConstraint</enum>
+    </property>
     <property name="leftMargin">
      <number>0</number>
     </property>
@@ -36,22 +42,6 @@
     <property name="bottomMargin">
      <number>0</number>
     </property>
-    <item>
-     <spacer name="top_spacer">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-      <property name="sizeType">
-       <enum>QSizePolicy::Fixed</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>20</width>
-        <height>8</height>
-       </size>
-      </property>
-     </spacer>
-    </item>
     <item>
      <widget class="QScrollArea" name="scroll_area">
       <property name="minimumSize">
@@ -68,9 +58,15 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>440</width>
-         <height>278</height>
+         <width>640</width>
+         <height>533</height>
         </rect>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>469</height>
+        </size>
        </property>
        <layout class="QVBoxLayout" name="scroll_layout">
         <property name="leftMargin">
@@ -86,15 +82,31 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QGroupBox" name="unlock_group">
+         <spacer name="top_spacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>8</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="environment_group">
           <property name="title">
            <string>Room Changes</string>
           </property>
-          <layout class="QVBoxLayout" name="unlock_layout">
+          <layout class="QVBoxLayout" name="verticalLayout_3">
            <item>
             <widget class="QCheckBox" name="area3_interior_shortcut_no_grapple_check">
              <property name="text">
-              <string>Remove Grapple Block in Area 3 Interior East - Area 3 Interior West Shortcut</string>
+              <string>Grapple Block in Area 3 - Transport to Area 3 Interior West</string>
              </property>
             </widget>
            </item>
@@ -111,14 +123,60 @@
            <item>
             <widget class="QCheckBox" name="elevator_grapple_blocks_check">
              <property name="text">
-              <string>Remove Grapple Blocks on the paths to other areas</string>
+              <string>Grapple Blocks leaving areas</string>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QLabel" name="elevator_grapple_blocks_label">
+             <property name="mouseTracking">
+              <bool>true</bool>
+             </property>
              <property name="text">
-              <string>Removes the Grapple Blocks that are near the exit elevators of certain areas</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Removes the Grapple Blocks that are near the exit elevators of certain areas. These include:&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Area 4 West to Area 4 East &lt;/li&gt;&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Area 5 Entrance to Area 6 &lt;/li&gt;&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Area 6 to Area 7 &lt;/li&gt;&lt;li style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Area 7 to Area 8 &lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="surface_crumbles_check">
+             <property name="text">
+              <string>Crumble Blocks in Surface - One-Way Drop</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="surface_crumbles_label">
+             <property name="mouseTracking">
+              <bool>true</bool>
+             </property>
+             <property name="text">
+              <string>Changes the Crumble Blocks after Scan Pulse to Power Beam Blocks, allowing for a two-way path through the room. This makes this section less dangerous without Charge Beam.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="area1_crumbles_check">
+             <property name="text">
+              <string>Crumble Blocks in Area 1 - Chozo Seal</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="area1_crumbles_label">
+             <property name="mouseTracking">
+              <bool>true</bool>
+             </property>
+             <property name="text">
+              <string>Changes the Crumble Blocks leaving Area 1 to Power Beam Blocks, allowing for earlier access to Area 2 with only Morph Ball. This helps make item placement less restrictive.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -165,25 +223,25 @@
              </property>
             </widget>
            </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
           </layout>
          </widget>
         </item>
        </layout>
       </widget>
      </widget>
-    </item>
-    <item>
-     <spacer name="verticalSpacer">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>20</width>
-        <height>40</height>
-       </size>
-      </property>
-     </spacer>
     </item>
    </layout>
   </widget>

--- a/test/test_files/log_files/samus_returns/starter_preset.rdvgame
+++ b/test/test_files/log_files/samus_returns/starter_preset.rdvgame
@@ -178,7 +178,9 @@
                     "area3_interior_shortcut_no_grapple": true,
                     "nerf_power_bombs": true,
                     "nerf_super_missiles": false,
-                    "allow_highly_dangerous_logic": false
+                    "allow_highly_dangerous_logic": false,
+                    "surface_crumbles": true,
+                    "area1_crumbles": true
                 }
             }
         ]

--- a/test/test_files/patcher_data/samus_returns/starter_preset.json
+++ b/test/test_files/patcher_data/samus_returns/starter_preset.json
@@ -3370,6 +3370,8 @@
       "nerf_power_bombs": true,
       "nerf_super_missiles": false,
       "remove_elevator_grapple_blocks": true,
-      "remove_grapple_block_area3_interior_shortcut": true
+      "remove_grapple_block_area3_interior_shortcut": true,
+      "patch_surface_crumbles": true,
+      "patch_area1_crumbles": true
     }
   }


### PR DESCRIPTION
- Adds new misc resources for removing certain crumble blocks as per the patcher
- Updates `starter_preset.json` and all relevant test files accordingly
- Updates logic to account for the misc resources
- Cleaned up patches tab to be more descriptive/fix bad names