### PR TITLE
AM2R: Make super Omegas/zetas not trickless

### DIFF
--- a/randovania/games/am2r/json_data/header.json
+++ b/randovania/games/am2r/json_data/header.json
@@ -2878,12 +2878,29 @@
                                 "comment": "Item requirements",
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Missiles",
-                                            "amount": 30,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Missiles",
+                                                        "amount": 30,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -3007,12 +3024,29 @@
                                 "comment": "Item requirements",
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Missiles",
-                                            "amount": 32,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Missiles",
+                                                        "amount": 32,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -3060,7 +3094,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Combat",
-                                                        "amount": 2,
+                                                        "amount": 3,
                                                         "negate": false
                                                     }
                                                 },

--- a/randovania/games/am2r/json_data/header.txt
+++ b/randovania/games/am2r/json_data/header.txt
@@ -218,7 +218,8 @@ Templates
       All of the following:
           Any of the following:
               # Item requirements
-              Missiles ≥ 30 or Super Missiles ≥ 6
+              Super Missiles ≥ 6
+              Missiles ≥ 30 and Combat (Intermediate)
               Charge Beam and Missile-Less Metroid Fights (Advanced)
           Any of the following:
               # Energy requirements
@@ -231,11 +232,12 @@ Templates
       All of the following:
           Any of the following:
               # Item requirements
-              Missiles ≥ 32 or Super Missiles ≥ 7
+              Super Missiles ≥ 7
+              Missiles ≥ 32 and Combat (Intermediate)
               Charge Beam and Missile-Less Metroid Fights (Advanced)
               All of the following:
                   # Backshots
-                  Combat (Intermediate)
+                  Combat (Advanced)
                   Missiles ≥ 11 or Super Missiles ≥ 3
           Any of the following:
               # Energy requirements


### PR DESCRIPTION
Not quite sure whether Omegas have the best approach
Both zetas and omegas are harder with supers only than guardian (which is combat beginner)

but omegas specifically can be killed quicker if you only do backshots. I currently bumped this to advanced.
Combat in general needs to be bumped up and redone completely, likely.