### PR TITLE
AM2R: Fix metroid fanfare not being shuffled.

### DIFF
--- a/randovania/games/am2r/exporter/patch_data_factory.py
+++ b/randovania/games/am2r/exporter/patch_data_factory.py
@@ -69,7 +69,7 @@ def _construct_music_shuffle_dict(music_mode: MusicMode, rng: Random) -> dict[st
         "musarea7b",
         "musfanfare",
         "musitemget",
-        "musmetroidappear",
+        "musmonsterappear",
         "musqueenbreak",
         "musqueenintro",
     ]


### PR DESCRIPTION
Community Updates uses "Monster" instead of "Metroid".