### PR TITLE
Workaround for when ammo does not have other items

### DIFF
--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -126,7 +126,10 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
         ammo_provided = major_configuration.calculate_provided_ammo()
         for ammo, state in ammo_configuration.pickups_state.items():
             for ammo_index, count in enumerate(state.ammo_count):
-                ammo_provided[ammo.items[ammo_index]] += count * state.pickup_count
+                if ammo.items[ammo_index] in ammo_provided:
+                    ammo_provided[ammo.items[ammo_index]] += count * state.pickup_count
+                else:
+                    ammo_provided[ammo.items[ammo_index]] = count * state.pickup_count
 
         resource_database = self.game_description.resource_database
 


### PR DESCRIPTION
This makes it possible to have ammo in the game without relying on other non-ammo items to give the same item.

Having that functionality is currently required for AM2R for items such as the flashlight/speedbooster upgrade/health drops.
This *could* be worked around, by making it an item similar to how flash shift does it:
![grafik](https://github.com/randovania/randovania/assets/38186597/6afd8738-d16e-4946-9ad3-8f1e872b3b74)
But having them in the ammo format works more nicely.

Thinking of other games/use cases:
- Games where there's ammo with a launcher not being possible to implement and where creating one on RDVs side could lead to more confusion
- "Ammo"-Style items which would be very weird with main item. For example, Ori 2's/Hollow Knight/Paper Mario shard/charm slot upgrades, Ori 2's Life/Energy Cells, Psycron's Jump upgrades and probably more I can't think of right now.
