### PR TITLE
SM: Make CWJ its own Trick + Minor Logic Updage

### DIFF
--- a/randovania/games/super_metroid/json_data/Crateria.json
+++ b/randovania/games/super_metroid/json_data/Crateria.json
@@ -914,15 +914,6 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Knowledge",
-                                                        "amount": 2,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
                                                         "name": "GravityJump",
                                                         "amount": 2,
                                                         "negate": false
@@ -949,16 +940,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Knowledge",
-                                                        "amount": 2,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "WallJump",
+                                                        "name": "CWJ",
                                                         "amount": 4,
                                                         "negate": false
                                                     }
@@ -4450,7 +4432,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "2 tap short charge from Alcatraz Escape",
+                                            "comment": null,
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -4471,12 +4453,45 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Shortcharge",
-                                                        "amount": 2,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "2 tap short charge from Alcatraz Escape",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Shortcharge",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "Charge shinespark from Landing Site",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Movement",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -6193,41 +6208,6 @@
                                                         "name": "ScrewAttack",
                                                         "amount": 1,
                                                         "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": "TODO: doesnt this require no entrance rando + no door rando?",
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "SpeedBooster",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Shortcharge",
-                                                                    "amount": 3,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "BlueSuitGlitch",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
                                                     }
                                                 }
                                             ]

--- a/randovania/games/super_metroid/json_data/Crateria.json
+++ b/randovania/games/super_metroid/json_data/Crateria.json
@@ -4477,7 +4477,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": "Charge shinespark from Landing Site",
+                                                                    "comment": "Charge shinespark from Landing Site: https://youtu.be/AkD2kSTrV-c",
                                                                     "items": [
                                                                         {
                                                                             "type": "resource",

--- a/randovania/games/super_metroid/json_data/Crateria.json
+++ b/randovania/games/super_metroid/json_data/Crateria.json
@@ -4487,6 +4487,24 @@
                                                                                 "amount": 2,
                                                                                 "negate": false
                                                                             }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "EntranceRando",
+                                                                                "amount": 1,
+                                                                                "negate": true
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "misc",
+                                                                                "name": "DoorLockRando",
+                                                                                "amount": 1,
+                                                                                "negate": true
+                                                                            }
                                                                         }
                                                                     ]
                                                                 }

--- a/randovania/games/super_metroid/json_data/Crateria.txt
+++ b/randovania/games/super_metroid/json_data/Crateria.txt
@@ -599,7 +599,7 @@ Extra - asset_id: 14
                   # 2 tap short charge from Alcatraz Escape
                   Short Charge (Intermediate)
                   # Charge shinespark from Landing Site: https://youtu.be/AkD2kSTrV-c
-                  Movement (Intermediate)
+                  Movement (Intermediate) and Disabled Door Lock Randomizer and Disabled Entrance Randomizer
   > Door to Climb
       Trivial
 

--- a/randovania/games/super_metroid/json_data/Crateria.txt
+++ b/randovania/games/super_metroid/json_data/Crateria.txt
@@ -129,9 +129,9 @@ Extra - asset_id: 3
           Grapple Beam or Space Jump
           # Short charge shinespark
           Speed Booster and Short Charge (Intermediate) and Disabled Door Lock Randomizer and Disabled Entrance Randomizer
-          Gravity Suit and Gravity Jump (Intermediate) and Knowledge (Intermediate)
+          Gravity Suit and Gravity Jump (Intermediate)
           # Using a CWJ to get across
-          Knowledge (Intermediate) and Movement (Advanced) and Wall Jumps (Expert)
+          Continuous Wall Jump (Expert) and Movement (Advanced)
           # HBJ across
           Horizontal Infinite Bomb Jump (Advanced) and Can Lay Bombs
   > Pickup (Missile Expansion)
@@ -593,8 +593,13 @@ Extra - asset_id: 14
   > Door to Terminator Room
       Any of the following:
           Screw Attack or Can Lay Any Bombs
-          # 2 tap short charge from Alcatraz Escape
-          Speed Booster and Shinespark (Beginner) and Short Charge (Intermediate)
+          All of the following:
+              Speed Booster and Shinespark (Beginner)
+              Any of the following:
+                  # 2 tap short charge from Alcatraz Escape
+                  Short Charge (Intermediate)
+                  # Charge shinespark from Landing Site
+                  Movement (Intermediate)
   > Door to Climb
       Trivial
 
@@ -878,10 +883,7 @@ Extra - asset_id: 28
   > Pickup (Missile Expansion)
       All of the following:
           After Crateria Wakeup
-          Any of the following:
-              Screw Attack or Can Lay Any Bombs
-              # TODO: doesnt this require no entrance rando + no door rando?
-              Speed Booster and Blue Suit Glitch (Intermediate) and Short Charge (Advanced)
+          Screw Attack or Can Lay Any Bombs
 
 > Door to Elevator to Blue Brinstar; Heals? False
   * Layers: default

--- a/randovania/games/super_metroid/json_data/Crateria.txt
+++ b/randovania/games/super_metroid/json_data/Crateria.txt
@@ -598,7 +598,7 @@ Extra - asset_id: 14
               Any of the following:
                   # 2 tap short charge from Alcatraz Escape
                   Short Charge (Intermediate)
-                  # Charge shinespark from Landing Site
+                  # Charge shinespark from Landing Site: https://youtu.be/AkD2kSTrV-c
                   Movement (Intermediate)
   > Door to Climb
       Trivial

--- a/randovania/games/super_metroid/json_data/header.json
+++ b/randovania/games/super_metroid/json_data/header.json
@@ -332,6 +332,11 @@
                 "long_name": "Mid-Air Morph",
                 "description": "Morphing while in the air allows Samus to get into elevated Morph Ball tunnels without needing Spring Ball or Bombs.",
                 "extra": {}
+            },
+            "CWJ": {
+                "long_name": "Continuous Wall Jump",
+                "description": "By barely clearing the top of a platform in a spin jump, Samus can wall jump off of the platform without changing directions, continuing the current jump.",
+                "extra": {}
             }
         },
         "damage": {
@@ -1054,10 +1059,6 @@
             4,
             5
         ],
-        "Knowledge": [
-            1,
-            2
-        ],
         "GravityJump": [
             2
         ],
@@ -1066,10 +1067,17 @@
             2,
             3
         ],
+        "CWJ": [
+            4
+        ],
         "HBJ": [
             1,
             3,
             4
+        ],
+        "Knowledge": [
+            1,
+            2
         ],
         "SpringBallJump": [
             1,


### PR DESCRIPTION
Added: CWJ as its own trick.
Fixed: CWJ over The Moat
Removed: Blue Suit from Old Mother Brain item
Added: Shinespark to Terminator from Landing Site