### PR TITLE
Bugfix/mouse wheel on tricks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.5.0] - 2023-11-??
 
 - Changed: The Changelog window has recieved a slight overhaul. The date of each release is shown, hyperlinks are fixed, and patch notes are now accessed through a drop-down box (previously used vertical tabs).
+- Changed: Trick level sliders ignore mouse scroll inputs, preventing unintended preset changes. 
 
 ### Resolver
 

--- a/randovania/gui/preset_settings/trick_level_tab.py
+++ b/randovania/gui/preset_settings/trick_level_tab.py
@@ -24,6 +24,23 @@ if TYPE_CHECKING:
     from randovania.layout.preset import Preset
 
 
+class TrickSlider(QtWidgets.QSlider):
+    """
+    A custom implementation of QSlider that filters out mouse wheel events
+    """
+
+    def __init__(self, orientation: QtCore.Qt.Orientation, parent: QtWidgets.QWidget | None = None):
+        super().__init__(orientation, parent)
+
+    def eventFilter(self, watched: QtCore.QObject, event: QtCore.QEvent) -> bool:
+        # filter out "Wheel" type events
+        if event.type() == QtCore.QEvent.Type.Wheel:
+            event.ignore()
+            return True
+
+        return super().eventFilter(watched, event)
+
+
 class PresetTrickLevel(PresetTab, Ui_PresetTrickLevel):
     def __init__(self, editor: PresetEditor, game_description: GameDescription, window_manager: WindowManager):
         super().__init__(editor, game_description, window_manager)
@@ -72,7 +89,8 @@ class PresetTrickLevel(PresetTab, Ui_PresetTrickLevel):
             for i in range(12):
                 slider_layout.setColumnStretch(i, 1)
 
-            horizontal_slider = QtWidgets.QSlider(self.trick_level_scroll_contents)
+            horizontal_slider = TrickSlider(self.trick_level_scroll_contents)
+            horizontal_slider.installEventFilter(horizontal_slider)  # enables scroll wheel filter
             horizontal_slider.setMaximum(5)
             horizontal_slider.setPageStep(2)
             horizontal_slider.setOrientation(QtCore.Qt.Orientation.Horizontal)


### PR DESCRIPTION
Created a new class `TrickSlider`, which is a subclass of `QtWidgets.QSlider`. This class has an event filter that removes Mouse Wheel events, and is used in the horizontal slider for added tricks. This should prevent users from accidentally changing trick values. 

Needs testing on a touchpad and on linux/mac. 