### PR TITLE
AM2R: Update starter preset with correct super count and a3 blocks enabled

### DIFF
--- a/randovania/games/am2r/generator/bootstrap.py
+++ b/randovania/games/am2r/generator/bootstrap.py
@@ -59,6 +59,9 @@ class AM2RBootstrap(MetroidBootstrap):
             if getattr(configuration, name):
                 enabled_resources.add(index)
 
+        if configuration.dock_rando.is_enabled():
+            enabled_resources.add("DoorLockRando")
+
         return enabled_resources
 
     def _damage_reduction(self, db: ResourceDatabase, current_resources: ResourceCollection):

--- a/randovania/games/am2r/presets/starter_preset.rdvpreset
+++ b/randovania/games/am2r/presets/starter_preset.rdvpreset
@@ -85,7 +85,7 @@
                 "Super Missile Launcher": {
                     "num_shuffled_pickups": 1,
                     "included_ammo": [
-                        5
+                        2
                     ]
                 },
                 "Power Bomb Launcher": {
@@ -177,6 +177,6 @@
         "supers_on_missile_doors": true,
         "grave_grotto_blocks": false,
         "nest_pipes": true,
-        "a3_entrance_blocks": false
+        "a3_entrance_blocks": true
     }
 }

--- a/test/games/am2r/layout/test_am2r_describer.py
+++ b/test/games/am2r/layout/test_am2r_describer.py
@@ -33,7 +33,7 @@ def test_am2r_format_params(has_artifacts: bool):
     assert dict(result) == {
         "Game Changes": [
             "Missiles need Launcher, Super Missiles need Launcher, Power Bombs need Launcher",
-            "Enable Septoggs, Add new Nest Pipes, Softlock block checks, Screw blocks near Pipes",
+            "Enable Septoggs, Add new Nest Pipes, Softlock block checks, Screw blocks near Pipes, Industrial Complex Bomb Blocks",
             "Skip gameplay cutscenes, Open Missile Doors with Supers",
         ],
         "Gameplay": ["Starts at Main Caves - Landing Site"],

--- a/test/games/am2r/layout/test_am2r_describer.py
+++ b/test/games/am2r/layout/test_am2r_describer.py
@@ -33,7 +33,8 @@ def test_am2r_format_params(has_artifacts: bool):
     assert dict(result) == {
         "Game Changes": [
             "Missiles need Launcher, Super Missiles need Launcher, Power Bombs need Launcher",
-            "Enable Septoggs, Add new Nest Pipes, Softlock block checks, Screw blocks near Pipes, Industrial Complex Bomb Blocks",
+            "Enable Septoggs, Add new Nest Pipes, Softlock block checks, Screw blocks near Pipes, "
+            "Industrial Complex Bomb Blocks",
             "Skip gameplay cutscenes, Open Missile Doors with Supers",
         ],
         "Gameplay": ["Starts at Main Caves - Landing Site"],


### PR DESCRIPTION
- Super Launcher now correctly gives 2 instead of 5
- A3 blocks are enabled

- Include DoorLockRando in bootstrap