### PR TITLE
Samus Returns - Major/Minor Updates

### DIFF
--- a/randovania/games/samus_returns/gui/preset_settings/__init__.py
+++ b/randovania/games/samus_returns/gui/preset_settings/__init__.py
@@ -12,16 +12,17 @@ def msr_preset_tabs(editor: PresetEditor, window_manager: WindowManager) -> list
     from randovania.games.samus_returns.gui.preset_settings.msr_aeion_tab import PresetMSRAeion
     from randovania.games.samus_returns.gui.preset_settings.msr_goal_tab import PresetMSRGoal
     from randovania.games.samus_returns.gui.preset_settings.msr_patches_tab import PresetMSRPatches
+    from randovania.gui.preset_settings.generation_tab import PresetGeneration
     from randovania.gui.preset_settings.location_pool_tab import PresetLocationPool
     from randovania.gui.preset_settings.metroid_item_pool_tab import MetroidPresetItemPool
     from randovania.gui.preset_settings.starting_area_tab import PresetMetroidStartingArea
     from randovania.gui.preset_settings.trick_level_tab import PresetTrickLevel
 
-    # from randovania.games.samus_returns.gui.preset_settings.msr_generation_tab import PresetMSRGeneration
     # from randovania.games.samus_returns.gui.preset_settings.msr_item_pool_tab import MSRPresetItemPool
 
     return [
         PresetTrickLevel,
+        PresetGeneration,
         PresetMetroidStartingArea,
         PresetLocationPool,
         PresetMSRGoal,

--- a/randovania/games/samus_returns/json_data/Area 2 - Entrance.json
+++ b/randovania/games/samus_returns/json_data/Area 2 - Entrance.json
@@ -812,7 +812,7 @@
                         }
                     }
                 },
-                "Door to Alpha Arena": {
+                "Door to Alpha+ Arena": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -832,7 +832,7 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Entrance",
-                        "area": "Alpha Arena",
+                        "area": "Alpha+ Arena",
                         "node": "Door to Teleporter Room"
                     },
                     "default_dock_weakness": "Power Beam Door",
@@ -922,7 +922,7 @@
                                 "items": []
                             }
                         },
-                        "Door to Alpha Arena": {
+                        "Door to Alpha+ Arena": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -955,7 +955,7 @@
                     },
                     "valid_starting_location": false,
                     "connections": {
-                        "Door to Alpha Arena": {
+                        "Door to Alpha+ Arena": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1354,7 +1354,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Alpha Arena": {
+                        "Dock to Alpha+ Arena": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -1505,7 +1505,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Dock to Alpha Arena": {
+                        "Dock to Alpha+ Arena": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1514,7 +1514,7 @@
                         }
                     }
                 },
-                "Dock to Alpha Arena": {
+                "Dock to Alpha+ Arena": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1531,7 +1531,7 @@
                     "dock_type": "other",
                     "default_connection": {
                         "region": "Area 2 - Entrance",
-                        "area": "Alpha Arena",
+                        "area": "Alpha+ Arena",
                         "node": "Dock to Main Shaft"
                     },
                     "default_dock_weakness": "Open Passage",
@@ -1717,7 +1717,7 @@
                 }
             }
         },
-        "Alpha Arena": {
+        "Alpha+ Arena": {
             "default_node": "Inside Arena",
             "extra": {
                 "total_boundings": {
@@ -1768,7 +1768,7 @@
                     "default_connection": {
                         "region": "Area 2 - Entrance",
                         "area": "Teleporter Room",
-                        "node": "Door to Alpha Arena"
+                        "node": "Door to Alpha+ Arena"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "exclude_from_dock_rando": false,
@@ -1803,7 +1803,7 @@
                     "default_connection": {
                         "region": "Area 2 - Entrance",
                         "area": "Main Shaft",
-                        "node": "Dock to Alpha Arena"
+                        "node": "Dock to Alpha+ Arena"
                     },
                     "default_dock_weakness": "Open Passage",
                     "exclude_from_dock_rando": false,
@@ -1841,12 +1841,12 @@
                         }
                     }
                 },
-                "Event - Alpha Metroid": {
+                "Event - Alpha Metroid+": {
                     "node_type": "event",
                     "heal": false,
                     "coordinates": {
-                        "x": 12237.149971426239,
-                        "y": -1005.7269981222956,
+                        "x": 12237.15,
+                        "y": -1005.73,
                         "z": 0.0
                     },
                     "description": "",
@@ -1911,9 +1911,9 @@
                                 ]
                             }
                         },
-                        "Event - Alpha Metroid": {
+                        "Event - Alpha Metroid+": {
                             "type": "template",
-                            "data": "Defeat Alpha Metroid"
+                            "data": "Defeat Alpha Metroid+"
                         }
                     }
                 },
@@ -1961,7 +1961,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 178,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Inside Arena": {
                             "type": "and",

--- a/randovania/games/samus_returns/json_data/Area 2 - Entrance.txt
+++ b/randovania/games/samus_returns/json_data/Area 2 - Entrance.txt
@@ -138,9 +138,9 @@ Extra - asset_id: collision_camera_003
           Stand on Frozen Enemy (Beginner) and Fully Freeze Enemy
           Morph Ball and Unmorph Extend (Beginner)
 
-> Door to Alpha Arena; Heals? False
+> Door to Alpha+ Arena; Heals? False
   * Layers: default
-  * Power Beam Door to Alpha Arena/Door to Teleporter Room
+  * Power Beam Door to Alpha+ Arena/Door to Teleporter Room
   * Extra - actor_name: Door008
   * Extra - actor_type: doorpowerpower
   > Below Teleporter
@@ -162,7 +162,7 @@ Extra - asset_id: collision_camera_003
       After Area 2 (Entrance) - Teleporter Unlocked
   > Door to Chozo Seal (Bottom)
       Trivial
-  > Door to Alpha Arena
+  > Door to Alpha+ Arena
       Trivial
   > Event - Teleporter Unlocked
       Trivial
@@ -170,7 +170,7 @@ Extra - asset_id: collision_camera_003
 > Start Point; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: ST_SG_Alpha_002
-  > Door to Alpha Arena
+  > Door to Alpha+ Arena
       Trivial
 
 ----------------
@@ -251,7 +251,7 @@ Extra - asset_id: collision_camera_005
   * Power Beam Door to Transport to Area 2 Exterior/Door to Main Shaft (Bottom)
   * Extra - actor_name: Door001
   * Extra - actor_type: doorpowerpower
-  > Dock to Alpha Arena
+  > Dock to Alpha+ Arena
       Any of the following:
           Use Spider Ball
           All of the following:
@@ -267,12 +267,12 @@ Extra - asset_id: collision_camera_005
   * Access Locked to Transport to Area 2 Exterior/Door to Main Shaft (Top)
   * Extra - actor_name: Door003
   * Extra - actor_type: doorpowerclosed
-  > Dock to Alpha Arena
+  > Dock to Alpha+ Arena
       Trivial
 
-> Dock to Alpha Arena; Heals? False
+> Dock to Alpha+ Arena; Heals? False
   * Layers: default
-  * Open Passage to Alpha Arena/Dock to Main Shaft
+  * Open Passage to Alpha+ Arena/Dock to Main Shaft
   > Door to Transport to Area 2 Exterior (Bottom)
       Trivial
   > Door to Transport to Area 2 Exterior (Top)
@@ -304,13 +304,13 @@ Extra - asset_id: collision_camera_006
       Morph Ball and Fleechswarm Protection
 
 ----------------
-Alpha Arena
+Alpha+ Arena
 Extra - total_boundings: {'x1': 10400.0, 'x2': 13900.0, 'y1': -1500.0, 'y2': -200.0}
 Extra - polygon: [[10400.0, -200.0], [10400.0, -1500.0], [13900.0, -1500.0], [13900.0, -200.0]]
 Extra - asset_id: collision_camera_007
 > Door to Teleporter Room; Heals? False
   * Layers: default
-  * Power Beam Door to Teleporter Room/Door to Alpha Arena
+  * Power Beam Door to Teleporter Room/Door to Alpha+ Arena
   * Extra - actor_name: Door008
   * Extra - actor_type: doorpowerpower
   > Inside Arena
@@ -318,13 +318,13 @@ Extra - asset_id: collision_camera_007
 
 > Dock to Main Shaft; Heals? False
   * Layers: default
-  * Open Passage to Main Shaft/Dock to Alpha Arena
+  * Open Passage to Main Shaft/Dock to Alpha+ Arena
   > Inside Arena
       Morph Ball and Shoot Any Missile
   > Outside Arena
       Trivial
 
-> Event - Alpha Metroid; Heals? False
+> Event - Alpha Metroid+; Heals? False
   * Layers: default
   * Event Area 2 (Entrance) - Alpha Metroid
   > Pickup (DNA)
@@ -337,8 +337,8 @@ Extra - asset_id: collision_camera_007
       Trivial
   > Dock to Main Shaft
       Morph Ball and Shoot Any Missile
-  > Event - Alpha Metroid
-      Defeat Alpha Metroid
+  > Event - Alpha Metroid+
+      Defeat Alpha Metroid+
 
 > Outside Arena; Heals? False
   * Layers: default
@@ -348,7 +348,7 @@ Extra - asset_id: collision_camera_007
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 178; Category? Minor
+  * Pickup 178; Category? Major
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Alpha_002
   > Inside Arena

--- a/randovania/games/samus_returns/json_data/Area 2 - Exterior.json
+++ b/randovania/games/samus_returns/json_data/Area 2 - Exterior.json
@@ -4731,7 +4731,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 177,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Room Center": {
                             "type": "and",
@@ -5077,7 +5077,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 181,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Room Center": {
                             "type": "and",

--- a/randovania/games/samus_returns/json_data/Area 2 - Exterior.txt
+++ b/randovania/games/samus_returns/json_data/Area 2 - Exterior.txt
@@ -813,7 +813,7 @@ Extra - asset_id: collision_camera_033
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 177; Category? Minor
+  * Pickup 177; Category? Major
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Alpha_001
   > Room Center
@@ -877,7 +877,7 @@ Extra - asset_id: collision_camera_035
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 181; Category? Minor
+  * Pickup 181; Category? Major
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Alpha_005
   > Room Center

--- a/randovania/games/samus_returns/json_data/Area 3 - Interior West.json
+++ b/randovania/games/samus_returns/json_data/Area 3 - Interior West.json
@@ -730,7 +730,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 185,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Start Point": {
                             "type": "and",
@@ -4955,7 +4955,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 193,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Door to Gamma+ Arena South Access": {
                             "type": "template",
@@ -5422,7 +5422,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 192,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Start Point (Right)": {
                             "type": "and",
@@ -5773,7 +5773,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 186,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Start Point (Inside Arena)": {
                             "type": "and",

--- a/randovania/games/samus_returns/json_data/Area 3 - Interior West.txt
+++ b/randovania/games/samus_returns/json_data/Area 3 - Interior West.txt
@@ -117,7 +117,7 @@ Extra - asset_id: collision_camera_007
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 185; Category? Minor
+  * Pickup 185; Category? Major
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Alpha_002
   > Start Point
@@ -791,7 +791,7 @@ Extra - asset_id: collision_camera_034
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 193; Category? Minor
+  * Pickup 193; Category? Major
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Gamma_004_B
   > Door to Gamma+ Arena South Access
@@ -870,7 +870,7 @@ Extra - asset_id: collision_camera_036
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 192; Category? Minor
+  * Pickup 192; Category? Major
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Gamma_003
   > Start Point (Right)
@@ -945,7 +945,7 @@ Extra - asset_id: collision_camera_038
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 186; Category? Minor
+  * Pickup 186; Category? Major
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Alpha_003
   > Start Point (Inside Arena)

--- a/randovania/games/samus_returns/json_data/Area 4 - West.json
+++ b/randovania/games/samus_returns/json_data/Area 4 - West.json
@@ -2921,8 +2921,8 @@
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
-                        "x": 2758.8915956151036,
-                        "y": -5902.260116389227,
+                        "x": 2758.89,
+                        "y": -5902.26,
                         "z": 0.0
                     },
                     "description": "",
@@ -2935,7 +2935,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 187,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Start Point": {
                             "type": "and",

--- a/randovania/games/samus_returns/json_data/Area 4 - West.txt
+++ b/randovania/games/samus_returns/json_data/Area 4 - West.txt
@@ -463,7 +463,7 @@ Extra - asset_id: collision_camera_007
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 187; Category? Minor
+  * Pickup 187; Category? Major
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Alpha_001
   > Start Point

--- a/randovania/games/samus_returns/json_data/Area 5 - Entrance.json
+++ b/randovania/games/samus_returns/json_data/Area 5 - Entrance.json
@@ -4359,7 +4359,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 188,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Room Center": {
                             "type": "and",
@@ -5529,7 +5529,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 202,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Start Point": {
                             "type": "and",

--- a/randovania/games/samus_returns/json_data/Area 5 - Entrance.txt
+++ b/randovania/games/samus_returns/json_data/Area 5 - Entrance.txt
@@ -648,7 +648,7 @@ Extra - asset_id: collision_camera_012
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 188; Category? Minor
+  * Pickup 188; Category? Major
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Alpha_001
   > Room Center
@@ -842,7 +842,7 @@ Extra - asset_id: collision_camera_016
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 202; Category? Minor
+  * Pickup 202; Category? Major
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Gamma_004
   > Start Point

--- a/randovania/games/samus_returns/json_data/Area 5 - Exterior.json
+++ b/randovania/games/samus_returns/json_data/Area 5 - Exterior.json
@@ -4981,7 +4981,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 200,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Start Point": {
                             "type": "and",

--- a/randovania/games/samus_returns/json_data/Area 5 - Exterior.txt
+++ b/randovania/games/samus_returns/json_data/Area 5 - Exterior.txt
@@ -703,7 +703,7 @@ Extra - asset_id: collision_camera_018
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 200; Category? Minor
+  * Pickup 200; Category? Major
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Gamma_002
   > Start Point

--- a/randovania/games/samus_returns/json_data/Area 5 - Interior.json
+++ b/randovania/games/samus_returns/json_data/Area 5 - Interior.json
@@ -5767,7 +5767,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 199,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Inside Arena": {
                             "type": "and",
@@ -6324,7 +6324,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 205,
-                    "location_category": "minor",
+                    "location_category": "major",
                     "connections": {
                         "Room Center": {
                             "type": "and",

--- a/randovania/games/samus_returns/json_data/Area 5 - Interior.txt
+++ b/randovania/games/samus_returns/json_data/Area 5 - Interior.txt
@@ -856,7 +856,7 @@ Extra - asset_id: collision_camera_022
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 199; Category? Minor
+  * Pickup 199; Category? Major
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Gamma_001
   > Inside Arena
@@ -954,7 +954,7 @@ Extra - asset_id: collision_camera_025
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 205; Category? Minor
+  * Pickup 205; Category? Major
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Zeta_002
   > Room Center

--- a/randovania/games/samus_returns/json_data/Area 7.json
+++ b/randovania/games/samus_returns/json_data/Area 7.json
@@ -5127,7 +5127,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 210,
-                    "location_category": "major",
+                    "location_category": "minor",
                     "connections": {
                         "Room Center": {
                             "type": "and",
@@ -5281,7 +5281,7 @@
                     },
                     "valid_starting_location": false,
                     "pickup_index": 208,
-                    "location_category": "major",
+                    "location_category": "minor",
                     "connections": {
                         "Room Center": {
                             "type": "and",

--- a/randovania/games/samus_returns/json_data/Area 7.txt
+++ b/randovania/games/samus_returns/json_data/Area 7.txt
@@ -760,7 +760,7 @@ Extra - asset_id: collision_camera_013
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 210; Category? Major
+  * Pickup 210; Category? Minor
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Omega_003
   > Room Center
@@ -795,7 +795,7 @@ Extra - asset_id: collision_camera_014
 
 > Pickup (DNA); Heals? False
   * Layers: default
-  * Pickup 208; Category? Major
+  * Pickup 208; Category? Minor
   * Extra - pickup_type: metroid
   * Extra - spawngroup: SG_Omega_001
   > Room Center

--- a/test/test_files/log_files/samus_returns/starter_preset.rdvgame
+++ b/test/test_files/log_files/samus_returns/starter_preset.rdvgame
@@ -271,7 +271,7 @@
                     "Spider Ball Room/Pickup (Spider Ball)": "Power Bomb Tank"
                 },
                 "Area 2 - Entrance": {
-                    "Alpha Arena/Pickup (DNA)": "Missile Tank",
+                    "Alpha+ Arena/Pickup (DNA)": "Missile Tank",
                     "Chozo Seal/Pickup (Missile Tank)": "Missile Tank",
                     "Chozo Seal/Pickup (Power Bomb Tank)": "Missile Tank",
                     "Teleporter Room/Pickup (Missile Tank)": "Baby Metroid",


### PR DESCRIPTION
- Adds Generation tab
- Fixes A2 Entrance Metroid not being correctly labelled as a plus variant
- Changes all plus variant Metroids to be Major locations
- Changes the two standard Omegas in A7 to be minor locations