### PR TITLE
Fix map tracker with a single non-default starting location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed: The Changelog window has recieved a slight overhaul. The date of each release is shown, hyperlinks are fixed, and patch notes are now accessed through a drop-down box (previously used vertical tabs).
 - Changed: Trick level sliders ignore mouse scroll inputs, preventing unintended preset changes. 
+- Fixed: Map tracker selects the correct start location if the preset has only one start location that is not the default. 
 
 ### Resolver
 

--- a/randovania/gui/tracker_window.py
+++ b/randovania/gui/tracker_window.py
@@ -624,10 +624,14 @@ class TrackerWindow(QtWidgets.QMainWindow, Ui_TrackerWindow):
                     self, "Starting Location", "Select starting location", location_names, 0, False
                 )
                 node_location = node_locations[location_names.index(selected_name[0])]
+        elif len(self.game_configuration.starting_location.locations) == 1:
+            if node_location is None:
+                node_location = self.game_configuration.starting_location.locations[0]
+        else:
+            raise ValueError("Preset without a starting location.")
 
-            # TODO If there is no `default_node` anymore, what would be the replacement?
-            node = region_list.node_by_identifier(node_location)
-            self._initial_state.node = region_list.nodes_to_area(node).get_start_nodes()[0]
+        node = region_list.node_by_identifier(node_location)
+        self._initial_state.node = node
 
         def is_resource_node_present(node: Node, state: State):
             if node.is_resource_node:

--- a/randovania/gui/tracker_window.py
+++ b/randovania/gui/tracker_window.py
@@ -610,8 +610,9 @@ class TrackerWindow(QtWidgets.QMainWindow, Ui_TrackerWindow):
     def setup_starting_location(self, node_location: NodeIdentifier | None) -> None:
         region_list = self.game_description.region_list
 
-        if len(self.game_configuration.starting_location.locations) > 1:
-            if node_location is None:
+        if node_location is None:
+            locations_len = len(self.game_configuration.starting_location.locations)
+            if locations_len > 1:
                 node_locations = sorted(
                     self.game_configuration.starting_location.locations,
                     key=lambda it: region_list.node_name(region_list.node_by_identifier(it), with_region=True),
@@ -624,11 +625,10 @@ class TrackerWindow(QtWidgets.QMainWindow, Ui_TrackerWindow):
                     self, "Starting Location", "Select starting location", location_names, 0, False
                 )
                 node_location = node_locations[location_names.index(selected_name[0])]
-        elif len(self.game_configuration.starting_location.locations) == 1:
-            if node_location is None:
+            elif locations_len == 1:
                 node_location = self.game_configuration.starting_location.locations[0]
-        else:
-            raise ValueError("Preset without a starting location.")
+            else:
+                raise ValueError("Preset without a starting location.")
 
         node = region_list.node_by_identifier(node_location)
         self._initial_state.node = node


### PR DESCRIPTION
Missing changelog and test.
Did this because of bug report in Discord.

I'm very unsure about the `raise ValueError("Preset without a starting location.")`. Do we have a better way to deal with it without spamming sentry in this case?
Should it actually be completly ignored and be fixed in the future by simply forbid to save a preset without a starting location?