### PR TITLE
Sync export with MSR patcher

### DIFF
--- a/randovania/games/samus_returns/gui/preset_settings/msr_aeion_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_aeion_tab.py
@@ -18,7 +18,6 @@ class PresetMSRAeion(PresetTab, Ui_PresetMSRAeion):
         super().__init__(editor, game_description, window_manager)
         self.setupUi(self)
 
-        self.aeion_tank_capacity_spin_box.valueChanged.connect(self._persist_tank_capacity)
         self.aeion_capacity_spin_box.valueChanged.connect(self._persist_capacity)
 
     @classmethod
@@ -32,12 +31,7 @@ class PresetMSRAeion(PresetTab, Ui_PresetMSRAeion):
     def on_preset_changed(self, preset: Preset) -> None:
         config = preset.configuration
         assert isinstance(config, MSRConfiguration)
-        self.aeion_tank_capacity_spin_box.setValue(config.aeion_per_tank)
         self.aeion_capacity_spin_box.setValue(config.starting_aeion)
-
-    def _persist_tank_capacity(self) -> None:
-        with self._editor as editor:
-            editor.set_configuration_field("aeion_per_tank", int(self.aeion_tank_capacity_spin_box.value()))
 
     def _persist_capacity(self) -> None:
         with self._editor as editor:

--- a/randovania/games/samus_returns/json_data/header.json
+++ b/randovania/games/samus_returns/json_data/header.json
@@ -66,7 +66,7 @@
                 "long_name": "Super Missile Launcher",
                 "max_capacity": 1,
                 "extra": {
-                    "item_id": "ITEM_WEAPON_SUPER_MISSILE_MAX"
+                    "item_id": "ITEM_WEAPON_SUPER_MISSILE"
                 }
             },
             "Pulse": {
@@ -148,7 +148,7 @@
                 "long_name": "Main Power Bomb",
                 "max_capacity": 1,
                 "extra": {
-                    "item_id": "ITEM_WEAPON_POWER_BOMB_MAX"
+                    "item_id": "ITEM_WEAPON_POWER_BOMB"
                 }
             },
             "Boots": {
@@ -199,7 +199,8 @@
                 "max_capacity": 99,
                 "extra": {
                     "item_id": "ITEM_WEAPON_SUPER_MISSILE_CURRENT",
-                    "item_capacity_id": "ITEM_RANDO_LOCKED_SUPERS"
+                    "item_capacity_id": "ITEM_WEAPON_SUPER_MISSILE_MAX",
+                    "item_export_id": "ITEM_SUPER_MISSILE_TANKS"
                 }
             },
             "PBAmmo": {
@@ -207,7 +208,8 @@
                 "max_capacity": 99,
                 "extra": {
                     "item_id": "ITEM_WEAPON_POWER_BOMB_CURRENT",
-                    "item_capacity_id": "ITEM_RANDO_LOCKED_PBS"
+                    "item_capacity_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                    "item_export_id": "ITEM_POWER_BOMB_TANKS"
                 }
             },
             "Aeion": {

--- a/randovania/games/samus_returns/layout/msr_configuration.py
+++ b/randovania/games/samus_returns/layout/msr_configuration.py
@@ -18,7 +18,6 @@ class MSRArtifactConfig(BitPackDataclass, JsonDataclass):
 class MSRConfiguration(BaseConfiguration):
     energy_per_tank: int = dataclasses.field(metadata={"min": 100, "max": 100, "precision": 1})
     starting_energy: int = dataclasses.field(metadata={"min": 99, "max": 99, "precision": 1})
-    aeion_per_tank: int = dataclasses.field(metadata={"min": 1, "max": 1000, "precision": 1})
     starting_aeion: int = dataclasses.field(metadata={"min": 1000, "max": 2200, "precision": 1})
     elevator_grapple_blocks: bool
     area3_interior_shortcut_no_grapple: bool

--- a/randovania/games/samus_returns/presets/starter_preset.rdvpreset
+++ b/randovania/games/samus_returns/presets/starter_preset.rdvpreset
@@ -164,7 +164,6 @@
         "check_if_beatable_after_base_patches": false,
         "energy_per_tank": 100,
         "starting_energy": 99,
-        "aeion_per_tank": 50,
         "starting_aeion": 1000,
         "nerf_power_bombs": true,
         "nerf_super_missiles": false,

--- a/randovania/gui/ui_files/preset_msr_aeion.ui
+++ b/randovania/gui/ui_files/preset_msr_aeion.ui
@@ -67,64 +67,6 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QGroupBox" name="aeion_tank_box">
-          <property name="title">
-           <string>Aeion tank</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_2">
-           <item row="0" column="0" colspan="2">
-            <widget class="QLabel" name="aeion_tank_capacity_description">
-             <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Configure how much aeion each Aeion Tank you collect will provide.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="wordWrap">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="aeion_tank_capacity_label">
-             <property name="text">
-              <string>Aeion per tank</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0" colspan="2">
-            <spacer name="aeion_tank_capacity_spacer">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Fixed</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="2" column="1">
-            <widget class="QSpinBox" name="aeion_tank_capacity_spin_box">
-             <property name="suffix">
-              <string> aeion</string>
-             </property>
-             <property name="minimum">
-              <number>50</number>
-             </property>
-             <property name="maximum">
-              <number>1000</number>
-             </property>
-             <property name="singleStep">
-              <number>10</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
          <widget class="QGroupBox" name="groupBox">
           <property name="title">
            <string>Aeion</string>

--- a/test/games/samus_returns/gui/test_msr_aeion_tab.py
+++ b/test/games/samus_returns/gui/test_msr_aeion_tab.py
@@ -21,11 +21,9 @@ def test_aeion_increase(skip_qtbot, msr_game_description, preset_manager):
     skip_qtbot.addWidget(tab)
     tab.on_preset_changed(preset)
 
-    tab.aeion_tank_capacity_spin_box.stepUp()
     tab.aeion_capacity_spin_box.stepUp()
     tab.on_preset_changed(editor.create_custom_preset_with())
 
     configuration = editor.configuration
     assert isinstance(configuration, MSRConfiguration)
-    assert configuration.aeion_per_tank == base_configuration.aeion_per_tank + 10
     assert configuration.starting_aeion == base_configuration.starting_aeion + 10

--- a/test/test_files/log_files/samus_returns/starter_preset.rdvgame
+++ b/test/test_files/log_files/samus_returns/starter_preset.rdvgame
@@ -175,7 +175,6 @@
                     "check_if_beatable_after_base_patches": false,
                     "energy_per_tank": 100,
                     "starting_energy": 99,
-                    "aeion_per_tank": 50,
                     "starting_aeion": 1000,
                     "elevator_grapple_blocks": true,
                     "area3_interior_shortcut_no_grapple": true,

--- a/test/test_files/patcher_data/samus_returns/starter_preset.json
+++ b/test/test_files/patcher_data/samus_returns/starter_preset.json
@@ -35,7 +35,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -208,7 +208,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -227,7 +227,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -246,7 +246,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -386,11 +386,11 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_WEAPON_SUPER_MISSILE_MAX",
+                        "item_id": "ITEM_WEAPON_SUPER_MISSILE",
                         "quantity": 1
                     },
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 5
                     }
                 ]
@@ -409,7 +409,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -580,7 +580,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -618,7 +618,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -637,7 +637,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -656,11 +656,11 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
+                        "item_id": "ITEM_WEAPON_POWER_BOMB",
                         "quantity": 1
                     },
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 5
                     }
                 ]
@@ -679,7 +679,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -698,7 +698,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -850,7 +850,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -869,7 +869,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -983,7 +983,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -1059,7 +1059,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -1097,7 +1097,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -1142,7 +1142,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -1199,7 +1199,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -1275,7 +1275,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -1313,7 +1313,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -1503,7 +1503,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -1522,7 +1522,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -1579,7 +1579,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -1598,7 +1598,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -1674,7 +1674,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -1693,7 +1693,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -1826,7 +1826,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -2073,7 +2073,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -2149,7 +2149,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -2225,7 +2225,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -2403,7 +2403,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -2460,7 +2460,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -2650,7 +2650,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -2688,7 +2688,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -2707,7 +2707,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -2783,7 +2783,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -2992,7 +2992,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -3053,7 +3053,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_PBS",
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -3129,7 +3129,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -3490,7 +3490,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -3506,7 +3506,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -3586,7 +3586,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -3750,7 +3750,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -3782,7 +3782,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -3846,7 +3846,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]
@@ -3878,7 +3878,7 @@
             "resources": [
                 [
                     {
-                        "item_id": "ITEM_RANDO_LOCKED_SUPERS",
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
                         "quantity": 1
                     }
                 ]


### PR DESCRIPTION
Little bit wild:
Patcher does everything from Lua but has parent classes and assumes that the first item is the important main item.
Non required mains works in randovania by just adding the main item to each ammo/tank item.
=> Had to prepend the main item to the ammo in that case.

I introduced an `item_export_id` because we need different items in starting inventory and in the pickups. E.g. we need to use `ITEM_WEAPON_POWER_BOMB_MAX` in starting inventory but `ITEM_POWER_BOMB_TANK` in pickups.
The game has implicit main item, which means as soon as you have a `ITEM_WEAPON_POWER_BOMB_MAX` you have the main item => patcher locks them by using  `ITEM_POWER_BOMB_TANK` in pickups.

Please never add an option to start with ammo without the main item :)