### PR TITLE
Allow ammo to be standalone in their category

### DIFF
--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -233,22 +233,17 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
         all_categories = list(pickup_database.pickup_categories.values())
 
         categories = set()
+        standard_broad_categories = set()
         for standard_pickup in pickup_database.standard_pickups.values():
             if not standard_pickup.hide_from_gui:
                 categories.add(standard_pickup.pickup_category)
+                standard_broad_categories.add(standard_pickup.broad_category.name)
 
-        # FIXME: this really shouldn't be done this way. This is just temporary to have ammo in their own category.
-        broad_to_category = {
-            "beam_related": "beam",
-            "morph_ball_related": "morph_ball",
-            "missile_related": "missile",
-        }
         for ammo_pickup in pickup_database.ammo_pickups.values():
-            if ammo_pickup.broad_category.name in broad_to_category:
-                proper_name = broad_to_category[ammo_pickup.broad_category.name]
-                categories.add(next(filter(lambda p: p.name == proper_name, all_categories)))
-            else:
-                categories.add(ammo_pickup.broad_category)
+            # When a proper distinction between UI and hint categories exists, this needs to be changed
+            if ammo_pickup.broad_category.name in standard_broad_categories:
+                continue
+            categories.add(ammo_pickup.broad_category)
 
         for standard_pickup_category in sorted(categories, key=lambda it: all_categories.index(it)):
             category_box = Foldable(None, standard_pickup_category.long_name)

--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -230,13 +230,26 @@ class PresetItemPool(PresetTab, Ui_PresetItemPool):
 
     def _create_categories_boxes(self, pickup_database: PickupDatabase, size_policy):
         self._boxes_for_category = {}
+        all_categories = list(pickup_database.pickup_categories.values())
 
         categories = set()
         for standard_pickup in pickup_database.standard_pickups.values():
             if not standard_pickup.hide_from_gui:
                 categories.add(standard_pickup.pickup_category)
 
-        all_categories = list(pickup_database.pickup_categories.values())
+        # FIXME: this really shouldn't be done this way. This is just temporary to have ammo in their own category.
+        broad_to_category = {
+            "beam_related": "beam",
+            "morph_ball_related": "morph_ball",
+            "missile_related": "missile",
+        }
+        for ammo_pickup in pickup_database.ammo_pickups.values():
+            if ammo_pickup.broad_category.name in broad_to_category:
+                proper_name = broad_to_category[ammo_pickup.broad_category.name]
+                categories.add(next(filter(lambda p: p.name == proper_name, all_categories)))
+            else:
+                categories.add(ammo_pickup.broad_category)
+
         for standard_pickup_category in sorted(categories, key=lambda it: all_categories.index(it)):
             category_box = Foldable(None, standard_pickup_category.long_name)
             category_box.setObjectName(f"category_box {standard_pickup_category}")


### PR DESCRIPTION
AM2R "needs" (as in, I dont want to provide worse UX) ammo currently in their own category, so here's this little hack.

Hopefully very very temporary, as dunc is working on refactoring hint category from the UI category. Dunno how far away that is tho, and wanted this in the the meantime

This PR fixes the crash that would happen when having a UI category with only ammo:
![grafik](https://github.com/randovania/randovania/assets/38186597/9bf0d794-1b44-4c45-892e-86247a7d5f0f)
