### PR TITLE
Dread: Proto EMMI Item Shinespark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ##### Artaria
 
 - Changed: Going to Transport to Dairon with Speed Booster now requires the Speed Booster Conservation trick set to Beginner.
+- Changed: The item above Proto EMMI now requires Speed Booster Conservation set to Beginner when reaching it with Speed from the top.
 
 ##### Burenia
 

--- a/randovania/games/dread/json_data/Artaria.json
+++ b/randovania/games/dread/json_data/Artaria.json
@@ -9672,7 +9672,7 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "https://youtu.be/AhrGDpzB3lI",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -9690,6 +9690,15 @@
                                                                     "name": "DoorLocks",
                                                                     "amount": 1,
                                                                     "negate": true
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Speedbooster",
+                                                                    "amount": 1,
+                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]

--- a/randovania/games/dread/json_data/Artaria.txt
+++ b/randovania/games/dread/json_data/Artaria.txt
@@ -1746,7 +1746,8 @@ Extra - asset_id: collision_camera_016
           Any of the following:
               Flash Shift or Use Spin Boost
               After Elun - Release X Parasites and Stand on Frozen Enemy (Intermediate) and Shoot Ice Missile
-              Speed Booster and Disabled Door Lock Randomizer
+              # https://youtu.be/AhrGDpzB3lI
+              Speed Booster and Speed Booster Conservation (Beginner) and Disabled Door Lock Randomizer
   > Door to Proto EMMI Battle
       After Artaria - Proto Central Unit or Can Slide
   > Start Point


### PR DESCRIPTION
- Changed: The item above Proto EMMI now requires Speed Booster Conservation set to Beginner when reaching it with Speed from the top.