### PR TITLE
AM2R: Lower alpha squad dmg and introduce trickless escape

### DIFF
--- a/randovania/games/am2r/json_data/Distribution Center.json
+++ b/randovania/games/am2r/json_data/Distribution Center.json
@@ -6127,17 +6127,55 @@
                                                                         }
                                                                     ]
                                                                 }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Doesn't require Alpha Squad to be defeated and trickless option",
+                                            "items": [
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Alpha Squad Defeated"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "Space Jump",
-                                                                    "amount": 1,
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 50,
                                                                     "negate": false
                                                                 }
                                                             }
                                                         ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Space Jump",
+                                                        "amount": 1,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]

--- a/randovania/games/am2r/json_data/Distribution Center.txt
+++ b/randovania/games/am2r/json_data/Distribution Center.txt
@@ -871,14 +871,15 @@ Extra - minimap_data: [{'x': 67, 'y': 45}, {'x': 67, 'y': 46}, {'x': 68, 'y': 45
                   Infinite Bomb Jumping (Advanced) and Can Use Bombs
           All of the following:
               # Doesn't require Alpha Squad to be defeated
+              Walljump (Expert)
               Movement (Advanced) or Alpha Squad Defeated
               Any of the following:
-                  Space Jump
-                  All of the following:
-                      Walljump (Expert)
-                      Any of the following:
-                          Morph Ball and Morph Glide (Advanced)
-                          Charged Bomb Jump (Advanced) and Can Use Charged Bomb Jump
+                  Morph Ball and Morph Glide (Advanced)
+                  Charged Bomb Jump (Advanced) and Can Use Charged Bomb Jump
+          All of the following:
+              # Doesn't require Alpha Squad to be defeated and trickless option
+              Space Jump
+              Movement (Intermediate) or Normal Damage ≥ 50 or Alpha Squad Defeated
   > Event - Right Bottom Alpha
       Defeat Alpha Squad
   > Event - Right Top Alpha

--- a/randovania/games/am2r/json_data/header.json
+++ b/randovania/games/am2r/json_data/header.json
@@ -2642,7 +2642,7 @@
                                         "data": {
                                             "type": "damage",
                                             "name": "Damage",
-                                            "amount": 250,
+                                            "amount": 150,
                                             "negate": false
                                         }
                                     },

--- a/randovania/games/am2r/json_data/header.txt
+++ b/randovania/games/am2r/json_data/header.txt
@@ -188,7 +188,7 @@ Templates
                       Super Missiles ≥ 2
                       Missiles ≥ 10 and Super Missiles
           # Damage requirements
-          Combat (Expert) or Normal Damage ≥ 250
+          Combat (Expert) or Normal Damage ≥ 150
 
 * Defeat dodging Gamma:
       All of the following:


### PR DESCRIPTION
alpha squad dmg 250 -> 150
SJ escape can be done trickless with dmg if alpha squad still alive