### PR TITLE
Allow up to 5 dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 5
     
     groups:
       pyside:


### PR DESCRIPTION
With merge queue this should be bearable.