### PR TITLE
Add dotnet to portable installations

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -188,6 +188,11 @@ jobs:
         run: |
           mv dist/randovania-* dist/randovania
 
+      - name: Remove dotnet from package
+        shell: bash
+        run: |
+          rm -r dist/randovania/data/dotnet_runtime
+
       - name: import windows certificate
         env:
           WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE }}

--- a/randovania.spec
+++ b/randovania.spec
@@ -24,6 +24,7 @@ datas=[
     ("randovania/data/gui_assets", "data/gui_assets"),
     ("randovania/data/icons", "data/icons"),
     ("randovania/data/nintendont", "data/nintendont"),
+    ("randovania/data/dotnet_runtime", "data/dotnet_runtime"),
     *pickup_databases,
     *presets,
     *game_assets,

--- a/randovania/__main__.py
+++ b/randovania/__main__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import multiprocessing
+import os
 import sys
 
 logging.basicConfig(level=logging.WARNING)
@@ -15,6 +16,13 @@ def main():
     randovania.setup_logging("INFO", None, quiet=True)
 
     logging.debug("Starting Randovania...")
+
+    # Add our local dotnet to path if it exists, which it only does for portable ones.
+    dotnet_path = randovania.get_data_path().joinpath("dotnet_runtime")
+    if dotnet_path.exists():
+        os.environ["PATH"] = f'{dotnet_path}{os.pathsep}{os.environ["PATH"]}'
+        os.environ["DOTNET_ROOT"] = f"{dotnet_path}"
+        logging.debug("Portable dotnet path exists, added as DOTNET_ROOT.")
 
     from randovania import cli
 

--- a/randovania/data/dotnet_runtime/.gitignore
+++ b/randovania/data/dotnet_runtime/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
This PR adds dotnet to portable releases. This was mostly done to stop AM2R from crashing on exporting, but will be useful for planets later down the line as well.

Shale tested this on Windows where it worked, I tested this on Linux where it also worked. So far, no one has tested this on macOS yet. I also need to test whether this works in flatpak later.