### PR TITLE
Fix dotnet_root for source builds

### DIFF
--- a/randovania/__main__.py
+++ b/randovania/__main__.py
@@ -19,7 +19,7 @@ def main():
 
     # Add our local dotnet to path if it exists, which it only does for portable ones.
     dotnet_path = randovania.get_data_path().joinpath("dotnet_runtime")
-    if dotnet_path.exists():
+    if randovania.is_frozen() and dotnet_path.exists():
         os.environ["PATH"] = f'{dotnet_path}{os.pathsep}{os.environ["PATH"]}'
         os.environ["DOTNET_ROOT"] = f"{dotnet_path}"
         logging.debug("Portable dotnet path exists, added as DOTNET_ROOT.")


### PR DESCRIPTION
when running from source, the directory does exist, but i dont want developers to properly populate it; it should just use the system provided one