### PR TITLE
Fix edge case with multiple dotnet runtimes

### DIFF
--- a/randovania/__main__.py
+++ b/randovania/__main__.py
@@ -22,6 +22,8 @@ def main():
     if randovania.is_frozen() and dotnet_path.exists():
         os.environ["PATH"] = f'{dotnet_path}{os.pathsep}{os.environ["PATH"]}'
         os.environ["DOTNET_ROOT"] = f"{dotnet_path}"
+        # This one is seemingly needed while we're still on dotnet6 to avoid some edge cases
+        os.environ["DOTNET_MULTILEVEL_LOOKUP"] = "0"
         logging.debug("Portable dotnet path exists, added as DOTNET_ROOT.")
 
     from randovania import cli


### PR DESCRIPTION
After more rigorous testing, seems like this env var fixes stuff if you have multiple dotnet runtimes installed. those being over dotnet6 may or may not have some factor there.
