### PR TITLE
Detect when minimum starting pickups is more than maximum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed: For Multiworld, sending collected locations to the server can no longer fail if there's an error encoding the inventory.
 - Changed: The directory layout has now changed, moving everything that isn't the executable to an `_internal` folder.
 - Changed: When verifying the installation, missing files and modified files are listed in the console and log. 
+- Changed: An explicit error is now displayed when a preset has minimum random starting items higher than the maximum.
 - Fixed: Map tracker selects the correct start location if the preset has only one start location that is not the default.
 - Fixed: When verifying the installation, the title of the popup now properly says "Verifying installation".
 

--- a/randovania/generator/generator.py
+++ b/randovania/generator/generator.py
@@ -37,15 +37,22 @@ if TYPE_CHECKING:
 DEFAULT_ATTEMPTS = 15
 
 
-def _validate_item_pool_size(
+def _validate_pickup_pool_size(
     item_pool: list[PickupEntry], game: GameDescription, configuration: BaseConfiguration
 ) -> None:
-    min_starting_items = configuration.standard_pickup_configuration.minimum_random_starting_pickups
-    if len(item_pool) > game.region_list.num_pickup_nodes + min_starting_items:
+    min_starting_pickups = configuration.standard_pickup_configuration.minimum_random_starting_pickups
+    if len(item_pool) > game.region_list.num_pickup_nodes + min_starting_pickups:
         raise InvalidConfiguration(
             "Item pool has {} items, which is more than {} (game) + {} (minimum starting items)".format(
-                len(item_pool), game.region_list.num_pickup_nodes, min_starting_items
+                len(item_pool), game.region_list.num_pickup_nodes, min_starting_pickups
             )
+        )
+
+    max_starting_pickups = configuration.standard_pickup_configuration.maximum_random_starting_pickups
+    if min_starting_pickups > max_starting_pickups:
+        raise InvalidConfiguration(
+            f"Preset has {min_starting_pickups} minimum starting items, "
+            f"which is more than the maximum of {max_starting_pickups}."
         )
 
 
@@ -139,7 +146,7 @@ async def _create_pools_and_fill(
         )
 
     for player_pool in player_pools:
-        _validate_item_pool_size(player_pool.pickups, player_pool.game, player_pool.configuration)
+        _validate_pickup_pool_size(player_pool.pickups, player_pool.game, player_pool.configuration)
 
     return await run_filler(rng, player_pools, status_update)
 

--- a/test/generator/test_generator.py
+++ b/test/generator/test_generator.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-@patch("randovania.generator.generator._validate_item_pool_size", autospec=True)
+@patch("randovania.generator.generator._validate_pickup_pool_size", autospec=True)
 @patch("randovania.generator.generator.create_player_pool", autospec=True)
 @patch("randovania.generator.generator._distribute_remaining_items", autospec=True)
 async def test_create_patches(


### PR DESCRIPTION
Fixes #5545.

I could've sworn this check existed. Looked into doing a GUI lock, but though how annoying it'd be to need to change the values in the correct order, so would need improved UX which is... lot of work. So not doing anything!