### PR TITLE
Dread: Artaria EMMI Zone First Entrance logic change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed: Going to Transport to Dairon with Speed Booster now requires the Speed Booster Conservation trick set to Beginner.
 - Changed: The item above Proto EMMI now requires Speed Booster Conservation set to Beginner when reaching it with Speed from the top.
+- Changed: Using Speed Booster to reach the pickup in EMMI Zone First Entrance now requires either the EMMI defeated or Speed Booster Conservation set to Beginner.
 
 ##### Burenia
 

--- a/randovania/games/dread/logic_database/Artaria.json
+++ b/randovania/games/dread/logic_database/Artaria.json
@@ -3188,6 +3188,32 @@
                                                         "amount": 1,
                                                         "negate": true
                                                     }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "ArtariaCU",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Speedbooster",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }

--- a/randovania/games/dread/logic_database/Artaria.txt
+++ b/randovania/games/dread/logic_database/Artaria.txt
@@ -577,7 +577,9 @@ Extra - asset_id: collision_camera_005
               Wall Jump (Beginner)
               Flash Shift or Spin Boost
           Grapple Beam and Grapple Movement (Beginner)
-          Speed Booster and Disabled Door Lock Randomizer
+          All of the following:
+              Speed Booster and Disabled Door Lock Randomizer
+              After Artaria - Central Unit or Speed Booster Conservation (Beginner)
           Morph Ball and Single-wall Wall Jump (Intermediate)
 
 > Event - Magnet EMMI Door Lock; Heals? False


### PR DESCRIPTION
- Changed: Using Speed Booster to reach the pickup in EMMI Zone First Entrance now requires either the EMMI defeated or Speed Booster Conservation set to Beginner.