### PR TITLE
Area 1 logic updates and videos

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-game_details_window.py

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-randovania
+game_details_window.py

--- a/randovania/games/samus_returns/logic_database/Area 1.json
+++ b/randovania/games/samus_returns/logic_database/Area 1.json
@@ -1687,7 +1687,7 @@
                         "Door to Outer Hub": {
                             "type": "or",
                             "data": {
-                                "comment": null,
+                                "comment": "https://www.youtube.com/watch?v=n_gpWjN5Px0 // SWJ",
                                 "items": [
                                     {
                                         "type": "template",
@@ -2103,7 +2103,7 @@
                         "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "https://www.youtube.com/watch?v=qAbaEaatlEU",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -2251,7 +2251,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "https://www.youtube.com/watch?v=PH-lM5iu70A",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -2277,6 +2277,15 @@
                                                         "type": "tricks",
                                                         "name": "SWJ",
                                                         "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "OoB",
+                                                        "amount": 2,
                                                         "negate": false
                                                     }
                                                 }
@@ -5549,7 +5558,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Can we get a video for this?",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -5596,6 +5605,32 @@
                                                                 }
                                                             }
                                                         ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "https://www.youtube.com/watch?v=sBO8Pew_ijQ",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SWJ",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "UnmorphExtend",
+                                                        "amount": 2,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]

--- a/randovania/games/samus_returns/logic_database/Area 1.json
+++ b/randovania/games/samus_returns/logic_database/Area 1.json
@@ -1687,7 +1687,7 @@
                         "Door to Outer Hub": {
                             "type": "or",
                             "data": {
-                                "comment": "https://www.youtube.com/watch?v=n_gpWjN5Px0 // SWJ",
+                                "comment": "SWJ: https://www.youtube.com/watch?v=n_gpWjN5Px0",
                                 "items": [
                                     {
                                         "type": "template",
@@ -5558,7 +5558,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "Can we get a video for this?",
+                                            "comment": "TODO: Can we get a video for this?",
                                             "items": [
                                                 {
                                                     "type": "resource",

--- a/randovania/games/samus_returns/logic_database/Area 1.txt
+++ b/randovania/games/samus_returns/logic_database/Area 1.txt
@@ -266,7 +266,7 @@ Extra - asset_id: collision_camera_012
   > Door to Spider Ball Balcony
       Trivial
   > Door to Outer Hub
-      # https://www.youtube.com/watch?v=n_gpWjN5Px0 // SWJ
+      # SWJ: https://www.youtube.com/watch?v=n_gpWjN5Px0
       Ice Beam or Single-wall Wall Jump (Intermediate) or Climb Rooms Vertically (High Jump)
 
 > Dock to Ice Beam Tutorial; Heals? False
@@ -915,7 +915,7 @@ Extra - asset_id: collision_camera_035
       Any of the following:
           Climb Rooms Vertically (No High Jump)
           All of the following:
-              # Can we get a video for this?
+              # TODO: Can we get a video for this?
               Phase Drift
               Any of the following:
                   Single-wall Wall Jump (Hypermode)

--- a/randovania/games/samus_returns/logic_database/Area 1.txt
+++ b/randovania/games/samus_returns/logic_database/Area 1.txt
@@ -266,6 +266,7 @@ Extra - asset_id: collision_camera_012
   > Door to Spider Ball Balcony
       Trivial
   > Door to Outer Hub
+      # https://www.youtube.com/watch?v=n_gpWjN5Px0 // SWJ
       Ice Beam or Single-wall Wall Jump (Intermediate) or Climb Rooms Vertically (High Jump)
 
 > Dock to Ice Beam Tutorial; Heals? False
@@ -335,6 +336,7 @@ Extra - asset_id: collision_camera_016
   * Extra - actor_name: Door017
   * Extra - actor_type: doorclosedpower
   > Pickup (Missile Tank)
+      # https://www.youtube.com/watch?v=qAbaEaatlEU
       Morph Ball and Melee Clip (Beginner) and Out of Bounds Movement (Beginner)
   > Room Bottom
       Morph Ball
@@ -359,7 +361,8 @@ Extra - asset_id: collision_camera_016
   > Door to Outer Hub
       Any of the following:
           Climb Rooms Vertically (No High Jump)
-          Morph Ball and Melee Clip (Advanced) and Single-wall Wall Jump (Advanced)
+          # https://www.youtube.com/watch?v=PH-lM5iu70A
+          Morph Ball and Melee Clip (Advanced) and Out of Bounds Movement (Intermediate) and Single-wall Wall Jump (Advanced)
 
 ----------------
 Alpha Arena North
@@ -912,10 +915,13 @@ Extra - asset_id: collision_camera_035
       Any of the following:
           Climb Rooms Vertically (No High Jump)
           All of the following:
+              # Can we get a video for this?
               Phase Drift
               Any of the following:
                   Single-wall Wall Jump (Hypermode)
                   Stand on Frozen Enemy (Intermediate) and Fully Freeze Enemy
+          # https://www.youtube.com/watch?v=sBO8Pew_ijQ
+          Single-wall Wall Jump (Intermediate) and Unmorph Extend (Intermediate)
 
 > Tunnel to Alpha Shaft Right; Heals? False
   * Layers: default


### PR DESCRIPTION
Spider Ball Room:
 - Added video for the melee clip to get down and grab both items at same time.
 - Added video for out of bounds SWJ to escape. (Added out of bounds movement at intermediate to account for not clipping back in during SWJ)
 
Shaft East:
 - Added video for SWJ to skip needing Icebeam/bombs/HJ/Spider.
 
Central Shaft:
 - Added video and logic for SWJ + Unmorph extend. (Can we get a video for whatever that hypermode stuff that needs phase drift is? I have no idea what that could even mean rn)