### PR TITLE
 Area 1 logic updates and videos

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 1.json
+++ b/randovania/games/samus_returns/logic_database/Area 1.json
@@ -1618,7 +1618,7 @@
                         "Door to Outer Hub": {
                             "type": "or",
                             "data": {
-                                "comment": null,
+                                "comment": "SWJ: https://youtu.be/n_gpWjN5Px0",
                                 "items": [
                                     {
                                         "type": "template",
@@ -2034,7 +2034,7 @@
                         "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "Melee Clip + Out Of bounds movement: https://youtu.be/qAbaEaatlEU (Will re-record with inputs at later date)",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -2182,7 +2182,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Video with inputs: https://www.youtube.com/watch?v=QmXq9hl-oB4",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -5518,15 +5518,58 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "SWJ",
-                                                                    "amount": 5,
-                                                                    "negate": false
+                                                                    "comment": "Unmorph extend: Need to test its difficulty without HJ but its trivial with it. Will record video when i do so.",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Movement",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "UnmorphExtend",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "SWJ + UE: https://youtu.be/sBO8Pew_ijQ",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "SWJ",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "UnmorphExtend",
+                                                        "amount": 2,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]

--- a/randovania/games/samus_returns/logic_database/Area 1.txt
+++ b/randovania/games/samus_returns/logic_database/Area 1.txt
@@ -258,6 +258,7 @@ Extra - asset_id: collision_camera_012
   > Door to Spider Ball Balcony
       Trivial
   > Door to Outer Hub
+      # SWJ: https://youtu.be/n_gpWjN5Px0
       Ice Beam or Single-wall Wall Jump (Intermediate) or Climb Rooms Vertically (High Jump)
 
 > Dock to Ice Beam Tutorial; Heals? False
@@ -327,6 +328,7 @@ Extra - asset_id: collision_camera_016
   * Extra - actor_name: Door017
   * Extra - actor_type: doorclosedpower
   > Pickup (Missile Tank)
+      # Melee Clip + Out Of bounds movement: https://youtu.be/qAbaEaatlEU (Will re-record with inputs at later date)
       Morph Ball and Melee Clip (Beginner) and Out of Bounds Movement (Beginner)
   > Room Bottom
       Morph Ball
@@ -351,6 +353,7 @@ Extra - asset_id: collision_camera_016
   > Door to Outer Hub
       Any of the following:
           Climb Rooms Vertically (No High Jump)
+          # Video with inputs: https://www.youtube.com/watch?v=QmXq9hl-oB4
           Morph Ball and Melee Clip (Advanced) and Single-wall Wall Jump (Advanced)
 
 ----------------
@@ -906,8 +909,11 @@ Extra - asset_id: collision_camera_035
           All of the following:
               Phase Drift
               Any of the following:
-                  Single-wall Wall Jump (Hypermode)
                   Stand on Frozen Enemy (Intermediate) and Fully Freeze Enemy
+                  # Unmorph extend: Need to test its difficulty without HJ but its trivial with it. Will record video when i do so.
+                  Movement (Advanced) and Unmorph Extend (Advanced)
+          # SWJ + UE: https://youtu.be/sBO8Pew_ijQ
+          Single-wall Wall Jump (Advanced) and Unmorph Extend (Intermediate)
 
 > Tunnel to Alpha Shaft Right; Heals? False
   * Layers: default


### PR DESCRIPTION
Spider ball room:
- Video for clipping out of bounds and getting both items with out of bounds movement.
- Video of clipping back out of bounds and single wall jumping back up to the top of the room and back in bounds.

Central Shaft:
- Change the trick requires for right side climb without spider/bombs.
- add left side climb with video for SWJ and UE.

Shaft East:
- Add video for SWJ.