### PR TITLE
[Dread] Update to Underlava Puzzle Room 2 logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Logic Database
 
+##### Cataris
+- Added: In Underlava Puzzle Room 2: Use Speed Booster with at least one upgrade to shinespark through the speed blocks from the right. 
+
 ##### Ferenia
 
 - Added: In EMMI Zone Exit Middle: Use Wave Beam and Charge Beam or Power Bombs to open the Upper Door to EMMI Zone Exit West, then traverse through that room to get to the upper door.

--- a/randovania/games/dread/logic_database/Cataris.json
+++ b/randovania/games/dread/logic_database/Cataris.json
@@ -24265,6 +24265,68 @@
                                     }
                                 ]
                             }
+                        },
+                        "Event - Speed Blocks Destroyed": {
+                            "type": "and",
+                            "data": {
+                                "comment": "Charge shinespark on above lava platform",
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Speed",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "SpeedBoostUpgrade",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Gravity",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "s020_magma:default:grapplepulloff1x2_000",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Speedbooster",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },

--- a/randovania/games/dread/logic_database/Cataris.json
+++ b/randovania/games/dread/logic_database/Cataris.json
@@ -24269,7 +24269,7 @@
                         "Event - Speed Blocks Destroyed": {
                             "type": "and",
                             "data": {
-                                "comment": "Charge shinespark on above lava platform",
+                                "comment": "https://youtu.be/syNED-7J8HM",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -24489,12 +24489,20 @@
                                                     "data": "Simple IBJ"
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "Speedbooster",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": "https://youtu.be/P_LWT9EYwdI",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Speedbooster",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]

--- a/randovania/games/dread/logic_database/Cataris.txt
+++ b/randovania/games/dread/logic_database/Cataris.txt
@@ -3875,7 +3875,7 @@ Extra - asset_id: collision_camera_053
   > Dock to Underlava Puzzle Room 1
       Morph Ball and After Cataris - Underlava Speed Blocks Destroyed
   > Event - Speed Blocks Destroyed
-      # Charge shinespark on above lava platform
+      # https://youtu.be/syNED-7J8HM
       Gravity Suit and Morph Ball and Speed Booster and Speed Booster Upgrade and After Cataris - Lava Grapple Block and Speed Booster Conservation (Beginner)
 
 > Tunnel to Dropdown Pit; Heals? False
@@ -3899,7 +3899,10 @@ Extra - asset_id: collision_camera_053
   > Pickup (Energy Part)
       All of the following:
           After Cataris - Underlava Speed Blocks Destroyed
-          Flash Shift or Speed Booster Conservation (Beginner) or Simple IBJ or Use Spin Boost
+          Any of the following:
+              Flash Shift or Simple IBJ or Use Spin Boost
+              # https://youtu.be/P_LWT9EYwdI
+              Speed Booster Conservation (Beginner)
   > Below Lava
       Morph Ball and After Cataris - Underlava Speed Blocks Destroyed
   > Event - Speed Blocks Destroyed

--- a/randovania/games/dread/logic_database/Cataris.txt
+++ b/randovania/games/dread/logic_database/Cataris.txt
@@ -3874,6 +3874,9 @@ Extra - asset_id: collision_camera_053
                   Heat/Cold Runs (Advanced) and Heat Damage ≥ 200
   > Dock to Underlava Puzzle Room 1
       Morph Ball and After Cataris - Underlava Speed Blocks Destroyed
+  > Event - Speed Blocks Destroyed
+      # Charge shinespark on above lava platform
+      Gravity Suit and Morph Ball and Speed Booster and Speed Booster Upgrade and After Cataris - Lava Grapple Block and Speed Booster Conservation (Beginner)
 
 > Tunnel to Dropdown Pit; Heals? False
   * Layers: default


### PR DESCRIPTION
You can break the speed blocks in Underlava Puzzle Room 2 from the right. After opening the grapple block (no changes), if you have a speedbooster upgrade you can charge a shinespark on the above-lava element, run back and morph into the grapple tunnel, and shinespark up and down to destroy the blocks. 

Screenshot of added trick connection:
![image](https://github.com/randovania/randovania/assets/25016775/13df8b2d-2b92-4fbb-bfe6-0892dd704704)
