### PR TITLE
Area 1 logic update

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 1.json
+++ b/randovania/games/samus_returns/logic_database/Area 1.json
@@ -6468,7 +6468,7 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Climb Rooms Vertically (No High Jump)"
+                                        "data": "Use Spider Ball"
                                     },
                                     {
                                         "type": "resource",
@@ -6476,6 +6476,15 @@
                                             "type": "tricks",
                                             "name": "Walljump",
                                             "amount": 3,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space",
+                                            "amount": 1,
                                             "negate": false
                                         }
                                     }

--- a/randovania/games/samus_returns/logic_database/Area 1.json
+++ b/randovania/games/samus_returns/logic_database/Area 1.json
@@ -1320,7 +1320,7 @@
                         "area": "Bomb Access",
                         "node": "Door to Bomb Room"
                     },
-                    "default_dock_weakness": "Power Beam Door",
+                    "default_dock_weakness": "Missile Door",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,

--- a/randovania/games/samus_returns/logic_database/Area 1.txt
+++ b/randovania/games/samus_returns/logic_database/Area 1.txt
@@ -1061,7 +1061,7 @@ Extra - asset_id: collision_camera_043
   * Extra - actor_name: Door007
   * Extra - actor_type: doorpowerpower
   > Pickup (Missile Tank)
-      Walljump (Advanced) or Climb Rooms Vertically (No High Jump)
+      Space Jump or Walljump (Advanced) or Use Spider Ball
   > Dock to Teleporter Access
       Trivial
 

--- a/randovania/games/samus_returns/logic_database/Area 1.txt
+++ b/randovania/games/samus_returns/logic_database/Area 1.txt
@@ -195,7 +195,7 @@ Extra - asset_id: collision_camera_008
 
 > Door to Bomb Access; Heals? False
   * Layers: default
-  * Power Beam Door to Bomb Access/Door to Bomb Room
+  * Missile Door to Bomb Access/Door to Bomb Room
   * Extra - actor_name: Door004
   * Extra - actor_type: doorpowerpower
   > Room Center


### PR DESCRIPTION
Spazer beam door inner room, updated to not have Simple IBJ be possibly required due to the crumble blocks at the bottom