### PR TITLE
Area 2 logic updates

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 2 - Entrance.json
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Entrance.json
@@ -1251,12 +1251,46 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "or",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Armor",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Armor",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Movement",
+                                                                                "amount": 3,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 150,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
@@ -1301,32 +1335,6 @@
                                                                 }
                                                             }
                                                         ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Movement",
-                                                        "amount": 3,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "damage",
-                                                        "name": "Damage",
-                                                        "amount": 150,
-                                                        "negate": false
                                                     }
                                                 }
                                             ]

--- a/randovania/games/samus_returns/logic_database/Area 2 - Entrance.json
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Entrance.json
@@ -648,10 +648,6 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Fully Freeze Enemy"
-                                                },
-                                                {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
@@ -659,6 +655,10 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Fully Freeze Enemy"
                                                 }
                                             ]
                                         }
@@ -1301,6 +1301,32 @@
                                                                 }
                                                             }
                                                         ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 150,
+                                                        "negate": false
                                                     }
                                                 }
                                             ]

--- a/randovania/games/samus_returns/logic_database/Area 2 - Entrance.txt
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Entrance.txt
@@ -245,9 +245,10 @@ Extra - asset_id: collision_camera_005
       Any of the following:
           Use Spider Ball
           All of the following:
-              Lightning Armor
+              Any of the following:
+                  Lightning Armor
+                  Movement (Advanced) and Normal Damage ≥ 150
               High Jump Boots or Space Jump or Super Jump (Intermediate) or Walljump (Beginner)
-          Movement (Advanced) and Normal Damage ≥ 150
   > Dock to Water Storage
       Any of the following:
           Single-wall Wall Jump (Intermediate) or Climb Rooms Vertically (High Jump)

--- a/randovania/games/samus_returns/logic_database/Area 2 - Entrance.txt
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Entrance.txt
@@ -247,6 +247,7 @@ Extra - asset_id: collision_camera_005
           All of the following:
               Lightning Armor
               High Jump Boots or Space Jump or Super Jump (Intermediate) or Walljump (Beginner)
+          Movement (Advanced) and Normal Damage ≥ 150
   > Dock to Water Storage
       Any of the following:
           Single-wall Wall Jump (Intermediate) or Climb Rooms Vertically (High Jump)

--- a/randovania/games/samus_returns/logic_database/Area 2 - Exterior.json
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Exterior.json
@@ -707,13 +707,8 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Spider",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Use Spider Ball"
                                                 }
                                             ]
                                         }
@@ -2482,12 +2477,90 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Grapple",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "https://www.youtube.com/watch?v=rfZa-HK-3mE",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "DBoost",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "AirMorph",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Walljump",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 70,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Armor",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/samus_returns/logic_database/Area 2 - Exterior.json
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Exterior.json
@@ -685,8 +685,25 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Spiderspark",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Spiderspark"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "template",

--- a/randovania/games/samus_returns/logic_database/Area 2 - Exterior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Exterior.txt
@@ -110,7 +110,7 @@ Extra - asset_id: collision_camera_005
   > Door to Alpha+ Arena North
       Any of the following:
           Space Jump or Can Spiderspark or Simple IBJ
-          Lightning Armor and Spider Ball
+          Lightning Armor and Use Spider Ball
   > Top of Wall
       Climb Rooms Vertically (No High Jump)
 
@@ -417,7 +417,14 @@ Extra - asset_id: collision_camera_024
   * Layers: default
   * Tunnel with Bomb Block to Outer Hub Shaft/Tunnel to Grapple Gap (Top)
   > Pickup (Aeion Tank)
-      Grapple Beam and Morph Ball
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Grapple Beam
+              All of the following:
+                  # https://www.youtube.com/watch?v=rfZa-HK-3mE
+                  Mid-Air Morph (Intermediate) and Damage Boost (Advanced) and Movement (Advanced) and Walljump (Advanced)
+                  Lightning Armor or Normal Damage ≥ 70
   > Tunnel to Outer Hub Shaft (Bottom)
       Morph Ball
 

--- a/randovania/games/samus_returns/logic_database/Area 2 - Exterior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Exterior.txt
@@ -109,7 +109,8 @@ Extra - asset_id: collision_camera_005
       Trivial
   > Door to Alpha+ Arena North
       Any of the following:
-          Space Jump or Can Spiderspark or Simple IBJ
+          Space Jump or Simple IBJ
+          Spiderspark (Beginner) and Can Spiderspark
           Lightning Armor and Use Spider Ball
   > Top of Wall
       Climb Rooms Vertically (No High Jump)

--- a/randovania/games/samus_returns/logic_database/Area 2 - Interior.json
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Interior.json
@@ -312,51 +312,67 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Climb Rooms Vertically (High Jump)"
-                                    },
-                                    {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "Armor",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "FrozenEnemy",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Fully Freeze Enemy"
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "tricks",
-                                                        "name": "SWJ",
-                                                        "amount": 2,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Fully Freeze Enemy"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "FrozenEnemy",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Armor",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "SWJ",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Climb Rooms Vertically (High Jump)"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]

--- a/randovania/games/samus_returns/logic_database/Area 2 - Interior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Interior.txt
@@ -38,7 +38,13 @@ Extra - asset_id: collision_camera009
   > Door to Varia Suit Room (Bottom)
       Morph Ball
   > Door to Varia Suit Room (Top)
-      Lightning Armor and Morph Ball and Stand on Frozen Enemy (Beginner) and Single-wall Wall Jump (Intermediate) and Climb Rooms Vertically (High Jump) and Fully Freeze Enemy
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Stand on Frozen Enemy (Beginner) and Fully Freeze Enemy
+              All of the following:
+                  Lightning Armor
+                  Single-wall Wall Jump (Intermediate) or Climb Rooms Vertically (High Jump)
 
 > Door to Fiery Path; Heals? False
   * Layers: default


### PR DESCRIPTION
Area 2 - entrance:
 - Add logic for getting from lightning armor room to top with movement and taking damage.
 
Area 2 - Exterior:
 - Update a check to be checking for ability to use spider ball instead of just having spider ball.
 - Add trick with video to grapple gap.
 
Area 2 - Interior:
 - Update main hub? requirements for getting to the top door to not be a bunch of and's stuck together when it should be OR.