### PR TITLE
Dread: Golzuna logic update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.1.0] - 2023-12-??
 
-- To be added.
+### Metroid Dread
+
+#### Logic Database
+
+##### Ghavoran
+
+- Changed: Golzuna logic has been overhauled to include Storm Missiles, Bombs, or Cross Bombs to fight it and forcing Flash Shift, Spin Boost, or Space Jump to dodge its attacks.
 
 ## [7.0.1] - 2023-11-??
 

--- a/randovania/games/dread/logic_database/Ghavoran.json
+++ b/randovania/games/dread/logic_database/Ghavoran.json
@@ -12069,35 +12069,18 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
-                                            "comment": "Requirements for dodging attacks. Not needed if at least beginner combat.",
+                                            "comment": "Requirements for dodging attacks.",
                                             "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Combat",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Dodge its slam attack",
                                                         "items": [
                                                             {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": "Dodge its slam attack",
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "template",
-                                                                            "data": "Can Slide"
-                                                                        }
-                                                                    ]
-                                                                }
+                                                                "type": "template",
+                                                                "data": "Can Slide"
                                                             },
                                                             {
                                                                 "type": "or",
@@ -12105,8 +12088,13 @@
                                                                     "comment": "Dodge its zappy attacks",
                                                                     "items": [
                                                                         {
-                                                                            "type": "template",
-                                                                            "data": "Use Spin Boost"
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Space",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
                                                                         },
                                                                         {
                                                                             "type": "and",
@@ -12114,19 +12102,31 @@
                                                                                 "comment": null,
                                                                                 "items": [
                                                                                     {
-                                                                                        "type": "resource",
+                                                                                        "type": "or",
                                                                                         "data": {
-                                                                                            "type": "items",
-                                                                                            "name": "Flash",
-                                                                                            "amount": 1,
-                                                                                            "negate": false
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "items",
+                                                                                                        "name": "Flash",
+                                                                                                        "amount": 1,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "template",
+                                                                                                    "data": "Use Spin Boost"
+                                                                                                }
+                                                                                            ]
                                                                                         }
                                                                                     },
                                                                                     {
                                                                                         "type": "resource",
                                                                                         "data": {
                                                                                             "type": "tricks",
-                                                                                            "name": "Walljump",
+                                                                                            "name": "Combat",
                                                                                             "amount": 1,
                                                                                             "negate": false
                                                                                         }
@@ -12149,13 +12149,67 @@
                                             "comment": "Requirements for killing Golzuna",
                                             "items": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Shoot Charge Beam"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Charge Beam methods",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Charge Beam"
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": "Plasma, Wave, or Power",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Beam Damage 120"
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Beam Damage 240"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Combat",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "Wide",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Beam Damage 75"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Combat",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Shinesparks only",
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -12181,17 +12235,8 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": null,
+                                                        "comment": "Missile methods",
                                                         "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Combat",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
                                                             {
                                                                 "type": "or",
                                                                 "data": {
@@ -12240,6 +12285,15 @@
                                                                                                                     "type": "items",
                                                                                                                     "name": "Speed",
                                                                                                                     "amount": 1,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "tricks",
+                                                                                                                    "name": "Combat",
+                                                                                                                    "amount": 2,
                                                                                                                     "negate": false
                                                                                                                 }
                                                                                                             }
@@ -12297,11 +12351,29 @@
                                                                                                                     "amount": 1,
                                                                                                                     "negate": false
                                                                                                                 }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "tricks",
+                                                                                                                    "name": "Combat",
+                                                                                                                    "amount": 2,
+                                                                                                                    "negate": false
+                                                                                                                }
                                                                                                             }
                                                                                                         ]
                                                                                                     }
                                                                                                 }
                                                                                             ]
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Combat",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
                                                                                         }
                                                                                     }
                                                                                 ]
@@ -12354,8 +12426,136 @@
                                                                                                 }
                                                                                             ]
                                                                                         }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Combat",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
                                                                                     }
                                                                                 ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "Minimum: 96 Storm missiles",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Storm",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "or",
+                                                                                        "data": {
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "items",
+                                                                                                        "name": "MissileAmmo",
+                                                                                                        "amount": 108,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "and",
+                                                                                                    "data": {
+                                                                                                        "comment": "Mimimum: 48 Storm missiles + 1 shinespark",
+                                                                                                        "items": [
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "items",
+                                                                                                                    "name": "MissileAmmo",
+                                                                                                                    "amount": 60,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "items",
+                                                                                                                    "name": "Speed",
+                                                                                                                    "amount": 1,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "tricks",
+                                                                                                                    "name": "Combat",
+                                                                                                                    "amount": 2,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "Bomb methods",
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "Normal Bombs",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Lay Bomb"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Combat",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "Cross Bombs",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Lay Cross Bomb"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Combat",
+                                                                                "amount": 1,
+                                                                                "negate": false
                                                                             }
                                                                         }
                                                                     ]
@@ -12378,15 +12578,6 @@
                                                         "type": "damage",
                                                         "name": "Damage",
                                                         "amount": 699,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "Combat",
-                                                        "amount": 2,
                                                         "negate": false
                                                     }
                                                 },

--- a/randovania/games/dread/logic_database/Ghavoran.json
+++ b/randovania/games/dread/logic_database/Ghavoran.json
@@ -12107,12 +12107,29 @@
                                                                                             "comment": null,
                                                                                             "items": [
                                                                                                 {
-                                                                                                    "type": "resource",
+                                                                                                    "type": "and",
                                                                                                     "data": {
-                                                                                                        "type": "items",
-                                                                                                        "name": "Flash",
-                                                                                                        "amount": 1,
-                                                                                                        "negate": false
+                                                                                                        "comment": null,
+                                                                                                        "items": [
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "items",
+                                                                                                                    "name": "Flash",
+                                                                                                                    "amount": 1,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "type": "resource",
+                                                                                                                "data": {
+                                                                                                                    "type": "items",
+                                                                                                                    "name": "FlashUpgrade",
+                                                                                                                    "amount": 2,
+                                                                                                                    "negate": false
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
                                                                                                     }
                                                                                                 },
                                                                                                 {
@@ -12165,10 +12182,6 @@
                                                                         {
                                                                             "type": "template",
                                                                             "data": "Beam Damage 120"
-                                                                        },
-                                                                        {
-                                                                            "type": "template",
-                                                                            "data": "Beam Damage 240"
                                                                         },
                                                                         {
                                                                             "type": "resource",

--- a/randovania/games/dread/logic_database/Ghavoran.json
+++ b/randovania/games/dread/logic_database/Ghavoran.json
@@ -12150,6 +12150,36 @@
                                                                                     }
                                                                                 ]
                                                                             }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": "Speed-only dodging, requires good rng on its attack cycle",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Combat",
+                                                                                            "amount": 4,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Speed",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Can Slide"
+                                                                                    }
+                                                                                ]
+                                                                            }
                                                                         }
                                                                     ]
                                                                 }

--- a/randovania/games/dread/logic_database/Ghavoran.json
+++ b/randovania/games/dread/logic_database/Ghavoran.json
@@ -12619,6 +12619,15 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }

--- a/randovania/games/dread/logic_database/Ghavoran.txt
+++ b/randovania/games/dread/logic_database/Ghavoran.txt
@@ -2074,6 +2074,8 @@ Extra - asset_id: collision_camera_026
                           Any of the following:
                               Use Spin Boost
                               Flash Shift and Flash Shift Upgrade ≥ 2
+                      # Speed-only dodging, requires good rng on its attack cycle
+                      Speed Booster and Combat (Expert) and Can Slide
           Any of the following:
               # Requirements for killing Golzuna
               All of the following:

--- a/randovania/games/dread/logic_database/Ghavoran.txt
+++ b/randovania/games/dread/logic_database/Ghavoran.txt
@@ -2061,22 +2061,31 @@ Extra - asset_id: collision_camera_026
   * Extra - tile_types: ('WEIGHT',)
   > Event - Golzuna
       All of the following:
-          Any of the following:
-              # Requirements for dodging attacks. Not needed if at least beginner combat.
-              Combat (Beginner)
+          All of the following:
+              # Requirements for dodging attacks.
               All of the following:
                   # Dodge its slam attack
                   Can Slide
                   Any of the following:
                       # Dodge its zappy attacks
-                      Use Spin Boost
-                      Flash Shift and Wall Jump (Beginner)
+                      Space Jump
+                      All of the following:
+                          Combat (Beginner)
+                          Flash Shift or Use Spin Boost
           Any of the following:
               # Requirements for killing Golzuna
-              Shoot Charge Beam
+              All of the following:
+                  # Charge Beam methods
+                  Shoot Charge Beam
+                  Any of the following:
+                      # Plasma, Wave, or Power
+                      Combat (Intermediate) or Beam Damage 120 or Beam Damage 240
+                      # Wide
+                      Combat (Beginner) and Beam Damage 75
+              # Shinesparks only
               Speed Booster and Combat (Advanced)
               All of the following:
-                  Combat (Intermediate)
+                  # Missile methods
                   Any of the following:
                       All of the following:
                           # Minimum: 35 Ice Missiles
@@ -2084,23 +2093,37 @@ Extra - asset_id: collision_camera_026
                           Any of the following:
                               Missiles ≥ 40
                               # Minimum: 18 Ice Missiles + 1 Shinespark
-                              Missiles ≥ 20 and Speed Booster
+                              Missiles ≥ 20 and Speed Booster and Combat (Intermediate)
                       All of the following:
                           # Minimum: 94 Super Missiles
-                          Shoot Super Missile
+                          Combat (Beginner) and Shoot Super Missile
                           Any of the following:
                               Missiles ≥ 100
                               # Minimum: 47 Super Missiles + 1 Shinespark
-                              Missiles ≥ 50 and Speed Booster
+                              Missiles ≥ 50 and Speed Booster and Combat (Intermediate)
                       All of the following:
                           # Minimum: 280 Normal Missiles
+                          Combat (Intermediate)
                           Any of the following:
                               Missiles ≥ 300
                               # Minimum: 140 Normal Missiles + 1 Shinespark
                               Missiles ≥ 150 and Speed Booster
+                      All of the following:
+                          # Minimum: 96 Storm missiles
+                          Storm Missile
+                          Any of the following:
+                              Missiles ≥ 108
+                              # Mimimum: 48 Storm missiles + 1 shinespark
+                              Missiles ≥ 60 and Speed Booster and Combat (Intermediate)
+              Any of the following:
+                  # Bomb methods
+                  # Normal Bombs
+                  Combat (Intermediate) and Lay Bomb
+                  # Cross Bombs
+                  Combat (Beginner) and Lay Cross Bomb
           Any of the following:
               # Energy Requirements
-              Combat (Intermediate) or Normal Damage ≥ 699
+              Normal Damage ≥ 699
               Combat (Beginner) and Normal Damage ≥ 349
 
 > Tunnel to Above Golzuna; Heals? False

--- a/randovania/games/dread/logic_database/Ghavoran.txt
+++ b/randovania/games/dread/logic_database/Ghavoran.txt
@@ -2125,7 +2125,7 @@ Extra - asset_id: collision_camera_026
                   Combat (Beginner) and Lay Cross Bomb
           Any of the following:
               # Energy Requirements
-              Normal Damage ≥ 699
+              Combat (Expert) or Normal Damage ≥ 699
               Combat (Beginner) and Normal Damage ≥ 349
 
 > Tunnel to Above Golzuna; Heals? False

--- a/randovania/games/dread/logic_database/Ghavoran.txt
+++ b/randovania/games/dread/logic_database/Ghavoran.txt
@@ -2071,7 +2071,9 @@ Extra - asset_id: collision_camera_026
                       Space Jump
                       All of the following:
                           Combat (Beginner)
-                          Flash Shift or Use Spin Boost
+                          Any of the following:
+                              Use Spin Boost
+                              Flash Shift and Flash Shift Upgrade ≥ 2
           Any of the following:
               # Requirements for killing Golzuna
               All of the following:
@@ -2079,7 +2081,7 @@ Extra - asset_id: collision_camera_026
                   Shoot Charge Beam
                   Any of the following:
                       # Plasma, Wave, or Power
-                      Combat (Intermediate) or Beam Damage 120 or Beam Damage 240
+                      Combat (Intermediate) or Beam Damage 120
                       # Wide
                       Combat (Beginner) and Beam Damage 75
               # Shinesparks only


### PR DESCRIPTION
- Changed: Golzuna logic has been overhauled to include Storm Missiles, Bombs, or Cross Bombs to fight it and forcing Flash Shift, Spin Boost, or Space Jump to dodge its attacks.