### PR TITLE
 Area 3 logic updates

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 3 - Exterior.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Exterior.json
@@ -1494,28 +1494,14 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Morph",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
                                                         "name": "Grapple",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Spider",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Use Spider Ball"
                                                 }
                                             ]
                                         }
@@ -2992,34 +2978,26 @@
                                                                 }
                                                             },
                                                             {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 30,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
                                                                 "type": "or",
                                                                 "data": {
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
-                                                                            "type": "and",
+                                                                            "type": "resource",
                                                                             "data": {
-                                                                                "comment": null,
-                                                                                "items": [
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "items",
-                                                                                            "name": "Phase",
-                                                                                            "amount": 1,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "damage",
-                                                                                            "name": "Damage",
-                                                                                            "amount": 30,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    }
-                                                                                ]
+                                                                                "type": "items",
+                                                                                "name": "Phase",
+                                                                                "amount": 1,
+                                                                                "negate": false
                                                                             }
                                                                         },
                                                                         {
@@ -3027,7 +3005,7 @@
                                                                             "data": {
                                                                                 "type": "damage",
                                                                                 "name": "Damage",
-                                                                                "amount": 30,
+                                                                                "amount": 40,
                                                                                 "negate": false
                                                                             }
                                                                         }

--- a/randovania/games/samus_returns/logic_database/Area 3 - Exterior.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Exterior.json
@@ -102,24 +102,10 @@
                             }
                         },
                         "Door to Entrance Hub": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Grapple",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Climb Rooms Vertically (No High Jump)"
-                                    }
-                                ]
+                                "items": []
                             }
                         },
                         "Door to Transport to Area 4 West (Top)": {
@@ -1479,8 +1465,25 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Spiderspark",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Spiderspark"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",
@@ -1501,6 +1504,15 @@
                                                     "data": {
                                                         "type": "items",
                                                         "name": "Grapple",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Spider",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -1737,8 +1749,25 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Spiderspark",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Spiderspark"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",
@@ -2939,12 +2968,122 @@
                             "data": "Lay Any Bomb"
                         },
                         "Door to Outer Hub Access": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "DBoost",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Phase",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "damage",
+                                                                                            "name": "Damage",
+                                                                                            "amount": 30,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 30,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Plasma",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Lay Power Bomb"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Shoot Beam Burst"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Spider",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Morph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -4225,7 +4364,7 @@
                         "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "TODO: Add methods without SJ (non-trickless)",
                                 "items": [
                                     {
                                         "type": "resource",

--- a/randovania/games/samus_returns/logic_database/Area 3 - Exterior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Exterior.txt
@@ -246,7 +246,7 @@ Extra - asset_id: collision_camera_030
       Any of the following:
           Space Jump or Simple IBJ
           Spiderspark (Beginner) and Can Spiderspark
-          Grapple Beam and Morph Ball and Spider Ball
+          Grapple Beam and Use Spider Ball
 
 > Door to Outer Hub Access; Heals? False
   * Layers: default
@@ -478,10 +478,8 @@ Extra - asset_id: collision_camera_035
           Any of the following:
               Plasma Beam or Spider Ball or Lay Power Bomb or Shoot Beam Burst
               All of the following:
-                  Damage Boost (Beginner)
-                  Any of the following:
-                      Normal Damage ≥ 30
-                      Phase Drift and Normal Damage ≥ 30
+                  Damage Boost (Beginner) and Normal Damage ≥ 30
+                  Phase Drift or Normal Damage ≥ 40
 
 > Elevator to Area 3 - Interior (West); Heals? False; Spawn Point; Default Node
   * Layers: default

--- a/randovania/games/samus_returns/logic_database/Area 3 - Exterior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Exterior.txt
@@ -11,7 +11,7 @@ Extra - asset_id: collision_camera_002
   > Elevator to Area 2 - Entrance
       Trivial
   > Door to Entrance Hub
-      Grapple Beam or Climb Rooms Vertically (No High Jump)
+      Trivial
   > Door to Transport to Area 4 West (Top)
       Trivial
 
@@ -244,8 +244,9 @@ Extra - asset_id: collision_camera_030
   * Extra - actor_type: doorpowerpower
   > Save Station
       Any of the following:
-          Space Jump or Can Spiderspark or Simple IBJ
-          Grapple Beam and Morph Ball
+          Space Jump or Simple IBJ
+          Spiderspark (Beginner) and Can Spiderspark
+          Grapple Beam and Morph Ball and Spider Ball
 
 > Door to Outer Hub Access; Heals? False
   * Layers: default
@@ -278,7 +279,7 @@ Extra - asset_id: collision_camera_030
   * Open Passage to Outer Hub Teleporter/Dock to Outer Hub
   > Pickup (Missile Tank Ceiling)
       Any of the following:
-          Can Spiderspark
+          Spiderspark (Beginner) and Can Spiderspark
           All of the following:
               Morph Ball
               Any of the following:
@@ -472,7 +473,15 @@ Extra - asset_id: collision_camera_035
   > Elevator to Area 3 - Interior (West)
       Lay Any Bomb
   > Door to Outer Hub Access
-      Morph Ball
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Plasma Beam or Spider Ball or Lay Power Bomb or Shoot Beam Burst
+              All of the following:
+                  Damage Boost (Beginner)
+                  Any of the following:
+                      Normal Damage ≥ 30
+                      Phase Drift and Normal Damage ≥ 30
 
 > Elevator to Area 3 - Interior (West); Heals? False; Spawn Point; Default Node
   * Layers: default
@@ -651,6 +660,7 @@ Extra - asset_id: collision_camera_037
       Morph Ball or After Area 3 (Exterior) - Gamma Shaft Grapple Block
   > Pickup (Missile Tank)
       All of the following:
+          # TODO: Add methods without SJ (non-trickless)
           Morph Ball and Shoot Any Missile
           Any of the following:
               Screw Attack and Space Jump

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior East.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior East.json
@@ -3946,7 +3946,7 @@
                                                 },
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Simple IBJ"
                                                 }
                                             ]
                                         }

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior East.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior East.json
@@ -3258,8 +3258,13 @@
                                                         "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "template",
-                                                                "data": "Climb Rooms Vertically (High Jump)"
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Space",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             },
                                                             {
                                                                 "type": "and",
@@ -3307,6 +3312,10 @@
                                                                         }
                                                                     ]
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Simple IBJ"
                                                             }
                                                         ]
                                                     }

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior East.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior East.json
@@ -2132,6 +2132,15 @@
                                                                         }
                                                                     ]
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Space",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             }
                                                         ]
                                                     }

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior East.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior East.json
@@ -284,8 +284,25 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Spiderspark",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Spiderspark"
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
                                                     "type": "template",
@@ -1798,7 +1815,7 @@
                                                                             "data": {
                                                                                 "type": "tricks",
                                                                                 "name": "Spiderspark",
-                                                                                "amount": 1,
+                                                                                "amount": 2,
                                                                                 "negate": false
                                                                             }
                                                                         },
@@ -2087,8 +2104,37 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Climb Rooms Vertically (No High Jump)"
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Simple IBJ"
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Spiderspark"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Spiderspark",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
                                                     "type": "and",
@@ -2766,8 +2812,8 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Movement",
-                                                                    "amount": 1,
+                                                                    "name": "Spiderspark",
+                                                                    "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -3175,8 +3221,8 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Movement",
-                                                        "amount": 1,
+                                                        "name": "Spiderspark",
+                                                        "amount": 2,
                                                         "negate": false
                                                     }
                                                 }
@@ -3228,12 +3274,29 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "UnmorphExtend",
-                                                                    "amount": 2,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Boots",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "UnmorphExtend",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -3843,8 +3906,25 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Spiderspark",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Spiderspark"
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
                                                     "type": "template",

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior East.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior East.txt
@@ -606,7 +606,7 @@ Extra - asset_id: collision_camera_027
       All of the following:
           Morph Ball and After Area 3 (Interior East) - Gamma Metroid Lower
           Any of the following:
-              Grapple Beam or Space Jump or Can Spiderspark
+              Grapple Beam or Space Jump or Simple IBJ
               Spiderspark (Beginner) and Can Spiderspark
   > Event - Gamma Metroid
       Defeat Gamma Metroid

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior East.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior East.txt
@@ -508,7 +508,7 @@ Extra - asset_id: collision_camera_025
           All of the following:
               Morph Ball
               Any of the following:
-                  Climb Rooms Vertically (High Jump)
+                  Space Jump or Simple IBJ
                   Stand on Frozen Enemy (Intermediate) and Fully Freeze Enemy
                   High Jump Boots and Unmorph Extend (Intermediate)
   > Door to Gamma Awakening

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior East.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior East.txt
@@ -38,7 +38,9 @@ Extra - asset_id: collision_camera_013
   > Tunnel to Gamma Arena South
       All of the following:
           Morph Ball
-          Grapple Beam or Space Jump or Can Spiderspark or Simple IBJ
+          Any of the following:
+              Grapple Beam or Space Jump or Simple IBJ
+              Spiderspark (Intermediate) and Can Spiderspark
   > Start Point
       Trivial
 
@@ -300,7 +302,7 @@ Extra - asset_id: collision_camera_022
               Varia Suit
               Any of the following:
                   Grapple Beam or Space Jump
-                  Power Bomb ≥ 2 and Spiderspark (Beginner) and Can Spiderspark
+                  Power Bomb ≥ 2 and Spiderspark (Intermediate) and Can Spiderspark
 
 > Door to Alpha Arena; Heals? False
   * Layers: default
@@ -332,7 +334,8 @@ Extra - asset_id: collision_camera_022
       All of the following:
           Morph Ball and Varia Suit
           Any of the following:
-              Grapple Beam or Climb Rooms Vertically (No High Jump)
+              Grapple Beam or Simple IBJ
+              Spiderspark (Intermediate) and Can Spiderspark
               Damage Boost (Intermediate) and Unmorph Extend (Intermediate)
 
 > Start Point; Heals? False; Default Node
@@ -436,7 +439,7 @@ Extra - asset_id: collision_camera_023
           Morph Ball
           Any of the following:
               Grapple Beam or Space Jump or Simple IBJ
-              Movement (Beginner) and Can Spiderspark
+              Spiderspark (Intermediate) and Can Spiderspark
   > Tunnel to Gamma Awakening (Top)
       All of the following:
           Morph Ball
@@ -501,12 +504,13 @@ Extra - asset_id: collision_camera_025
   * Extra - actor_type: doorpowerpower
   > Door to Fan Puzzle Room
       Any of the following:
-          Movement (Beginner) and Can Spiderspark
+          Spiderspark (Intermediate) and Can Spiderspark
           All of the following:
               Morph Ball
               Any of the following:
-                  Unmorph Extend (Intermediate) or Climb Rooms Vertically (High Jump)
+                  Climb Rooms Vertically (High Jump)
                   Stand on Frozen Enemy (Intermediate) and Fully Freeze Enemy
+                  High Jump Boots and Unmorph Extend (Intermediate)
   > Door to Gamma Awakening
       Trivial
 
@@ -601,7 +605,9 @@ Extra - asset_id: collision_camera_027
   > Tunnel to Gamma Arena South Access
       All of the following:
           Morph Ball and After Area 3 (Interior East) - Gamma Metroid Lower
-          Grapple Beam or Space Jump or Can Spiderspark or Simple IBJ
+          Any of the following:
+              Grapple Beam or Space Jump or Can Spiderspark
+              Spiderspark (Beginner) and Can Spiderspark
   > Event - Gamma Metroid
       Defeat Gamma Metroid
 

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior East.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior East.txt
@@ -334,7 +334,7 @@ Extra - asset_id: collision_camera_022
       All of the following:
           Morph Ball and Varia Suit
           Any of the following:
-              Grapple Beam or Simple IBJ
+              Grapple Beam or Space Jump or Simple IBJ
               Spiderspark (Intermediate) and Can Spiderspark
               Damage Boost (Intermediate) and Unmorph Extend (Intermediate)
 

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior West.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior West.json
@@ -3601,8 +3601,34 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Climb Rooms Vertically (No High Jump)"
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Space",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Boots",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Simple IBJ"
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
                                                     "type": "and",

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior West.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior West.json
@@ -159,8 +159,25 @@
                                             "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Spiderspark",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Spiderspark"
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
                                                     "type": "and",
@@ -223,31 +240,26 @@
                                                                         }
                                                                     ]
                                                                 }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Lay Bomb"
                                                             },
                                                             {
-                                                                "type": "and",
+                                                                "type": "resource",
                                                                 "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "items",
-                                                                                "name": "Bomb",
-                                                                                "amount": 1,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "UBJ",
-                                                                                "amount": 2,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
+                                                                    "type": "tricks",
+                                                                    "name": "UBJ",
+                                                                    "amount": 2,
+                                                                    "negate": false
                                                                 }
                                                             }
                                                         ]
@@ -1385,8 +1397,25 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Spiderspark",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Spiderspark"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",
@@ -2248,8 +2277,25 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Spiderspark"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Spiderspark",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "template",
@@ -2452,8 +2498,25 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Spiderspark",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Spiderspark"
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
                                                     "type": "template",
@@ -2535,8 +2598,25 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Spiderspark",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Spiderspark"
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
                                                     "type": "template",
@@ -2888,8 +2968,25 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Spiderspark",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Spiderspark"
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
                                                     "type": "template",
@@ -3482,8 +3579,25 @@
                                                     "data": "Climb Rooms Vertically (No High Jump)"
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Spiderspark"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Spiderspark",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
                                                     "type": "resource",
@@ -4651,8 +4765,25 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Spiderspark"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Spiderspark",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior West.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior West.json
@@ -2298,8 +2298,34 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Climb Rooms Vertically (High Jump)"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Boots",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Space",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Simple IBJ"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior West.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior West.txt
@@ -386,7 +386,7 @@ Extra - asset_id: collision_camera_012
   * Layers: default
   > Door to Save Station Hallway
       Any of the following:
-          Grapple Beam or Climb Rooms Vertically (High Jump)
+          High Jump Boots or Grapple Beam or Space Jump or Simple IBJ
           Spiderspark (Intermediate) and Can Spiderspark
           Stand on Frozen Enemy (Intermediate) and Fully Freeze Enemy
   > Pickup (Missile Tank)

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior West.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior West.txt
@@ -562,7 +562,7 @@ Extra - asset_id: collision_camera_026
               Shoot Beam Burst
               Knowledge (Beginner) and Lay Power Bomb
           Any of the following:
-              Grapple Beam or Climb Rooms Vertically (No High Jump)
+              High Jump Boots or Grapple Beam or Space Jump or Simple IBJ
               Spiderspark (Intermediate) and Can Spiderspark
   > Above Teleporter
       Trivial

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior West.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior West.txt
@@ -25,10 +25,11 @@ Extra - asset_id: collision_camera_006
       All of the following:
           Morph Ball and Shoot Super Missile
           Any of the following:
-              Can Spiderspark
+              Spiderspark (Intermediate) and Can Spiderspark
               All of the following:
-                  Bomb and Gravity Suit and Underwater Bomb Jump (Intermediate)
+                  Gravity Suit
                   High Jump Boots or Space Jump or Super Jump (Intermediate) or Unmorph Extend (Intermediate) or Simple IBJ
+              Underwater Bomb Jump (Intermediate) and Lay Bomb
 
 > Door to Gamma Arena North; Heals? False
   * Layers: default
@@ -239,7 +240,7 @@ Extra - asset_id: collision_camera_009
       Morph Ball and Shoot Super Missile
   > Left of Missile Block
       Any of the following:
-          Can Spiderspark
+          Spiderspark (Intermediate) and Can Spiderspark
           All of the following:
               Morph Ball
               Any of the following:
@@ -385,7 +386,8 @@ Extra - asset_id: collision_camera_012
   * Layers: default
   > Door to Save Station Hallway
       Any of the following:
-          Grapple Beam or Can Spiderspark or Climb Rooms Vertically (High Jump)
+          Grapple Beam or Climb Rooms Vertically (High Jump)
+          Spiderspark (Intermediate) and Can Spiderspark
           Stand on Frozen Enemy (Intermediate) and Fully Freeze Enemy
   > Pickup (Missile Tank)
       Morph Ball and Shoot Any Missile
@@ -413,7 +415,9 @@ Extra - asset_id: collision_camera_024
   > Left of Grapple Block
       All of the following:
           Morph Ball and Shoot Any Missile
-          Grapple Beam or Space Jump or Can Spiderspark or Simple IBJ
+          Any of the following:
+              Grapple Beam or Space Jump or Simple IBJ
+              Spiderspark (Intermediate) and Can Spiderspark
 
 > Tunnel to Shaft West; Heals? False
   * Layers: default
@@ -421,7 +425,9 @@ Extra - asset_id: collision_camera_024
   > Pickup (Missile Tank)
       All of the following:
           Morph Ball and Shoot Any Missile
-          Grapple Beam or Space Jump or Can Spiderspark or Simple IBJ
+          Any of the following:
+              Grapple Beam or Space Jump or Simple IBJ
+              Spiderspark (Intermediate) and Can Spiderspark
 
 > Tunnel to Shaft East; Heals? False
   * Layers: default
@@ -474,7 +480,8 @@ Extra - asset_id: collision_camera_025
       All of the following:
           Lay Any Bomb
           Any of the following:
-              Space Jump or Can Spiderspark or Simple IBJ
+              Space Jump or Simple IBJ
+              Spiderspark (Intermediate) and Can Spiderspark
               All of the following:
                   Grapple Beam
                   Spider Ball or Movement (Beginner)
@@ -554,7 +561,9 @@ Extra - asset_id: collision_camera_026
           Any of the following:
               Shoot Beam Burst
               Knowledge (Beginner) and Lay Power Bomb
-          Grapple Beam or Can Spiderspark or Climb Rooms Vertically (No High Jump)
+          Any of the following:
+              Grapple Beam or Climb Rooms Vertically (No High Jump)
+              Spiderspark (Intermediate) and Can Spiderspark
   > Above Teleporter
       Trivial
 
@@ -739,7 +748,8 @@ Extra - asset_id: collision_camera_032
   * Extra - actor_type: doorpowerpower
   > Elevator to Area 3 - Interior (East)
       Any of the following:
-          Phase Drift or Can Spiderspark
+          Phase Drift
+          Spiderspark (Intermediate) and Can Spiderspark
           All of the following:
               Morph Ball
               Any of the following:


### PR DESCRIPTION
Area 3 - Exterior:
 - Transport to Area 2 Entrance, seal -> Entrance hub door make trivial
 - Transport to Area 3 interior west (upper), Ammo Recarge -> Outer hub access add logic for getting past / destroying the turret.
 - Outer Hub, Change spider sparks to be beginner tricks, add spider ball for trickless of climbing further.

Area 3 - Interior (east):
 - Gamma awakening access, change movement req to spiderball trick. Add HJ for the unmorph extend to getting to supermissile door.
 - Fiery Path, change climb vertical no high jump to be Simple IBJ or Spiderspark.

Area 3 - interior (west):
 - Transport to Area 3 exterior (upper), update logic for spiderspark trick and raise underwater bomb jump out of gravity suit check layer.
 
 
 Miscellaneous changes for can spiderspark to being an AND of can spiderspark and the trick at intermediate for non-intended spidersparks