### PR TITLE
Dread: Add Power Bomb Limitations to Preset Summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
+- Added: Power Bomb Limitations now shows up on the Preset Summary when enabled.
+
 #### Logic Database
 
 ##### Ferenia

--- a/randovania/games/dread/layout/preset_describer.py
+++ b/randovania/games/dread/layout/preset_describer.py
@@ -116,6 +116,9 @@ class DreadPresetDescriber(GamePresetDescriber):
                 {
                     "X Starts Released": configuration.x_starts_released,
                 },
+                {
+                    "Power Bomb Limitations": configuration.nerf_power_bombs,
+                },
             ],
             "Environmental Damage": _format_environmental_damage(configuration),
         }

--- a/test/games/dread/layout/test_dread_describer.py
+++ b/test/games/dread/layout/test_dread_describer.py
@@ -64,13 +64,16 @@ def _get_expected_game_changes_text(rb_damage_mode: DreadRavenBeakDamageMode):
         return [
             "Open Hanubia Shortcut, Easier Path to Itorash in Hanubia",
             "Raven Beak Damage: Unmodified",
+            "Power Bomb Limitations",
         ]
     elif rb_damage_mode == DreadRavenBeakDamageMode.CONSISTENT_HIGH:
         return [
             "Open Hanubia Shortcut, Easier Path to Itorash in Hanubia",
             "Raven Beak Damage: Consistent, without damage reduction",
+            "Power Bomb Limitations",
         ]
     else:
         return [
             "Open Hanubia Shortcut, Easier Path to Itorash in Hanubia",
+            "Power Bomb Limitations",
         ]


### PR DESCRIPTION
- Added: Power Bomb Limitations now shows up on the Preset Summary when enabled.