### PR TITLE
MSR - Add Diggernaut Chase Sequence reward as boss location

### DIFF
--- a/randovania/games/samus_returns/generator/bootstrap.py
+++ b/randovania/games/samus_returns/generator/bootstrap.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 def all_dna_locations(game: GameDescription, config: MSRArtifactConfig) -> list[PickupNode]:
     locations = []
-    _boss_indices = [37, 139, 171]
+    _boss_indices = [37, 99, 139, 171]
     _stronger_metroid_indices = [177, 178, 181, 185, 186, 187, 188, 192, 193, 199, 200, 202, 205, 209]
 
     for node in game.region_list.all_nodes:

--- a/randovania/games/samus_returns/generator/pool_creator.py
+++ b/randovania/games/samus_returns/generator/pool_creator.py
@@ -50,8 +50,8 @@ def artifact_pool(game: GameDescription, config: MSRArtifactConfig) -> PoolResul
     if config.prefer_stronger_metroids:
         max_artifacts += 14
     if config.prefer_bosses:
-        if max_artifacts <= 36:
-            max_artifacts += 3
+        if max_artifacts <= 35:
+            max_artifacts += 4
     if not config.prefer_metroids and not config.prefer_stronger_metroids and not config.prefer_bosses:
         max_artifacts = 39
     if config.required_artifacts > max_artifacts:

--- a/randovania/games/samus_returns/gui/preset_settings/msr_goal_tab.py
+++ b/randovania/games/samus_returns/gui/preset_settings/msr_goal_tab.py
@@ -58,8 +58,8 @@ class PresetMSRGoal(PresetTab, Ui_PresetMSRGoal):
         if self.prefer_stronger_metroids_check.isChecked():
             preferred += 14
         if self.prefer_bosses_check.isChecked():
-            if preferred <= 36:
-                preferred += 3
+            if preferred <= 35:
+                preferred += 4
         if preferred == 0:
             preferred = 39
         return preferred

--- a/randovania/gui/ui_files/preset_msr_goal.ui
+++ b/randovania/gui/ui_files/preset_msr_goal.ui
@@ -118,7 +118,7 @@
        <item>
         <widget class="QCheckBox" name="prefer_bosses_check">
          <property name="text">
-          <string>Prefer Bosses (Arachnus, Diggernaut, Queen Metroid)</string>
+          <string>Prefer Bosses (Arachnus, Diggernaut Chase Reward, Diggernaut, Queen Metroid)</string>
          </property>
         </widget>
        </item>

--- a/test/games/samus_returns/generator/test_msr_bootstrap.py
+++ b/test/games/samus_returns/generator/test_msr_bootstrap.py
@@ -20,7 +20,7 @@ from randovania.generator.pickup_pool import pool_creator
         (MSRArtifactConfig(True, True, False, 39), range(172, 211)),
         (MSRArtifactConfig(False, False, False, 6), [37, 41, 48, 149, 86, 93]),
         (MSRArtifactConfig(False, False, False, 0), []),
-        (MSRArtifactConfig(False, False, True, 3), [37, 139, 171]),
+        (MSRArtifactConfig(False, False, True, 4), [37, 99, 139, 171]),
         (MSRArtifactConfig(True, False, False, 1), [183]),
         (MSRArtifactConfig(False, True, False, 2), [178, 187]),
         (MSRArtifactConfig(True, True, True, 1), [197]),

--- a/test/games/samus_returns/gui/preset_settings/test_msr_goal_tab.py
+++ b/test/games/samus_returns/gui/preset_settings/test_msr_goal_tab.py
@@ -16,10 +16,10 @@ from randovania.interface_common.preset_editor import PresetEditor
     [
         (True, False, False, 25),
         (False, True, False, 14),
-        (False, False, True, 3),
+        (False, False, True, 4),
         (True, True, False, 39),
-        (True, False, True, 28),
-        (False, True, True, 17),
+        (True, False, True, 29),
+        (False, True, True, 18),
         (True, True, True, 39),
     ],
 )


### PR DESCRIPTION
I added the Diggernaut Chase Sequence reward (vanilla Space Jump) as a boss location to add more value to the boss goal. It fits since Diggernaut is a boss, so the chase, although removed, could be considered a "boss" or something equivalent in importance. A neat side effect of this is now every even area has a boss check (2, 4, 6, 8). This is also more relevant now since the area has be relocked by Charge, so it's less "free" to access.

![image](https://github.com/randovania/randovania/assets/38679103/400969f1-097f-459d-8bc4-dab041017b91)
