### PR TITLE
Use wordwrap for prime/echoes energy labels

### DIFF
--- a/randovania/gui/ui_files/preset_patcher_energy.ui
+++ b/randovania/gui/ui_files/preset_patcher_energy.ui
@@ -42,9 +42,9 @@
        <property name="geometry">
         <rect>
          <x>0</x>
-         <y>-35</y>
-         <width>460</width>
-         <height>661</height>
+         <y>0</y>
+         <width>451</width>
+         <height>778</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -189,6 +189,9 @@
              <property name="text">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Configure how Dark Aether safe zones operate and how logic uses them.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
           </layout>
@@ -264,7 +267,7 @@
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Configure how much damage per second you take in Dark Aether, per suit.&lt;br/&gt;Light Suit is always imune.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="wordWrap">
-              <bool>false</bool>
+              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -320,6 +323,9 @@
             <widget class="QLabel" name="heated_damage_description">
              <property name="text">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Configure how much damage per second you take in heated rooms, when you don't have proper protection.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Makes sure that the marked text labels are wrapping now.
![grafik](https://github.com/randovania/randovania/assets/38186597/1f39ac80-a5db-4cf5-8e99-9f4fdbd9c153)
