### PR TITLE
Randomprime v1.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Prime
 
+- Fixed: Some rooms not appearing on map when "Open map from start" export option is selected
 - Fixed: Parasite Queen permadeath when skipping death cutscene
 - Fixed: Black bar in Control Tower cutscene
 - Fixed: Minor PAL issues regarding Skippable Cutscenes in Exterior Docking Hangar and Sunchamber

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ exporters = [
     "open-dread-rando>=2.8.3",
 
     # Metroid Prime 1
-    "py_randomprime>=1.20.3",
+    "py_randomprime>=1.20.4",
     "random-enemy-attributes>=1.0.3",
 
     # Metroid Prime 1/2

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -814,9 +814,9 @@ class PrimePatchDataFactory(PatchDataFactory):
             starting_memo = None
 
         if self.cosmetic_patches.open_map and self.configuration.teleporters.is_vanilla:
-            map_default_state = "Visible"
+            map_default_state = "Always"
         else:
-            map_default_state = "Default"
+            map_default_state = "MapStationOrVisit"
 
         credits_string = credits_spoiler.prime_trilogy_credits(
             self.configuration.standard_pickup_configuration,

--- a/requirements.txt
+++ b/requirements.txt
@@ -206,7 +206,7 @@ psutil==5.9.6
     #   pytest-xdist
 py-cord==2.4.1
     # via randovania (setup.py)
-py-randomprime==1.20.3
+py-randomprime==1.20.4
     # via
     #   open-prime-rando
     #   randovania (setup.py)


### PR DESCRIPTION
The patcher export modifications are to avoid deprecated enum values. The new values are equivalent functionality.