### PR TITLE
Fix Burenia fan item logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: Pseudo Wave Beam to break the bottom right blob in Burenia Hub to Dairon. Requires Slide and Gravity Suit or Diffusion Beam.
 - Fixed: When using Power Bomb to break the bottom right blob in Burenia Hub to Dairon, also require the ability to shoot a beam.
-- Fixed: Burenia Hub to Dairon: Getting the item in the fan with only Flash Shift now requires at least one Flash Shift Upgrade as well
+- Fixed: Burenia Hub to Dairon: Getting the item in the fan with only Flash Shift now requires at least one Flash Shift Upgrade as well, and also only requires Intermediate movement (instead of Advanced).
 
 ### AM2R
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: Pseudo Wave Beam to break the bottom right blob in Burenia Hub to Dairon. Requires Slide and Gravity Suit or Diffusion Beam.
 - Fixed: When using Power Bomb to break the bottom right blob in Burenia Hub to Dairon, also require the ability to shoot a beam.
+- Fixed: Burenia Hub to Dairon: Getting the item in the fan with only Flash Shift now requires at least one Flash Shift Upgrade as well
 
 ### AM2R
 

--- a/randovania/games/dread/logic_database/Burenia.json
+++ b/randovania/games/dread/logic_database/Burenia.json
@@ -1481,6 +1481,15 @@
                                                         "amount": 3,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "FlashUpgrade",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }

--- a/randovania/games/dread/logic_database/Burenia.json
+++ b/randovania/games/dread/logic_database/Burenia.json
@@ -1478,7 +1478,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Movement",
-                                                        "amount": 3,
+                                                        "amount": 2,
                                                         "negate": false
                                                     }
                                                 },

--- a/randovania/games/dread/logic_database/Burenia.txt
+++ b/randovania/games/dread/logic_database/Burenia.txt
@@ -258,7 +258,7 @@ Extra - asset_id: collision_camera_002
           Speed Booster
           # A grounded bomb jump with cross bombs to get past the fan
           Movement (Beginner) and Lay Cross Bomb
-          Flash Shift and Movement (Advanced)
+          Flash Shift and Flash Shift Upgrade and Movement (Advanced)
   > Event - Dairon Hub Grapple Block
       Grapple Beam
   > Raft - Top Water Level

--- a/randovania/games/dread/logic_database/Burenia.txt
+++ b/randovania/games/dread/logic_database/Burenia.txt
@@ -258,7 +258,7 @@ Extra - asset_id: collision_camera_002
           Speed Booster
           # A grounded bomb jump with cross bombs to get past the fan
           Movement (Beginner) and Lay Cross Bomb
-          Flash Shift and Flash Shift Upgrade and Movement (Advanced)
+          Flash Shift and Flash Shift Upgrade and Movement (Intermediate)
   > Event - Dairon Hub Grapple Block
       Grapple Beam
   > Raft - Top Water Level


### PR DESCRIPTION
The "Flash-only" trick to get the item in the Burenia fan requires the player to Flash Shift quickly twice to the left. The logic didn't have a Flash Shift Upgrade in the requirements, so a seed could end up being unsolvable if the player was not given enough upgrades.