### PR TITLE
Fixes beginner amorbis logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.0] - 2024-01-??
+
+### Metroid Prime 2: Echoes
+
+#### Logic Database
+
+- Changed: Revised Amorbis requirements (trivial requires a good weapon + 1 E, beginner requires either a weapon or 1 E, intermediate neither)
+
 ## [7.1.0] - 2023-12-??
 
 - Fixed: Bug with progressive suits in the autotracker always highlighting first suit

--- a/randovania/games/prime2/logic_database/Agon Wastes.json
+++ b/randovania/games/prime2/logic_database/Agon Wastes.json
@@ -14672,6 +14672,168 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "damage",
+                                            "name": "DarkWorld1",
+                                            "amount": 30,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 100,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Shoot Supers"
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Light",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "LightAmmo",
+                                                                                            "amount": 60,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 100,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Shoot Supers"
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Light",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "LightAmmo",
+                                                                                            "amount": 60,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "damage",
+                                            "name": "Damage",
+                                            "amount": 10,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -15787,7 +15949,7 @@
                                         "data": {
                                             "type": "damage",
                                             "name": "DarkWorld1",
-                                            "amount": 50,
+                                            "amount": 30,
                                             "negate": false
                                         }
                                     },
@@ -15849,15 +16011,6 @@
                                                                                         "type": "resource",
                                                                                         "data": {
                                                                                             "type": "items",
-                                                                                            "name": "Charge",
-                                                                                            "amount": 1,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "items",
                                                                                             "name": "Light",
                                                                                             "amount": 1,
                                                                                             "negate": false
@@ -15896,12 +16049,50 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "resource",
+                                                                "type": "or",
                                                                 "data": {
-                                                                    "type": "damage",
-                                                                    "name": "Damage",
-                                                                    "amount": 30,
-                                                                    "negate": false
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 100,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Shoot Supers"
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Light",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "LightAmmo",
+                                                                                            "amount": 60,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
                                                                 }
                                                             }
                                                         ]
@@ -15934,6 +16125,15 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "damage",
+                                            "name": "Damage",
+                                            "amount": 10,
+                                            "negate": false
                                         }
                                     }
                                 ]

--- a/randovania/games/prime2/logic_database/Agon Wastes.txt
+++ b/randovania/games/prime2/logic_database/Agon Wastes.txt
@@ -1885,7 +1885,20 @@ Extra - in_dark_aether: True
   > Event - Dark Agon Temple Key Gate
       Dark Agon Key 1 and Dark Agon Key 2 and Dark Agon Key 3
   > Event - Amorbis
-      Morph Ball Bomb and Morph Ball and After Dark Agon Temple Key Gate
+      All of the following:
+          Morph Ball Bomb and Morph Ball and After Dark Agon Temple Key Gate and Normal Damage ≥ 10 and Dark World Damage ≥ 30
+          Any of the following:
+              Combat (Intermediate)
+              All of the following:
+                  Normal Damage ≥ 100
+                  Any of the following:
+                      Shoot Supers
+                      Light Beam and Light Ammo ≥ 60
+              All of the following:
+                  Combat (Beginner)
+                  Any of the following:
+                      Normal Damage ≥ 100 or Shoot Supers
+                      Light Beam and Light Ammo ≥ 60
   > Safe Zone (Behind Key Gate)
       All of the following:
           After Dark Agon Temple Key Gate
@@ -1992,15 +2005,19 @@ Extra - in_dark_aether: True
       Dark Agon Key 1 and Dark Agon Key 2 and Dark Agon Key 3 and Morph Ball Bomb and Morph Ball and Space Jump Boots and Bomb Space Jump (Expert) and Single Room Out of Bounds (Expert) and Slope Jump (Expert) and Standable Terrain (Expert) and Dark World Damage ≥ 175
   > Event - Amorbis
       All of the following:
-          Morph Ball Bomb and Morph Ball and Dark World Damage ≥ 50
+          Morph Ball Bomb and Morph Ball and Normal Damage ≥ 10 and Dark World Damage ≥ 30
           Dark World Damage ≥ 30 or Activate Safe Zone
           Any of the following:
               All of the following:
                   Normal Damage ≥ 100
                   Any of the following:
                       Shoot Supers
-                      Charge Beam and Light Beam and Light Ammo ≥ 60
-              Combat (Beginner) and Normal Damage ≥ 30
+                      Light Beam and Light Ammo ≥ 60
+              All of the following:
+                  Combat (Beginner)
+                  Any of the following:
+                      Normal Damage ≥ 100 or Shoot Supers
+                      Light Beam and Light Ammo ≥ 60
               Combat (Intermediate) and Dark World Damage ≥ 10
 
 ----------------


### PR DESCRIPTION
At some point, some logic seems to have been added to perform an in-bounds Amorbis trigger skip after lowering the key gate, but we ended up with duplicate pathways to the Amorbis event.

The pathway from the Dark Agon Temple Access door -> Amorbis had only the barest minimum requirements to complete, while the path from the safe zone on the other side of the fight trigger -> Amorbis had some combat trick logic.

Even for the pathway from the safe zone to the fight, I thought that Combat (Beginner) requiring only 30 extra health was a bit tight, so refactored this a bit:

Things that make fight easier:
-1 extra E on top of bare minimum health reqs
-Either supers or light beam and some ammo (I don't think charge really matters that much in this fight with light beam, so removed it as a requirement for considering light a 'good weapon')

So then trivial requires both of those things, beginner requires one or the other, and intermediate goes back to bare minimum health reqs.