### PR TITLE
MSR - Teleporter updates A1-A4

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 1.json
+++ b/randovania/games/samus_returns/logic_database/Area 1.json
@@ -7665,12 +7665,10 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Teleporter": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "Area 1 Teleporter",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         },
                         "Tunnel to Teleporter Access": {

--- a/randovania/games/samus_returns/logic_database/Area 1.txt
+++ b/randovania/games/samus_returns/logic_database/Area 1.txt
@@ -1266,7 +1266,7 @@ Extra - asset_id: collision_camera_049
   * Layers: default
   * Open Passage to Shaft East/Dock to Teleporter Room
   > Teleporter
-      After Area 1 - Teleporter Unlocked
+      Trivial
   > Tunnel to Teleporter Access
       Lay Any Bomb
   > Event - Teleporter Unlocked

--- a/randovania/games/samus_returns/logic_database/Area 2 - Entrance.json
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Entrance.json
@@ -797,12 +797,10 @@
                             }
                         },
                         "Teleporter": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "Area 2 Entrance Teleporter",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         },
                         "Door to Chozo Seal (Bottom)": {

--- a/randovania/games/samus_returns/logic_database/Area 2 - Entrance.txt
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Entrance.txt
@@ -150,7 +150,7 @@ Extra - asset_id: collision_camera_003
   > Pickup (Missile Tank)
       Morph Ball
   > Teleporter
-      After Area 2 (Entrance) - Teleporter Unlocked
+      Trivial
   > Door to Chozo Seal (Bottom)
       Trivial
   > Door to Alpha+ Arena

--- a/randovania/games/samus_returns/logic_database/Area 2 - Exterior.json
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Exterior.json
@@ -203,12 +203,10 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Teleporter": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "Area 2 Exterior Teleporter Upper",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         },
                         "Door to Outer Hub Shaft (Bottom)": {
@@ -4343,29 +4341,12 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Teleporter": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "Area 2 Exterior Teleporter Heat",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Varia",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "type": "items",
+                                "name": "Varia",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Door to Hot Split": {

--- a/randovania/games/samus_returns/logic_database/Area 2 - Exterior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Exterior.txt
@@ -18,7 +18,7 @@ Extra - asset_id: collision_camera_005
   * Extra - actor_type: weightactivatedplatform
   * Extra - start_point_actor_name: ST_FromArea02B
   > Teleporter
-      After Area 2 (Exterior) - Teleporter Unlocked (Upper)
+      Trivial
   > Door to Outer Hub Shaft (Bottom)
       Baby Metroid or Lay Any Bomb
   > Door to Outer Hub Shaft (Top)
@@ -747,7 +747,7 @@ Extra - asset_id: collision_camera_032
 > Below Pickup; Heals? False
   * Layers: default
   > Teleporter
-      Varia Suit and After Area 2 (Exterior) - Teleporter Unlocked (Heat)
+      Varia Suit
   > Door to Hot Split
       Varia Suit
   > Pickup (Missile Tank)

--- a/randovania/games/samus_returns/logic_database/Area 2 - Interior.json
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Interior.json
@@ -2785,12 +2785,10 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Teleporter": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "Area 2 Interior Teleporter",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         },
                         "Under Teleporter": {

--- a/randovania/games/samus_returns/logic_database/Area 2 - Interior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Interior.txt
@@ -455,7 +455,7 @@ Extra - asset_id: collision_camera016
 > Next to Teleporter; Heals? False
   * Layers: default
   > Teleporter
-      After Area 2 (Interior) - Teleporter Unlocked
+      Trivial
   > Under Teleporter
       Morph Ball
   > Event - Teleporter Unlocked

--- a/randovania/games/samus_returns/logic_database/Area 3 - Exterior.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Exterior.json
@@ -1103,12 +1103,10 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Teleporter": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "Area 3 Exterior Teleporter West",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         },
                         "Event - Teleporter Unlocked": {
@@ -1638,12 +1636,10 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Teleporter": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "Area 3 Exterior Teleporter East",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         },
                         "Event - Teleporter Unlocked": {

--- a/randovania/games/samus_returns/logic_database/Area 3 - Exterior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Exterior.txt
@@ -177,7 +177,7 @@ Extra - asset_id: collision_camera_023
   * Layers: default
   * Open Passage to Outer Hub/Dock to Outer Hub Teleporter
   > Teleporter
-      After Area 3 (Exterior) - Teleporter Unlocked (West)
+      Trivial
   > Event - Teleporter Unlocked
       Trivial
 
@@ -267,7 +267,7 @@ Extra - asset_id: collision_camera_030
   * Extra - actor_name: Door017
   * Extra - actor_type: doorpowerpower
   > Teleporter
-      After Area 3 (Exterior) - Teleporter Unlocked (East)
+      Trivial
   > Event - Teleporter Unlocked
       Trivial
   > Below Crumble Blocks

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior East.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior East.json
@@ -1493,12 +1493,10 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Teleporter": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "Area 3 Interior East Teleporter",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         },
                         "Event - Teleporter Unlocked": {

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior East.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior East.txt
@@ -245,7 +245,7 @@ Extra - asset_id: collision_camera_019
   * Extra - actor_name: Door005
   * Extra - actor_type: doorchargecharge
   > Teleporter
-      After Area 3 (Interior East) - Teleporter Unlocked
+      Trivial
   > Event - Teleporter Unlocked
       Trivial
 

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior West.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior West.json
@@ -3799,12 +3799,10 @@
                             }
                         },
                         "Teleporter": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "Area 3 Interior East Teleporter Lower",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         },
                         "Door to Shaft West": {
@@ -6281,29 +6279,12 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Teleporter": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "Area 3 Interior West Teleporter Upper",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Event - Teleporter Unlocked": {

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior West.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior West.txt
@@ -594,7 +594,7 @@ Extra - asset_id: collision_camera_026
   > Save Station
       Trivial
   > Teleporter
-      After Area 3 (Interior West) - Teleporter Unlocked (Lower)
+      Trivial
   > Door to Shaft West
       Any of the following:
           Single-wall Wall Jump (Intermediate) or Climb Rooms Vertically (No High Jump)
@@ -1018,7 +1018,7 @@ Extra - asset_id: collision_camera_040
   * Extra - actor_name: Door020
   * Extra - actor_type: doorpowerpower
   > Teleporter
-      Morph Ball and After Area 3 (Interior West) - Teleporter Unlocked (Upper)
+      Morph Ball
   > Event - Teleporter Unlocked
       Trivial
 

--- a/randovania/games/samus_returns/logic_database/Area 4 - East.json
+++ b/randovania/games/samus_returns/logic_database/Area 4 - East.json
@@ -3867,12 +3867,10 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Teleporter": {
-                            "type": "resource",
+                            "type": "and",
                             "data": {
-                                "type": "events",
-                                "name": "Area 4 East Teleporter",
-                                "amount": 1,
-                                "negate": false
+                                "comment": null,
+                                "items": []
                             }
                         },
                         "Door to Main Shaft": {

--- a/randovania/games/samus_returns/logic_database/Area 4 - East.txt
+++ b/randovania/games/samus_returns/logic_database/Area 4 - East.txt
@@ -580,7 +580,7 @@ Extra - asset_id: collision_camera_012
 > Next to Teleporter; Heals? False
   * Layers: default
   > Teleporter
-      After Area 4 (East) - Teleporter Unlocked
+      Trivial
   > Door to Main Shaft
       Any of the following:
           Space Jump or Use Spider Ball

--- a/randovania/games/samus_returns/logic_database/Area 4 - West.json
+++ b/randovania/games/samus_returns/logic_database/Area 4 - West.json
@@ -512,29 +512,12 @@
                             "data": "Lay Any Bomb"
                         },
                         "Teleporter": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Morph",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "Area 4 West Teleporter",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Dock to Moheek Hallway": {

--- a/randovania/games/samus_returns/logic_database/Area 4 - West.txt
+++ b/randovania/games/samus_returns/logic_database/Area 4 - West.txt
@@ -87,7 +87,7 @@ Extra - asset_id: collision_camera_001
   > Save Station
       Lay Any Bomb
   > Teleporter
-      Morph Ball and After Area 4 (West) - Teleporter Unlocked
+      Morph Ball
   > Dock to Moheek Hallway
       Trivial
   > Event - Teleporter Unlocked


### PR DESCRIPTION
Fixes the connections to the teleporters in Areas 1-4 to not require the event of unlocking them to access the node itself