### PR TITLE
Add tournament layouts to the auto-tracker for Prime and Echoes

### DIFF
--- a/randovania/data/gui_assets/tracker/prime1-pixel-tournament.json
+++ b/randovania/data/gui_assets/tracker/prime1-pixel-tournament.json
@@ -1,0 +1,224 @@
+{
+	"game": "prime1",
+	"elements": [
+		{
+			"row": 3,
+			"column": 6,
+			"resources": [
+				"Wavebuster"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/wavebuster.png"
+		},
+		{
+			"row": 3,
+			"column": 7,
+			"resources": [
+				"Ice Spreader"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/ice_spreader.png"
+		},
+		{
+			"row": 4,
+			"column": 4,
+			"resources": [
+				"Grapple Beam"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/grapple_beam.png"
+		},
+		{
+			"row": 4,
+			"column": 5,
+			"resources": [
+				"Charge Beam"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/charge_beam.png"
+		},
+		{
+			"row": 4,
+			"column": 6,
+			"resources": [
+				"Wave Beam"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/wave_beam.png"
+		},
+		{
+			"row": 3,
+			"column": 8,
+			"resources": [
+				"Flamethrower"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/flamethrower.png"
+		},
+		{
+			"row": 3,
+			"column": 9,
+			"resources": [
+				"Varia Suit"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/varia_suit.png"
+		},
+		{
+			"row": 3,
+			"column": 2,
+			"resources": [
+				"Space Jump Boots"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/space_jump_boots.png"
+		},
+		{
+			"row": 3,
+			"column": 3,
+			"resources": [
+				"Morph Ball"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/morph_ball.png"
+		},
+		{
+			"row": 3,
+			"column": 4,
+			"resources": [
+				"Missile"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/missile_launcher.png"
+		},
+		{
+			"row": 3,
+			"column": 5,
+			"resources": [
+				"Super Missile"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/super_missile.png"
+		},
+		{
+			"row": 4,
+			"column": 7,
+			"resources": [
+				"Ice Beam"
+			],
+			"image_path": [
+				"gui_assets/tracker/pixel-icons/mp1/ice_beam.png"
+			]
+		},
+		{
+			"row": 4,
+			"column": 2,
+			"resources": [
+				"Morph Ball Bomb"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/morph_ball_bomb.png"
+		},
+		{
+			"row": 4,
+			"column": 3,
+			"resources": [
+				"Boost Ball"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/boost_ball_alt.png"
+		},
+		{
+			"row": 5,
+			"column": 2,
+			"resources": [
+				"Spider Ball"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/spider_ball.png"
+		},
+		{
+			"row": 5,
+			"column": 3,
+			"resources": [
+				"Power Bomb"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/power_bomb.png"
+		},
+		{
+			"row": 4,
+			"column": 8,
+			"resources": [
+				"Plasma Beam"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/plasma_beam.png"
+		},
+		{
+			"row": 4,
+			"column": 9,
+			"resources": [
+				"Gravity Suit"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/gravity_suit.png"
+		},
+		{
+			"row": 5,
+			"column": 8,
+			"resources": [
+				"X-Ray Visor"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/x-ray_visor_alt.png"
+		},
+		{
+			"row": 5,
+			"column": 9,
+			"resources": [
+				"Phazon Suit"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/phazon_suit.png"
+		},
+		{
+			"row": 5,
+			"column": 4,
+			"resources": [
+				"Scan Visor"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/scan_visor_alt.png"
+		},
+		{
+			"row": 5,
+			"column": 5,
+			"resources": [],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/energy_tank.png"
+		},
+		{
+			"row": 6,
+			"column": 5,
+			"label": "14",
+			"style": "font:18pt 'Consolas';color:white",
+			"resources": [
+				"Energy Tank"
+			]
+		},
+		{
+			"row": 5,
+			"column": 6,
+			"resources": [],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/artifact.png"
+		},
+		{
+			"row": 6,
+			"column": 6,
+			"label": "12",
+			"style": "font:18pt 'Consolas';color:white",
+			"resources": [
+				"Artifact of Truth",
+				"Artifact of Strength",
+				"Artifact of Elder",
+				"Artifact of Wild",
+				"Artifact of Lifegiver",
+				"Artifact of Warrior",
+				"Artifact of Chozo",
+				"Artifact of Nature",
+				"Artifact of Sun",
+				"Artifact of World",
+				"Artifact of Spirit",
+				"Artifact of Newborn"
+			]
+		},
+		{
+			"row": 5,
+			"column": 7,
+			"resources": [
+				"Thermal Visor"
+			],
+			"image_path": "gui_assets/tracker/pixel-icons/mp1/thermal_visor_alt.png"
+		}
+	]
+}

--- a/randovania/data/gui_assets/tracker/prime1-pixel-tournament.json
+++ b/randovania/data/gui_assets/tracker/prime1-pixel-tournament.json
@@ -180,7 +180,7 @@
 		{
 			"row": 6,
 			"column": 5,
-			"label": "14",
+			"label": "{capacity}",
 			"style": "font:18pt 'Consolas';color:white",
 			"resources": [
 				"Energy Tank"
@@ -195,7 +195,7 @@
 		{
 			"row": 6,
 			"column": 6,
-			"label": "12",
+			"label": "{capacity}",
 			"style": "font:18pt 'Consolas';color:white",
 			"resources": [
 				"Artifact of Truth",

--- a/randovania/data/gui_assets/tracker/prime1-pixel-tournament.json
+++ b/randovania/data/gui_assets/tracker/prime1-pixel-tournament.json
@@ -181,7 +181,7 @@
 			"row": 6,
 			"column": 5,
 			"label": "{capacity}",
-			"style": "font:18pt 'Consolas';color:white",
+			"style": "font:18pt;color:white",
 			"resources": [
 				"Energy Tank"
 			]
@@ -196,7 +196,7 @@
 			"row": 6,
 			"column": 6,
 			"label": "{capacity}",
-			"style": "font:18pt 'Consolas';color:white",
+			"style": "font:18pt;color:white",
 			"resources": [
 				"Artifact of Truth",
 				"Artifact of Strength",

--- a/randovania/data/gui_assets/tracker/prime2-pixel-tournament.json
+++ b/randovania/data/gui_assets/tracker/prime2-pixel-tournament.json
@@ -176,7 +176,7 @@
             "row": 6,
             "column": 4,
             "label": "{capacity}",
-            "style": "font:18pt 'Consolas';color:white",
+            "style": "font:18pt;color:white",
             "resources": [
                 "Dark Agon Key 1",
                 "Dark Agon Key 2",
@@ -193,7 +193,7 @@
             "row": 6,
             "column": 5,
             "label": "{capacity}",
-            "style": "font:18pt 'Consolas';color:white",
+            "style": "font:18pt;color:white",
             "resources": [
                 "Dark Torvus Key 1",
                 "Dark Torvus Key 2",
@@ -210,7 +210,7 @@
             "row": 6,
             "column": 6,
             "label": "{capacity}",
-            "style": "font:18pt 'Consolas';color:white",
+            "style": "font:18pt;color:white",
             "resources": [
                 "Ing Hive Key 1",
                 "Ing Hive Key 2",
@@ -227,7 +227,7 @@
             "row": 6,
             "column": 7,
             "label": "{capacity}",
-            "style": "font:18pt 'Consolas';color:white",
+            "style": "font:18pt;color:white",
             "resources": [
                 "Sky Temple Key 1",
                 "Sky Temple Key 2",

--- a/randovania/data/gui_assets/tracker/prime2-pixel-tournament.json
+++ b/randovania/data/gui_assets/tracker/prime2-pixel-tournament.json
@@ -1,0 +1,244 @@
+{
+    "game": "prime2",
+    "elements": [
+        {
+            "row": 3,
+            "column": 6,
+            "resources": [
+                "Super Missile"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/super_missile.png"
+        },
+        {
+            "row": 3,
+            "column": 7,
+            "resources": [
+                "Seeker Launcher"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/seeker_launcher.png"
+        },
+        {
+            "row": 4,
+            "column": 4,
+            "resources": [
+                "Dark Beam"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/dark_beam.png"
+        },
+        {
+            "row": 4,
+            "column": 5,
+            "resources": [
+                "Light Beam"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/light_beam.png"
+        },
+        {
+            "row": 4,
+            "column": 6,
+            "resources": [
+                "Annihilator Beam"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/annihilator_beam.png"
+        },
+        {
+            "row": 3,
+            "column": 8,
+            "resources": [
+                "Dark Visor"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/dark_visor_alt.png"
+        },
+        {
+            "row": 3,
+            "column": 9,
+            "resources": [
+                "Echo Visor"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/echo_visor_alt.png"
+        },
+        {
+            "row": 3,
+            "column": 2,
+            "resources": [
+                "Space Jump Boots"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/space_jump_boots.png"
+        },
+        {
+            "row": 3,
+            "column": 3,
+            "resources": [
+                "Gravity Boost"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/gravity_boost.png"
+        },
+        {
+            "row": 3,
+            "column": 4,
+            "resources": [
+                "Grapple Beam"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/grapple_beam.png"
+        },
+        {
+            "row": 3,
+            "column": 5,
+            "resources": [
+                "Screw Attack"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/screw_attack.png"
+        },
+        {
+            "row": 4,
+            "column": 7,
+            "resources": [
+                "Dark Suit",
+                "Light Suit"
+            ],
+            "disabled_image_path": "gui_assets/tracker/pixel-icons/mp2/dark_suit.png",
+            "image_path": [
+                "gui_assets/tracker/pixel-icons/mp2/dark_suit.png",
+                "gui_assets/tracker/pixel-icons/mp2/light_suit.png"
+            ]
+        },
+        {
+            "row": 4,
+            "column": 2,
+            "resources": [
+                "Morph Ball Bomb"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/morph_ball_bomb.png"
+        },
+        {
+            "row": 4,
+            "column": 3,
+            "resources": [
+                "Power Bomb"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/power_bomb.png"
+        },
+        {
+            "row": 5,
+            "column": 2,
+            "resources": [
+                "Boost Ball"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/boost_ball_alt.png"
+        },
+        {
+            "row": 5,
+            "column": 3,
+            "resources": [
+                "Spider Ball"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/spider_ball.png"
+        },
+        {
+            "row": 4,
+            "column": 8,
+            "resources": [
+                "Violet Translator"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/violet_translator_alt.png"
+        },
+        {
+            "row": 4,
+            "column": 9,
+            "resources": [
+                "Amber Translator"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/amber_translator_alt.png"
+        },
+        {
+            "row": 5,
+            "column": 8,
+            "resources": [
+                "Emerald Translator"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/emerald_translator_alt.png"
+        },
+        {
+            "row": 5,
+            "column": 9,
+            "resources": [
+                "Cobalt Translator"
+            ],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/cobalt_translator_alt.png"
+        },
+        {
+            "row": 5,
+            "column": 4,
+            "resources": [],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/dark_agon_key-recolored.png"
+        },
+        {
+            "row": 6,
+            "column": 4,
+            "label": "{capacity}",
+            "style": "font:18pt 'Consolas';color:white",
+            "resources": [
+                "Dark Agon Key 1",
+                "Dark Agon Key 2",
+                "Dark Agon Key 3"
+            ]
+        },
+        {
+            "row": 5,
+            "column": 5,
+            "resources": [],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/dark_torvus_key-recolored.png"
+        },
+        {
+            "row": 6,
+            "column": 5,
+            "label": "{capacity}",
+            "style": "font:18pt 'Consolas';color:white",
+            "resources": [
+                "Dark Torvus Key 1",
+                "Dark Torvus Key 2",
+                "Dark Torvus Key 3"
+            ]
+        },
+        {
+            "row": 5,
+            "column": 6,
+            "resources": [],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/ing_hive_key-recolored.png"
+        },
+        {
+            "row": 6,
+            "column": 6,
+            "label": "{capacity}",
+            "style": "font:18pt 'Consolas';color:white",
+            "resources": [
+                "Ing Hive Key 1",
+                "Ing Hive Key 2",
+                "Ing Hive Key 3"
+            ]
+        },
+        {
+            "row": 5,
+            "column": 7,
+            "resources": [],
+            "image_path": "gui_assets/tracker/pixel-icons/mp2/sky_temple_key.png"
+        },
+        {
+            "row": 6,
+            "column": 7,
+            "label": "{capacity}",
+            "style": "font:18pt 'Consolas';color:white",
+            "resources": [
+                "Sky Temple Key 1",
+                "Sky Temple Key 2",
+                "Sky Temple Key 3",
+                "Sky Temple Key 4",
+                "Sky Temple Key 5",
+                "Sky Temple Key 6",
+                "Sky Temple Key 7",
+                "Sky Temple Key 8",
+                "Sky Temple Key 9"
+            ]
+        }
+    ]
+}

--- a/randovania/data/gui_assets/tracker/trackers.json
+++ b/randovania/data/gui_assets/tracker/trackers.json
@@ -13,7 +13,7 @@
             "Pixel Art (8 Lines)": "prime1-pixel-eight-lines.json",
             "Pixel Art (3 Lines)": "prime1-pixel-three-lines.json",
             "Pixel Art (2 Lines)": "prime1-pixel-two-lines.json",
-            "Pixel Art (Tournament)": "prime1-pixel-tournament.json"
+            "Pixel Art (Stream-friendly)": "prime1-pixel-tournament.json"
         },
         "prime2": {
             "Game Art (Standard)": "prime2-game.json",
@@ -24,7 +24,7 @@
             "Pixel Art (8 Lines)": "prime2-pixel-eight-lines.json",
             "Pixel Art (3 Lines)": "prime2-pixel-three-lines.json",
             "Pixel Art (2 Lines)": "prime2-pixel-two-lines.json",
-            "Pixel Art (Tournament)": "prime2-pixel-tournament.json",
+            "Pixel Art (Stream-friendly)": "prime2-pixel-tournament.json",
             "Pixel Art (Debug Info)": "prime2-debug.json"
         },
         "prime3": {

--- a/randovania/data/gui_assets/tracker/trackers.json
+++ b/randovania/data/gui_assets/tracker/trackers.json
@@ -12,7 +12,8 @@
             "Pixel Art (Standard)": "prime1-pixel.json",
             "Pixel Art (8 Lines)": "prime1-pixel-eight-lines.json",
             "Pixel Art (3 Lines)": "prime1-pixel-three-lines.json",
-            "Pixel Art (2 Lines)": "prime1-pixel-two-lines.json"
+            "Pixel Art (2 Lines)": "prime1-pixel-two-lines.json",
+            "Pixel Art (Tournament)": "prime1-pixel-tournament.json"
         },
         "prime2": {
             "Game Art (Standard)": "prime2-game.json",
@@ -23,6 +24,7 @@
             "Pixel Art (8 Lines)": "prime2-pixel-eight-lines.json",
             "Pixel Art (3 Lines)": "prime2-pixel-three-lines.json",
             "Pixel Art (2 Lines)": "prime2-pixel-two-lines.json",
+            "Pixel Art (Tournament)": "prime2-pixel-tournament.json",
             "Pixel Art (Debug Info)": "prime2-debug.json"
         },
         "prime3": {

--- a/randovania/gui/widgets/item_tracker_widget.py
+++ b/randovania/gui/widgets/item_tracker_widget.py
@@ -107,6 +107,8 @@ class ItemTrackerWidget(QtWidgets.QGroupBox):
             elif "label" in element:
                 label = QtWidgets.QLabel(self)
                 label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+                if "style" in element:
+                    label.setStyleSheet(element["style"])
                 text_template = element["label"]
                 labels.append(label)
 


### PR DESCRIPTION
Gives the key/artifact labels big numbers to make them easier to see on tournament restreams.
This is achieved by allowing tracker layouts to define stylesheets for labels.  

![image](https://github.com/randovania/randovania/assets/22754714/a264077d-a055-40a1-867c-a4cafc16b9b6)

![image](https://github.com/randovania/randovania/assets/22754714/76da155f-aef6-4963-8114-27661f8ac582)
