### PR TITLE
Surface, Area 1, and Area 4 logic additions

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 1.json
+++ b/randovania/games/samus_returns/logic_database/Area 1.json
@@ -5645,6 +5645,36 @@
                                                                         }
                                                                     ]
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Climb Rooms Vertically (High Jump)"
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "Wall Jumps: https://youtu.be/365gGTEEtYg",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Walljump",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Movement",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
                                                             }
                                                         ]
                                                     }
@@ -5671,6 +5701,32 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "UnmorphExtend",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "High Wall Jump: https://www.youtube.com/watch?v=U2rVU-4bxUA",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Boots",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Walljump",
                                                         "amount": 2,
                                                         "negate": false
                                                     }

--- a/randovania/games/samus_returns/logic_database/Area 1.json
+++ b/randovania/games/samus_returns/logic_database/Area 1.json
@@ -5647,8 +5647,13 @@
                                                                 }
                                                             },
                                                             {
-                                                                "type": "template",
-                                                                "data": "Climb Rooms Vertically (High Jump)"
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Boots",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             },
                                                             {
                                                                 "type": "and",

--- a/randovania/games/samus_returns/logic_database/Area 1.txt
+++ b/randovania/games/samus_returns/logic_database/Area 1.txt
@@ -916,11 +916,16 @@ Extra - asset_id: collision_camera_035
           All of the following:
               Phase Drift
               Any of the following:
+                  Climb Rooms Vertically (High Jump)
                   Stand on Frozen Enemy (Intermediate) and Fully Freeze Enemy
                   # Unmorph extend: Need to test its difficulty without HJ but its trivial with it. Will record video when i do so.
                   Movement (Advanced) and Unmorph Extend (Advanced)
+                  # Wall Jumps: https://youtu.be/365gGTEEtYg
+                  Movement (Intermediate) and Walljump (Intermediate)
           # SWJ + UE: https://youtu.be/sBO8Pew_ijQ
           Single-wall Wall Jump (Advanced) and Unmorph Extend (Intermediate)
+          # High Wall Jump: https://www.youtube.com/watch?v=U2rVU-4bxUA
+          High Jump Boots and Walljump (Intermediate)
 
 > Tunnel to Alpha Shaft Right; Heals? False
   * Layers: default

--- a/randovania/games/samus_returns/logic_database/Area 1.txt
+++ b/randovania/games/samus_returns/logic_database/Area 1.txt
@@ -916,7 +916,7 @@ Extra - asset_id: collision_camera_035
           All of the following:
               Phase Drift
               Any of the following:
-                  Climb Rooms Vertically (High Jump)
+                  High Jump Boots
                   Stand on Frozen Enemy (Intermediate) and Fully Freeze Enemy
                   # Unmorph extend: Need to test its difficulty without HJ but its trivial with it. Will record video when i do so.
                   Movement (Advanced) and Unmorph Extend (Advanced)

--- a/randovania/games/samus_returns/logic_database/Area 4 - East.json
+++ b/randovania/games/samus_returns/logic_database/Area 4 - East.json
@@ -4925,7 +4925,50 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Wave Beam"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Power Bomb"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Phase",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Baby",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }

--- a/randovania/games/samus_returns/logic_database/Area 4 - East.json
+++ b/randovania/games/samus_returns/logic_database/Area 4 - East.json
@@ -576,8 +576,20 @@
                                         }
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Shoot Wave Beam"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Shoot Wave Beam"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Lay Power Bomb"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "or",
@@ -4925,50 +4937,7 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Shoot Wave Beam"
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Lay Power Bomb"
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Phase",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Baby",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
+                                "items": []
                             }
                         }
                     }

--- a/randovania/games/samus_returns/logic_database/Area 4 - East.txt
+++ b/randovania/games/samus_returns/logic_database/Area 4 - East.txt
@@ -738,7 +738,9 @@ Extra - asset_id: collision_camera_AfterChase
   * Layers: default
   * Tunnel to Main Shaft/Tunnel to Space Jump Room
   > Door from Main Shaft
-      Trivial
+      All of the following:
+          Lay Power Bomb or Shoot Wave Beam
+          Baby Metroid or Phase Drift
 
 > Bottom of Shaft; Heals? False
   * Layers: default

--- a/randovania/games/samus_returns/logic_database/Area 4 - East.txt
+++ b/randovania/games/samus_returns/logic_database/Area 4 - East.txt
@@ -106,7 +106,8 @@ Extra - asset_id: collision_camera_001
   * Extra - actor_type: doorpowerpower
   > Door to Space Jump Room (Bottom)
       All of the following:
-          Morph Ball and Shoot Wave Beam
+          Morph Ball
+          Lay Power Bomb or Shoot Wave Beam
           Any of the following:
               Baby Metroid or Phase Drift
               Spiderspark (Advanced) and Can Spiderspark
@@ -738,9 +739,7 @@ Extra - asset_id: collision_camera_AfterChase
   * Layers: default
   * Tunnel to Main Shaft/Tunnel to Space Jump Room
   > Door from Main Shaft
-      All of the following:
-          Lay Power Bomb or Shoot Wave Beam
-          Baby Metroid or Phase Drift
+      Trivial
 
 > Bottom of Shaft; Heals? False
   * Layers: default

--- a/randovania/games/samus_returns/logic_database/Surface - West.json
+++ b/randovania/games/samus_returns/logic_database/Surface - West.json
@@ -1415,7 +1415,7 @@
                                                             {
                                                                 "type": "or",
                                                                 "data": {
-                                                                    "comment": null,
+                                                                    "comment": "Break the bomb block",
                                                                     "items": [
                                                                         {
                                                                             "type": "template",
@@ -1469,7 +1469,7 @@
                                                             {
                                                                 "type": "or",
                                                                 "data": {
-                                                                    "comment": null,
+                                                                    "comment": "Break the baby blocks",
                                                                     "items": [
                                                                         {
                                                                             "type": "and",

--- a/randovania/games/samus_returns/logic_database/Surface - West.json
+++ b/randovania/games/samus_returns/logic_database/Surface - West.json
@@ -1379,7 +1379,7 @@
                                                                 "data": {
                                                                     "type": "tricks",
                                                                     "name": "Spiderspark",
-                                                                    "amount": 2,
+                                                                    "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             }
@@ -1393,20 +1393,53 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Lay Power Bomb"
+                                                                "data": "Simple IBJ"
                                                             },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Spider",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
                                                             {
                                                                 "type": "or",
                                                                 "data": {
                                                                     "comment": null,
                                                                     "items": [
                                                                         {
-                                                                            "type": "resource",
+                                                                            "type": "template",
+                                                                            "data": "Lay Power Bomb"
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
                                                                             "data": {
-                                                                                "type": "items",
-                                                                                "name": "Space",
-                                                                                "amount": 1,
-                                                                                "negate": false
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Lay Bomb"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "AirMorph",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         },
                                                                         {
@@ -1432,18 +1465,6 @@
                                                                         }
                                                                     ]
                                                                 }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Lay Bomb"
                                                             },
                                                             {
                                                                 "type": "or",
@@ -1453,13 +1474,13 @@
                                                                         {
                                                                             "type": "and",
                                                                             "data": {
-                                                                                "comment": null,
+                                                                                "comment": "SJ Movement: https://www.youtube.com/watch?v=9BBVrE-_2UU",
                                                                                 "items": [
                                                                                     {
                                                                                         "type": "resource",
                                                                                         "data": {
                                                                                             "type": "items",
-                                                                                            "name": "Armor",
+                                                                                            "name": "Space",
                                                                                             "amount": 1,
                                                                                             "negate": false
                                                                                         }
@@ -1468,8 +1489,8 @@
                                                                                         "type": "resource",
                                                                                         "data": {
                                                                                             "type": "tricks",
-                                                                                            "name": "IBJ",
-                                                                                            "amount": 2,
+                                                                                            "name": "Movement",
+                                                                                            "amount": 3,
                                                                                             "negate": false
                                                                                         }
                                                                                     }
@@ -1479,75 +1500,28 @@
                                                                         {
                                                                             "type": "and",
                                                                             "data": {
-                                                                                "comment": null,
+                                                                                "comment": "Freeze enemy: https://www.youtube.com/watch?v=3WCWdGmymCU",
                                                                                 "items": [
+                                                                                    {
+                                                                                        "type": "template",
+                                                                                        "data": "Fully Freeze Enemy"
+                                                                                    },
                                                                                     {
                                                                                         "type": "resource",
                                                                                         "data": {
-                                                                                            "type": "items",
-                                                                                            "name": "Spider",
-                                                                                            "amount": 1,
+                                                                                            "type": "tricks",
+                                                                                            "name": "FrozenEnemy",
+                                                                                            "amount": 2,
                                                                                             "negate": false
                                                                                         }
                                                                                     },
                                                                                     {
-                                                                                        "type": "or",
+                                                                                        "type": "resource",
                                                                                         "data": {
-                                                                                            "comment": null,
-                                                                                            "items": [
-                                                                                                {
-                                                                                                    "type": "and",
-                                                                                                    "data": {
-                                                                                                        "comment": null,
-                                                                                                        "items": [
-                                                                                                            {
-                                                                                                                "type": "resource",
-                                                                                                                "data": {
-                                                                                                                    "type": "items",
-                                                                                                                    "name": "Armor",
-                                                                                                                    "amount": 1,
-                                                                                                                    "negate": false
-                                                                                                                }
-                                                                                                            },
-                                                                                                            {
-                                                                                                                "type": "resource",
-                                                                                                                "data": {
-                                                                                                                    "type": "tricks",
-                                                                                                                    "name": "IBJ",
-                                                                                                                    "amount": 1,
-                                                                                                                    "negate": false
-                                                                                                                }
-                                                                                                            }
-                                                                                                        ]
-                                                                                                    }
-                                                                                                },
-                                                                                                {
-                                                                                                    "type": "and",
-                                                                                                    "data": {
-                                                                                                        "comment": null,
-                                                                                                        "items": [
-                                                                                                            {
-                                                                                                                "type": "resource",
-                                                                                                                "data": {
-                                                                                                                    "type": "items",
-                                                                                                                    "name": "Space",
-                                                                                                                    "amount": 1,
-                                                                                                                    "negate": false
-                                                                                                                }
-                                                                                                            },
-                                                                                                            {
-                                                                                                                "type": "resource",
-                                                                                                                "data": {
-                                                                                                                    "type": "tricks",
-                                                                                                                    "name": "AirMorph",
-                                                                                                                    "amount": 1,
-                                                                                                                    "negate": false
-                                                                                                                }
-                                                                                                            }
-                                                                                                        ]
-                                                                                                    }
-                                                                                                }
-                                                                                            ]
+                                                                                            "type": "items",
+                                                                                            "name": "Armor",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
                                                                                         }
                                                                                     }
                                                                                 ]

--- a/randovania/games/samus_returns/logic_database/Surface - West.txt
+++ b/randovania/games/samus_returns/logic_database/Surface - West.txt
@@ -184,10 +184,12 @@ Extra - asset_id: collision_camera_017
               Spider Ball and Simple IBJ
               All of the following:
                   Any of the following:
+                      # Break the bomb block
                       Lay Power Bomb
                       Mid-Air Morph (Beginner) and Lay Bomb
                       Lightning Armor and Simple IBJ
                   Any of the following:
+                      # Break the baby blocks
                       # SJ Movement: https://www.youtube.com/watch?v=9BBVrE-_2UU
                       Space Jump and Movement (Advanced)
                       # Freeze enemy: https://www.youtube.com/watch?v=3WCWdGmymCU

--- a/randovania/games/samus_returns/logic_database/Surface - West.txt
+++ b/randovania/games/samus_returns/logic_database/Surface - West.txt
@@ -180,21 +180,18 @@ Extra - asset_id: collision_camera_017
       All of the following:
           Baby Metroid
           Any of the following:
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spiderspark (Beginner) and Can Spiderspark
+              Spider Ball and Simple IBJ
               All of the following:
-                  Lay Power Bomb
                   Any of the following:
-                      Space Jump
+                      Lay Power Bomb
+                      Mid-Air Morph (Beginner) and Lay Bomb
                       Lightning Armor and Simple IBJ
-              All of the following:
-                  Lay Bomb
                   Any of the following:
-                      Lightning Armor and Infinite Bomb Jump (Intermediate)
-                      All of the following:
-                          Spider Ball
-                          Any of the following:
-                              Lightning Armor and Infinite Bomb Jump (Beginner)
-                              Space Jump and Mid-Air Morph (Beginner)
+                      # SJ Movement: https://www.youtube.com/watch?v=9BBVrE-_2UU
+                      Space Jump and Movement (Advanced)
+                      # Freeze enemy: https://www.youtube.com/watch?v=3WCWdGmymCU
+                      Lightning Armor and Stand on Frozen Enemy (Intermediate) and Fully Freeze Enemy
 
 ----------------
 Landing Site Storage


### PR DESCRIPTION
- Adds a Space Jump method and an Ice Beam method to collect the Transport to Area 8 Missile Tank in Surface - West.
- For the same item as above, IBJ now requires Spider Ball to collect the item since the Baby will not destroy the blocks otherwise.
- In Area 1's Central Shaft, adds two different High Jump methods to climb to the top, and one with only Phase Drift.
- Adds Power Bombs as an alternative to Wave for Area 4 - East's Main Shaft bottom Super Missile Tank.