### PR TITLE
AM2R: Add Unlocked save station option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### AM2R
 
 - Added: New option to place DNA anywhere.
+- Added: New option to force Save Station doors to be blue.
 
 #### Logic Database
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### AM2R
 
 - Added: New option to place DNA anywhere.
-- Added: New option to force Save Station doors to be blue.
+- Added: New option to force Save Station doors to be normal doors.
 
 #### Logic Database
 

--- a/randovania/games/am2r/generator/base_patches_factory.py
+++ b/randovania/games/am2r/generator/base_patches_factory.py
@@ -1,7 +1,45 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from randovania.game_description.db.dock_node import DockNode
+from randovania.games.am2r.layout.am2r_configuration import AM2RConfiguration
 from randovania.generator.base_patches_factory import BasePatchesFactory
+
+if TYPE_CHECKING:
+    from random import Random
+
+    from randovania.game_description.db.dock import DockWeakness
+    from randovania.game_description.game_description import GameDescription
+    from randovania.game_description.game_patches import GamePatches
+    from randovania.layout.base.base_configuration import BaseConfiguration
 
 
 class AM2RBasePatchesFactory(BasePatchesFactory):
-    pass
+    def create_base_patches(
+        self,
+        configuration: BaseConfiguration,
+        rng: Random,
+        game: GameDescription,
+        is_multiworld: bool,
+        player_index: int,
+        rng_required: bool = True,
+    ) -> GamePatches:
+        assert isinstance(configuration, AM2RConfiguration)
+        parent = super().create_base_patches(configuration, rng, game, is_multiworld, player_index, rng_required)
+
+        get_node = game.region_list.typed_node_by_identifier
+
+        dock_weakness: list[tuple[DockNode, DockWeakness]] = []
+        blue_door = game.dock_weakness_database.get_by_weakness("door", "Normal Door")
+
+        if configuration.blue_save_doors:
+            for area in game.region_list.all_areas:
+                if area.extra.get("unlocked_save_station"):
+                    for node in area.nodes:
+                        if isinstance(node, DockNode) and node.dock_type.short_name == "door":
+                            dock_weakness.append((node, blue_door))
+                            # TODO: This is not correct in entrance rando
+                            dock_weakness.append((get_node(node.default_connection, DockNode), blue_door))
+
+        return parent.assign_dock_weakness(dock_weakness)

--- a/randovania/games/am2r/gui/preset_settings/am2r_patches_tab.py
+++ b/randovania/games/am2r/gui/preset_settings/am2r_patches_tab.py
@@ -28,6 +28,7 @@ _FIELDS = [
     "softlock_prevention_blocks",
     "a3_entrance_blocks",
     "screw_blocks",
+    "blue_save_doors",
 ]
 
 

--- a/randovania/games/am2r/layout/am2r_configuration.py
+++ b/randovania/games/am2r/layout/am2r_configuration.py
@@ -34,6 +34,7 @@ class AM2RConfiguration(BaseConfiguration):
     grave_grotto_blocks: bool
     nest_pipes: bool
     a3_entrance_blocks: bool
+    blue_save_doors: bool
 
     @classmethod
     def game_enum(cls) -> RandovaniaGame:

--- a/randovania/games/am2r/logic_database/Distribution Center.json
+++ b/randovania/games/am2r/logic_database/Distribution Center.json
@@ -1413,7 +1413,8 @@
                         "x": 60,
                         "y": 47
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {
@@ -6381,7 +6382,8 @@
                         "x": 70,
                         "y": 43
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {
@@ -8365,7 +8367,8 @@
                         "x": 68,
                         "y": 48
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Door to Facility Storage Intersection East": {

--- a/randovania/games/am2r/logic_database/Distribution Center.txt
+++ b/randovania/games/am2r/logic_database/Distribution Center.txt
@@ -185,6 +185,7 @@ Extra - minimap_data: [{'x': 58, 'y': 46}, {'x': 58, 'y': 47}, {'x': 59, 'y': 46
 Energy Distribution Entrance Save Station
 Extra - map_name: rm_a5c03
 Extra - minimap_data: [{'x': 60, 'y': 47}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 17
@@ -929,6 +930,7 @@ Extra - minimap_data: [{'x': 67, 'y': 45}, {'x': 67, 'y': 46}, {'x': 68, 'y': 45
 Distribution Facility Save Station
 Extra - map_name: rm_a5c19
 Extra - minimap_data: [{'x': 70, 'y': 43}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 18
@@ -1214,6 +1216,7 @@ Extra - minimap_data: [{'x': 64, 'y': 48}, {'x': 65, 'y': 48}, {'x': 66, 'y': 48
 Facility Storage Save Station
 Extra - map_name: rm_a5c28
 Extra - minimap_data: [{'x': 68, 'y': 48}]
+Extra - unlocked_save_station: True
 > Door to Facility Storage Intersection East; Heals? False
   * Layers: default
   * Normal Door to Facility Storage Intersection East/Door to Facility Storage Save Station; Dock Lock Rando incompatible with: Spider Ball Door, Screw Attack Door

--- a/randovania/games/am2r/logic_database/GFS Thoth.json
+++ b/randovania/games/am2r/logic_database/GFS Thoth.json
@@ -1950,7 +1950,8 @@
                         "x": 45,
                         "y": 6
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Door to Thoth West Lift": {

--- a/randovania/games/am2r/logic_database/GFS Thoth.txt
+++ b/randovania/games/am2r/logic_database/GFS Thoth.txt
@@ -271,6 +271,7 @@ Extra - minimap_data: [{'x': 47, 'y': 5}, {'x': 48, 'y': 5}, {'x': 49, 'y': 5}]
 Thoth Save Station Access
 Extra - map_name: rm_a8a12
 Extra - minimap_data: [{'x': 44, 'y': 6}, {'x': 45, 'y': 6}]
+Extra - unlocked_save_station: True
 > Door to Thoth West Lift; Heals? False
   * Layers: default
   * Normal Door to Thoth West Lift/Door to Thoth Save Station Access

--- a/randovania/games/am2r/logic_database/Genetics Laboratory.json
+++ b/randovania/games/am2r/logic_database/Genetics Laboratory.json
@@ -1465,7 +1465,8 @@
                         "x": 8,
                         "y": 23
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {

--- a/randovania/games/am2r/logic_database/Genetics Laboratory.txt
+++ b/randovania/games/am2r/logic_database/Genetics Laboratory.txt
@@ -214,6 +214,7 @@ Extra - minimap_data: [{'x': 7, 'y': 23}]
 Laboratory Save Station
 Extra - map_name: rm_a7b02A
 Extra - minimap_data: [{'x': 8, 'y': 23}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 24

--- a/randovania/games/am2r/logic_database/Golden Temple.json
+++ b/randovania/games/am2r/logic_database/Golden Temple.json
@@ -523,7 +523,8 @@
                         "x": 53,
                         "y": 14
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {
@@ -2647,7 +2648,8 @@
                         "x": 69,
                         "y": 11
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {
@@ -3696,7 +3698,8 @@
                         "x": 60,
                         "y": 11
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {

--- a/randovania/games/am2r/logic_database/Golden Temple.txt
+++ b/randovania/games/am2r/logic_database/Golden Temple.txt
@@ -68,6 +68,7 @@ Extra - minimap_data: [{'x': 51, 'y': 13}]
 Breeding Grounds Save Station
 Extra - map_name: rm_a1h02
 Extra - minimap_data: [{'x': 53, 'y': 14}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 3
@@ -325,6 +326,7 @@ Extra - minimap_data: [{'x': 68, 'y': 9}, {'x': 69, 'y': 9}]
 Outer Temple Save Station
 Extra - map_name: rm_a1h07
 Extra - minimap_data: [{'x': 68, 'y': 11}, {'x': 69, 'y': 11}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 5
@@ -457,6 +459,7 @@ Extra - minimap_data: [{'x': 50, 'y': 11}]
 Inner Temple Save Station
 Extra - map_name: rm_a1a01
 Extra - minimap_data: [{'x': 60, 'y': 11}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 4

--- a/randovania/games/am2r/logic_database/Hydro Station.json
+++ b/randovania/games/am2r/logic_database/Hydro Station.json
@@ -1784,7 +1784,8 @@
                         "x": 32,
                         "y": 21
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {
@@ -2362,7 +2363,8 @@
                         "x": 36,
                         "y": 18
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Vertical Dock to Hydro Station Exterior": {
@@ -7975,7 +7977,8 @@
                         "x": 27,
                         "y": 22
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {

--- a/randovania/games/am2r/logic_database/Hydro Station.txt
+++ b/randovania/games/am2r/logic_database/Hydro Station.txt
@@ -253,6 +253,7 @@ Extra - minimap_data: [{'x': 38, 'y': 21}]
 Inner Save Station
 Extra - map_name: rm_a2a01A
 Extra - minimap_data: [{'x': 32, 'y': 21}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 6
@@ -347,6 +348,7 @@ Extra - minimap_data: []
 Arachnus Save Station
 Extra - map_name: rm_a2a03
 Extra - minimap_data: [{'x': 35, 'y': 18}, {'x': 36, 'y': 18}]
+Extra - unlocked_save_station: True
 > Vertical Dock to Hydro Station Exterior; Heals? False
   * Layers: default
   * 2-Tiles Wide Dock to Hydro Station Exterior/Vertical Dock to Arachnus Save Station
@@ -1197,6 +1199,7 @@ Extra - minimap_data: [{'x': 28, 'y': 19}, {'x': 28, 'y': 20}, {'x': 28, 'y': 21
 Breeding Grounds Save Station
 Extra - map_name: rm_a2c02
 Extra - minimap_data: [{'x': 27, 'y': 22}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 7

--- a/randovania/games/am2r/logic_database/Industrial Complex.json
+++ b/randovania/games/am2r/logic_database/Industrial Complex.json
@@ -13,7 +13,8 @@
                         "x": 52,
                         "y": 24
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {
@@ -3207,7 +3208,8 @@
                         "x": 65,
                         "y": 21
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "In Sand": {
@@ -6942,7 +6944,8 @@
                         "x": 73,
                         "y": 28
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {

--- a/randovania/games/am2r/logic_database/Industrial Complex.txt
+++ b/randovania/games/am2r/logic_database/Industrial Complex.txt
@@ -2,6 +2,7 @@
 Eastern Cave Save Station
 Extra - map_name: rm_a3h01
 Extra - minimap_data: [{'x': 52, 'y': 24}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 9
@@ -433,6 +434,7 @@ Extra - minimap_data: [{'x': 60, 'y': 22}, {'x': 60, 'y': 23}, {'x': 61, 'y': 22
 Upper Factory Save Station
 Extra - map_name: rm_a3a02
 Extra - minimap_data: [{'x': 64, 'y': 21}, {'x': 65, 'y': 21}]
+Extra - unlocked_save_station: True
 > In Sand; Heals? False
   * Layers: default
   > Vertical Dock to Industrial Complex Exterior
@@ -963,6 +965,7 @@ Extra - minimap_data: [{'x': 74, 'y': 25}, {'x': 74, 'y': 26}, {'x': 74, 'y': 27
 Lower Factory Save Station
 Extra - map_name: rm_a3a17
 Extra - minimap_data: [{'x': 73, 'y': 28}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 11

--- a/randovania/games/am2r/logic_database/Main Caves.json
+++ b/randovania/games/am2r/logic_database/Main Caves.json
@@ -1106,7 +1106,8 @@
                         "x": 37,
                         "y": 13
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {
@@ -1509,7 +1510,8 @@
                         "x": 26,
                         "y": 15
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {
@@ -5628,7 +5630,8 @@
                         "x": 42,
                         "y": 33
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {
@@ -7464,7 +7467,8 @@
                         "x": 43,
                         "y": 51
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {
@@ -10156,7 +10160,8 @@
                         "x": 54,
                         "y": 34
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {

--- a/randovania/games/am2r/logic_database/Main Caves.txt
+++ b/randovania/games/am2r/logic_database/Main Caves.txt
@@ -124,6 +124,7 @@ Extra - minimap_data: [{'x': 34, 'y': 13}, {'x': 35, 'y': 12}, {'x': 35, 'y': 13
 Surface Cave Save Station
 Extra - map_name: rm_a0h03a
 Extra - minimap_data: [{'x': 37, 'y': 13}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 1
@@ -197,6 +198,7 @@ Extra - minimap_data: [{'x': 27, 'y': 15}, {'x': 28, 'y': 15}, {'x': 29, 'y': 15
 Surface Pond Save Station
 Extra - map_name: rm_a0h04c
 Extra - minimap_data: [{'x': 26, 'y': 15}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 2
@@ -786,6 +788,7 @@ Extra - minimap_data: [{'x': 43, 'y': 30}, {'x': 43, 'y': 31}, {'x': 43, 'y': 32
 Western Cave Save Station
 Extra - map_name: rm_a0h26
 Extra - minimap_data: [{'x': 42, 'y': 33}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 13
@@ -1030,6 +1033,7 @@ Extra - minimap_data: [{'x': 44, 'y': 47}, {'x': 44, 'y': 48}, {'x': 44, 'y': 49
 Southern Cave Save Station
 Extra - map_name: rm_a0h33
 Extra - minimap_data: [{'x': 43, 'y': 51}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 20
@@ -1463,6 +1467,7 @@ Extra - minimap_data: [{'x': 53, 'y': 34}, {'x': 53, 'y': 35}, {'x': 53, 'y': 36
 Mining Facility Save Station
 Extra - map_name: rm_a0h19
 Extra - minimap_data: [{'x': 54, 'y': 34}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 12

--- a/randovania/games/am2r/logic_database/The Depths.json
+++ b/randovania/games/am2r/logic_database/The Depths.json
@@ -3024,7 +3024,8 @@
                         "x": 10,
                         "y": 56
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {
@@ -4546,7 +4547,8 @@
                         "x": 22,
                         "y": 39
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {
@@ -6613,7 +6615,8 @@
                         "x": 9,
                         "y": 42
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Horizontal Dock to Bubble Lair Skorp Snag": {
@@ -6829,7 +6832,8 @@
                         "x": 23,
                         "y": 53
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {

--- a/randovania/games/am2r/logic_database/The Depths.txt
+++ b/randovania/games/am2r/logic_database/The Depths.txt
@@ -493,6 +493,7 @@ Extra - minimap_data: [{'x': 11, 'y': 55}, {'x': 11, 'y': 56}]
 Omega Nest Entrance Save Station
 Extra - map_name: rm_a6a15
 Extra - minimap_data: [{'x': 10, 'y': 56}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 21
@@ -744,6 +745,7 @@ Extra - minimap_data: [{'x': 21, 'y': 29}, {'x': 21, 'y': 30}, {'x': 21, 'y': 31
 Bubble Lair Save Station
 Extra - map_name: rm_a6b06
 Extra - minimap_data: [{'x': 22, 'y': 39}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 22
@@ -1044,6 +1046,7 @@ Extra - minimap_data: [{'x': 10, 'y': 39}, {'x': 10, 'y': 40}, {'x': 10, 'y': 41
 Bubble Lair Exit Save Station
 Extra - map_name: rm_a6b16
 Extra - minimap_data: [{'x': 9, 'y': 42}]
+Extra - unlocked_save_station: True
 > Horizontal Dock to Bubble Lair Skorp Snag; Heals? False
   * Layers: default
   * 3-Tiles High Dock to Bubble Lair Skorp Snag/Horizontal Dock to Bubble Lair Exit Save Station
@@ -1086,6 +1089,7 @@ Extra - minimap_data: [{'x': 11, 'y': 37}, {'x': 11, 'y': 39}, {'x': 12, 'y': 37
 Hideout Save Station
 Extra - map_name: rm_a6a10B
 Extra - minimap_data: [{'x': 23, 'y': 53}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True
   * Layers: default
   * Extra - save_room: 26

--- a/randovania/games/am2r/logic_database/The Tower.json
+++ b/randovania/games/am2r/logic_database/The Tower.json
@@ -5717,7 +5717,8 @@
                         "x": 37,
                         "y": 32
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {
@@ -6245,7 +6246,8 @@
                         "x": 34,
                         "y": 39
                     }
-                ]
+                ],
+                "unlocked_save_station": true
             },
             "nodes": {
                 "Save Station": {

--- a/randovania/games/am2r/logic_database/The Tower.txt
+++ b/randovania/games/am2r/logic_database/The Tower.txt
@@ -712,6 +712,7 @@ Extra - minimap_data: [{'x': 25, 'y': 42}, {'x': 26, 'y': 42}, {'x': 27, 'y': 42
 Exterior Save Station
 Extra - map_name: rm_a4h14
 Extra - minimap_data: [{'x': 37, 'y': 32}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 15
@@ -816,6 +817,7 @@ Extra - minimap_data: [{'x': 35, 'y': 39}, {'x': 35, 'y': 40}, {'x': 35, 'y': 41
 Inner Save Station
 Extra - map_name: rm_a4a02
 Extra - minimap_data: [{'x': 34, 'y': 39}]
+Extra - unlocked_save_station: True
 > Save Station; Heals? True; Spawn Point; Default Node
   * Layers: default
   * Extra - save_room: 14

--- a/randovania/gui/ui_files/preset_am2r_patches.ui
+++ b/randovania/gui/ui_files/preset_am2r_patches.ui
@@ -204,14 +204,14 @@
            <item>
             <widget class="QCheckBox" name="blue_save_doors_check">
              <property name="text">
-              <string>Force blue Save Station Doors</string>
+              <string>Unlock Save Station Doors</string>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QLabel" name="blue_save_doors_label">
              <property name="text">
-              <string>Ensures all Save Station doors are blue doors, even with door lock rando enabled.</string>
+              <string>Ensures all Save Station doors are normal (blue) doors, even with door lock rando enabled.</string>
              </property>
             </widget>
            </item>

--- a/randovania/gui/ui_files/preset_am2r_patches.ui
+++ b/randovania/gui/ui_files/preset_am2r_patches.ui
@@ -44,7 +44,7 @@
          <x>0</x>
          <y>0</y>
          <width>745</width>
-         <height>944</height>
+         <height>996</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="scroll_layout">
@@ -198,6 +198,20 @@
              </property>
              <property name="wordWrap">
               <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="blue_save_doors_check">
+             <property name="text">
+              <string>Force blue Save Station Doors</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="blue_save_doors_label">
+             <property name="text">
+              <string>Ensures all Save Station doors are blue doors, even with door lock rando enabled.</string>
              </property>
             </widget>
            </item>

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -1023,6 +1023,13 @@ def _migrate_v69(preset: dict) -> dict:
     return preset
 
 
+def _migrate_v70(preset: dict) -> dict:
+    if preset["game"] == "am2r":
+        preset["configuration"]["blue_save_doors"] = False
+
+    return preset
+
+
 _MIGRATIONS = [
     _migrate_v1,  # v1.1.1-247-gaf9e4a69
     _migrate_v2,  # v1.2.2-71-g0fbabe91
@@ -1093,6 +1100,7 @@ _MIGRATIONS = [
     _migrate_v67,
     _migrate_v68,
     _migrate_v69,
+    _migrate_v70,
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/test/games/am2r/generator/test_am2r_base_patches.py
+++ b/test/games/am2r/generator/test_am2r_base_patches.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from random import Random
+
+from randovania.games.am2r.generator.base_patches_factory import AM2RBasePatchesFactory
+from randovania.games.am2r.layout.am2r_configuration import AM2RConfiguration
+from randovania.layout import filtered_database
+
+_door_list = [
+    1047,
+    1751,
+    1259,
+    596,
+    1258,
+    1279,
+    1280,
+    1454,
+    1137,
+    878,
+    409,
+    1246,
+    1248,
+    1330,
+    1281,
+    1336,
+    1331,
+    1393,
+    1361,
+    1491,
+    1257,
+    1416,
+    1614,
+    1561,
+    1720,
+    1656,
+    601,
+]
+
+
+def test_base_patches(am2r_game_description, preset_manager) -> None:
+    # Setup
+    game = am2r_game_description.game
+    base = preset_manager.default_preset_for_game(game).get_preset()
+    preset = dataclasses.replace(base, uuid=uuid.UUID("b41fde84-1f57-4b79-8cd6-3e5a78077fa6"))
+    base_configuration = preset.configuration
+    assert isinstance(base_configuration, AM2RConfiguration)
+    base_configuration = dataclasses.replace(base_configuration, blue_save_doors=True)
+    game_description = filtered_database.game_description_for_layout(base_configuration)
+
+    # Run
+    result = AM2RBasePatchesFactory().create_base_patches(base_configuration, Random(0), game_description, False, 0)
+
+    # Assert
+    for num in _door_list:
+        assert num in result.dock_connection


### PR DESCRIPTION
Planning to later also do another configuration change for am2r (exclude certain doors in labs from being shuffled), not sure how i should handle preset migrations there. Should I just stuff the next thing also into v70? or should i make a v71 for it?