### PR TITLE
AM2R: slight logic adjustments for 2 a3 rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ##### Industrial Complex
 
 - Added: In Lower Factory Intersection: Can now climb the room by shinesparking after a short charge.
+- Added: In Treadmill Room: Going from right to left is now possible via a beginner Shinespark or an intermediate Morph Glide.
 - Fixed: In Lower Factory Intersection: Climbing the room now correctly needs a damage boost for wall jumps.
+- Fixed: In Shirk Prisons: Going from right to left, now requires Morph Ball, or 4 (Super) Missiles.
+- Fixed: In Treadmill Room: Going from right to left via Movement is now impossible.
 - Changed: In Torizo Arena: New weapon, health, and dodging requirements for fighting Torizo.
 
 ##### Genetics Labratory

--- a/randovania/games/am2r/logic_database/Industrial Complex.json
+++ b/randovania/games/am2r/logic_database/Industrial Complex.json
@@ -5522,6 +5522,41 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Morph Ball",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Missiles",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Super Missiles",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -5903,17 +5938,43 @@
                                             "comment": "A way to climb the left",
                                             "items": [
                                                 {
+                                                    "type": "template",
+                                                    "data": "Power Grip Wall"
+                                                },
+                                                {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Movement",
+                                                        "name": "Shinesparking",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Power Grip Wall"
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "Morph Ball",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "MorphGlide",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }

--- a/randovania/games/am2r/logic_database/Industrial Complex.txt
+++ b/randovania/games/am2r/logic_database/Industrial Complex.txt
@@ -761,7 +761,9 @@ Extra - minimap_data: [{'x': 66, 'y': 26}, {'x': 67, 'y': 26}, {'x': 68, 'y': 26
   * Layers: default
   * 4-Tiles High Dock to Treadmill Room/Horizontal Dock to Shirk Prisons
   > Horizontal Dock to Upper Factory Autoad Fork
-      Speed Booster and Disabled Entrance Rando
+      All of the following:
+          Speed Booster and Disabled Entrance Rando
+          Missiles ≥ 4 or Morph Ball or Super Missiles ≥ 4
 
 > Horizontal Dock to Upper Factory Autoad Fork; Heals? False
   * Layers: default
@@ -806,8 +808,10 @@ Extra - minimap_data: [{'x': 70, 'y': 26}, {'x': 71, 'y': 26}, {'x': 72, 'y': 26
   > Horizontal Dock to Shirk Prisons
       All of the following:
           Speed Booster
-          # A way to climb the left
-          Movement (Beginner) or Power Grip Wall
+          Any of the following:
+              # A way to climb the left
+              Shinesparking Tricks (Beginner) or Power Grip Wall
+              Morph Ball and Morph Glide (Intermediate)
   > Pickup (Missile Tank)
       All of the following:
           Morph Ball and Speed Booster and Shinesparking Tricks (Beginner)


### PR DESCRIPTION
- Added: In Treadmill Room: Going from right to left is now possible via a beginner Shinespark or an intermediate Morph Glide.
- Fixed: In Shirk Prisons: Going from right to left, now requires Morph Ball, or 4 (Super) Missiles.
- Fixed: In Treadmill Room: Going from right to left via Movement is now impossible.