### PR TITLE
AM2R: fix research site not being shuffleable

### DIFF
--- a/randovania/games/am2r/logic_database/header.json
+++ b/randovania/games/am2r/logic_database/header.json
@@ -4783,6 +4783,7 @@
                         "Missile Door",
                         "Normal Door",
                         "Power Bomb Door",
+                        "Research Site Open Hatch",
                         "Super Missile Door",
                         "Tester-Locked Door",
                         "Tower Energy Restored Door"
@@ -4810,6 +4811,7 @@
                         "Normal Door",
                         "Plasma Beam Door",
                         "Power Bomb Door",
+                        "Research Site Open Hatch",
                         "Screw Attack Door",
                         "Serris-Locked Door",
                         "Spazer Beam Door",

--- a/randovania/games/am2r/logic_database/header.txt
+++ b/randovania/games/am2r/logic_database/header.txt
@@ -522,6 +522,7 @@ Dock Weaknesses
           Missile Door
           Normal Door
           Power Bomb Door
+          Research Site Open Hatch
           Super Missile Door
           Tester-Locked Door
           Tower Energy Restored Door
@@ -548,6 +549,7 @@ Dock Weaknesses
           Normal Door
           Plasma Beam Door
           Power Bomb Door
+          Research Site Open Hatch
           Screw Attack Door
           Serris-Locked Door
           Spazer Beam Door


### PR DESCRIPTION
#5776 forgot to change the change_from/change_to fields.
This fixes it. No changelog entry needed, as it's already there.