### PR TITLE
AM2R: Wrap starting memo text

### DIFF
--- a/randovania/games/am2r/exporter/patch_data_factory.py
+++ b/randovania/games/am2r/exporter/patch_data_factory.py
@@ -182,9 +182,21 @@ class AM2RPatchDataFactory(PatchDataFactory):
     def _create_starting_popup(self, patches: GamePatches) -> dict | None:
         extra_items = item_names.additional_starting_equipment(patches.configuration, patches.game, patches)
         if extra_items:
+            i = 0
+            items_with_length = [""]
+            # Go through the items, so that we can wrap them
+            for item in extra_items:
+                if len(items_with_length[i] + item) < 60:
+                    if items_with_length[i] != "":
+                        items_with_length[i] = items_with_length[i] + ", " + item
+                    else:
+                        items_with_length[i] = item
+                else:
+                    i += 1
+                    items_with_length.append(item)
             return {
                 "header": "Extra starting items:",
-                "description": ", ".join(extra_items),
+                "description": "#".join(items_with_length),  # A '#' is a newline character in GameMaker
             }
         else:
             return None


### PR DESCRIPTION
Makes the starting text wrap in AM2R. No changelog entry needed, as the starting memo feature was introduced in dev builds after the last stable release.
Before:
![grafik](https://github.com/randovania/randovania/assets/38186597/5bf7c698-6ce1-43a0-a620-04edc30283ba)

After:
![grafik](https://github.com/randovania/randovania/assets/38186597/3388f890-02fa-4a08-b133-6bdb36ff6cdf)
