### PR TITLE
AM2R - Fix A2 EMP Slot Requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.0] - 2024-02-??
+
+### AM2R
+
+#### Logic Database
+
+##### Hydro Station
+
+- Fixed: In Breeding Grounds Entrance: Activating the EMP Slot now properly accounts for Missiles.
+
 ## [7.2.0] - 2024-01-05
 
 - **Major** - Added: Rebranded Randovania icons.

--- a/randovania/games/am2r/logic_database/Hydro Station.json
+++ b/randovania/games/am2r/logic_database/Hydro Station.json
@@ -7946,7 +7946,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Missile Launcher",
+                                                        "name": "Missiles",
                                                         "amount": 20,
                                                         "negate": false
                                                     }

--- a/randovania/games/am2r/logic_database/Hydro Station.txt
+++ b/randovania/games/am2r/logic_database/Hydro Station.txt
@@ -1193,7 +1193,7 @@ Extra - minimap_data: [{'x': 28, 'y': 19}, {'x': 28, 'y': 20}, {'x': 28, 'y': 21
   > Event - EMP Slot
       All of the following:
           After Area 5 - Distribution Center Energy Activated
-          Missile Launcher ≥ 20 or Can Use Bombs
+          Missiles ≥ 20 or Can Use Bombs
 
 ----------------
 Breeding Grounds Save Station


### PR DESCRIPTION
Activating the EMP Slot incorrectly checked for Missile Launchers instead of Missiles