### PR TITLE
AM2R: Add option for generic credits to not have players in colors

### DIFF
--- a/randovania/exporter/hints/credits_spoiler.py
+++ b/randovania/exporter/hints/credits_spoiler.py
@@ -17,10 +17,10 @@ class OwnedPickupLocation(NamedTuple):
     player_name: str | None
     location: PickupLocation
 
-    def export(self, namer: HintNamer) -> str:
+    def export(self, namer: HintNamer, use_player_color: bool = True) -> str:
         hint = namer.format_location(self.location, with_region=True, with_area=True, with_color=False)
         if self.player_name is not None:
-            hint = f"{namer.format_player(self.player_name, with_color=True)}'s {hint}"
+            hint = f"{namer.format_player(self.player_name, with_color=use_player_color)}'s {hint}"
         return hint
 
 
@@ -54,6 +54,7 @@ def generic_credits(
     players_config: PlayersConfiguration,
     namer: HintNamer,
     pickup_name_format: str = "{}",
+    use_player_color: bool = True,
 ) -> dict[str, str]:
     major_pickup_name_order = {
         pickup.name: index for index, pickup in enumerate(standard_pickup_configuration.pickups_state.keys())
@@ -63,7 +64,9 @@ def generic_credits(
         return major_pickup_name_order.get(p.name, math.inf), p.name
 
     details = get_locations_for_major_pickups_and_keys(all_patches, players_config)
-    major_pickups_spoiler = {pickup: [entry.export(namer) for entry in entries] for pickup, entries in details.items()}
+    major_pickups_spoiler = {
+        pickup: [entry.export(namer, use_player_color) for entry in entries] for pickup, entries in details.items()
+    }
 
     return {
         pickup_name_format.format(pickup.name): "\n".join(major_pickups_spoiler[pickup]) or "Nowhere"

--- a/randovania/games/am2r/exporter/hint_namer.py
+++ b/randovania/games/am2r/exporter/hint_namer.py
@@ -35,8 +35,7 @@ def _area_name(region_list: RegionList, pickup_node: PickupNode, hide_region: bo
 
 
 def colorize_text(color: AM2RColor, text: str, with_color: bool) -> str:
-    # FIXME: This is bad. We should instead change generic_credits, to allow coloring item+player
-    if with_color and False:
+    if with_color:
         return f"{color.value}{text}{AM2RColor.WHITE.value}"
     else:
         return text

--- a/randovania/games/am2r/exporter/hint_namer.py
+++ b/randovania/games/am2r/exporter/hint_namer.py
@@ -35,7 +35,8 @@ def _area_name(region_list: RegionList, pickup_node: PickupNode, hide_region: bo
 
 
 def colorize_text(color: AM2RColor, text: str, with_color: bool) -> str:
-    if with_color:
+    # FIXME: This is bad. We should instead change generic_credits, to allow coloring item+player
+    if with_color and False:
         return f"{color.value}{text}{AM2RColor.WHITE.value}"
     else:
         return text

--- a/randovania/games/am2r/exporter/patch_data_factory.py
+++ b/randovania/games/am2r/exporter/patch_data_factory.py
@@ -374,6 +374,8 @@ class AM2RPatchDataFactory(PatchDataFactory):
             self.description.all_patches,
             self.players_config,
             AM2RHintNamer(self.description.all_patches, self.players_config),
+            "{}",
+            False,
         )
         # am2r credits uses the following syntax:
         # * indicates a header


### PR DESCRIPTION
~~Wanted to at least open this PR. Depending on how much effort it is to change generic_credits (should hopefully:tm: just be a signature change?), I might do that later.~~
Hacky way gotten rid of.

Some games (i.e. AM2R) do not support color. In order to avoid writing a whole new credits function, I just added a param to let it not use color.

Needed as part of AM2R MW.