### PR TITLE
Add more am2r offworld models

### DIFF
--- a/randovania/games/am2r/pickup_database/pickup-database.json
+++ b/randovania/games/am2r/pickup_database/pickup-database.json
@@ -612,5 +612,5 @@
         }
     },
     "default_pickups": {},
-    "default_offworld_model": "sItemUnknown"
+    "default_offworld_model": "sItemRDV"
 }

--- a/randovania/games/dread/generator/pool_creator.py
+++ b/randovania/games/dread/generator/pool_creator.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from frozendict import frozendict
+
 from randovania.game_description.pickup import pickup_category
 from randovania.game_description.pickup.pickup_entry import PickupEntry, PickupGeneratorParams, PickupModel
 from randovania.game_description.resources.location_category import LocationCategory
 from randovania.games.dread.layout.dread_configuration import DreadArtifactConfig, DreadConfiguration
+from randovania.games.game import RandovaniaGame
 from randovania.generator.pickup_pool import PoolResults
 
 if TYPE_CHECKING:
@@ -42,6 +45,7 @@ def create_dread_artifact(
         model=PickupModel(game=resource_database.game_enum, name=f"DNA_{artifact_number + 1}"),
         pickup_category=DREAD_ARTIFACT_CATEGORY,
         broad_category=pickup_category.GENERIC_KEY_CATEGORY,
+        offworld_models=frozendict({RandovaniaGame.AM2R: "sItemDNA"}),
         generator_params=PickupGeneratorParams(
             preferred_location_category=LocationCategory.MAJOR,
             probability_offset=0.25,

--- a/randovania/games/dread/pickup_database/pickup-database.json
+++ b/randovania/games/dread/pickup_database/pickup-database.json
@@ -212,6 +212,7 @@
             "broad_category": "beam_related",
             "model_name": "powerup_grapplebeam",
             "offworld_models": {
+                "am2r": "sItemGrappleBeamDread",
                 "prime1": "Grapple Beam",
                 "prime2": "GrappleBeam"
             },
@@ -266,7 +267,7 @@
             "broad_category": "missile_related",
             "model_name": "powerup_icemissile",
             "offworld_models": {
-                "am2r": "sItemIceBeam",
+                "am2r": "sItemIceMissilesDread",
                 "prime1": "Ice Spreader",
                 "prime2": "SuperMissile"
             },
@@ -300,6 +301,7 @@
             "broad_category": "missile_related",
             "model_name": "powerup_stormmissile",
             "offworld_models": {
+                "am2r": "sItemStormMissilesDread",
                 "prime1": "Wavebuster",
                 "prime2": "SeekerLauncher"
             },
@@ -411,7 +413,7 @@
             "broad_category": "morph_ball_related",
             "model_name": "powerup_morphball",
             "offworld_models": {
-                "am2r": "sItemMorphBall",
+                "am2r": "sItemMorphBallDread",
                 "prime1": "Morph Ball"
             },
             "progression": [
@@ -444,7 +446,7 @@
             "broad_category": "morph_ball_related",
             "model_name": "powerup_crossbomb",
             "offworld_models": {
-                "am2r": "sItemBomb",
+                "am2r": "sItemCrossBombsDread",
                 "prime1": "Morph Ball Bomb",
                 "prime2": "MorphBallBomb"
             },
@@ -512,7 +514,7 @@
             "broad_category": "misc",
             "model_name": "powerup_spidermagnet",
             "offworld_models": {
-                "am2r": "sItemSpiderBall",
+                "am2r": "sItemSpiderMagnetDread",
                 "prime1": "Spider Ball",
                 "prime2": "SpiderBall"
             },
@@ -529,7 +531,7 @@
             "broad_category": "misc",
             "model_name": "powerup_speedbooster",
             "offworld_models": {
-                "am2r": "sItemSpeedBooster",
+                "am2r": "sItemSpeedBoosterDread",
                 "prime1": "Boost Ball",
                 "prime2": "BoostBall"
             },
@@ -546,7 +548,7 @@
             "broad_category": "misc",
             "model_name": "powerup_doublejump",
             "offworld_models": {
-                "am2r": "sItemHijump",
+                "am2r": "sItemSpinBoostDread",
                 "prime1": "Space Jump Boots",
                 "prime2": "SpaceJumpBoots"
             },
@@ -629,7 +631,7 @@
             "broad_category": "life_support",
             "model_name": "item_energyfragment",
             "offworld_models": {
-                "am2r": "sItemEnergyTank",
+                "am2r": "sItemEnergyPartDread",
                 "prime1": "Energy Tank",
                 "prime2": "EnergyTankSmall"
             },
@@ -644,7 +646,9 @@
             "pickup_category": "misc",
             "broad_category": "misc",
             "model_name": "item_speedboostupgrade",
-            "offworld_models": {},
+            "offworld_models": {
+                "am2r": "sItemSpeedBoosterUpgrade"
+            },
             "progression": [
                 "SpeedBoostUpgrade"
             ],

--- a/randovania/games/prime1/pickup_database/pickup-database.json
+++ b/randovania/games/prime1/pickup_database/pickup-database.json
@@ -326,7 +326,7 @@
             "broad_category": "morph_ball_related",
             "model_name": "Morph Ball Bomb",
             "offworld_models": {
-                "am2r": "sItemBomb",
+                "am2r": "sItemBombsPrime",
                 "dread": "powerup_bomb",
                 "prime2": "MorphBallBomb"
             },

--- a/randovania/games/prime2/pickup_database/pickup-database.json
+++ b/randovania/games/prime2/pickup_database/pickup-database.json
@@ -488,7 +488,7 @@
             "broad_category": "morph_ball_related",
             "model_name": "PowerBomb",
             "offworld_models": {
-                "am2r": "sItemPBombLauncher",
+                "am2r": "sItemPowerBombLauncherEchoes",
                 "prime1": "Power Bomb",
                 "dread": "powerup_powerbomb"
             },
@@ -511,7 +511,7 @@
             "broad_category": "morph_ball_related",
             "model_name": "BoostBall",
             "offworld_models": {
-                "am2r": "sItemSpeedBooster",
+                "am2r": "sItemCannonBallEchoes",
                 "prime1": "Boost Ball",
                 "dread": "powerup_speedbooster"
             },
@@ -590,7 +590,7 @@
             "broad_category": "movement",
             "model_name": "ScrewAttack",
             "offworld_models": {
-                "am2r": "sItemScrewAttack",
+                "am2r": "sItemScrewAttackEchoes",
                 "dread": "powerup_screwattack"
             },
             "progression": [
@@ -692,7 +692,7 @@
             "broad_category": "beam_related",
             "model_name": "SuperMissile",
             "offworld_models": {
-                "am2r": "sItemSMissileLauncher",
+                "am2r": "sItemSuperMissilesEchoes",
                 "prime1": "Super Missile",
                 "dread": "powerup_supermissile"
             },


### PR DESCRIPTION
I know that Dread DNA cant be placed offworld right now. But thanatos has expressed interest in a feature for that, so I'm just planning ahead for when such a feature will eventually be implemented.