### PR TITLE
Use qdesktopservices instead of webbrowser

### DIFF
--- a/randovania/gui/lib/qt_network_client.py
+++ b/randovania/gui/lib/qt_network_client.py
@@ -4,11 +4,10 @@ import asyncio
 import datetime
 import functools
 import json
-import webbrowser
 from typing import TYPE_CHECKING
 
 import PySide6
-from PySide6 import QtCore, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 from PySide6.QtCore import Signal
 
 import randovania
@@ -157,7 +156,9 @@ class QtNetworkClient(QtCore.QObject, NetworkClient):
 
         sid = await self.server_call("start_discord_login_flow")
         url = self.configuration["server_address"] + f"/login?sid={sid}"
-        webbrowser.open(url)
+        result = QtGui.QDesktopServices.openUrl(QtCore.QUrl(url))
+        if not result:
+            raise RuntimeError("Unable to open a web-browser to login into Discord")
 
     async def login_as_guest(self, name: str = "Unknown"):
         if "guest_secret" not in self.configuration:

--- a/test/gui/lib/test_qt_network_client.py
+++ b/test/gui/lib/test_qt_network_client.py
@@ -78,7 +78,7 @@ async def test_handle_network_errors_exception(skip_qtbot, qapp, mocker, excepti
 
 
 async def test_login_to_discord(client, mocker: pytest_mock.MockerFixture):
-    mock_browser_open = mocker.patch("webbrowser.open")
+    mock_browser_open = mocker.patch("PySide6.QtGui.QDesktopServices.openUrl")
     client.server_call = AsyncMock(return_value="THE_SID")
 
     # Run
@@ -87,6 +87,14 @@ async def test_login_to_discord(client, mocker: pytest_mock.MockerFixture):
     # Assert
     mock_browser_open.assert_called_once_with("http://localhost:5000/login?sid=THE_SID")
     client.server_call.assert_awaited_once_with("start_discord_login_flow")
+
+
+async def test_login_to_discord_raise(client, mocker: pytest_mock.MockerFixture):
+    mocker.patch("PySide6.QtGui.QDesktopServices.openUrl", return_value=False)
+    client.server_call = AsyncMock(return_value="THE_SID")
+
+    with pytest.raises(RuntimeError, match="Unable to open a web-browser to login into Discord"):
+        await client.login_with_discord()
 
 
 @pytest.mark.parametrize("connection_state", [ConnectionState.Disconnected, ConnectionState.Connected])


### PR DESCRIPTION
Hopefully fixes #5843 
But this didn't get any public testing yet. It didn't regress for me locally at least, so there's that.
Dunno if we should get testing now and don't merge on issues, or merge first then get testing and then revert if we have any.