### PR TITLE
Fix pickup filtering for items that start the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.3.0] - 2024-02-??
 
+- Fixed: Searching for your own pickup in Multiworld sessions will now show only pickups which match *exactly* the name, instead of showing pickups which start with that name.
+
 ### AM2R
 
 #### Logic Database

--- a/randovania/gui/game_details/pickup_details_tab.py
+++ b/randovania/gui/game_details/pickup_details_tab.py
@@ -237,4 +237,4 @@ class PickupDetailsTab(GameDetailsTab, Ui_PickupDetailsTab):
         if target is None:
             self.search_pickup_proxy.setFilterFixedString("<@NOT PRESENT@>")
         else:
-            self.search_pickup_proxy.setFilterFixedString(target)
+            self.search_pickup_proxy.setFilterRegularExpression(f"^{target}$")


### PR DESCRIPTION
Before:
![grafik](https://github.com/randovania/randovania/assets/38186597/930741fe-ba30-4124-b564-8b0654934933)
After:
![grafik](https://github.com/randovania/randovania/assets/38186597/6edb1adf-8d28-458c-a905-6d4f1aac408e)
![grafik](https://github.com/randovania/randovania/assets/38186597/15911a49-e64d-4a80-b42f-5dc70144af5f)
Shouldn't cause any performance loss hopefully, as i'm pretty sure that setFixedString was also using a regex in the background.