### PR TITLE
AM2R: Main Caves logic updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### Main Caves
 
-- Fixed: In Surface Hi-Jump Challenge: Now correctly uses normal damage vs lava damage for damage boost.
+- Fixed: In Surface Hi-Jump Challenge: Now correctly uses normal damage instead of lava damage for damage boost.
 - Fixed: In Drivel Drive: Intended Ballspark now requires Gravity.
 - Changed: In Drivel Drive: Bumped mockball method to Expert.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Logic Database
 
+##### Main Caves
+
+- Fixed: In Surface Hi-Jump Challenge: Now correctly uses normal damage vs lava damage for damage boost.
+- Fixed: In Drivel Drive: Intended Ballspark now requires Gravity.
+- Changed: In Drivel Drive: Bumped mockball method to Expert.
+
 ##### Hydro Station
 
 - Fixed: In Breeding Grounds Entrance: Activating the EMP Slot now properly accounts for Missiles.

--- a/randovania/games/am2r/logic_database/Main Caves.json
+++ b/randovania/games/am2r/logic_database/Main Caves.json
@@ -3799,7 +3799,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "damage",
-                                                        "name": "Lava",
+                                                        "name": "Damage",
                                                         "amount": 7,
                                                         "negate": false
                                                     }
@@ -7948,7 +7948,7 @@
                                                             {
                                                                 "type": "and",
                                                                 "data": {
-                                                                    "comment": "Intended method",
+                                                                    "comment": "Intended Ballspark Method",
                                                                     "items": [
                                                                         {
                                                                             "type": "template",
@@ -7960,6 +7960,15 @@
                                                                                 "type": "tricks",
                                                                                 "name": "Shinesparking",
                                                                                 "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Gravity Suit",
+                                                                                "amount": 1,
                                                                                 "negate": false
                                                                             }
                                                                         }
@@ -7985,51 +7994,51 @@
                                                                             "data": {
                                                                                 "type": "tricks",
                                                                                 "name": "Shinesparking",
-                                                                                "amount": 3,
-                                                                                "negate": false
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": "Go Through Lava",
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Gravity Suit",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "and",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "tricks",
-                                                                                "name": "DamageBoost",
-                                                                                "amount": 1,
+                                                                                "amount": 4,
                                                                                 "negate": false
                                                                             }
                                                                         },
                                                                         {
-                                                                            "type": "resource",
+                                                                            "type": "or",
                                                                             "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Lava",
-                                                                                "amount": 10,
-                                                                                "negate": false
+                                                                                "comment": "Damage Requirements",
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "Gravity Suit",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "and",
+                                                                                        "data": {
+                                                                                            "comment": null,
+                                                                                            "items": [
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "damage",
+                                                                                                        "name": "Lava",
+                                                                                                        "amount": 10,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                },
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "tricks",
+                                                                                                        "name": "DamageBoost",
+                                                                                                        "amount": 1,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         }
                                                                     ]

--- a/randovania/games/am2r/logic_database/Main Caves.txt
+++ b/randovania/games/am2r/logic_database/Main Caves.txt
@@ -578,7 +578,7 @@ Extra - minimap_data: [{'x': 49, 'y': 20}, {'x': 49, 'y': 21}, {'x': 50, 'y': 20
       Any of the following:
           Can Use Spider Ball or Space Jump Wall
           # damage boost
-          Damage Boost (Beginner) and Lava Damage ≥ 7
+          Damage Boost (Beginner) and Normal Damage ≥ 7
           # Jump with hi
           Hi-Jump Boots and Movement (Intermediate)
           # glide
@@ -1223,14 +1223,15 @@ Extra - minimap_data: [{'x': 35, 'y': 53}, {'x': 36, 'y': 53}, {'x': 37, 'y': 53
       All of the following:
           Speed Booster
           Any of the following:
-              # Intended method
-              Shinesparking Tricks (Intermediate) and Can Use Spring Ball
-              # Mockball method
-              Morph Ball and Shinesparking Tricks (Advanced)
-          Any of the following:
-              # Go Through Lava
-              Gravity Suit
-              Damage Boost (Beginner) and Lava Damage ≥ 10
+              # Intended Ballspark Method
+              Gravity Suit and Shinesparking Tricks (Intermediate) and Can Use Spring Ball
+              All of the following:
+                  # Mockball method
+                  Morph Ball and Shinesparking Tricks (Expert)
+                  Any of the following:
+                      # Damage Requirements
+                      Gravity Suit
+                      Damage Boost (Beginner) and Lava Damage ≥ 10
 
 > Horizontal Dock to Halzyn Hallway; Heals? False
   * Layers: default


### PR DESCRIPTION
- Fixed: In Surface Hi-Jump Challenge: Now correctly uses normal damage vs lava damage for damage boost.
- Fixed: In Drivel Drive: Intended Ballspark now requires Gravity.
- Changed: In Drivel Drive: Bumped mockball method to Expert.