### PR TITLE
AM2R MW: fix progressives with random starting items

### DIFF
--- a/randovania/game_connection/connector/am2r_remote_connector.py
+++ b/randovania/game_connection/connector/am2r_remote_connector.py
@@ -184,10 +184,16 @@ class AM2RRemoteConnector(RemoteConnector):
 
         for progressive_name, actual_items in progressives:
             quantity = inventory_dict.pop(progressive_name, 0)
-            for index in range(quantity):
+            if quantity == 0:
+                continue
+            index = 0
+            while True:
                 if index >= len(actual_items):
                     break
-                inventory_dict[actual_items[index]] += 1
+                actual_item = actual_items[index]
+                if actual_item not in inventory_dict:
+                    inventory_dict[actual_item] += 1
+                index += 1
 
         inventory = Inventory(
             {

--- a/randovania/game_connection/connector/am2r_remote_connector.py
+++ b/randovania/game_connection/connector/am2r_remote_connector.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import uuid
 from collections import defaultdict
@@ -186,11 +187,14 @@ class AM2RRemoteConnector(RemoteConnector):
             quantity = inventory_dict.pop(progressive_name, 0)
             if quantity == 0:
                 continue
-            index = 0
-            while True:
+            for index in itertools.count():
                 if index >= len(actual_items):
                     break
                 actual_item = actual_items[index]
+                # This is for dealing with mixed progressives (i.e. one hijump+one progressive jump)
+                # In that case the progressive jump is always supposed to give the later item. So if the actual item
+                # already exists in the inventory, we don't assign it again, but instead assign the next item in the
+                # progressive chain
                 if actual_item not in inventory_dict:
                     inventory_dict[actual_item] += 1
                 index += 1

--- a/test/game_connection/connector/test_am2r_remote_connector.py
+++ b/test/game_connection/connector/test_am2r_remote_connector.py
@@ -97,13 +97,20 @@ async def test_new_inventory_received(connector: AM2RRemoteConnector):
     missile_launcher = connector.game.resource_database.get_item_by_name("Missile Launcher")
     assert connector.last_inventory[missile_launcher].capacity == 1
 
-    connector.new_inventory_received("items:Hi-Jump Boots|1,Progressive Jump|1,")
+    # Second test with mixed progressives
+    connector.new_inventory_received("items:Hi-Jump Boots|1,Progressive Jump|1,Progressive Suit|1,Gravity Suit|1,")
 
     # Check HJ and SJ
     hijump = connector.game.resource_database.get_item_by_name("Hi-Jump Boots")
     assert connector.last_inventory[hijump].capacity == 1
     spacejump = connector.game.resource_database.get_item_by_name("Space Jump")
     assert connector.last_inventory[spacejump].capacity == 1
+
+    # Check varia and gravity
+    varia = connector.game.resource_database.get_item_by_name("Varia Suit")
+    assert connector.last_inventory[varia].capacity == 1
+    gravity = connector.game.resource_database.get_item_by_name("Gravity Suit")
+    assert connector.last_inventory[gravity].capacity == 1
 
 
 async def test_new_received_pickups_received(connector: AM2RRemoteConnector):

--- a/test/game_connection/connector/test_am2r_remote_connector.py
+++ b/test/game_connection/connector/test_am2r_remote_connector.py
@@ -97,6 +97,14 @@ async def test_new_inventory_received(connector: AM2RRemoteConnector):
     missile_launcher = connector.game.resource_database.get_item_by_name("Missile Launcher")
     assert connector.last_inventory[missile_launcher].capacity == 1
 
+    connector.new_inventory_received("items:Hi-Jump Boots|1,Progressive Jump|1,")
+
+    # Check HJ and SJ
+    hijump = connector.game.resource_database.get_item_by_name("Hi-Jump Boots")
+    assert connector.last_inventory[hijump].capacity == 1
+    spacejump = connector.game.resource_database.get_item_by_name("Space Jump")
+    assert connector.last_inventory[spacejump].capacity == 1
+
 
 async def test_new_received_pickups_received(connector: AM2RRemoteConnector):
     connector.receive_remote_pickups = AsyncMock()


### PR DESCRIPTION
When geting random starting items, the game gives you the resource directly (i.e. `Hi-Jump`). Thus mixing between the normal resource and the progressive, which we need to account for.