### PR TITLE
Make drop descriptions clearer

### DIFF
--- a/randovania/games/am2r/pickup_database/text_data.json
+++ b/randovania/games/am2r/pickup_database/text_data.json
@@ -124,23 +124,23 @@
 		"text_header": "Got Unknown Item"
 	},
 	"Small Health Drop": {
-		"text_desc": "Current health {Small Health DropChanged} by {Small Health Drop}",
+		"text_desc": "Health refilled by {Small Health Drop}",
 		"text_header": "Got Small Health Drop"
 	},
 	"Big Health Drop": {
-		"text_desc": "Current health {Big Health DropChanged} by {Big Health Drop}",
+		"text_desc": "Health refilled by {Big Health Drop}",
 		"text_header": "Got Big Health Drop"
 	},
 	"Missile Drop": {
-		"text_desc": "Current Missiles {Missile DropChanged} by {Missile Drop}",
+		"text_desc": "Missiles refilled by {Missile Drop}",
 		"text_header": "Got Missile Drop"
 	},
 	"Super Missile Drop": {
-		"text_desc": "Current Super Missiles {Super Missile DropChanged} by {Super Missile Drop}",
+		"text_desc": "Super Missiles refilled by {Super Missile Drop}",
 		"text_header": "Got Super Missile Drop"
 	},
 	"Power Bomb Drop": {
-		"text_desc": "Current Power Bombs {Power Bomb DropChanged} by {Power Bomb Drop}",
+		"text_desc": "Power Bombs refilled by {Power Bomb Drop}",
 		"text_header": "Got Power Bomb Drop"
 	},
 	"Speed Booster Upgrade": {

--- a/test/test_files/patcher_data/am2r/progressive_items.json
+++ b/test/test_files/patcher_data/am2r/progressive_items.json
@@ -62,7 +62,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Power Bomb Drop",
-                "description": "Current Power Bombs increased by 1"
+                "description": "Power Bombs refilled by 1"
             }
         },
         "oItemSpiderBall": {
@@ -74,7 +74,7 @@
             "quantity": 5,
             "text": {
                 "header": "Got Small Health Drop",
-                "description": "Current health increased by 5"
+                "description": "Health refilled by 5"
             }
         },
         "oItemJumpBall": {
@@ -110,7 +110,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemSpaceJump": {
@@ -158,7 +158,7 @@
             "quantity": 2,
             "text": {
                 "header": "Got Missile Drop",
-                "description": "Current Missiles increased by 2"
+                "description": "Missiles refilled by 2"
             }
         },
         "oItemCBeam": {
@@ -290,7 +290,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemM_56": {
@@ -314,7 +314,7 @@
             "quantity": 5,
             "text": {
                 "header": "Got Small Health Drop",
-                "description": "Current health increased by 5"
+                "description": "Health refilled by 5"
             }
         },
         "oItemPB_58": {
@@ -530,7 +530,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemM_152": {
@@ -554,7 +554,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemM_154": {
@@ -626,7 +626,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Super Missile Drop",
-                "description": "Current Super Missiles increased by 1"
+                "description": "Super Missiles refilled by 1"
             }
         },
         "oItemPB_160": {
@@ -698,7 +698,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Power Bomb Drop",
-                "description": "Current Power Bombs increased by 1"
+                "description": "Power Bombs refilled by 1"
             }
         },
         "oItemM_202": {
@@ -782,7 +782,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemSM_209": {
@@ -830,7 +830,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemPB_213": {
@@ -890,7 +890,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Super Missile Drop",
-                "description": "Current Super Missiles increased by 1"
+                "description": "Super Missiles refilled by 1"
             }
         },
         "oItemM_252": {
@@ -902,7 +902,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Super Missile Drop",
-                "description": "Current Super Missiles increased by 1"
+                "description": "Super Missiles refilled by 1"
             }
         },
         "oItemPB_253": {
@@ -950,7 +950,7 @@
             "quantity": 2,
             "text": {
                 "header": "Got Missile Drop",
-                "description": "Current Missiles increased by 2"
+                "description": "Missiles refilled by 2"
             }
         },
         "oItemM_257": {
@@ -962,7 +962,7 @@
             "quantity": 5,
             "text": {
                 "header": "Got Small Health Drop",
-                "description": "Current health increased by 5"
+                "description": "Health refilled by 5"
             }
         },
         "oItemPB_258": {
@@ -1058,7 +1058,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Super Missile Drop",
-                "description": "Current Super Missiles increased by 1"
+                "description": "Super Missiles refilled by 1"
             }
         },
         "oItemETank_306": {
@@ -1082,7 +1082,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemM_308": {
@@ -1130,7 +1130,7 @@
             "quantity": 2,
             "text": {
                 "header": "Got Missile Drop",
-                "description": "Current Missiles increased by 2"
+                "description": "Missiles refilled by 2"
             }
         },
         "oItemDNA_352": {
@@ -1238,7 +1238,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Super Missile Drop",
-                "description": "Current Super Missiles increased by 1"
+                "description": "Super Missiles refilled by 1"
             }
         },
         "oItemDNA_361": {
@@ -1286,7 +1286,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Power Bomb Drop",
-                "description": "Current Power Bombs increased by 1"
+                "description": "Power Bombs refilled by 1"
             }
         },
         "oItemDNA_365": {
@@ -1298,7 +1298,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemDNA_366": {
@@ -1322,7 +1322,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Power Bomb Drop",
-                "description": "Current Power Bombs increased by 1"
+                "description": "Power Bombs refilled by 1"
             }
         },
         "oItemDNA_368": {
@@ -1370,7 +1370,7 @@
             "quantity": 5,
             "text": {
                 "header": "Got Small Health Drop",
-                "description": "Current health increased by 5"
+                "description": "Health refilled by 5"
             }
         },
         "oItemDNA_372": {
@@ -1406,7 +1406,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemDNA_375": {
@@ -1454,7 +1454,7 @@
             "quantity": 2,
             "text": {
                 "header": "Got Missile Drop",
-                "description": "Current Missiles increased by 2"
+                "description": "Missiles refilled by 2"
             }
         },
         "oItemDNA_379": {
@@ -1538,7 +1538,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemDNA_386": {
@@ -1550,7 +1550,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Power Bomb Drop",
-                "description": "Current Power Bombs increased by 1"
+                "description": "Power Bombs refilled by 1"
             }
         },
         "oItemDNA_387": {
@@ -1574,7 +1574,7 @@
             "quantity": 5,
             "text": {
                 "header": "Got Small Health Drop",
-                "description": "Current health increased by 5"
+                "description": "Health refilled by 5"
             }
         },
         "oItemDNA_389": {
@@ -1598,7 +1598,7 @@
             "quantity": 2,
             "text": {
                 "header": "Got Missile Drop",
-                "description": "Current Missiles increased by 2"
+                "description": "Missiles refilled by 2"
             }
         },
         "oItemDNA_391": {

--- a/test/test_files/patcher_data/am2r/starting_items.json
+++ b/test/test_files/patcher_data/am2r/starting_items.json
@@ -186,7 +186,7 @@
             "quantity": 2,
             "text": {
                 "header": "Got Missile Drop",
-                "description": "Current Missiles increased by 2"
+                "description": "Missiles refilled by 2"
             }
         },
         "oItemWBeam": {
@@ -198,7 +198,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Power Bomb Drop",
-                "description": "Current Power Bombs increased by 1"
+                "description": "Power Bombs refilled by 1"
             }
         },
         "oItemSBeam": {
@@ -282,7 +282,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemM_55": {
@@ -378,7 +378,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Super Missile Drop",
-                "description": "Current Super Missiles increased by 1"
+                "description": "Super Missiles refilled by 1"
             }
         },
         "oItemM_102": {
@@ -426,7 +426,7 @@
             "quantity": 5,
             "text": {
                 "header": "Got Small Health Drop",
-                "description": "Current health increased by 5"
+                "description": "Health refilled by 5"
             }
         },
         "oItemM_106": {
@@ -438,7 +438,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemM_107": {
@@ -462,7 +462,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemM_109": {
@@ -486,7 +486,7 @@
             "quantity": 2,
             "text": {
                 "header": "Got Missile Drop",
-                "description": "Current Missiles increased by 2"
+                "description": "Missiles refilled by 2"
             }
         },
         "oItemM_111": {
@@ -666,7 +666,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemM_163": {
@@ -702,7 +702,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Power Bomb Drop",
-                "description": "Current Power Bombs increased by 1"
+                "description": "Power Bombs refilled by 1"
             }
         },
         "oItemM_202": {
@@ -726,7 +726,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemM_204": {
@@ -774,7 +774,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Power Bomb Drop",
-                "description": "Current Power Bombs increased by 1"
+                "description": "Power Bombs refilled by 1"
             }
         },
         "oItemM_208": {
@@ -798,7 +798,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemM_210": {
@@ -822,7 +822,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Power Bomb Drop",
-                "description": "Current Power Bombs increased by 1"
+                "description": "Power Bombs refilled by 1"
             }
         },
         "oItemPB_212": {
@@ -858,7 +858,7 @@
             "quantity": 5,
             "text": {
                 "header": "Got Small Health Drop",
-                "description": "Current health increased by 5"
+                "description": "Health refilled by 5"
             }
         },
         "oItemSM_215": {
@@ -906,7 +906,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Super Missile Drop",
-                "description": "Current Super Missiles increased by 1"
+                "description": "Super Missiles refilled by 1"
             }
         },
         "oItemPB_253": {
@@ -918,7 +918,7 @@
             "quantity": 5,
             "text": {
                 "header": "Got Small Health Drop",
-                "description": "Current health increased by 5"
+                "description": "Health refilled by 5"
             }
         },
         "oItemETank_254": {
@@ -930,7 +930,7 @@
             "quantity": 5,
             "text": {
                 "header": "Got Small Health Drop",
-                "description": "Current health increased by 5"
+                "description": "Health refilled by 5"
             }
         },
         "oItemM_255": {
@@ -942,7 +942,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Super Missile Drop",
-                "description": "Current Super Missiles increased by 1"
+                "description": "Super Missiles refilled by 1"
             }
         },
         "oItemSM_256": {
@@ -954,7 +954,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Super Missile Drop",
-                "description": "Current Super Missiles increased by 1"
+                "description": "Super Missiles refilled by 1"
             }
         },
         "oItemM_257": {
@@ -978,7 +978,7 @@
             "quantity": 2,
             "text": {
                 "header": "Got Missile Drop",
-                "description": "Current Missiles increased by 2"
+                "description": "Missiles refilled by 2"
             }
         },
         "oItemM_259": {
@@ -1014,7 +1014,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Super Missile Drop",
-                "description": "Current Super Missiles increased by 1"
+                "description": "Super Missiles refilled by 1"
             }
         },
         "oItemPB_302": {
@@ -1074,7 +1074,7 @@
             "quantity": 2,
             "text": {
                 "header": "Got Missile Drop",
-                "description": "Current Missiles increased by 2"
+                "description": "Missiles refilled by 2"
             }
         },
         "oItemM_307": {
@@ -1086,7 +1086,7 @@
             "quantity": 1,
             "text": {
                 "header": "Got Power Bomb Drop",
-                "description": "Current Power Bombs increased by 1"
+                "description": "Power Bombs refilled by 1"
             }
         },
         "oItemM_308": {
@@ -1266,7 +1266,7 @@
             "quantity": 5,
             "text": {
                 "header": "Got Small Health Drop",
-                "description": "Current health increased by 5"
+                "description": "Health refilled by 5"
             }
         },
         "oItemDNA_363": {
@@ -1314,7 +1314,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemDNA_367": {
@@ -1398,7 +1398,7 @@
             "quantity": 2,
             "text": {
                 "header": "Got Missile Drop",
-                "description": "Current Missiles increased by 2"
+                "description": "Missiles refilled by 2"
             }
         },
         "oItemDNA_374": {
@@ -1470,7 +1470,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemDNA_380": {
@@ -1542,7 +1542,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemDNA_386": {
@@ -1638,7 +1638,7 @@
             "quantity": 20,
             "text": {
                 "header": "Got Big Health Drop",
-                "description": "Current health increased by 20"
+                "description": "Health refilled by 20"
             }
         },
         "oItemDNA_394": {


### PR DESCRIPTION
IDK if it's actually clearer now. Sure hope so tho.
Could look weird with negatives, aka `Missiles refilled by -10`.
Fixes https://github.com/randovania/YAMS/issues/138