### PR TITLE
AM2R: Clean up path requirements to go to Serris

### DIFF
--- a/randovania/games/am2r/logic_database/Distribution Center.json
+++ b/randovania/games/am2r/logic_database/Distribution Center.json
@@ -9949,32 +9949,6 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": "Path requirements",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "A5IceItem",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "events",
-                                                        "name": "BossSerris",
-                                                        "amount": 1,
-                                                        "negate": true
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
                                         "type": "or",
                                         "data": {
                                             "comment": "Item requirements",

--- a/randovania/games/am2r/logic_database/Distribution Center.txt
+++ b/randovania/games/am2r/logic_database/Distribution Center.txt
@@ -1483,8 +1483,6 @@ Extra - minimap_data: [{'x': 64, 'y': 49}, {'x': 64, 'y': 50}, {'x': 65, 'y': 49
   * Layers: default
   > Event - Serris
       All of the following:
-          # Path requirements
-          After Area 5 - Distribution Center Item at Ice location Collected and Before Boss - Serris Defeated
           Any of the following:
               # Item requirements
               Combat (Advanced)


### PR DESCRIPTION
These seem to cause some issues with the resolver.
The `After Area 5 - Distribution Center Item at Ice location Collected` can be safely removed, because that's already implied by *going* to this node.
The `Before Boss - Serris Defeated` can be safely removed, because if serris is defated, it would by default just choose the other paths. It also doesnt really matter whether we visit this event multiple times or not.