### PR TITLE
Fix auto tracker tooltip for non Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.3.0] - 2024-02-??
 
+- Fixed: For Linux and macOS, the auto tracker tooltip will not show black text on black background anymore.
 - Fixed: Searching for your own pickup in Multiworld sessions will now show only pickups which match *exactly* the name, instead of showing pickups which start with that name.
 - Fixed: The import in a multiworld session is blocked if it contains an unsupported game.
 - Fixed: Opening the webbrowser for Discord Login doesn't fail on Linux anymore.

--- a/randovania/gui/lib/tracker_item_image.py
+++ b/randovania/gui/lib/tracker_item_image.py
@@ -16,7 +16,7 @@ class TrackerItemImage(QLabel):
         self.transparent_pixmap = transparent_pixmap
         self.opaque_pixmap = opaque_pixmap
         self._ignoring_mouse_events = False
-        self.setStyleSheet("QToolTip { color: black; }")
+        self.setStyleSheet("QToolTip { color: black; background-color: white; }")
 
     def set_checked(self, is_opaque: bool):
         self.setPixmap(self.opaque_pixmap if is_opaque else self.transparent_pixmap)


### PR DESCRIPTION
Looks like normally the tooltips in general usually use their native theming. Hyperbola forced the foreground color to black to have better contrast/accessibility, but for systems where the default tooltip background is dark, this made things much worse.
I couldve either made an OS check and only styled the foreground color on windows, or i just force a custom tooltip everywhere. Opted for the latter.
Before:
![grafik](https://github.com/randovania/randovania/assets/38186597/9d054b2b-30e1-49fe-a52e-9f7bc7385d52)

After:
![grafik](https://github.com/randovania/randovania/assets/38186597/cd6d81df-c3dc-49bb-8174-bccef7dbc3c2)
