### PR TITLE
Don't try to add duplicate entries to DB editor

### DIFF
--- a/randovania/gui/docks/resource_database_editor.py
+++ b/randovania/gui/docks/resource_database_editor.py
@@ -117,6 +117,9 @@ class ResourceDatabaseGenericModel(QtCore.QAbstractTableModel):
                     return True
             else:
                 if value:
+                    all_items = self._get_items()
+                    if any(item.short_name == value for item in all_items):
+                        return False
                     return self.append_item(self._create_item(value))
         return False
 


### PR DESCRIPTION
I thought about display a warning popup with `Entry already exists!`, but then i'd need to figure how to properly await that function without making the setData function async.
Thus i lowered my expectations until they were fully met.
Also apparently the whole DB editor just doesnt have any tests at all????
Fixes #4506