### PR TITLE
Prime 1: Introduce a seperate required amount of artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Bomb Jump in Right Entrance, out of the water to the Grapple Block Alcove. Requires Diagonal Bomb Jump and either Out of Water Bomb Jump or Gravity Suit.
 - Added: Video showing the Grapple Movement trick in Right Entrance.
 
+### Metroid Prime
+
+- Added: It is now possible to have a seperate total amount and required amount of Artifacts.
+
 ### Metroid Prime 2: Echoes
 
 #### Logic Database

--- a/randovania/games/prime1/exporter/patch_data_factory.py
+++ b/randovania/games/prime1/exporter/patch_data_factory.py
@@ -1000,6 +1000,8 @@ class PrimePatchDataFactory(PatchDataFactory):
                 "artifactTempleLayerOverrides": {
                     artifact.long_name: not starting_resources.has_resource(artifact) for artifact in artifacts
                 },
+                "requiredArtifactCount": (12 - self.configuration.artifact_target.value)
+                + self.configuration.artifact_required.value,
             },
             "tweaks": ctwk_config,
             "levelData": level_data,

--- a/randovania/games/prime1/generator/pickup_pool/artifacts.py
+++ b/randovania/games/prime1/generator/pickup_pool/artifacts.py
@@ -22,18 +22,18 @@ ARTIFACT_CATEGORY = pickup_category.PickupCategory(
 
 def add_artifacts(
     resource_database: ResourceDatabase,
-    mode: LayoutArtifactMode,
+    total: LayoutArtifactMode,
     artifact_minimum_progression: int,
 ) -> PoolResults:
     """
     :param resource_database:
-    :param mode
+    :param total
     :param artifact_minimum_progression
     :return:
     """
     item_pool: list[PickupEntry] = []
 
-    artifacts_to_place = mode.value
+    artifacts_to_place = total.value
 
     for i in range(artifacts_to_place):
         item_pool.append(create_artifact(i, artifact_minimum_progression, resource_database))

--- a/randovania/games/prime1/generator/pickup_pool/pool_creator.py
+++ b/randovania/games/prime1/generator/pickup_pool/pool_creator.py
@@ -14,5 +14,9 @@ if TYPE_CHECKING:
 def prime1_specific_pool(results: PoolResults, configuration: BaseConfiguration, game: GameDescription):
     assert isinstance(configuration, PrimeConfiguration)
     results.extend_with(
-        add_artifacts(game.resource_database, configuration.artifact_target, configuration.artifact_minimum_progression)
+        add_artifacts(
+            game.resource_database,
+            configuration.artifact_target,
+            configuration.artifact_minimum_progression,
+        )
     )

--- a/randovania/games/prime1/gui/preset_settings/prime_goal_tab.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_goal_tab.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from PySide6 import QtCore
 
 from randovania.games.prime1.layout.artifact_mode import LayoutArtifactMode
+from randovania.games.prime1.layout.prime_configuration import PrimeConfiguration
 from randovania.gui.generated.preset_prime_goal_ui import Ui_PresetPrimeGoal
 from randovania.gui.preset_settings.preset_tab import PresetTab
 
@@ -32,21 +33,23 @@ class PresetPrimeGoal(PresetTab, Ui_PresetPrimeGoal):
     def uses_patches_tab(cls) -> bool:
         return False
 
-    def _update_editor(self):
+    def _update_editor(self) -> None:
         with self._editor as editor:
             editor.set_configuration_field("artifact_target", LayoutArtifactMode(self.placed_slider.value()))
             editor.set_configuration_field("artifact_required", LayoutArtifactMode(self.required_slider.value()))
 
-    def _on_placed_slider_changed(self):
+    def _on_placed_slider_changed(self) -> None:
         self.placed_slider_label.setText(str(self.placed_slider.value()))
         self._update_editor()
 
-    def _on_required_slider_changed(self):
+    def _on_required_slider_changed(self) -> None:
         self.required_slider_label.setText(str(self.required_slider.value()))
         self._update_editor()
 
-    def on_preset_changed(self, preset: Preset):
-        placed = preset.configuration.artifact_target
-        required = preset.configuration.artifact_required
+    def on_preset_changed(self, preset: Preset) -> None:
+        config = preset.configuration
+        assert isinstance(config, PrimeConfiguration)
+        placed = config.artifact_target
+        required = config.artifact_required
         self.placed_slider.setValue(placed.num_artifacts)
         self.required_slider.setValue(required.num_artifacts)

--- a/randovania/games/prime1/gui/preset_settings/prime_goal_tab.py
+++ b/randovania/games/prime1/gui/preset_settings/prime_goal_tab.py
@@ -21,7 +21,8 @@ class PresetPrimeGoal(PresetTab, Ui_PresetPrimeGoal):
         self.setupUi(self)
 
         self.goal_layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
-        self.slider.valueChanged.connect(self._on_slider_changed)
+        self.placed_slider.valueChanged.connect(self._on_placed_slider_changed)
+        self.required_slider.valueChanged.connect(self._on_required_slider_changed)
 
     @classmethod
     def tab_title(cls) -> str:
@@ -33,12 +34,19 @@ class PresetPrimeGoal(PresetTab, Ui_PresetPrimeGoal):
 
     def _update_editor(self):
         with self._editor as editor:
-            editor.set_configuration_field("artifact_target", LayoutArtifactMode(self.slider.value()))
+            editor.set_configuration_field("artifact_target", LayoutArtifactMode(self.placed_slider.value()))
+            editor.set_configuration_field("artifact_required", LayoutArtifactMode(self.required_slider.value()))
 
-    def _on_slider_changed(self):
-        self.slider_label.setText(str(self.slider.value()))
+    def _on_placed_slider_changed(self):
+        self.placed_slider_label.setText(str(self.placed_slider.value()))
+        self._update_editor()
+
+    def _on_required_slider_changed(self):
+        self.required_slider_label.setText(str(self.required_slider.value()))
         self._update_editor()
 
     def on_preset_changed(self, preset: Preset):
-        artifacts = preset.configuration.artifact_target
-        self.slider.setValue(artifacts.num_artifacts)
+        placed = preset.configuration.artifact_target
+        required = preset.configuration.artifact_required
+        self.placed_slider.setValue(placed.num_artifacts)
+        self.required_slider.setValue(required.num_artifacts)

--- a/randovania/games/prime1/layout/prime_configuration.py
+++ b/randovania/games/prime1/layout/prime_configuration.py
@@ -155,3 +155,13 @@ class PrimeConfiguration(BaseConfiguration):
         if self.items_every_room:
             layers.add("items_every_room")
         return layers
+
+    def unsupported_features(self) -> list[str]:
+        result = super().unsupported_features()
+
+        if self.artifact_required.value > self.artifact_target.value:
+            result.append(
+                "The amount of required artifacts cannot be higher than the total amount of shuffled artifacts."
+            )
+
+        return result

--- a/randovania/games/prime1/layout/prime_configuration.py
+++ b/randovania/games/prime1/layout/prime_configuration.py
@@ -82,6 +82,7 @@ class PrimeConfiguration(BaseConfiguration):
     hints: HintConfiguration
     energy_per_tank: int = dataclasses.field(metadata={"min": 1, "max": 1000, "precision": 1})
     artifact_target: LayoutArtifactMode
+    artifact_required: LayoutArtifactMode
     artifact_minimum_progression: int = dataclasses.field(metadata={"min": 0, "max": 99})
     heat_damage: float = dataclasses.field(metadata={"min": 0.1, "max": 99.9, "precision": 3.0})
     warp_to_start: bool

--- a/randovania/gui/ui_files/preset_prime_goal.ui
+++ b/randovania/gui/ui_files/preset_prime_goal.ui
@@ -34,7 +34,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QLabel" name="goal_description">
+     <widget class="QLabel" name="placed_description">
       <property name="text">
        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls how many Artifacts will be placed.&lt;/p&gt;&lt;p&gt;You can always check Artifact Temple for hints where the artifacts were placed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
@@ -46,7 +46,7 @@
     <item>
      <layout class="QHBoxLayout" name="slider_layout">
       <item>
-       <widget class="QSlider" name="slider">
+       <widget class="QSlider" name="placed_slider">
         <property name="maximum">
          <number>12</number>
         </property>
@@ -62,7 +62,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="slider_label">
+       <widget class="QLabel" name="placed_slider_label">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -80,6 +80,43 @@
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <widget class="QLabel" name="required_description">
+      <property name="text">
+       <string>
+Controls how many Artifacts are required.
+
+This controls how many Artifacts are needed in order to unlock Impact Crater. This can be different from the amount of placed Artifacts.</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QSlider" name="required_slider">
+        <property name="maximum">
+         <number>12</number>
+        </property>
+        <property name="pageStep">
+         <number>2</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="required_slider_label">
+        <property name="text">
+         <string>0</string>
         </property>
        </widget>
       </item>

--- a/randovania/layout/preset_migration.py
+++ b/randovania/layout/preset_migration.py
@@ -1037,6 +1037,13 @@ def _migrate_v71(preset: dict) -> dict:
     return preset
 
 
+def _migrate_v72(preset: dict) -> dict:
+    if preset["game"] == "prime1":
+        preset["configuration"]["artifact_required"] = preset["configuration"]["artifact_target"]
+
+    return preset
+
+
 _MIGRATIONS = [
     _migrate_v1,  # v1.1.1-247-gaf9e4a69
     _migrate_v2,  # v1.2.2-71-g0fbabe91
@@ -1109,6 +1116,7 @@ _MIGRATIONS = [
     _migrate_v69,
     _migrate_v70,
     _migrate_v71,
+    _migrate_v72,
 ]
 CURRENT_VERSION = migration_lib.get_version(_MIGRATIONS)
 

--- a/test/games/prime1/layout/test_prime_configuration.py
+++ b/test/games/prime1/layout/test_prime_configuration.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import dataclasses
+
+from randovania.games.game import RandovaniaGame
+from randovania.games.prime1.layout.artifact_mode import LayoutArtifactMode
+from randovania.games.prime1.layout.prime_configuration import PrimeConfiguration
+
+
+def test_has_unsupported_features(preset_manager):
+    preset = preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME).get_preset()
+    assert isinstance(preset.configuration, PrimeConfiguration)
+
+    configuration = preset.configuration
+
+    configuration = dataclasses.replace(
+        configuration,
+        artifact_required=LayoutArtifactMode.FIVE,
+        artifact_target=LayoutArtifactMode.ONE,
+    )
+
+    assert configuration.unsupported_features() == [
+        "The amount of required artifacts cannot be higher than the total amount of shuffled artifacts."
+    ]
+
+
+def test_no_unsupported_features(preset_manager):
+    preset = preset_manager.default_preset_for_game(RandovaniaGame.METROID_PRIME).get_preset()
+    assert preset.configuration.unsupported_features() == []

--- a/test/test_files/patcher_data/prime1/all_game_multi/world_2.json
+++ b/test/test_files/patcher_data/prime1/all_game_multi/world_2.json
@@ -133,7 +133,8 @@
             "Artifact of World": false,
             "Artifact of Spirit": false,
             "Artifact of Newborn": false
-        }
+        },
+        "requiredArtifactCount": 12
     },
     "tweaks": {},
     "levelData": {

--- a/test/test_files/patcher_data/prime1/all_game_multi/world_6.json
+++ b/test/test_files/patcher_data/prime1/all_game_multi/world_6.json
@@ -133,7 +133,8 @@
             "Artifact of World": false,
             "Artifact of Spirit": false,
             "Artifact of Newborn": false
-        }
+        },
+        "requiredArtifactCount": 12
     },
     "tweaks": {},
     "levelData": {

--- a/test/test_files/randomprime_expected_data.json
+++ b/test/test_files/randomprime_expected_data.json
@@ -35,7 +35,7 @@
         "forceFusion": false
     },
     "gameConfig": {
-        "resultsString": "7.1.0.dev244-dirty | Seed Hash - Putrid Shriekbat Polluted (AAAAAAAA)",
+        "resultsString": "7.3.0.dev211-dirty | Seed Hash - Putrid Shriekbat Polluted (AAAAAAAA)",
         "bossSizes": {},
         "noDoors": false,
         "startingRoom": "Tallon Overworld:Landing Site",
@@ -108,7 +108,7 @@
             "gameNameFull": "Metroid Prime: Randomizer - AAAAAAAA",
             "description": "Seed Hash: Putrid Shriekbat Polluted"
         },
-        "mainMenuMessage": "Randovania v7.1.0.dev244-dirty\nPutrid Shriekbat Polluted",
+        "mainMenuMessage": "Randovania v7.3.0.dev211-dirty\nPutrid Shriekbat Polluted",
         "creditsString": "&push;&font=C29C51F1;&main-color=#89D6FF;Major Item Locations&pop;\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Charge Beam&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Sanctuary Fortress - Sanctuary Energy Controller\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wave Beam&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Torvus Bog - Great Bridge\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Beam&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Temple Grounds - Temple Assembly Site\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Plasma Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Root Cave\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Grapple Beam&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Dark Agon Wastes - Junction Site\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Thermal Visor&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Torvus Bog - Torvus Energy Controller\n\n&push;&font=C29C51F1;&main-color=#33ffd6;X-Ray Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Alcove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Boost Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Life Grove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Spider Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Storage Depot A\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Power Bomb&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Main Plaza\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Varia Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Landing Site\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Gravity Suit&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Great Temple - Transport B Access\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Phazon Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Cargo Freight Lift to Deck Gamma\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Super Missile&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Temple Grounds - Windchamber Gateway\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wavebuster&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Sunchamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Spreader&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Sandcanyon\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Flamethrower&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Torvus Bog - Training Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Chozo&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Dark Agon Wastes - Ing Cache 1\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Elder&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Sand Cache\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Lifegiver&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Temple Grounds - Storage Cavern B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Nature&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Sanctuary Fortress - Hall of Combat Mastery\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Newborn&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Great Temple - Transport A Access\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Spirit&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Temple Grounds - Transport to Agon Wastes\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Strength&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Storage D\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Truth&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Mining Station Access\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Warrior&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Agon Wastes - Portal Access A\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Wild&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Transport Tunnel B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of World&pop;\n&push;&main-color=#d4cc33;Echoes&pop;'s Ing Hive - Culling Chamber",
         "artifactHints": {
             "Artifact of Sun": "&push;&main-color=#c300ff;Artifact of Sun&pop; has no need to be located.",
@@ -138,6 +138,7 @@
             "Artifact of Spirit": true,
             "Artifact of Newborn": true
         },
+        "requiredArtifactCount": 12,
         "startingMemo": "Artifact of Sun, 5 Missiles"
     },
     "tweaks": {

--- a/test/test_files/randomprime_expected_data_crazy.json
+++ b/test/test_files/randomprime_expected_data_crazy.json
@@ -35,7 +35,7 @@
         "forceFusion": false
     },
     "gameConfig": {
-        "resultsString": "7.1.0.dev244-dirty | Seed Hash - Geemer Shriekbat Fission (AAAAAAAA)",
+        "resultsString": "7.3.0.dev211-dirty | Seed Hash - Geemer Shriekbat Fission (AAAAAAAA)",
         "bossSizes": {},
         "noDoors": true,
         "startingRoom": "Magmoor Caverns:Shore Tunnel",
@@ -108,7 +108,7 @@
             "gameNameFull": "Metroid Prime: Randomizer - AAAAAAAA",
             "description": "Seed Hash: Geemer Shriekbat Fission"
         },
-        "mainMenuMessage": "Randovania v7.1.0.dev244-dirty\nGeemer Shriekbat Fission",
+        "mainMenuMessage": "Randovania v7.3.0.dev211-dirty\nGeemer Shriekbat Fission",
         "creditsString": "&push;&font=C29C51F1;&main-color=#89D6FF;Major Item Locations&pop;\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Charge Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Dynamo\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wave Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Lava Lake\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Research Core\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Plasma Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Research Lab Aether\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Missile Launcher&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Transport Tunnel A\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Grapple Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Fiery Shores\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Combat Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Control Tower\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Thermal Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Storage Depot B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;X-Ray Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Storage Cavern\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Space Jump Boots&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Gravity Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Boost Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Research Lab Aether\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Spider Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Elite Research\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Power Bomb&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Main Plaza\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Gravity Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Ruined Nursery\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Phazon Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Gravity Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Super Missile&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Antechamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wavebuster&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Hydra Lab Entryway\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Spreader&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Security Access B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Flamethrower&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Phendrana's Edge\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Chozo&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Life Grove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Elder&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Life Grove Tunnel\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Lifegiver&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Arbor Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Nature&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Transport Tunnel B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Strength&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Overgrown Cavern\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Sun&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Ventilation Shaft\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Truth&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Metroid Quarantine A\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Warrior&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Cargo Freight Lift to Deck Gamma\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Wild&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Storage Depot A",
         "artifactHints": {
             "Artifact of World": "&push;&main-color=#c300ff;Artifact of World&pop; has no need to be located.",
@@ -138,6 +138,7 @@
             "Artifact of Spirit": false,
             "Artifact of Newborn": false
         },
+        "requiredArtifactCount": 12,
         "startingMemo": "Varia Suit"
     },
     "tweaks": {

--- a/test/test_files/randomprime_expected_data_one_way_door.json
+++ b/test/test_files/randomprime_expected_data_one_way_door.json
@@ -35,7 +35,7 @@
         "forceFusion": false
     },
     "gameConfig": {
-        "resultsString": "7.1.0.dev244-dirty | Seed Hash - Geemer Shriekbat Fission (AAAAAAAA)",
+        "resultsString": "7.3.0.dev211-dirty | Seed Hash - Geemer Shriekbat Fission (AAAAAAAA)",
         "bossSizes": {
             "parasiteQueen": 2.793023329531004,
             "incineratorDrone": 1.8717449187219573,
@@ -113,7 +113,7 @@
             "gameNameFull": "Metroid Prime: Randomizer - AAAAAAAA",
             "description": "Seed Hash: Geemer Shriekbat Fission"
         },
-        "mainMenuMessage": "Randovania v7.1.0.dev244-dirty\nGeemer Shriekbat Fission",
+        "mainMenuMessage": "Randovania v7.3.0.dev211-dirty\nGeemer Shriekbat Fission",
         "creditsString": "&push;&font=C29C51F1;&main-color=#89D6FF;Major Item Locations&pop;\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Charge Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ice Ruins East\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wave Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Arbor Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Ruined Fountain\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Plasma Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Central Dynamo\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Missile Launcher&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Alcove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Grapple Beam&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Ruined Gallery\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Combat Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Landing Site\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Thermal Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Ventilation Shaft\n\n&push;&font=C29C51F1;&main-color=#33ffd6;X-Ray Visor&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Furnace\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Space Jump Boots&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Hall of the Elders\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Boost Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Main Plaza\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Spider Ball&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Watery Hall\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Power Bomb&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Transport Access North\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Varia Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Main Plaza\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Gravity Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phazon Mines - Fungal Hall B\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Phazon Suit&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Burn Dome\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Super Missile&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Warrior Shrine\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Wavebuster&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Phendrana Canyon\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Ice Spreader&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Tallon Overworld - Life Grove\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Flamethrower&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ice Ruins East\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Chozo&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Triclops Pit\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Elder&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Storage Cavern\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Lifegiver&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Chapel of the Elders\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Nature&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Phendrana Shorelines\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Strength&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Magma Pool\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Sun&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Magmoor Caverns - Lava Lake\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Truth&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ice Ruins West\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Warrior&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Chozo Ruins - Elder Chamber\n\n&push;&font=C29C51F1;&main-color=#33ffd6;Artifact of Wild&pop;\n&push;&main-color=#d4cc33;Prime&pop;'s Phendrana Drifts - Ruined Courtyard",
         "artifactHints": {
             "Artifact of World": "&push;&main-color=#c300ff;Artifact of World&pop; has no need to be located.",
@@ -142,7 +142,8 @@
             "Artifact of World": false,
             "Artifact of Spirit": false,
             "Artifact of Newborn": false
-        }
+        },
+        "requiredArtifactCount": 12
     },
     "tweaks": {
         "playerSize": 0.3,


### PR DESCRIPTION
![grafik](https://github.com/randovania/randovania/assets/38186597/944978b0-f606-40e0-b5e7-383ad7d10c10)
This seperates the total amount of artifacts and required artifacts, so the player is able to choose for which artifacts they route for. 
For example, you can have 7 total artifacts, but 3 required. You are able to get hints for all 7 artifacts, but only 3 are needed to reach Impact crater. 
Logic assumes that have you to collect all 7 artifacts tho, in order to ensure that all 7 artifacts are reachable and the player is thus *always* able to choose which artifacts they go for, and not *forced* to go for specific ones.
Fix #3323 