### PR TITLE
Bump am2r yams to 1.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ aiohttp==3.8.6
     #   randovania (setup.py)
 aiosignal==1.3.1
     # via aiohttp
-am2r-yams==1.2.3
+am2r-yams==1.2.4
     # via randovania (setup.py)
 appdirs==1.4.4
     # via randovania (setup.py)


### PR DESCRIPTION
No changelog entry needed, as it's still MW fixes.
Apparently i somehow reverted an important commit in the patcher right before the 1.2.3 release. whoops.