### PR TITLE
Dread: Remove pushing Wide Beam Blocks with Wave and no Wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Logic Database
 
+- Removed: It's no longer logical to push Wide Beam Blocks with Wave Beam without Wide Beam.
+
 ##### Artaria
 
 - Added: Single Wall Jump (Beginner) to cross the pillar left to right in White EMMI Introduction.

--- a/randovania/games/dread/logic_database/Artaria.json
+++ b/randovania/games/dread/logic_database/Artaria.json
@@ -22267,8 +22267,25 @@
                             }
                         },
                         "Event - EMMI Wide Beam Block": {
-                            "type": "template",
-                            "data": "Push Wide Beam Block with Wave Beam"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Push Wide Beam Block"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Wave",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },

--- a/randovania/games/dread/logic_database/Artaria.txt
+++ b/randovania/games/dread/logic_database/Artaria.txt
@@ -4147,7 +4147,7 @@ Extra - asset_id: collision_camera_069
   > Door to EMMI Zone Spinner
       After Artaria - EMMI Wide Beam Block
   > Event - EMMI Wide Beam Block
-      Push Wide Beam Block with Wave Beam
+      Wave Beam and Push Wide Beam Block
 
 > Door to EMMI Zone Spinner; Heals? False
   * Layers: default

--- a/randovania/games/dread/logic_database/Cataris.json
+++ b/randovania/games/dread/logic_database/Cataris.json
@@ -17683,10 +17683,6 @@
                                                 }
                                             ]
                                         }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Push Wide Beam Block with Wave Beam"
                                     }
                                 ]
                             }
@@ -21668,10 +21664,6 @@
                                                 }
                                             ]
                                         }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Push Wide Beam Block with Wave Beam"
                                     }
                                 ]
                             }

--- a/randovania/games/dread/logic_database/Cataris.txt
+++ b/randovania/games/dread/logic_database/Cataris.txt
@@ -2838,7 +2838,7 @@ Extra - asset_id: collision_camera_040
       Speed Booster and Speed Booster Conservation (Beginner)
   > Event - Push Wide Beam Block
       Any of the following:
-          Push Wide Beam Block or Push Wide Beam Block with Wave Beam
+          Push Wide Beam Block
           Diffusion Abuse (Intermediate) and Shoot Diffusion Beam
 
 > Pickup (Missile Tank); Heals? False
@@ -3496,7 +3496,7 @@ Extra - asset_id: collision_camera_048
               Heat/Cold Runs (Intermediate) and Heat Damage ≥ 150
   > Event - Wide Beam Block
       Any of the following:
-          Push Wide Beam Block or Push Wide Beam Block with Wave Beam
+          Push Wide Beam Block
           Diffusion Abuse (Intermediate) and Shoot Diffusion Beam
   > Event - Blob
       Lay Bomb or Shoot Beam

--- a/randovania/games/dread/logic_database/Dairon.json
+++ b/randovania/games/dread/logic_database/Dairon.json
@@ -353,8 +353,25 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Event - Push Wide Beam Block": {
-                            "type": "template",
-                            "data": "Push Wide Beam Block with Wave Beam"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Push Wide Beam Block"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Wave",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         "Wide Beam Block - Adjacent": {
                             "type": "resource",
@@ -1147,7 +1164,16 @@
                                     },
                                     {
                                         "type": "template",
-                                        "data": "Push Wide Beam Block with Wave Beam"
+                                        "data": "Push Wide Beam Block"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Wave",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -8778,8 +8804,25 @@
                             }
                         },
                         "Event - Ferenia Transport Wide Beam Block  Above": {
-                            "type": "template",
-                            "data": "Push Wide Beam Block with Wave Beam"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Push Wide Beam Block"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Wave",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },

--- a/randovania/games/dread/logic_database/Dairon.txt
+++ b/randovania/games/dread/logic_database/Dairon.txt
@@ -72,7 +72,7 @@ Extra - asset_id: collision_camera_001
   * Extra - right_shield_entity: {EMPTY}
   * Extra - right_shield_def: None
   > Event - Push Wide Beam Block
-      Push Wide Beam Block with Wave Beam
+      Wave Beam and Push Wide Beam Block
   > Wide Beam Block - Adjacent
       After Dairon - Wide Beam Block Cataris Transport
   > Wide Beam Block - Above
@@ -195,7 +195,7 @@ Extra - asset_id: collision_camera_002
   > Tunnel to Big Hub
       Lay Bomb or Lay Power Bomb
   > Event - Push Wide Beam Block
-      Movement (Beginner) and Push Wide Beam Block with Wave Beam
+      Wave Beam and Movement (Beginner) and Push Wide Beam Block
 
 > Dock to EMMI Zone Exit East; Heals? False
   * Layers: default
@@ -1476,7 +1476,7 @@ Extra - asset_id: collision_camera_019
   > Elevator to Ferenia
       Trivial
   > Event - Ferenia Transport Wide Beam Block  Above
-      Push Wide Beam Block with Wave Beam
+      Wave Beam and Push Wide Beam Block
 
 > Elevator to Ferenia; Heals? False; Default Node
   * Layers: default

--- a/randovania/games/dread/logic_database/header.json
+++ b/randovania/games/dread/logic_database/header.json
@@ -5008,27 +5008,6 @@
                     ]
                 }
             },
-            "Push Wide Beam Block with Wave Beam": {
-                "type": "and",
-                "data": {
-                    "comment": null,
-                    "items": [
-                        {
-                            "type": "template",
-                            "data": "Shoot Charge Beam"
-                        },
-                        {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Wave",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    ]
-                }
-            },
             "Shoot Super Ice Missile": {
                 "type": "and",
                 "data": {

--- a/randovania/games/dread/logic_database/header.txt
+++ b/randovania/games/dread/logic_database/header.txt
@@ -378,9 +378,6 @@ Templates
 * Lay Normal Bomb:
       Bomb and Morph Ball
 
-* Push Wide Beam Block with Wave Beam:
-      Wave Beam and Shoot Charge Beam
-
 * Shoot Super Ice Missile:
       All of the following:
           Ice Missile and Shoot Missile


### PR DESCRIPTION
We have learned that pushing Wide Beam Blocks with Plasma or Wave, without Wide is possible, and at the time we thought it made sense to do so with Wave, from an angle. However, based on our current understanding, this should be considered a bug in the implementation of split beams.