### PR TITLE
Dread: Implement cosmetic option for volume sliders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
+- Added: Changing the volume of the music, SFX and background ambience is now possible via cosmetic options.
 - Changed: Speed Booster Upgrades and Flash Shift Upgrades are now considered minor items instead of major.
 
 #### Logic Database

--- a/randovania/games/dread/exporter/patch_data_factory.py
+++ b/randovania/games/dread/exporter/patch_data_factory.py
@@ -383,7 +383,12 @@ class DreadPatchDataFactory(PatchDataFactory):
                     "bShowEnemyLife": c.show_enemy_life,
                     "bShowEnemyDamage": c.show_enemy_damage,
                     "bShowPlayerDamage": c.show_player_damage,
-                }
+                },
+                "SoundSystemATK": {
+                    "fMusicVolume": c.music_volume / 100,
+                    "fSfxVolume": c.sfx_volume / 100,
+                    "fEnvironmentStreamsVolume": c.ambience_volume / 100,
+                },
             },
             "lua": {
                 "custom_init": {

--- a/randovania/games/dread/gui/dialog/dread_cosmetic_patches_dialog.py
+++ b/randovania/games/dread/gui/dialog/dread_cosmetic_patches_dialog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+from functools import partial
 from typing import TYPE_CHECKING
 
 from randovania.games.dread.layout.dread_cosmetic_patches import (
@@ -11,7 +12,7 @@ from randovania.games.dread.layout.dread_cosmetic_patches import (
 )
 from randovania.gui.dialog.base_cosmetic_patches_dialog import BaseCosmeticPatchesDialog
 from randovania.gui.generated.dread_cosmetic_patches_dialog_ui import Ui_DreadCosmeticPatchesDialog
-from randovania.gui.lib import signal_handling
+from randovania.gui.lib import signal_handling, slider_updater
 from randovania.gui.lib.signal_handling import set_combo_with_value
 
 if TYPE_CHECKING:
@@ -32,8 +33,20 @@ class DreadCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_DreadCosmeticPatc
         for missile_cosmetic_type in DreadMissileCosmeticType:
             self.missile_cosmetic_dropdown.addItem(missile_cosmetic_type.long_name, missile_cosmetic_type)
 
-        self.on_new_cosmetic_patches(current)
+        self.field_name_to_slider_mapping = {
+            "music": self.music_slider,
+            "sfx": self.sfx_slider,
+            "ambience": self.ambience_slider,
+        }
+
+        for field_name, slider in self.field_name_to_slider_mapping.items():
+            label: QtWidgets.QLabel = getattr(self, f"{field_name}_label")
+            updater = slider_updater.create_label_slider_updater(label, True)
+            updater(slider)
+            setattr(self, f"{field_name}_label_updater", updater)
+
         self.connect_signals()
+        self.on_new_cosmetic_patches(current)
 
     def connect_signals(self) -> None:
         super().connect_signals()
@@ -44,6 +57,8 @@ class DreadCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_DreadCosmeticPatc
         self._persist_check_field(self.show_player_damage, "show_player_damage")
         self._persist_check_field(self.show_death_counter, "show_death_counter")
         self._persist_check_field(self.enable_auto_tracker, "enable_auto_tracker")
+        for field_name, slider in self.field_name_to_slider_mapping.items():
+            slider.valueChanged.connect(partial(self._on_slider_update, slider, field_name))
         signal_handling.on_combo(self.room_names_dropdown, self._on_room_name_mode_update)
         signal_handling.on_combo(self.missile_cosmetic_dropdown, self._on_missile_cosmetic_update)
         self._persist_shield_type_update("alt_ice_missile", self.alt_ice_missile)
@@ -60,6 +75,9 @@ class DreadCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_DreadCosmeticPatc
         self.show_player_damage.setChecked(patches.show_player_damage)
         self.show_death_counter.setChecked(patches.show_death_counter)
         self.enable_auto_tracker.setChecked(patches.enable_auto_tracker)
+        for field_name, slider in self.field_name_to_slider_mapping.items():
+            slider = self.field_name_to_slider_mapping[field_name]
+            slider.setValue(getattr(patches, f"{field_name}_volume"))
         set_combo_with_value(self.room_names_dropdown, patches.show_room_names)
         set_combo_with_value(self.missile_cosmetic_dropdown, patches.missile_cosmetic)
 
@@ -84,6 +102,12 @@ class DreadCosmeticPatchesDialog(BaseCosmeticPatchesDialog, Ui_DreadCosmeticPatc
 
     def _on_missile_cosmetic_update(self, value: DreadMissileCosmeticType) -> None:
         self._cosmetic_patches = dataclasses.replace(self._cosmetic_patches, missile_cosmetic=value)
+
+    def _on_slider_update(self, slider: QtWidgets.QSlider, field_name: str, _: None) -> None:
+        self._cosmetic_patches = dataclasses.replace(
+            self._cosmetic_patches, **{f"{field_name}_volume": slider.value()}  # type: ignore[arg-type]
+        )
+        getattr(self, f"{field_name}_label_updater")(slider)
 
     @property
     def cosmetic_patches(self) -> DreadCosmeticPatches:

--- a/randovania/games/dread/layout/dread_cosmetic_patches.py
+++ b/randovania/games/dread/layout/dread_cosmetic_patches.py
@@ -121,6 +121,9 @@ class DreadCosmeticPatches(BaseCosmeticPatches):
     show_player_damage: bool = False
     show_death_counter: bool = False
     enable_auto_tracker: bool = True
+    music_volume: int = 100
+    sfx_volume: int = 100
+    ambience_volume: int = 100
     show_room_names: DreadRoomGuiType = DreadRoomGuiType.NONE
     missile_cosmetic: DreadMissileCosmeticType = DreadMissileCosmeticType.NONE
     alt_ice_missile: DreadShieldType = DreadShieldType.DEFAULT

--- a/randovania/gui/ui_files/dread_cosmetic_patches_dialog.ui
+++ b/randovania/gui/ui_files/dread_cosmetic_patches_dialog.ui
@@ -23,9 +23,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-144</y>
+        <y>0</y>
         <width>384</width>
-        <height>462</height>
+        <height>668</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -131,6 +131,99 @@
             </item>
             <item>
              <widget class="QComboBox" name="missile_cosmetic_dropdown"/>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="music_title_label">
+            <property name="text">
+             <string>Music Volume:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="music_group">
+            <item>
+             <widget class="QSlider" name="music_slider">
+              <property name="maximum">
+               <number>100</number>
+              </property>
+              <property name="sliderPosition">
+               <number>100</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="music_label">
+              <property name="text">
+               <string>100%</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="sfx_title_label">
+            <property name="text">
+             <string>SFX Volume:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="sfx_group">
+            <item>
+             <widget class="QSlider" name="sfx_slider">
+              <property name="maximum">
+               <number>100</number>
+              </property>
+              <property name="sliderPosition">
+               <number>100</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="sfx_label">
+              <property name="text">
+               <string>100%</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="ambience_title_label">
+            <property name="text">
+             <string>Background Ambience Volume:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="ambience_group">
+            <item>
+             <widget class="QSlider" name="ambience_slider">
+              <property name="maximum">
+               <number>100</number>
+              </property>
+              <property name="sliderPosition">
+               <number>100</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="ambience_label">
+              <property name="text">
+               <string>100%</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>

--- a/randovania/interface_common/persisted_options.py
+++ b/randovania/interface_common/persisted_options.py
@@ -194,6 +194,7 @@ _CONVERTER_FOR_VERSION = [
     _convert_v25,
     _only_new_fields,  # added allow_crash_reporting
     _only_new_fields,  # added DebugConnectorBuilder's layout_uuid
+    _only_new_fields,  # added Dread's music sliders
 ]
 _CURRENT_OPTIONS_FILE_VERSION = migration_lib.get_version(_CONVERTER_FOR_VERSION)
 

--- a/test/games/dread/gui/test_dread_cosmetic_patches_dialog.py
+++ b/test/games/dread/gui/test_dread_cosmetic_patches_dialog.py
@@ -40,6 +40,29 @@ def test_certain_field(skip_qtbot: pytestqt.qtbot.QtBot, widget_field: str, fiel
     assert dialog.cosmetic_patches == DreadCosmeticPatches(**{field_name: True})  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize(
+    ("slider_name", "label_name", "field_name"),
+    [
+        ("music_slider", "music_label", "music_volume"),
+        ("sfx_slider", "sfx_label", "sfx_volume"),
+        ("ambience_slider", "ambience_label", "ambience_volume"),
+    ],
+)
+def test_certain_slider(skip_qtbot: pytestqt.qtbot.QtBot, slider_name: str, label_name: str, field_name: str) -> None:
+    cosmetic_patches = DreadCosmeticPatches(**{field_name: 0})  # type: ignore[arg-type]
+
+    dialog = DreadCosmeticPatchesDialog(None, cosmetic_patches)
+    label = getattr(dialog, label_name)
+    skip_qtbot.addWidget(dialog)
+    assert label.text() == "  0%"
+
+    slider = getattr(dialog, slider_name)
+    slider.setValue(80)
+
+    assert dialog.cosmetic_patches == DreadCosmeticPatches(**{field_name: 80})  # type: ignore[arg-type]
+    assert label.text() == " 80%"
+
+
 def test_room_names_dropdown(skip_qtbot: pytestqt.qtbot.QtBot) -> None:
     cosmetic_patches = DreadCosmeticPatches(show_room_names=DreadRoomGuiType.NONE)
 

--- a/test/test_files/patcher_data/dread/all_game_multi/world_4.json
+++ b/test/test_files/patcher_data/dread/all_game_multi/world_4.json
@@ -3911,10 +3911,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Some Words (XXXXXXXX)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Some Words (XXXXXXXX)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Some Words (XXXXXXXX)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Some Words (XXXXXXXX)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Some Words (XXXXXXXX)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Some Words (XXXXXXXX)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Some Words (XXXXXXXX)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."
@@ -3949,6 +3949,11 @@
                 "bShowEnemyLife": false,
                 "bShowEnemyDamage": false,
                 "bShowPlayerDamage": false
+            },
+            "SoundSystemATK": {
+                "fMusicVolume": 1.0,
+                "fSfxVolume": 1.0,
+                "fEnvironmentStreamsVolume": 1.0
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/all_game_multi/world_8.json
+++ b/test/test_files/patcher_data/dread/all_game_multi/world_8.json
@@ -3912,10 +3912,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Some Words (XXXXXXXX)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Some Words (XXXXXXXX)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Some Words (XXXXXXXX)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Some Words (XXXXXXXX)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Some Words (XXXXXXXX)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Some Words (XXXXXXXX)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Some Words (XXXXXXXX)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."
@@ -3950,6 +3950,11 @@
                 "bShowEnemyLife": false,
                 "bShowEnemyDamage": false,
                 "bShowPlayerDamage": false
+            },
+            "SoundSystemATK": {
+                "fMusicVolume": 1.0,
+                "fSfxVolume": 1.0,
+                "fEnvironmentStreamsVolume": 1.0
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/crazy_settings.json
+++ b/test/test_files/patcher_data/dread/crazy_settings.json
@@ -3678,10 +3678,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."
@@ -3714,6 +3714,11 @@
                 "bShowEnemyLife": false,
                 "bShowEnemyDamage": false,
                 "bShowPlayerDamage": false
+            },
+            "SoundSystemATK": {
+                "fMusicVolume": 1.0,
+                "fSfxVolume": 1.0,
+                "fEnvironmentStreamsVolume": 1.0
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/custom_start.json
+++ b/test/test_files/patcher_data/dread/custom_start.json
@@ -3681,10 +3681,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."
@@ -3716,6 +3716,11 @@
                 "bShowEnemyLife": false,
                 "bShowEnemyDamage": false,
                 "bShowPlayerDamage": false
+            },
+            "SoundSystemATK": {
+                "fMusicVolume": 1.0,
+                "fSfxVolume": 1.0,
+                "fEnvironmentStreamsVolume": 1.0
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/dread_dread_multiworld_expected.json
+++ b/test/test_files/patcher_data/dread/dread_dread_multiworld_expected.json
@@ -3823,10 +3823,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."
@@ -3858,6 +3858,11 @@
                 "bShowEnemyLife": false,
                 "bShowEnemyDamage": false,
                 "bShowPlayerDamage": false
+            },
+            "SoundSystemATK": {
+                "fMusicVolume": 1.0,
+                "fSfxVolume": 1.0,
+                "fEnvironmentStreamsVolume": 1.0
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/dread_prime1_multiworld_expected.json
+++ b/test/test_files/patcher_data/dread/dread_prime1_multiworld_expected.json
@@ -3802,10 +3802,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."
@@ -3837,6 +3837,11 @@
                 "bShowEnemyLife": false,
                 "bShowEnemyDamage": false,
                 "bShowPlayerDamage": false
+            },
+            "SoundSystemATK": {
+                "fMusicVolume": 1.0,
+                "fSfxVolume": 1.0,
+                "fEnvironmentStreamsVolume": 1.0
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/elevator_rando.json
+++ b/test/test_files/patcher_data/dread/elevator_rando.json
@@ -4023,10 +4023,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."
@@ -4056,6 +4056,11 @@
                 "bShowEnemyLife": false,
                 "bShowEnemyDamage": false,
                 "bShowPlayerDamage": false
+            },
+            "SoundSystemATK": {
+                "fMusicVolume": 1.0,
+                "fSfxVolume": 1.0,
+                "fEnvironmentStreamsVolume": 1.0
             }
         },
         "lua": {

--- a/test/test_files/patcher_data/dread/starter_preset.json
+++ b/test/test_files/patcher_data/dread/starter_preset.json
@@ -3659,10 +3659,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."
@@ -3692,6 +3692,11 @@
                 "bShowEnemyLife": false,
                 "bShowEnemyDamage": false,
                 "bShowPlayerDamage": false
+            },
+            "SoundSystemATK": {
+                "fMusicVolume": 1.0,
+                "fSfxVolume": 1.0,
+                "fEnvironmentStreamsVolume": 1.0
             }
         },
         "lua": {


### PR DESCRIPTION
Adds volume sliders to the cosmetic options for music (`fMusicVolume`) , SFX (`fSfxVolume`) and background ambience (`fEnvironmentStreamsVolume`)
![grafik](https://github.com/randovania/randovania/assets/38186597/ebfac449-b443-4245-b6e3-81dc33325b20)

Fixes #5247 