### PR TITLE
MSR - Fix wrong event being required in A3 Interior East

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior East.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior East.json
@@ -1230,7 +1230,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 3 (Exterior) - Inner Hub Access Grapple Block Left",
+                                            "name": "Area 3 (Interior East) - Double Back Grapple Block Left",
                                             "amount": 1,
                                             "negate": false
                                         }

--- a/randovania/games/samus_returns/logic_database/Area 3 - Interior East.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Interior East.txt
@@ -196,7 +196,7 @@ Extra - asset_id: collision_camera_018
   > Energy Recharge Station
       Trivial
   > Tunnel to Double Back (Top)
-      Morph Ball and After Area 3 (Exterior) - Outer Hub Access Grapple Block Left
+      Morph Ball and After Area 3 (Interior East) - Double Back Grapple Block Left
 
 > Door to Mini-Shaft East; Heals? False
   * Layers: default


### PR DESCRIPTION
The puzzle was checking for the event in Exterior by mistake