### PR TITLE
AM2R: Force vanilla music for race seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### AM2R
 
 - **Major** - Added: Multiworld support for AM2R. 
+- Changed: Race seeds will now ignore Music Shuffle and force vanilla music.
 - Changed: Minimal Logic has been adjusted. It now also checks for Morph Ball, Missile Launcher, the DNA and the Baby collection.
 - Changed: The Baby now checks for all DNA being collected and will display a message if not.
 

--- a/randovania/games/am2r/exporter/patch_data_factory.py
+++ b/randovania/games/am2r/exporter/patch_data_factory.py
@@ -352,7 +352,9 @@ class AM2RPatchDataFactory(PatchDataFactory):
             "etank_hud_rotation": c.etank_hud_rotation,
             "dna_hud_rotation": c.dna_hud_rotation,
             "room_names_on_hud": c.show_room_names.value,
-            "music_shuffle": _construct_music_shuffle_dict(c.music, Random(seed_number)),
+            "music_shuffle": _construct_music_shuffle_dict(
+                c.music if self.description.has_spoiler else MusicMode.VANILLA, Random(seed_number)
+            ),
         }
 
     def _get_text_data(self) -> dict:

--- a/randovania/gui/ui_files/am2r_cosmetic_patches_dialog.ui
+++ b/randovania/gui/ui_files/am2r_cosmetic_patches_dialog.ui
@@ -46,7 +46,7 @@
         <x>0</x>
         <y>0</y>
         <width>423</width>
-        <height>676</height>
+        <height>696</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -271,84 +271,89 @@
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Music</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="music_sub_label">
-         <property name="text">
-          <string>Changes the way music triggers behave.</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="vanilla_music_option">
-         <property name="text">
-          <string>Vanilla</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="vanilla_music_label">
-         <property name="text">
-          <string>Does not shuffle any songs.</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="type_music_option">
-         <property name="text">
-          <string>Per Type</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="type_music_label">
-         <property name="text">
-          <string>Only shuffles songs within certain types, those being &quot;combat&quot;, &quot;exploration&quot; and &quot;fanfares&quot;. This ensures that you won't be hearing boss music while trying to explore an area. Certain songs, such as the Credits song are exempt from shuffling.</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignJustify|Qt::AlignVCenter</set>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="full_music_option">
-         <property name="text">
-          <string>Full Random</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="full_music_label">
-         <property name="text">
-          <string>Will shuffle all songs.</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
+        <layout class="QVBoxLayout" name="music_layout">
+         <item>
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Music</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="music_sub_label">
+           <property name="text">
+            <string>Changes the way music triggers behave.
+Race seeds will ignore this value and force &quot;Vanilla&quot;.</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="vanilla_music_option">
+           <property name="text">
+            <string>Vanilla</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="vanilla_music_label">
+           <property name="text">
+            <string>Does not shuffle any songs.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="type_music_option">
+           <property name="text">
+            <string>Per Type</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="type_music_label">
+           <property name="text">
+            <string>Only shuffles songs within certain types, those being &quot;combat&quot;, &quot;exploration&quot; and &quot;fanfares&quot;. This ensures that you won't be hearing boss music while trying to explore an area. Certain songs, such as the Credits song are exempt from shuffling.</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignJustify|Qt::AlignVCenter</set>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="full_music_option">
+           <property name="text">
+            <string>Full Random</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="full_music_label">
+           <property name="text">
+            <string>Will shuffle all songs.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <spacer name="verticalSpacer">


### PR DESCRIPTION
This was a request, to not have accidentally someone use music shuffle in races.
![grafik](https://github.com/randovania/randovania/assets/38186597/1f824065-063d-475c-9736-24b4a2f1ee2a)
