### PR TITLE
MSR - Rename Dam Interior rooms and split off chambers

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 2 - Dam Exterior.json
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Dam Exterior.json
@@ -193,7 +193,7 @@
                     "dock_type": "elevator",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Main Hub",
+                        "area": "Transport to Area 2 Dam Exterior",
                         "node": "Elevator to Area 2 - Dam Exterior"
                     },
                     "default_dock_weakness": "Elevator",

--- a/randovania/games/samus_returns/logic_database/Area 2 - Dam Exterior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Dam Exterior.txt
@@ -13,7 +13,7 @@ Extra - asset_id: collision_camera_005
 
 > Elevator to Area 2 - Dam Interior; Heals? False
   * Layers: default
-  * Elevator to Main Hub/Elevator to Area 2 - Dam Exterior
+  * Elevator to Transport to Area 2 Dam Exterior/Elevator to Area 2 - Dam Exterior
   * Extra - actor_name: LE_Platform_Elevator_FromArea02B
   * Extra - actor_type: weightactivatedplatform
   * Extra - start_point_actor_name: ST_FromArea02B

--- a/randovania/games/samus_returns/logic_database/Area 2 - Dam Interior.json
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Dam Interior.json
@@ -9,7 +9,7 @@
         "scenario_id": "s025_area2b"
     },
     "areas": {
-        "Main Hub": {
+        "Transport to Area 2 Dam Exterior": {
             "default_node": "Elevator to Area 2 - Dam Exterior",
             "extra": {
                 "total_boundings": {
@@ -67,35 +67,6 @@
                 "asset_id": "collision_camera009"
             },
             "nodes": {
-                "Pickup (Wave Beam)": {
-                    "node_type": "pickup",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -5464.877934852794,
-                        "y": 839.7108995406816,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "LE_PowerUp_WaveBeam",
-                        "actor_type": "itemsphere_wavebeam"
-                    },
-                    "valid_starting_location": false,
-                    "pickup_index": 46,
-                    "location_category": "major",
-                    "connections": {
-                        "Door to Varia Suit Room (Middle)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Elevator to Area 2 - Dam Exterior": {
                     "node_type": "dock",
                     "heal": false,
@@ -291,21 +262,21 @@
                                 ]
                             }
                         },
-                        "Door to Fiery Path": {
+                        "Door to Lava Generator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Door to Fiery Balcony": {
+                        "Door to Generator Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Door to Varia Suit Room (Bottom)": {
+                        "Door to Wave Beam Chamber Access (Bottom)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -314,7 +285,7 @@
                                 "negate": false
                             }
                         },
-                        "Door to Varia Suit Room (Top)": {
+                        "Door to Wave Beam Chamber Access (Top)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -397,173 +368,8 @@
                                     }
                                 ]
                             }
-                        }
-                    }
-                },
-                "Door to Fiery Path": {
-                    "node_type": "dock",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -10642.949713097676,
-                        "y": -963.1256096388192,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "Door002",
-                        "actor_type": "doorchargecharge"
-                    },
-                    "valid_starting_location": false,
-                    "dock_type": "door",
-                    "default_connection": {
-                        "region": "Area 2 - Dam Interior",
-                        "area": "Fiery Path",
-                        "node": "Door to Main Hub"
-                    },
-                    "default_dock_weakness": "Charge Beam Door",
-                    "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
-                    "override_default_open_requirement": null,
-                    "override_default_lock_requirement": null,
-                    "connections": {
-                        "Save Station": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Door to Fiery Balcony": {
-                    "node_type": "dock",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -5756.313911900608,
-                        "y": -1471.4441742570998,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "Door003",
-                        "actor_type": "doorchargecharge"
-                    },
-                    "valid_starting_location": false,
-                    "dock_type": "door",
-                    "default_connection": {
-                        "region": "Area 2 - Dam Interior",
-                        "area": "Fiery Balcony",
-                        "node": "Door to Main Hub"
-                    },
-                    "default_dock_weakness": "Charge Beam Door",
-                    "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
-                    "override_default_open_requirement": null,
-                    "override_default_lock_requirement": null,
-                    "connections": {
-                        "Save Station": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
                         },
-                        "Door to Wallfire Path": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Door to Wallfire Path": {
-                    "node_type": "dock",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -5756.313911900608,
-                        "y": -719.1326986220447,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "Door005",
-                        "actor_type": "doorpowerpower"
-                    },
-                    "valid_starting_location": false,
-                    "dock_type": "door",
-                    "default_connection": {
-                        "region": "Area 2 - Dam Interior",
-                        "area": "Wallfire Path",
-                        "node": "Door to Main Hub"
-                    },
-                    "default_dock_weakness": "Power Beam Door",
-                    "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
-                    "override_default_open_requirement": null,
-                    "override_default_lock_requirement": null,
-                    "connections": {
-                        "Door to Fiery Balcony": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
-                "Door to Varia Suit Room (Bottom)": {
-                    "node_type": "dock",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3363.83,
-                        "y": 250.06,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "Door008",
-                        "actor_type": "doorpowerpower"
-                    },
-                    "valid_starting_location": false,
-                    "dock_type": "door",
-                    "default_connection": {
-                        "region": "Area 2 - Dam Interior",
-                        "area": "Varia Suit Room",
-                        "node": "Door to Main Hub (Bottom)"
-                    },
-                    "default_dock_weakness": "Wave Beam Door",
-                    "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
-                    "override_default_open_requirement": null,
-                    "override_default_lock_requirement": null,
-                    "connections": {
-                        "Save Station": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Door to Varia Suit Room (Middle)": {
+                        "Dock to Wave Beam Chamber": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -591,12 +397,305 @@
                         }
                     }
                 },
-                "Door to Varia Suit Room (Middle)": {
+                "Door to Lava Generator": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -10642.949713097676,
+                        "y": -963.1256096388192,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "actor_name": "Door002",
+                        "actor_type": "doorchargecharge"
+                    },
+                    "valid_starting_location": false,
+                    "dock_type": "door",
+                    "default_connection": {
+                        "region": "Area 2 - Dam Interior",
+                        "area": "Lava Generator",
+                        "node": "Door to Transport to Area 2 Dam Exterior"
+                    },
+                    "default_dock_weakness": "Charge Beam Door",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [],
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {
+                        "Save Station": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Door to Generator Access": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -5756.313911900608,
+                        "y": -1471.4441742570998,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "actor_name": "Door003",
+                        "actor_type": "doorchargecharge"
+                    },
+                    "valid_starting_location": false,
+                    "dock_type": "door",
+                    "default_connection": {
+                        "region": "Area 2 - Dam Interior",
+                        "area": "Generator Access",
+                        "node": "Door to Transport to Area 2 Dam Exterior"
+                    },
+                    "default_dock_weakness": "Charge Beam Door",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [],
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {
+                        "Save Station": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Door to Varia Chamber Access": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        }
+                    }
+                },
+                "Door to Varia Chamber Access": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -5756.313911900608,
+                        "y": -719.1326986220447,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "actor_name": "Door005",
+                        "actor_type": "doorpowerpower"
+                    },
+                    "valid_starting_location": false,
+                    "dock_type": "door",
+                    "default_connection": {
+                        "region": "Area 2 - Dam Interior",
+                        "area": "Varia Chamber Access",
+                        "node": "Door to Transport to Area 2 Dam Exterior"
+                    },
+                    "default_dock_weakness": "Power Beam Door",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [],
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {
+                        "Door to Generator Access": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        }
+                    }
+                },
+                "Door to Wave Beam Chamber Access (Bottom)": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -3363.83,
+                        "y": 250.06,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "actor_name": "Door008",
+                        "actor_type": "doorpowerpower"
+                    },
+                    "valid_starting_location": false,
+                    "dock_type": "door",
+                    "default_connection": {
+                        "region": "Area 2 - Dam Interior",
+                        "area": "Wave Beam Chamber Access",
+                        "node": "Door to Transport to Area 2 Dam Exterior (Bottom)"
+                    },
+                    "default_dock_weakness": "Wave Beam Door",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [],
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {
+                        "Save Station": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        }
+                    }
+                },
+                "Door to Wave Beam Chamber Access (Top)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
                         "x": -3370.605448625478,
-                        "y": 710.9368631707173,
+                        "y": 1741.1291541304317,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "actor_name": "Door019",
+                        "actor_type": "doorpowerpower"
+                    },
+                    "valid_starting_location": false,
+                    "dock_type": "door",
+                    "default_connection": {
+                        "region": "Area 2 - Dam Interior",
+                        "area": "Wave Beam Chamber Access",
+                        "node": "Door to Transport to Area 2 Dam Exterior (Top)"
+                    },
+                    "default_dock_weakness": "Wave Beam Door",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [],
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {
+                        "Save Station": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Morph",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        }
+                    }
+                },
+                "Dock to Wave Beam Chamber": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -4481.48,
+                        "y": 520.99,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "dock_type": "other",
+                    "default_connection": {
+                        "region": "Area 2 - Dam Interior",
+                        "area": "Wave Beam Chamber",
+                        "node": "Dock from Transport to Area 2 Dam Exterior"
+                    },
+                    "default_dock_weakness": "Open Passage",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [],
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {}
+                }
+            }
+        },
+        "Wave Beam Chamber": {
+            "default_node": null,
+            "extra": {
+                "total_boundings": {
+                    "x1": -5800.0,
+                    "x2": -3300.0,
+                    "y1": 425.0,
+                    "y2": 1575.0
+                },
+                "polygon": [
+                    [
+                        -5800.0,
+                        1575.0
+                    ],
+                    [
+                        -5800.0,
+                        425.0
+                    ],
+                    [
+                        -3300.0,
+                        425.0
+                    ],
+                    [
+                        -3300.0,
+                        1575.0
+                    ]
+                ],
+                "asset_id": "collision_camera009"
+            },
+            "nodes": {
+                "Pickup (Wave Beam)": {
+                    "node_type": "pickup",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -5464.877934852794,
+                        "y": 839.7108995406816,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "actor_name": "LE_PowerUp_WaveBeam",
+                        "actor_type": "itemsphere_wavebeam"
+                    },
+                    "valid_starting_location": false,
+                    "pickup_index": 46,
+                    "location_category": "major",
+                    "connections": {
+                        "Door to Wave Beam Chamber Access": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Door to Wave Beam Chamber Access": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -3370.61,
+                        "y": 710.94,
                         "z": 0.0
                     },
                     "description": "",
@@ -611,8 +710,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Varia Suit Room",
-                        "node": "Door to Main Hub (Middle)"
+                        "area": "Wave Beam Chamber Access",
+                        "node": "Door to Wave Beam Chamber"
                     },
                     "default_dock_weakness": "Missile Door",
                     "exclude_from_dock_rando": false,
@@ -636,46 +735,6 @@
                         }
                     }
                 },
-                "Door to Varia Suit Room (Top)": {
-                    "node_type": "dock",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -3370.605448625478,
-                        "y": 1741.1291541304317,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "Door019",
-                        "actor_type": "doorpowerpower"
-                    },
-                    "valid_starting_location": false,
-                    "dock_type": "door",
-                    "default_connection": {
-                        "region": "Area 2 - Dam Interior",
-                        "area": "Varia Suit Room",
-                        "node": "Door to Main Hub (Top)"
-                    },
-                    "default_dock_weakness": "Wave Beam Door",
-                    "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
-                    "override_default_open_requirement": null,
-                    "override_default_lock_requirement": null,
-                    "connections": {
-                        "Save Station": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Morph",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        }
-                    }
-                },
                 "Next to Pickup": {
                     "node_type": "generic",
                     "heal": false,
@@ -693,7 +752,42 @@
                     },
                     "valid_starting_location": false,
                     "connections": {
-                        "Door to Varia Suit Room (Middle)": {
+                        "Door to Wave Beam Chamber Access": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Dock from Transport to Area 2 Dam Exterior": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -4481.48,
+                        "y": 520.99,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "dock_type": "other",
+                    "default_connection": {
+                        "region": "Area 2 - Dam Interior",
+                        "area": "Transport to Area 2 Dam Exterior",
+                        "node": "Dock to Wave Beam Chamber"
+                    },
+                    "default_dock_weakness": "Blocked Passage",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [],
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {
+                        "Next to Pickup": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -704,11 +798,11 @@
                 }
             }
         },
-        "Varia Suit Room": {
-            "default_node": "Start Point",
+        "Wave Beam Chamber Access": {
+            "default_node": null,
             "extra": {
                 "total_boundings": {
-                    "x1": -4200.0,
+                    "x1": -3400.0,
                     "x2": 1000.0,
                     "y1": -4600.0,
                     "y2": 2400.0
@@ -720,26 +814,6 @@
                     ],
                     [
                         -3400.0,
-                        350.0
-                    ],
-                    [
-                        -4200.0,
-                        100.0
-                    ],
-                    [
-                        -4200.0,
-                        -1600.0
-                    ],
-                    [
-                        -3800.0,
-                        -1600.0
-                    ],
-                    [
-                        -3200.0,
-                        -2000.0
-                    ],
-                    [
-                        -3200.0,
                         -4000.0
                     ],
                     [
@@ -774,35 +848,6 @@
                 "asset_id": "collision_camera011"
             },
             "nodes": {
-                "Pickup (Varia Suit)": {
-                    "node_type": "pickup",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -2048.0737799156054,
-                        "y": -852.0368402408785,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "LE_PowerUp_VariaSuite",
-                        "actor_type": "itemsphere_variasuit"
-                    },
-                    "valid_starting_location": false,
-                    "pickup_index": 45,
-                    "location_category": "major",
-                    "connections": {
-                        "Door to Wallfire Path": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
                 "Ammo Recharge Station": {
                     "node_type": "generic",
                     "heal": false,
@@ -821,35 +866,14 @@
                     },
                     "valid_starting_location": false,
                     "connections": {
-                        "Pickup (Varia Suit)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Use Spider Ball"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "SpiderClip",
-                                            "amount": 3,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Door to Main Hub (Bottom)": {
+                        "Door to Transport to Area 2 Dam Exterior (Bottom)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Door to Main Hub (Middle)": {
+                        "Door to Wave Beam Chamber": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -981,109 +1005,31 @@
                                     }
                                 ]
                             }
-                        }
-                    }
-                },
-                "Door to Fiery Balcony": {
-                    "node_type": "dock",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -4170.986445923523,
-                        "y": -1382.765006742858,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "Door004",
-                        "actor_type": "doorchargecharge"
-                    },
-                    "valid_starting_location": false,
-                    "dock_type": "door",
-                    "default_connection": {
-                        "region": "Area 2 - Dam Interior",
-                        "area": "Fiery Balcony",
-                        "node": "Door to Varia Suit Room"
-                    },
-                    "default_dock_weakness": "Charge Beam Door",
-                    "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
-                    "override_default_open_requirement": null,
-                    "override_default_lock_requirement": null,
-                    "connections": {
-                        "Door to Wallfire Path": {
+                        },
+                        "Dock to Varia Chamber (OoB)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "SpiderClip",
+                                            "amount": 3,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Use Spider Ball"
+                                    }
+                                ]
                             }
                         }
                     }
                 },
-                "Door to Wallfire Path": {
-                    "node_type": "dock",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -4144.885060685721,
-                        "y": -730.2303757978011,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "Door006",
-                        "actor_type": "doorpowerpower"
-                    },
-                    "valid_starting_location": false,
-                    "dock_type": "door",
-                    "default_connection": {
-                        "region": "Area 2 - Dam Interior",
-                        "area": "Wallfire Path",
-                        "node": "Door to Varia Suit Room"
-                    },
-                    "default_dock_weakness": "Missile Door",
-                    "exclude_from_dock_rando": false,
-                    "incompatible_dock_weaknesses": [],
-                    "override_default_open_requirement": null,
-                    "override_default_lock_requirement": null,
-                    "connections": {
-                        "Pickup (Varia Suit)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Door to Fiery Balcony": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Inside Shortcut": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Screw",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Start Point": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Door to Main Hub (Bottom)": {
+                "Door to Transport to Area 2 Dam Exterior (Bottom)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1103,8 +1049,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Main Hub",
-                        "node": "Door to Varia Suit Room (Bottom)"
+                        "area": "Transport to Area 2 Dam Exterior",
+                        "node": "Door to Wave Beam Chamber Access (Bottom)"
                     },
                     "default_dock_weakness": "Wave Beam Door",
                     "exclude_from_dock_rando": false,
@@ -1121,12 +1067,12 @@
                         }
                     }
                 },
-                "Door to Main Hub (Middle)": {
+                "Door to Wave Beam Chamber": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -3361.843503551653,
-                        "y": 722.7467357731914,
+                        "x": -3361.84,
+                        "y": 722.75,
                         "z": 0.0
                     },
                     "description": "",
@@ -1141,8 +1087,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Main Hub",
-                        "node": "Door to Varia Suit Room (Middle)"
+                        "area": "Wave Beam Chamber",
+                        "node": "Door to Wave Beam Chamber Access"
                     },
                     "default_dock_weakness": "Missile Door",
                     "exclude_from_dock_rando": false,
@@ -1159,7 +1105,7 @@
                         }
                     }
                 },
-                "Door to Teleporter Shaft Access": {
+                "Door to Interior Teleporter Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1179,8 +1125,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Teleporter Shaft Access",
-                        "node": "Door to Varia Suit Room"
+                        "area": "Interior Teleporter Access",
+                        "node": "Door to Wave Beam Chamber Access"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "exclude_from_dock_rando": false,
@@ -1258,7 +1204,7 @@
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
                         "area": "Gamma Arena",
-                        "node": "Door to Varia Suit Room"
+                        "node": "Door to Wave Beam Chamber Access"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "exclude_from_dock_rando": false,
@@ -1377,12 +1323,12 @@
                         }
                     }
                 },
-                "Door to Main Hub (Top)": {
+                "Door to Transport to Area 2 Dam Exterior (Top)": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -3370.543965297587,
-                        "y": 1758.101683539348,
+                        "x": -3370.54,
+                        "y": 1758.1,
                         "z": 0.0
                     },
                     "description": "",
@@ -1397,8 +1343,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Main Hub",
-                        "node": "Door to Varia Suit Room (Top)"
+                        "area": "Transport to Area 2 Dam Exterior",
+                        "node": "Door to Wave Beam Chamber Access (Top)"
                     },
                     "default_dock_weakness": "Wave Beam Door",
                     "exclude_from_dock_rando": false,
@@ -1411,83 +1357,6 @@
                             "data": {
                                 "comment": null,
                                 "items": []
-                            }
-                        }
-                    }
-                },
-                "Pickup (Super Missile Tank)": {
-                    "node_type": "pickup",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -2361.290402769233,
-                        "y": -1556.7742416615397,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {
-                        "actor_name": "HP_Item_002",
-                        "actor_type": "item_supermissiletank"
-                    },
-                    "valid_starting_location": false,
-                    "pickup_index": 48,
-                    "location_category": "minor",
-                    "connections": {
-                        "Inside Shortcut": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        }
-                    }
-                },
-                "Inside Shortcut": {
-                    "node_type": "generic",
-                    "heal": false,
-                    "coordinates": {
-                        "x": -2700.608410860662,
-                        "y": -1365.3640832509896,
-                        "z": 0.0
-                    },
-                    "description": "",
-                    "layers": [
-                        "default"
-                    ],
-                    "extra": {},
-                    "valid_starting_location": false,
-                    "connections": {
-                        "Door to Wallfire Path": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Screw",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Pickup (Super Missile Tank)": {
-                            "type": "template",
-                            "data": "Lay Any Bomb"
-                        },
-                        "Bottom of Morph Ball Shaft": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Screw",
-                                "amount": 1,
-                                "negate": false
-                            }
-                        },
-                        "Right Shaft": {
-                            "type": "resource",
-                            "data": {
-                                "type": "items",
-                                "name": "Screw",
-                                "amount": 1,
-                                "negate": false
                             }
                         }
                     }
@@ -1558,20 +1427,20 @@
                                 "negate": false
                             }
                         },
-                        "Inside Shortcut": {
+                        "Bottom of Morph Ball Shaft": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Dock to Varia Chamber (Blocks)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
                                 "name": "Screw",
                                 "amount": 1,
                                 "negate": false
-                            }
-                        },
-                        "Bottom of Morph Ball Shaft": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
                             }
                         }
                     }
@@ -1591,21 +1460,21 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Door to Teleporter Shaft Access": {
+                        "Door to Interior Teleporter Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Door to Main Hub (Top)": {
+                        "Door to Transport to Area 2 Dam Exterior (Top)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Inside Shortcut": {
+                        "Dock to Varia Chamber (Blocks)": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -1616,35 +1485,82 @@
                         }
                     }
                 },
-                "Start Point": {
-                    "node_type": "generic",
+                "Dock to Varia Chamber (Blocks)": {
+                    "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -2500.0,
-                        "y": -700.0,
+                        "x": -1650.0,
+                        "y": -1370.0,
                         "z": 0.0
                     },
                     "description": "",
                     "layers": [
                         "default"
                     ],
-                    "extra": {
-                        "start_point_actor_name": "ST_CheckPoint_004"
-                    },
+                    "extra": {},
                     "valid_starting_location": false,
+                    "dock_type": "other",
+                    "default_connection": {
+                        "region": "Area 2 - Dam Interior",
+                        "area": "Varia Chamber",
+                        "node": "Dock to Wave Beam Chamber Access"
+                    },
+                    "default_dock_weakness": "Open Passage",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [],
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Wallfire Path": {
-                            "type": "and",
+                        "Bottom of Morph Ball Shaft": {
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Right Shaft": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
+                },
+                "Dock to Varia Chamber (OoB)": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -1926.36,
+                        "y": -307.87,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "dock_type": "other",
+                    "default_connection": {
+                        "region": "Area 2 - Dam Interior",
+                        "area": "Varia Chamber",
+                        "node": "Dock from Wave Beam Chamber Access"
+                    },
+                    "default_dock_weakness": "Open Passage",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [],
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {}
                 }
             }
         },
-        "Fiery Path": {
+        "Lava Generator": {
             "default_node": "Start Point",
             "extra": {
                 "total_boundings": {
@@ -1710,7 +1626,7 @@
                 "asset_id": "collision_camera012"
             },
             "nodes": {
-                "Door to Main Hub": {
+                "Door to Transport to Area 2 Dam Exterior": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1730,8 +1646,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Main Hub",
-                        "node": "Door to Fiery Path"
+                        "area": "Transport to Area 2 Dam Exterior",
+                        "node": "Door to Lava Generator"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "exclude_from_dock_rando": false,
@@ -1771,7 +1687,7 @@
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
                         "area": "Gamma Arena",
-                        "node": "Door to Fiery Path"
+                        "node": "Door to Lava Generator"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "exclude_from_dock_rando": false,
@@ -1797,7 +1713,7 @@
                         }
                     }
                 },
-                "Door to Fiery Storage": {
+                "Door to Crumble Cavern": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1817,8 +1733,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Fiery Storage",
-                        "node": "Door to Fiery Path"
+                        "area": "Crumble Cavern",
+                        "node": "Door to Lava Generator"
                     },
                     "default_dock_weakness": "Power Bomb Door",
                     "exclude_from_dock_rando": false,
@@ -1837,7 +1753,7 @@
                         }
                     }
                 },
-                "Door to Fiery Balcony": {
+                "Door to Generator Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1857,8 +1773,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Fiery Balcony",
-                        "node": "Door to Fiery Path"
+                        "area": "Generator Access",
+                        "node": "Door to Lava Generator"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "exclude_from_dock_rando": false,
@@ -1918,7 +1834,7 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Door to Main Hub": {
+                        "Door to Transport to Area 2 Dam Exterior": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -1936,7 +1852,7 @@
                                 "negate": false
                             }
                         },
-                        "Door to Fiery Storage": {
+                        "Door to Crumble Cavern": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -1945,7 +1861,7 @@
                                 "negate": false
                             }
                         },
-                        "Door to Fiery Balcony": {
+                        "Door to Generator Access": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -2154,7 +2070,7 @@
                 }
             }
         },
-        "Fiery Storage": {
+        "Crumble Cavern": {
             "default_node": null,
             "extra": {
                 "total_boundings": {
@@ -2204,7 +2120,7 @@
                     "pickup_index": 43,
                     "location_category": "minor",
                     "connections": {
-                        "Door to Fiery Path": {
+                        "Door to Lava Generator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -2232,7 +2148,7 @@
                         }
                     }
                 },
-                "Door to Fiery Path": {
+                "Door to Lava Generator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2252,8 +2168,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Fiery Path",
-                        "node": "Door to Fiery Storage"
+                        "area": "Lava Generator",
+                        "node": "Door to Crumble Cavern"
                     },
                     "default_dock_weakness": "Power Bomb Door",
                     "exclude_from_dock_rando": false,
@@ -2420,7 +2336,7 @@
                 }
             }
         },
-        "Teleporter Shaft Access": {
+        "Interior Teleporter Access": {
             "default_node": null,
             "extra": {
                 "total_boundings": {
@@ -2458,7 +2374,7 @@
                 "asset_id": "collision_camera015"
             },
             "nodes": {
-                "Door to Varia Suit Room": {
+                "Door to Wave Beam Chamber Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2478,8 +2394,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Varia Suit Room",
-                        "node": "Door to Teleporter Shaft Access"
+                        "area": "Wave Beam Chamber Access",
+                        "node": "Door to Interior Teleporter Access"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "exclude_from_dock_rando": false,
@@ -2487,7 +2403,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tunnel to Teleporter Shaft": {
+                        "Tunnel to Interior Teleporter": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -2502,7 +2418,7 @@
                         }
                     }
                 },
-                "Tunnel to Teleporter Shaft": {
+                "Tunnel to Interior Teleporter": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2519,8 +2435,8 @@
                     "dock_type": "tunnel",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Teleporter Shaft",
-                        "node": "Tunnel to Teleporter Shaft Access"
+                        "area": "Interior Teleporter",
+                        "node": "Tunnel to Interior Teleporter Access"
                     },
                     "default_dock_weakness": "Tunnel",
                     "exclude_from_dock_rando": false,
@@ -2528,7 +2444,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Varia Suit Room": {
+                        "Door to Wave Beam Chamber Access": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -2557,7 +2473,7 @@
                     },
                     "valid_starting_location": false,
                     "connections": {
-                        "Door to Varia Suit Room": {
+                        "Door to Wave Beam Chamber Access": {
                             "type": "template",
                             "data": "Lay Any Bomb"
                         }
@@ -2565,7 +2481,7 @@
                 }
             }
         },
-        "Teleporter Shaft": {
+        "Interior Teleporter": {
             "default_node": "Teleporter",
             "extra": {
                 "total_boundings": {
@@ -2648,7 +2564,7 @@
                         }
                     }
                 },
-                "Door to Horseshoe Path": {
+                "Door to Fleech Swarm Corridor": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2668,8 +2584,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Horseshoe Path",
-                        "node": "Door to Teleporter Shaft"
+                        "area": "Fleech Swarm Corridor",
+                        "node": "Door to Interior Teleporter"
                     },
                     "default_dock_weakness": "Wave Beam Door",
                     "exclude_from_dock_rando": false,
@@ -2686,7 +2602,7 @@
                         }
                     }
                 },
-                "Door to Fan Tunnel": {
+                "Door to Teleporter Storage": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2706,8 +2622,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Fan Tunnel",
-                        "node": "Door to Teleporter Shaft"
+                        "area": "Teleporter Storage",
+                        "node": "Door to Interior Teleporter"
                     },
                     "default_dock_weakness": "Plasma Beam Door",
                     "exclude_from_dock_rando": false,
@@ -2724,7 +2640,7 @@
                         }
                     }
                 },
-                "Tunnel to High Jump Shaft": {
+                "Tunnel to High Jump Chamber Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2741,8 +2657,8 @@
                     "dock_type": "tunnel",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "High Jump Shaft",
-                        "node": "Tunnel to Teleporter Shaft"
+                        "area": "High Jump Chamber Access",
+                        "node": "Tunnel to Interior Teleporter"
                     },
                     "default_dock_weakness": "Tunnel",
                     "exclude_from_dock_rando": false,
@@ -2761,7 +2677,7 @@
                         }
                     }
                 },
-                "Tunnel to Teleporter Shaft Access": {
+                "Tunnel to Interior Teleporter Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2778,8 +2694,8 @@
                     "dock_type": "tunnel",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Teleporter Shaft Access",
-                        "node": "Tunnel to Teleporter Shaft"
+                        "area": "Interior Teleporter Access",
+                        "node": "Tunnel to Interior Teleporter"
                     },
                     "default_dock_weakness": "Tunnel",
                     "exclude_from_dock_rando": false,
@@ -2813,21 +2729,21 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Door to Horseshoe Path": {
+                        "Door to Fleech Swarm Corridor": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Door to Fan Tunnel": {
+                        "Door to Teleporter Storage": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Tunnel to High Jump Shaft": {
+                        "Tunnel to High Jump Chamber Access": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -2836,7 +2752,7 @@
                                 "negate": false
                             }
                         },
-                        "Tunnel to Teleporter Shaft Access": {
+                        "Tunnel to Interior Teleporter Access": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -2991,7 +2907,7 @@
                 }
             }
         },
-        "Horseshoe Path": {
+        "Fleech Swarm Corridor": {
             "default_node": null,
             "extra": {
                 "total_boundings": {
@@ -3033,7 +2949,7 @@
                 "asset_id": "collision_camera017"
             },
             "nodes": {
-                "Door to High Jump Storage": {
+                "Door to Dam Basement": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3053,8 +2969,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "High Jump Storage",
-                        "node": "Door to Horseshoe Path"
+                        "area": "Dam Basement",
+                        "node": "Door to Fleech Swarm Corridor"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "exclude_from_dock_rando": false,
@@ -3062,7 +2978,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Teleporter Shaft": {
+                        "Door to Interior Teleporter": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3169,7 +3085,7 @@
                         }
                     }
                 },
-                "Door to Teleporter Shaft": {
+                "Door to Interior Teleporter": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3189,8 +3105,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Teleporter Shaft",
-                        "node": "Door to Horseshoe Path"
+                        "area": "Interior Teleporter",
+                        "node": "Door to Fleech Swarm Corridor"
                     },
                     "default_dock_weakness": "Wave Beam Door",
                     "exclude_from_dock_rando": false,
@@ -3198,7 +3114,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to High Jump Storage": {
+                        "Door to Dam Basement": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3223,7 +3139,7 @@
                 }
             }
         },
-        "High Jump Storage": {
+        "Dam Basement": {
             "default_node": null,
             "extra": {
                 "total_boundings": {
@@ -3273,7 +3189,7 @@
                     "pickup_index": 40,
                     "location_category": "major",
                     "connections": {
-                        "Door to Horseshoe Path": {
+                        "Door to Fleech Swarm Corridor": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3302,7 +3218,7 @@
                     "pickup_index": 41,
                     "location_category": "minor",
                     "connections": {
-                        "Tunnel to High Jump Secret": {
+                        "Tunnel to Gullugg Hideout": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -3313,7 +3229,7 @@
                         }
                     }
                 },
-                "Door to Horseshoe Path": {
+                "Door to Fleech Swarm Corridor": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3333,8 +3249,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Horseshoe Path",
-                        "node": "Door to High Jump Storage"
+                        "area": "Fleech Swarm Corridor",
+                        "node": "Door to Dam Basement"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "exclude_from_dock_rando": false,
@@ -3351,7 +3267,7 @@
                         }
                     }
                 },
-                "Tunnel to High Jump Secret": {
+                "Tunnel to Gullugg Hideout": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3368,8 +3284,8 @@
                     "dock_type": "tunnel",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "High Jump Secret",
-                        "node": "Tunnel to High Jump Storage"
+                        "area": "Gullugg Hideout",
+                        "node": "Tunnel to Dam Basement"
                     },
                     "default_dock_weakness": "Tunnel",
                     "exclude_from_dock_rando": false,
@@ -3390,7 +3306,7 @@
                 }
             }
         },
-        "High Jump Secret": {
+        "Gullugg Hideout": {
             "default_node": null,
             "extra": {
                 "total_boundings": {
@@ -3420,7 +3336,7 @@
                 "asset_id": "collision_camera019"
             },
             "nodes": {
-                "Tunnel to High Jump Storage": {
+                "Tunnel to Dam Basement": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3437,8 +3353,8 @@
                     "dock_type": "tunnel",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "High Jump Storage",
-                        "node": "Tunnel to High Jump Secret"
+                        "area": "Dam Basement",
+                        "node": "Tunnel to Gullugg Hideout"
                     },
                     "default_dock_weakness": "Tunnel",
                     "exclude_from_dock_rando": false,
@@ -3446,13 +3362,13 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tunnel to High Jump Room": {
+                        "Tunnel to High Jump Chamber": {
                             "type": "template",
                             "data": "Lay Any Bomb"
                         }
                     }
                 },
-                "Tunnel to High Jump Room": {
+                "Tunnel to High Jump Chamber": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3469,8 +3385,8 @@
                     "dock_type": "tunnel",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "High Jump Room",
-                        "node": "Tunnel to High Jump Secret"
+                        "area": "High Jump Chamber",
+                        "node": "Tunnel to Gullugg Hideout"
                     },
                     "default_dock_weakness": "Tunnel with Bomb Block",
                     "exclude_from_dock_rando": false,
@@ -3478,7 +3394,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tunnel to High Jump Storage": {
+                        "Tunnel to Dam Basement": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3594,7 +3510,7 @@
                 }
             }
         },
-        "High Jump Room": {
+        "High Jump Chamber": {
             "default_node": "Room Center",
             "extra": {
                 "total_boundings": {
@@ -3653,7 +3569,7 @@
                         }
                     }
                 },
-                "Door to High Jump Shaft": {
+                "Door to High Jump Chamber Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3673,8 +3589,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "High Jump Shaft",
-                        "node": "Door to High Jump Room"
+                        "area": "High Jump Chamber Access",
+                        "node": "Door to High Jump Chamber"
                     },
                     "default_dock_weakness": "Missile Door",
                     "exclude_from_dock_rando": false,
@@ -3691,7 +3607,7 @@
                         }
                     }
                 },
-                "Tunnel to High Jump Secret": {
+                "Tunnel to Gullugg Hideout": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3708,8 +3624,8 @@
                     "dock_type": "tunnel",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "High Jump Secret",
-                        "node": "Tunnel to High Jump Room"
+                        "area": "Gullugg Hideout",
+                        "node": "Tunnel to High Jump Chamber"
                     },
                     "default_dock_weakness": "Tunnel with Bomb Block",
                     "exclude_from_dock_rando": false,
@@ -3747,14 +3663,14 @@
                                 "items": []
                             }
                         },
-                        "Door to High Jump Shaft": {
+                        "Door to High Jump Chamber Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Tunnel to High Jump Secret": {
+                        "Tunnel to Gullugg Hideout": {
                             "type": "template",
                             "data": "Lay Any Bomb"
                         }
@@ -3762,7 +3678,7 @@
                 }
             }
         },
-        "High Jump Shaft": {
+        "High Jump Chamber Access": {
             "default_node": null,
             "extra": {
                 "total_boundings": {
@@ -3792,7 +3708,7 @@
                 "asset_id": "collision_camera022"
             },
             "nodes": {
-                "Door to High Jump Room": {
+                "Door to High Jump Chamber": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3812,8 +3728,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "High Jump Room",
-                        "node": "Door to High Jump Shaft"
+                        "area": "High Jump Chamber",
+                        "node": "Door to High Jump Chamber Access"
                     },
                     "default_dock_weakness": "Missile Door",
                     "exclude_from_dock_rando": false,
@@ -3821,7 +3737,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Tunnel to Teleporter Shaft": {
+                        "Tunnel to Interior Teleporter": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4016,7 +3932,7 @@
                         }
                     }
                 },
-                "Tunnel to Teleporter Shaft": {
+                "Tunnel to Interior Teleporter": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4033,8 +3949,8 @@
                     "dock_type": "tunnel",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Teleporter Shaft",
-                        "node": "Tunnel to High Jump Shaft"
+                        "area": "Interior Teleporter",
+                        "node": "Tunnel to High Jump Chamber Access"
                     },
                     "default_dock_weakness": "Tunnel",
                     "exclude_from_dock_rando": false,
@@ -4042,7 +3958,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to High Jump Room": {
+                        "Door to High Jump Chamber": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -4055,7 +3971,300 @@
                 }
             }
         },
-        "Wallfire Path": {
+        "Varia Chamber": {
+            "default_node": "Start Point",
+            "extra": {
+                "total_boundings": {
+                    "x1": -4200.0,
+                    "x2": -1550.0,
+                    "y1": -1700.0,
+                    "y2": -100.0
+                },
+                "polygon": [
+                    [
+                        -1550.0,
+                        -100.0
+                    ],
+                    [
+                        -4200.0,
+                        -100.0
+                    ],
+                    [
+                        -4200.0,
+                        -1700.0
+                    ],
+                    [
+                        -1550.0,
+                        -1700.0
+                    ]
+                ],
+                "asset_id": "collision_camera011"
+            },
+            "nodes": {
+                "Pickup (Varia Suit)": {
+                    "node_type": "pickup",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -2048.0737799156054,
+                        "y": -852.0368402408785,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "actor_name": "LE_PowerUp_VariaSuite",
+                        "actor_type": "itemsphere_variasuit"
+                    },
+                    "valid_starting_location": false,
+                    "pickup_index": 45,
+                    "location_category": "major",
+                    "connections": {
+                        "Door to Varia Chamber Access": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Door to Generator Access": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -4170.986445923523,
+                        "y": -1382.765006742858,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "actor_name": "Door004",
+                        "actor_type": "doorchargecharge"
+                    },
+                    "valid_starting_location": false,
+                    "dock_type": "door",
+                    "default_connection": {
+                        "region": "Area 2 - Dam Interior",
+                        "area": "Generator Access",
+                        "node": "Door to Varia Chamber"
+                    },
+                    "default_dock_weakness": "Charge Beam Door",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [],
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {
+                        "Door to Varia Chamber Access": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Door to Varia Chamber Access": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -4144.885060685721,
+                        "y": -730.2303757978011,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "actor_name": "Door006",
+                        "actor_type": "doorpowerpower"
+                    },
+                    "valid_starting_location": false,
+                    "dock_type": "door",
+                    "default_connection": {
+                        "region": "Area 2 - Dam Interior",
+                        "area": "Varia Chamber Access",
+                        "node": "Door to Varia Chamber"
+                    },
+                    "default_dock_weakness": "Missile Door",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [],
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {
+                        "Pickup (Varia Suit)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Door to Generator Access": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Start Point": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Dock to Wave Beam Chamber Access": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        }
+                    }
+                },
+                "Pickup (Super Missile Tank)": {
+                    "node_type": "pickup",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -2361.290402769233,
+                        "y": -1556.7742416615397,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "actor_name": "HP_Item_002",
+                        "actor_type": "item_supermissiletank"
+                    },
+                    "valid_starting_location": false,
+                    "pickup_index": 48,
+                    "location_category": "minor",
+                    "connections": {
+                        "Dock to Wave Beam Chamber Access": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        }
+                    }
+                },
+                "Start Point": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -2500.0,
+                        "y": -700.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {
+                        "start_point_actor_name": "ST_CheckPoint_004"
+                    },
+                    "valid_starting_location": false,
+                    "connections": {
+                        "Door to Varia Chamber Access": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Dock to Wave Beam Chamber Access": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -1650.0,
+                        "y": -1370.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "dock_type": "other",
+                    "default_connection": {
+                        "region": "Area 2 - Dam Interior",
+                        "area": "Wave Beam Chamber Access",
+                        "node": "Dock to Varia Chamber (Blocks)"
+                    },
+                    "default_dock_weakness": "Open Passage",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [],
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {
+                        "Door to Varia Chamber Access": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Screw",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Pickup (Super Missile Tank)": {
+                            "type": "template",
+                            "data": "Lay Any Bomb"
+                        }
+                    }
+                },
+                "Dock from Wave Beam Chamber Access": {
+                    "node_type": "dock",
+                    "heal": false,
+                    "coordinates": {
+                        "x": -1926.36,
+                        "y": -307.87,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "dock_type": "other",
+                    "default_connection": {
+                        "region": "Area 2 - Dam Interior",
+                        "area": "Wave Beam Chamber Access",
+                        "node": "Dock to Varia Chamber (OoB)"
+                    },
+                    "default_dock_weakness": "Blocked Passage",
+                    "exclude_from_dock_rando": false,
+                    "incompatible_dock_weaknesses": [],
+                    "override_default_open_requirement": null,
+                    "override_default_lock_requirement": null,
+                    "connections": {
+                        "Door to Varia Chamber Access": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "Varia Chamber Access": {
             "default_node": null,
             "extra": {
                 "total_boundings": {
@@ -4085,7 +4294,7 @@
                 "asset_id": "collision_camera035"
             },
             "nodes": {
-                "Door to Main Hub": {
+                "Door to Transport to Area 2 Dam Exterior": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4105,8 +4314,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Main Hub",
-                        "node": "Door to Wallfire Path"
+                        "area": "Transport to Area 2 Dam Exterior",
+                        "node": "Door to Varia Chamber Access"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "exclude_from_dock_rando": false,
@@ -4114,7 +4323,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Varia Suit Room": {
+                        "Door to Varia Chamber": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4123,12 +4332,12 @@
                         }
                     }
                 },
-                "Door to Varia Suit Room": {
+                "Door to Varia Chamber": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
-                        "x": -4157.688261913317,
-                        "y": -710.3418450231351,
+                        "x": -4157.69,
+                        "y": -710.34,
                         "z": 0.0
                     },
                     "description": "",
@@ -4143,16 +4352,16 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Varia Suit Room",
-                        "node": "Door to Wallfire Path"
+                        "area": "Varia Chamber",
+                        "node": "Door to Varia Chamber Access"
                     },
-                    "default_dock_weakness": "Missile Door",
+                    "default_dock_weakness": "Access Open",
                     "exclude_from_dock_rando": false,
                     "incompatible_dock_weaknesses": [],
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Main Hub": {
+                        "Door to Transport to Area 2 Dam Exterior": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4163,7 +4372,7 @@
                 }
             }
         },
-        "Fan Tunnel": {
+        "Teleporter Storage": {
             "default_node": null,
             "extra": {
                 "total_boundings": {
@@ -4213,13 +4422,13 @@
                     "pickup_index": 42,
                     "location_category": "minor",
                     "connections": {
-                        "Door to Teleporter Shaft": {
+                        "Door to Interior Teleporter": {
                             "type": "template",
                             "data": "Lay Any Bomb"
                         }
                     }
                 },
-                "Door to Teleporter Shaft": {
+                "Door to Interior Teleporter": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4239,8 +4448,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Teleporter Shaft",
-                        "node": "Door to Fan Tunnel"
+                        "area": "Interior Teleporter",
+                        "node": "Door to Teleporter Storage"
                     },
                     "default_dock_weakness": "Plasma Beam Door",
                     "exclude_from_dock_rando": false,
@@ -4310,7 +4519,7 @@
                 "asset_id": "collision_camera037"
             },
             "nodes": {
-                "Door to Fiery Path": {
+                "Door to Lava Generator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4330,7 +4539,7 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Fiery Path",
+                        "area": "Lava Generator",
                         "node": "Door to Gamma Arena"
                     },
                     "default_dock_weakness": "Charge Beam Door",
@@ -4348,7 +4557,7 @@
                         }
                     }
                 },
-                "Door to Varia Suit Room": {
+                "Door to Wave Beam Chamber Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4368,7 +4577,7 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Varia Suit Room",
+                        "area": "Wave Beam Chamber Access",
                         "node": "Door to Gamma Arena"
                     },
                     "default_dock_weakness": "Power Beam Door",
@@ -4428,14 +4637,14 @@
                     },
                     "valid_starting_location": false,
                     "connections": {
-                        "Door to Fiery Path": {
+                        "Door to Lava Generator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": []
                             }
                         },
-                        "Door to Varia Suit Room": {
+                        "Door to Wave Beam Chamber Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4479,7 +4688,7 @@
                 }
             }
         },
-        "Fiery Balcony": {
+        "Generator Access": {
             "default_node": null,
             "extra": {
                 "total_boundings": {
@@ -4509,7 +4718,7 @@
                 "asset_id": "collision_camera041"
             },
             "nodes": {
-                "Door to Main Hub": {
+                "Door to Transport to Area 2 Dam Exterior": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4529,8 +4738,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Main Hub",
-                        "node": "Door to Fiery Balcony"
+                        "area": "Transport to Area 2 Dam Exterior",
+                        "node": "Door to Generator Access"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "exclude_from_dock_rando": false,
@@ -4538,7 +4747,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Varia Suit Room": {
+                        "Door to Varia Chamber": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4564,7 +4773,7 @@
                                 ]
                             }
                         },
-                        "Door to Fiery Path": {
+                        "Door to Lava Generator": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4592,7 +4801,7 @@
                         }
                     }
                 },
-                "Door to Varia Suit Room": {
+                "Door to Varia Chamber": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4612,8 +4821,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Varia Suit Room",
-                        "node": "Door to Fiery Balcony"
+                        "area": "Varia Chamber",
+                        "node": "Door to Generator Access"
                     },
                     "default_dock_weakness": "Charge Beam Door",
                     "exclude_from_dock_rando": false,
@@ -4621,7 +4830,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Main Hub": {
+                        "Door to Transport to Area 2 Dam Exterior": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4649,7 +4858,7 @@
                         }
                     }
                 },
-                "Door to Fiery Path": {
+                "Door to Lava Generator": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4669,8 +4878,8 @@
                     "dock_type": "door",
                     "default_connection": {
                         "region": "Area 2 - Dam Interior",
-                        "area": "Fiery Path",
-                        "node": "Door to Fiery Balcony"
+                        "area": "Lava Generator",
+                        "node": "Door to Generator Access"
                     },
                     "default_dock_weakness": "Power Beam Door",
                     "exclude_from_dock_rando": false,
@@ -4678,7 +4887,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Main Hub": {
+                        "Door to Transport to Area 2 Dam Exterior": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/samus_returns/logic_database/Area 2 - Dam Interior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Dam Interior.txt
@@ -1,16 +1,8 @@
 ----------------
-Main Hub
+Transport to Area 2 Dam Exterior
 Extra - total_boundings: {'x1': -10700.0, 'x2': -3300.0, 'y1': -1500.0, 'y2': 2400.0}
 Extra - polygon: [[-8400.0, 2400.0], [-8400.0, 1000.0], [-10700.0, 1000.0], [-10700.0, -1300.0], [-8500.0, -1300.0], [-7500.0, -1500.0], [-5700.0, -1500.0], [-5700.0, -100.0], [-5200.0, 0.0], [-3300.0, 0.0], [-3300.0, 2400.0]]
 Extra - asset_id: collision_camera009
-> Pickup (Wave Beam); Heals? False
-  * Layers: default
-  * Pickup 46; Category? Major
-  * Extra - actor_name: LE_PowerUp_WaveBeam
-  * Extra - actor_type: itemsphere_wavebeam
-  > Door to Varia Suit Room (Middle)
-      Trivial
-
 > Elevator to Area 2 - Dam Exterior; Heals? False; Spawn Point; Default Node
   * Layers: default
   * Elevator to Outer Hub/Elevator to Area 2 - Dam Interior
@@ -32,13 +24,13 @@ Extra - asset_id: collision_camera009
           Stand on Frozen Enemy (Intermediate) and Fully Freeze Enemy
           Morph Ball and Unmorph Extend (Beginner)
           Phase Drift and Mid-Air Morph (Intermediate) and Use Spider Ball
-  > Door to Fiery Path
+  > Door to Lava Generator
       Trivial
-  > Door to Fiery Balcony
+  > Door to Generator Access
       Trivial
-  > Door to Varia Suit Room (Bottom)
+  > Door to Wave Beam Chamber Access (Bottom)
       Morph Ball
-  > Door to Varia Suit Room (Top)
+  > Door to Wave Beam Chamber Access (Top)
       All of the following:
           Morph Ball
           Any of the following:
@@ -46,46 +38,71 @@ Extra - asset_id: collision_camera009
               All of the following:
                   Lightning Armor
                   Single-wall Wall Jump (Intermediate) or Climb Rooms Vertically (High Jump)
+  > Dock to Wave Beam Chamber
+      Morph Ball and Melee Clip (Intermediate)
 
-> Door to Fiery Path; Heals? False
+> Door to Lava Generator; Heals? False
   * Layers: default
-  * Charge Beam Door to Fiery Path/Door to Main Hub
+  * Charge Beam Door to Lava Generator/Door to Transport to Area 2 Dam Exterior
   * Extra - actor_name: Door002
   * Extra - actor_type: doorchargecharge
   > Save Station
       Trivial
 
-> Door to Fiery Balcony; Heals? False
+> Door to Generator Access; Heals? False
   * Layers: default
-  * Charge Beam Door to Fiery Balcony/Door to Main Hub
+  * Charge Beam Door to Generator Access/Door to Transport to Area 2 Dam Exterior
   * Extra - actor_name: Door003
   * Extra - actor_type: doorchargecharge
   > Save Station
       Trivial
-  > Door to Wallfire Path
+  > Door to Varia Chamber Access
       Morph Ball
 
-> Door to Wallfire Path; Heals? False
+> Door to Varia Chamber Access; Heals? False
   * Layers: default
-  * Power Beam Door to Wallfire Path/Door to Main Hub
+  * Power Beam Door to Varia Chamber Access/Door to Transport to Area 2 Dam Exterior
   * Extra - actor_name: Door005
   * Extra - actor_type: doorpowerpower
-  > Door to Fiery Balcony
+  > Door to Generator Access
       Morph Ball
 
-> Door to Varia Suit Room (Bottom); Heals? False
+> Door to Wave Beam Chamber Access (Bottom); Heals? False
   * Layers: default
-  * Wave Beam Door to Varia Suit Room/Door to Main Hub (Bottom)
+  * Wave Beam Door to Wave Beam Chamber Access/Door to Transport to Area 2 Dam Exterior (Bottom)
   * Extra - actor_name: Door008
   * Extra - actor_type: doorpowerpower
   > Save Station
       Morph Ball
-  > Door to Varia Suit Room (Middle)
-      Morph Ball and Melee Clip (Intermediate)
 
-> Door to Varia Suit Room (Middle); Heals? False
+> Door to Wave Beam Chamber Access (Top); Heals? False
   * Layers: default
-  * Missile Door to Varia Suit Room/Door to Main Hub (Middle)
+  * Wave Beam Door to Wave Beam Chamber Access/Door to Transport to Area 2 Dam Exterior (Top)
+  * Extra - actor_name: Door019
+  * Extra - actor_type: doorpowerpower
+  > Save Station
+      Morph Ball
+
+> Dock to Wave Beam Chamber; Heals? False
+  * Layers: default
+  * Open Passage to Wave Beam Chamber/Dock from Transport to Area 2 Dam Exterior
+
+----------------
+Wave Beam Chamber
+Extra - total_boundings: {'x1': -5800.0, 'x2': -3300.0, 'y1': 425.0, 'y2': 1575.0}
+Extra - polygon: [[-5800.0, 1575.0], [-5800.0, 425.0], [-3300.0, 425.0], [-3300.0, 1575.0]]
+Extra - asset_id: collision_camera009
+> Pickup (Wave Beam); Heals? False
+  * Layers: default
+  * Pickup 46; Category? Major
+  * Extra - actor_name: LE_PowerUp_WaveBeam
+  * Extra - actor_type: itemsphere_wavebeam
+  > Door to Wave Beam Chamber Access
+      Trivial
+
+> Door to Wave Beam Chamber Access; Heals? False
+  * Layers: default
+  * Missile Door to Wave Beam Chamber Access/Door to Wave Beam Chamber
   * Extra - actor_name: Door009
   * Extra - actor_type: doorpowerpower
   > Pickup (Wave Beam)
@@ -93,42 +110,30 @@ Extra - asset_id: collision_camera009
   > Next to Pickup
       Trivial
 
-> Door to Varia Suit Room (Top); Heals? False
-  * Layers: default
-  * Wave Beam Door to Varia Suit Room/Door to Main Hub (Top)
-  * Extra - actor_name: Door019
-  * Extra - actor_type: doorpowerpower
-  > Save Station
-      Morph Ball
-
 > Next to Pickup; Heals? False
   * Layers: default
   * Extra - start_point_actor_name: ST_CheckPoint_003
-  > Door to Varia Suit Room (Middle)
+  > Door to Wave Beam Chamber Access
+      Trivial
+
+> Dock from Transport to Area 2 Dam Exterior; Heals? False
+  * Layers: default
+  * Blocked Passage to Transport to Area 2 Dam Exterior/Dock to Wave Beam Chamber
+  > Next to Pickup
       Trivial
 
 ----------------
-Varia Suit Room
-Extra - total_boundings: {'x1': -4200.0, 'x2': 1000.0, 'y1': -4600.0, 'y2': 2400.0}
-Extra - polygon: [[-3400.0, 2400.0], [-3400.0, 350.0], [-4200.0, 100.0], [-4200.0, -1600.0], [-3800.0, -1600.0], [-3200.0, -2000.0], [-3200.0, -4000.0], [-1850.0, -4100.0], [-1850.0, -4600.0], [1000.0, -4600.0], [1000.0, -3000.0], [100.0, -3000.0], [-200.0, -2900.0], [-200.0, 2400.0]]
+Wave Beam Chamber Access
+Extra - total_boundings: {'x1': -3400.0, 'x2': 1000.0, 'y1': -4600.0, 'y2': 2400.0}
+Extra - polygon: [[-3400.0, 2400.0], [-3400.0, -4000.0], [-1850.0, -4100.0], [-1850.0, -4600.0], [1000.0, -4600.0], [1000.0, -3000.0], [100.0, -3000.0], [-200.0, -2900.0], [-200.0, 2400.0]]
 Extra - asset_id: collision_camera011
-> Pickup (Varia Suit); Heals? False
-  * Layers: default
-  * Pickup 45; Category? Major
-  * Extra - actor_name: LE_PowerUp_VariaSuite
-  * Extra - actor_type: itemsphere_variasuit
-  > Door to Wallfire Path
-      Trivial
-
 > Ammo Recharge Station; Heals? False
   * Layers: default
   * Extra - actor_name: LE_Platform_AmmoCharge
   * Extra - actor_type: weightactivatedplatform
-  > Pickup (Varia Suit)
-      Spider Ball Clip (Advanced) and Use Spider Ball
-  > Door to Main Hub (Bottom)
+  > Door to Transport to Area 2 Dam Exterior (Bottom)
       Trivial
-  > Door to Main Hub (Middle)
+  > Door to Wave Beam Chamber
       Trivial
   > Top of Morph Ball Shaft
       All of the following:
@@ -139,48 +144,28 @@ Extra - asset_id: collision_camera011
               # Dealing with the Gravitt
               Lightning Armor or Bomb or Power Bomb or Combat (Beginner) or Shoot Any Missile
               Damage Boost (Beginner) and Normal Damage ≥ 30
+  > Dock to Varia Chamber (OoB)
+      Spider Ball Clip (Advanced) and Use Spider Ball
 
-> Door to Fiery Balcony; Heals? False
+> Door to Transport to Area 2 Dam Exterior (Bottom); Heals? False
   * Layers: default
-  * Charge Beam Door to Fiery Balcony/Door to Varia Suit Room
-  * Extra - actor_name: Door004
-  * Extra - actor_type: doorchargecharge
-  > Door to Wallfire Path
-      Trivial
-
-> Door to Wallfire Path; Heals? False
-  * Layers: default
-  * Missile Door to Wallfire Path/Door to Varia Suit Room
-  * Extra - actor_name: Door006
-  * Extra - actor_type: doorpowerpower
-  > Pickup (Varia Suit)
-      Trivial
-  > Door to Fiery Balcony
-      Trivial
-  > Inside Shortcut
-      Screw Attack
-  > Start Point
-      Trivial
-
-> Door to Main Hub (Bottom); Heals? False
-  * Layers: default
-  * Wave Beam Door to Main Hub/Door to Varia Suit Room (Bottom)
+  * Wave Beam Door to Transport to Area 2 Dam Exterior/Door to Wave Beam Chamber Access (Bottom)
   * Extra - actor_name: Door008
   * Extra - actor_type: doorclosedpower
   > Ammo Recharge Station
       Trivial
 
-> Door to Main Hub (Middle); Heals? False
+> Door to Wave Beam Chamber; Heals? False
   * Layers: default
-  * Missile Door to Main Hub/Door to Varia Suit Room (Middle)
+  * Missile Door to Wave Beam Chamber/Door to Wave Beam Chamber Access
   * Extra - actor_name: Door009
   * Extra - actor_type: doorpowerpower
   > Ammo Recharge Station
       Trivial
 
-> Door to Teleporter Shaft Access; Heals? False
+> Door to Interior Teleporter Access; Heals? False
   * Layers: default
-  * Power Beam Door to Teleporter Shaft Access/Door to Varia Suit Room
+  * Power Beam Door to Interior Teleporter Access/Door to Wave Beam Chamber Access
   * Extra - actor_name: Door012
   * Extra - actor_type: doorpowerpower
   > Right Shaft
@@ -190,7 +175,7 @@ Extra - asset_id: collision_camera011
 
 > Door to Gamma Arena; Heals? False
   * Layers: default
-  * Power Beam Door to Gamma Arena/Door to Varia Suit Room
+  * Power Beam Door to Gamma Arena/Door to Wave Beam Chamber Access
   * Extra - actor_name: Door018
   * Extra - actor_type: doorpowerpower
   > Bottom of Morph Ball Shaft
@@ -203,32 +188,13 @@ Extra - asset_id: collision_camera011
                   Phase Drift and Lay Bomb
                   Spring Ball or Mid-Air Morph (Intermediate)
 
-> Door to Main Hub (Top); Heals? False
+> Door to Transport to Area 2 Dam Exterior (Top); Heals? False
   * Layers: default
-  * Wave Beam Door to Main Hub/Door to Varia Suit Room (Top)
+  * Wave Beam Door to Transport to Area 2 Dam Exterior/Door to Wave Beam Chamber Access (Top)
   * Extra - actor_name: Door019
   * Extra - actor_type: doorpowerpower
   > Right Shaft
       Trivial
-
-> Pickup (Super Missile Tank); Heals? False
-  * Layers: default
-  * Pickup 48; Category? Minor
-  * Extra - actor_name: HP_Item_002
-  * Extra - actor_type: item_supermissiletank
-  > Inside Shortcut
-      Trivial
-
-> Inside Shortcut; Heals? False
-  * Layers: default
-  > Door to Wallfire Path
-      Screw Attack
-  > Pickup (Super Missile Tank)
-      Lay Any Bomb
-  > Bottom of Morph Ball Shaft
-      Screw Attack
-  > Right Shaft
-      Screw Attack
 
 > Bottom of Morph Ball Shaft; Heals? False
   * Layers: default
@@ -241,34 +207,40 @@ Extra - asset_id: collision_camera011
   * Layers: default
   > Ammo Recharge Station
       Morph Ball
-  > Inside Shortcut
-      Screw Attack
   > Bottom of Morph Ball Shaft
       Trivial
+  > Dock to Varia Chamber (Blocks)
+      Screw Attack
 
 > Right Shaft; Heals? False
   * Layers: default
-  > Door to Teleporter Shaft Access
+  > Door to Interior Teleporter Access
       Trivial
-  > Door to Main Hub (Top)
+  > Door to Transport to Area 2 Dam Exterior (Top)
       Trivial
-  > Inside Shortcut
+  > Dock to Varia Chamber (Blocks)
       Screw Attack
 
-> Start Point; Heals? False; Default Node
+> Dock to Varia Chamber (Blocks); Heals? False
   * Layers: default
-  * Extra - start_point_actor_name: ST_CheckPoint_004
-  > Door to Wallfire Path
-      Trivial
+  * Open Passage to Varia Chamber/Dock to Wave Beam Chamber Access
+  > Bottom of Morph Ball Shaft
+      Screw Attack
+  > Right Shaft
+      Screw Attack
+
+> Dock to Varia Chamber (OoB); Heals? False
+  * Layers: default
+  * Open Passage to Varia Chamber/Dock from Wave Beam Chamber Access
 
 ----------------
-Fiery Path
+Lava Generator
 Extra - total_boundings: {'x1': -13000.0, 'x2': -5700.0, 'y1': -4600.0, 'y2': -200.0}
 Extra - polygon: [[-5700.0, -1500.0], [-7100.0, -1500.0], [-8700.0, -1000.0], [-9700.0, -1000.0], [-10600.0, -900.0], [-10600.0, -200.0], [-13000.0, -200.0], [-13000.0, -3300.0], [-10100.0, -3300.0], [-8500.0, -4600.0], [-5750.0, -4600.0], [-5750.0, -3400.0], [-5700.0, -3200.0]]
 Extra - asset_id: collision_camera012
-> Door to Main Hub; Heals? False
+> Door to Transport to Area 2 Dam Exterior; Heals? False
   * Layers: default
-  * Charge Beam Door to Main Hub/Door to Fiery Path
+  * Charge Beam Door to Transport to Area 2 Dam Exterior/Door to Lava Generator
   * Extra - actor_name: Door002
   * Extra - actor_type: doorchargecharge
   > Under Pickup
@@ -276,7 +248,7 @@ Extra - asset_id: collision_camera012
 
 > Door to Gamma Arena; Heals? False
   * Layers: default
-  * Charge Beam Door to Gamma Arena/Door to Fiery Path
+  * Charge Beam Door to Gamma Arena/Door to Lava Generator
   * Extra - actor_name: Door010
   * Extra - actor_type: doorchargecharge
   > Under Pickup
@@ -284,17 +256,17 @@ Extra - asset_id: collision_camera012
   > Start Point
       Trivial
 
-> Door to Fiery Storage; Heals? False
+> Door to Crumble Cavern; Heals? False
   * Layers: default
-  * Power Bomb Door to Fiery Storage/Door to Fiery Path
+  * Power Bomb Door to Crumble Cavern/Door to Lava Generator
   * Extra - actor_name: Door015
   * Extra - actor_type: doorpowerpower
   > Under Pickup
       Varia Suit
 
-> Door to Fiery Balcony; Heals? False
+> Door to Generator Access; Heals? False
   * Layers: default
-  * Power Beam Door to Fiery Balcony/Door to Fiery Path
+  * Power Beam Door to Generator Access/Door to Lava Generator
   * Extra - actor_name: Door020
   * Extra - actor_type: doorpowerpower
   > Under Pickup
@@ -310,13 +282,13 @@ Extra - asset_id: collision_camera012
 
 > Under Pickup; Heals? False
   * Layers: default
-  > Door to Main Hub
+  > Door to Transport to Area 2 Dam Exterior
       Varia Suit
   > Door to Gamma Arena
       Varia Suit
-  > Door to Fiery Storage
+  > Door to Crumble Cavern
       Varia Suit
-  > Door to Fiery Balcony
+  > Door to Generator Access
       Varia Suit
   > Pickup (Missile Tank)
       All of the following:
@@ -339,7 +311,7 @@ Extra - asset_id: collision_camera012
       Varia Suit
 
 ----------------
-Fiery Storage
+Crumble Cavern
 Extra - total_boundings: {'x1': -5850.0, 'x2': -2700.0, 'y1': -4002.070068359375, 'y2': -2800.0}
 Extra - polygon: [[-5850.0, -2800.0], [-5850.0, -4002.070068359375], [-2700.0, -4002.070068359375], [-2700.0, -2800.0]]
 Extra - asset_id: collision_camera013
@@ -348,12 +320,12 @@ Extra - asset_id: collision_camera013
   * Pickup 43; Category? Minor
   * Extra - actor_name: LE_Item_006
   * Extra - actor_type: item_powerbombtank
-  > Door to Fiery Path
+  > Door to Lava Generator
       Morph Ball and Varia Suit
 
-> Door to Fiery Path; Heals? False
+> Door to Lava Generator; Heals? False
   * Layers: default
-  * Power Bomb Door to Fiery Path/Door to Fiery Storage
+  * Power Bomb Door to Lava Generator/Door to Crumble Cavern
   * Extra - actor_name: Door015
   * Extra - actor_type: doorpowerpower
   > Pickup (Power Bomb Tank)
@@ -369,35 +341,35 @@ Extra - asset_id: collision_camera013
                       Power Bomb ≥ 2 and Movement (Expert) and Lay Power Bomb
 
 ----------------
-Teleporter Shaft Access
+Interior Teleporter Access
 Extra - total_boundings: {'x1': -1700.0, 'x2': 3100.0, 'y1': -3100.0, 'y2': -1700.0}
 Extra - polygon: [[-300.0, -1700.0], [-300.0, -2339.639892578125], [-1700.0, -2339.639892578125], [-1700.0, -3100.0], [3100.0, -3100.0], [3100.0, -1700.0]]
 Extra - asset_id: collision_camera015
-> Door to Varia Suit Room; Heals? False
+> Door to Wave Beam Chamber Access; Heals? False
   * Layers: default
-  * Power Beam Door to Varia Suit Room/Door to Teleporter Shaft Access
+  * Power Beam Door to Wave Beam Chamber Access/Door to Interior Teleporter Access
   * Extra - actor_name: Door012
   * Extra - actor_type: doorpowerpower
-  > Tunnel to Teleporter Shaft
+  > Tunnel to Interior Teleporter
       Morph Ball
   > Energy Recharge Station
       Lay Any Bomb
 
-> Tunnel to Teleporter Shaft; Heals? False
+> Tunnel to Interior Teleporter; Heals? False
   * Layers: default
-  * Tunnel to Teleporter Shaft/Tunnel to Teleporter Shaft Access
-  > Door to Varia Suit Room
+  * Tunnel to Interior Teleporter/Tunnel to Interior Teleporter Access
+  > Door to Wave Beam Chamber Access
       Morph Ball
 
 > Energy Recharge Station; Heals? True
   * Layers: default
   * Extra - actor_name: LE_Platform_EnergyCharge
   * Extra - actor_type: weightactivatedplatform
-  > Door to Varia Suit Room
+  > Door to Wave Beam Chamber Access
       Lay Any Bomb
 
 ----------------
-Teleporter Shaft
+Interior Teleporter
 Extra - total_boundings: {'x1': 2200.0, 'x2': 4700.0, 'y1': -6800.0, 'y2': -1600.0}
 Extra - polygon: [[3000.0, -1600.0], [3000.0, -5200.0], [2200.0, -5200.0], [2200.0, -6800.0], [4700.0, -6800.0], [4700.0, -1600.0]]
 Extra - asset_id: collision_camera016
@@ -410,43 +382,43 @@ Extra - asset_id: collision_camera016
   > Next to Teleporter
       Trivial
 
-> Door to Horseshoe Path; Heals? False
+> Door to Fleech Swarm Corridor; Heals? False
   * Layers: default
-  * Wave Beam Door to Horseshoe Path/Door to Teleporter Shaft
+  * Wave Beam Door to Fleech Swarm Corridor/Door to Interior Teleporter
   * Extra - actor_name: Door016
   * Extra - actor_type: doorpowerpower
   > Under Teleporter
       Trivial
 
-> Door to Fan Tunnel; Heals? False
+> Door to Teleporter Storage; Heals? False
   * Layers: default
-  * Plasma Beam Door to Fan Tunnel/Door to Teleporter Shaft
+  * Plasma Beam Door to Teleporter Storage/Door to Interior Teleporter
   * Extra - actor_name: Door017
   * Extra - actor_type: doorpowerpower
   > Under Teleporter
       Trivial
 
-> Tunnel to High Jump Shaft; Heals? False
+> Tunnel to High Jump Chamber Access; Heals? False
   * Layers: default
-  * Tunnel to High Jump Shaft/Tunnel to Teleporter Shaft
+  * Tunnel to High Jump Chamber Access/Tunnel to Interior Teleporter
   > Under Teleporter
       Morph Ball
 
-> Tunnel to Teleporter Shaft Access; Heals? False
+> Tunnel to Interior Teleporter Access; Heals? False
   * Layers: default
-  * Tunnel to Teleporter Shaft Access/Tunnel to Teleporter Shaft
+  * Tunnel to Interior Teleporter Access/Tunnel to Interior Teleporter
   > Under Teleporter
       Morph Ball
 
 > Under Teleporter; Heals? False
   * Layers: default
-  > Door to Horseshoe Path
+  > Door to Fleech Swarm Corridor
       Trivial
-  > Door to Fan Tunnel
+  > Door to Teleporter Storage
       Trivial
-  > Tunnel to High Jump Shaft
+  > Tunnel to High Jump Chamber Access
       Morph Ball
-  > Tunnel to Teleporter Shaft Access
+  > Tunnel to Interior Teleporter Access
       Morph Ball
   > Next to Teleporter
       All of the following:
@@ -471,32 +443,32 @@ Extra - asset_id: collision_camera016
       Trivial
 
 ----------------
-Horseshoe Path
+Fleech Swarm Corridor
 Extra - total_boundings: {'x1': -4000.0, 'x2': 2300.0, 'y1': -8100.0, 'y2': -5400.0}
 Extra - polygon: [[-4000.0, -5400.0], [-4000.0, -8100.0], [-1700.0, -8100.0], [-1700.0, -7100.0], [-400.0, -6200.0], [2300.0, -6200.0], [2300.0, -5400.0]]
 Extra - asset_id: collision_camera017
-> Door to High Jump Storage; Heals? False
+> Door to Dam Basement; Heals? False
   * Layers: default
-  * Power Beam Door to High Jump Storage/Door to Horseshoe Path
+  * Power Beam Door to Dam Basement/Door to Fleech Swarm Corridor
   * Extra - actor_name: Door014
   * Extra - actor_type: doorpowerpower
-  > Door to Teleporter Shaft
+  > Door to Interior Teleporter
       All of the following:
           Morph Ball
           Any of the following:
               High Jump Boots or Gravity Suit or Space Jump or Spider Ball or Walljump (Beginner)
               Bomb and Mid-Air Morph (Intermediate) and Infinite Bomb Jump (Intermediate)
 
-> Door to Teleporter Shaft; Heals? False
+> Door to Interior Teleporter; Heals? False
   * Layers: default
-  * Wave Beam Door to Teleporter Shaft/Door to Horseshoe Path
+  * Wave Beam Door to Interior Teleporter/Door to Fleech Swarm Corridor
   * Extra - actor_name: Door016
   * Extra - actor_type: doorpowerpower
-  > Door to High Jump Storage
+  > Door to Dam Basement
       Morph Ball and Fleechswarm Protection
 
 ----------------
-High Jump Storage
+Dam Basement
 Extra - total_boundings: {'x1': -1800.0, 'x2': 300.0, 'y1': -8100.0, 'y2': -7100.0}
 Extra - polygon: [[-1800.0, -7100.0], [-1800.0, -8100.0], [300.0, -8100.0], [300.0, -7100.0]]
 Extra - asset_id: collision_camera018
@@ -505,7 +477,7 @@ Extra - asset_id: collision_camera018
   * Pickup 40; Category? Major
   * Extra - actor_name: LE_Item_001
   * Extra - actor_type: item_energytank
-  > Door to Horseshoe Path
+  > Door to Fleech Swarm Corridor
       Trivial
 
 > Pickup (Missile Tank); Heals? False
@@ -513,38 +485,38 @@ Extra - asset_id: collision_camera018
   * Pickup 41; Category? Minor
   * Extra - actor_name: LE_Item_002
   * Extra - actor_type: item_missiletank
-  > Tunnel to High Jump Secret
+  > Tunnel to Gullugg Hideout
       Morph Ball
 
-> Door to Horseshoe Path; Heals? False
+> Door to Fleech Swarm Corridor; Heals? False
   * Layers: default
-  * Power Beam Door to Horseshoe Path/Door to High Jump Storage
+  * Power Beam Door to Fleech Swarm Corridor/Door to Dam Basement
   * Extra - actor_name: Door014
   * Extra - actor_type: doorpowerpower
   > Pickup (Energy Tank)
       Trivial
 
-> Tunnel to High Jump Secret; Heals? False
+> Tunnel to Gullugg Hideout; Heals? False
   * Layers: default
-  * Tunnel to High Jump Secret/Tunnel to High Jump Storage
+  * Tunnel to Gullugg Hideout/Tunnel to Dam Basement
   > Pickup (Missile Tank)
       Morph Ball
 
 ----------------
-High Jump Secret
+Gullugg Hideout
 Extra - total_boundings: {'x1': 200.0, 'x2': 2300.0, 'y1': -8400.0, 'y2': -7100.0}
 Extra - polygon: [[200.0, -7100.0], [200.0, -8400.0], [2300.0, -8400.0], [2300.0, -7100.0]]
 Extra - asset_id: collision_camera019
-> Tunnel to High Jump Storage; Heals? False
+> Tunnel to Dam Basement; Heals? False
   * Layers: default
-  * Tunnel to High Jump Storage/Tunnel to High Jump Secret
-  > Tunnel to High Jump Room
+  * Tunnel to Dam Basement/Tunnel to Gullugg Hideout
+  > Tunnel to High Jump Chamber
       Lay Any Bomb
 
-> Tunnel to High Jump Room; Heals? False
+> Tunnel to High Jump Chamber; Heals? False
   * Layers: default
-  * Tunnel with Bomb Block to High Jump Room/Tunnel to High Jump Secret
-  > Tunnel to High Jump Storage
+  * Tunnel with Bomb Block to High Jump Chamber/Tunnel to Gullugg Hideout
+  > Tunnel to Dam Basement
       All of the following:
           Morph Ball
           Any of the following:
@@ -553,7 +525,7 @@ Extra - asset_id: collision_camera019
               Spiderspark (Intermediate) and Can Spiderspark
 
 ----------------
-High Jump Room
+High Jump Chamber
 Extra - total_boundings: {'x1': 2200.0, 'x2': 4700.0, 'y1': -8960.0, 'y2': -7100.0}
 Extra - polygon: [[2200.0, -7100.0], [2200.0, -8960.0], [4700.0, -8960.0], [4700.0, -7100.0]]
 Extra - asset_id: collision_camera021
@@ -565,17 +537,17 @@ Extra - asset_id: collision_camera021
   > Room Center
       Trivial
 
-> Door to High Jump Shaft; Heals? False
+> Door to High Jump Chamber Access; Heals? False
   * Layers: default
-  * Missile Door to High Jump Shaft/Door to High Jump Room
+  * Missile Door to High Jump Chamber Access/Door to High Jump Chamber
   * Extra - actor_name: Door013
   * Extra - actor_type: doorpowerpower
   > Room Center
       Trivial
 
-> Tunnel to High Jump Secret; Heals? False
+> Tunnel to Gullugg Hideout; Heals? False
   * Layers: default
-  * Tunnel with Bomb Block to High Jump Secret/Tunnel to High Jump Room
+  * Tunnel with Bomb Block to Gullugg Hideout/Tunnel to High Jump Chamber
   > Room Center
       Lay Any Bomb
 
@@ -584,22 +556,22 @@ Extra - asset_id: collision_camera021
   * Extra - start_point_actor_name: ST_CheckPoint_002
   > Pickup (High Jump Boots)
       Trivial
-  > Door to High Jump Shaft
+  > Door to High Jump Chamber Access
       Trivial
-  > Tunnel to High Jump Secret
+  > Tunnel to Gullugg Hideout
       Lay Any Bomb
 
 ----------------
-High Jump Shaft
+High Jump Chamber Access
 Extra - total_boundings: {'x1': 4600.0, 'x2': 6100.0, 'y1': -8200.0, 'y2': -3900.0}
 Extra - polygon: [[4600.0, -3900.0], [4600.0, -8200.0], [6100.0, -8200.0], [6100.0, -3900.0]]
 Extra - asset_id: collision_camera022
-> Door to High Jump Room; Heals? False
+> Door to High Jump Chamber; Heals? False
   * Layers: default
-  * Missile Door to High Jump Room/Door to High Jump Shaft
+  * Missile Door to High Jump Chamber/Door to High Jump Chamber Access
   * Extra - actor_name: Door013
   * Extra - actor_type: doorpowerpower
-  > Tunnel to Teleporter Shaft
+  > Tunnel to Interior Teleporter
       All of the following:
           Morph Ball
           Any of the following:
@@ -614,35 +586,98 @@ Extra - asset_id: collision_camera022
                   High Jump Boots or Walljump (Intermediate)
               High Jump Boots and Super Jump (Intermediate)
 
-> Tunnel to Teleporter Shaft; Heals? False
+> Tunnel to Interior Teleporter; Heals? False
   * Layers: default
-  * Tunnel to Teleporter Shaft/Tunnel to High Jump Shaft
-  > Door to High Jump Room
+  * Tunnel to Interior Teleporter/Tunnel to High Jump Chamber Access
+  > Door to High Jump Chamber
       Morph Ball
 
 ----------------
-Wallfire Path
-Extra - total_boundings: {'x1': -5800.0, 'x2': -4100.0, 'y1': -800.0, 'y2': -41.720699310302734}
-Extra - polygon: [[-5800.0, -41.720699310302734], [-5800.0, -800.0], [-4100.0, -800.0], [-4100.0, -41.720699310302734]]
-Extra - asset_id: collision_camera035
-> Door to Main Hub; Heals? False
+Varia Chamber
+Extra - total_boundings: {'x1': -4200.0, 'x2': -1550.0, 'y1': -1700.0, 'y2': -100.0}
+Extra - polygon: [[-1550.0, -100.0], [-4200.0, -100.0], [-4200.0, -1700.0], [-1550.0, -1700.0]]
+Extra - asset_id: collision_camera011
+> Pickup (Varia Suit); Heals? False
   * Layers: default
-  * Power Beam Door to Main Hub/Door to Wallfire Path
-  * Extra - actor_name: Door005
-  * Extra - actor_type: doorpowerpower
-  > Door to Varia Suit Room
+  * Pickup 45; Category? Major
+  * Extra - actor_name: LE_PowerUp_VariaSuite
+  * Extra - actor_type: itemsphere_variasuit
+  > Door to Varia Chamber Access
       Trivial
 
-> Door to Varia Suit Room; Heals? False
+> Door to Generator Access; Heals? False
   * Layers: default
-  * Missile Door to Varia Suit Room/Door to Wallfire Path
+  * Charge Beam Door to Generator Access/Door to Varia Chamber
+  * Extra - actor_name: Door004
+  * Extra - actor_type: doorchargecharge
+  > Door to Varia Chamber Access
+      Trivial
+
+> Door to Varia Chamber Access; Heals? False
+  * Layers: default
+  * Missile Door to Varia Chamber Access/Door to Varia Chamber
   * Extra - actor_name: Door006
   * Extra - actor_type: doorpowerpower
-  > Door to Main Hub
+  > Pickup (Varia Suit)
+      Trivial
+  > Door to Generator Access
+      Trivial
+  > Start Point
+      Trivial
+  > Dock to Wave Beam Chamber Access
+      Screw Attack
+
+> Pickup (Super Missile Tank); Heals? False
+  * Layers: default
+  * Pickup 48; Category? Minor
+  * Extra - actor_name: HP_Item_002
+  * Extra - actor_type: item_supermissiletank
+  > Dock to Wave Beam Chamber Access
+      Screw Attack
+
+> Start Point; Heals? False; Default Node
+  * Layers: default
+  * Extra - start_point_actor_name: ST_CheckPoint_004
+  > Door to Varia Chamber Access
+      Trivial
+
+> Dock to Wave Beam Chamber Access; Heals? False
+  * Layers: default
+  * Open Passage to Wave Beam Chamber Access/Dock to Varia Chamber (Blocks)
+  > Door to Varia Chamber Access
+      Screw Attack
+  > Pickup (Super Missile Tank)
+      Lay Any Bomb
+
+> Dock from Wave Beam Chamber Access; Heals? False
+  * Layers: default
+  * Blocked Passage to Wave Beam Chamber Access/Dock to Varia Chamber (OoB)
+  > Door to Varia Chamber Access
       Trivial
 
 ----------------
-Fan Tunnel
+Varia Chamber Access
+Extra - total_boundings: {'x1': -5800.0, 'x2': -4100.0, 'y1': -800.0, 'y2': -41.720699310302734}
+Extra - polygon: [[-5800.0, -41.720699310302734], [-5800.0, -800.0], [-4100.0, -800.0], [-4100.0, -41.720699310302734]]
+Extra - asset_id: collision_camera035
+> Door to Transport to Area 2 Dam Exterior; Heals? False
+  * Layers: default
+  * Power Beam Door to Transport to Area 2 Dam Exterior/Door to Varia Chamber Access
+  * Extra - actor_name: Door005
+  * Extra - actor_type: doorpowerpower
+  > Door to Varia Chamber
+      Trivial
+
+> Door to Varia Chamber; Heals? False
+  * Layers: default
+  * Access Open to Varia Chamber/Door to Varia Chamber Access
+  * Extra - actor_name: Door006
+  * Extra - actor_type: doorpowerpower
+  > Door to Transport to Area 2 Dam Exterior
+      Trivial
+
+----------------
+Teleporter Storage
 Extra - total_boundings: {'x1': -100.0, 'x2': 2300.0, 'y1': -7000.0, 'y2': -6200.0}
 Extra - polygon: [[-100.0, -6200.0], [-100.0, -7000.0], [2300.0, -7000.0], [2300.0, -6200.0]]
 Extra - asset_id: collision_camera036
@@ -651,12 +686,12 @@ Extra - asset_id: collision_camera036
   * Pickup 42; Category? Minor
   * Extra - actor_name: LE_Item_005
   * Extra - actor_type: item_senergytank
-  > Door to Teleporter Shaft
+  > Door to Interior Teleporter
       Lay Any Bomb
 
-> Door to Teleporter Shaft; Heals? False
+> Door to Interior Teleporter; Heals? False
   * Layers: default
-  * Plasma Beam Door to Teleporter Shaft/Door to Fan Tunnel
+  * Plasma Beam Door to Interior Teleporter/Door to Teleporter Storage
   * Extra - actor_name: Door017
   * Extra - actor_type: doorpowerpower
   > Pickup (Aeion Tank)
@@ -669,17 +704,17 @@ Gamma Arena
 Extra - total_boundings: {'x1': -5850.0, 'x2': -1750.0, 'y1': -5100.0, 'y2': -3900.0}
 Extra - polygon: [[-1750.0, -3900.0], [-5850.0, -3900.0], [-5850.0, -5100.0], [-1750.0, -5100.0]]
 Extra - asset_id: collision_camera037
-> Door to Fiery Path; Heals? False
+> Door to Lava Generator; Heals? False
   * Layers: default
-  * Charge Beam Door to Fiery Path/Door to Gamma Arena
+  * Charge Beam Door to Lava Generator/Door to Gamma Arena
   * Extra - actor_name: Door010
   * Extra - actor_type: doorchargecharge
   > Room Center
       Trivial
 
-> Door to Varia Suit Room; Heals? False
+> Door to Wave Beam Chamber Access; Heals? False
   * Layers: default
-  * Power Beam Door to Varia Suit Room/Door to Gamma Arena
+  * Power Beam Door to Wave Beam Chamber Access/Door to Gamma Arena
   * Extra - actor_name: Door018
   * Extra - actor_type: doorpowerpower
   > Room Center
@@ -694,9 +729,9 @@ Extra - asset_id: collision_camera037
 > Room Center; Heals? False; Default Node
   * Layers: default
   * Extra - start_point_actor_name: ST_Gamma_001_Checkpoint
-  > Door to Fiery Path
+  > Door to Lava Generator
       Trivial
-  > Door to Varia Suit Room
+  > Door to Wave Beam Chamber Access
       Trivial
   > Event - Gamma Metroid
       Defeat Gamma Metroid
@@ -710,33 +745,33 @@ Extra - asset_id: collision_camera037
       Trivial
 
 ----------------
-Fiery Balcony
+Generator Access
 Extra - total_boundings: {'x1': -5800.0, 'x2': -4100.0, 'y1': -2800.0, 'y2': -800.0}
 Extra - polygon: [[-5800.0, -800.0], [-5800.0, -2800.0], [-4100.0, -2800.0], [-4100.0, -800.0]]
 Extra - asset_id: collision_camera041
-> Door to Main Hub; Heals? False
+> Door to Transport to Area 2 Dam Exterior; Heals? False
   * Layers: default
-  * Charge Beam Door to Main Hub/Door to Fiery Balcony
+  * Charge Beam Door to Transport to Area 2 Dam Exterior/Door to Generator Access
   * Extra - actor_name: Door003
   * Extra - actor_type: doorchargecharge
-  > Door to Varia Suit Room
+  > Door to Varia Chamber
       Screw Attack and Varia Suit
-  > Door to Fiery Path
+  > Door to Lava Generator
       Morph Ball and Varia Suit
 
-> Door to Varia Suit Room; Heals? False
+> Door to Varia Chamber; Heals? False
   * Layers: default
-  * Charge Beam Door to Varia Suit Room/Door to Fiery Balcony
+  * Charge Beam Door to Varia Chamber/Door to Generator Access
   * Extra - actor_name: Door004
   * Extra - actor_type: doorchargecharge
-  > Door to Main Hub
+  > Door to Transport to Area 2 Dam Exterior
       Screw Attack and Varia Suit
 
-> Door to Fiery Path; Heals? False
+> Door to Lava Generator; Heals? False
   * Layers: default
-  * Power Beam Door to Fiery Path/Door to Fiery Balcony
+  * Power Beam Door to Lava Generator/Door to Generator Access
   * Extra - actor_name: Door020
   * Extra - actor_type: doorpowerpower
-  > Door to Main Hub
+  > Door to Transport to Area 2 Dam Exterior
       Morph Ball and Varia Suit
 


### PR DESCRIPTION
Area 2 - Dam Interior room renames

- Main Hub -> Transport to Area 2 Dam Exterior
- Split Varia Suit Room into Varia Chamber and Wave Beam Chamber Access
- Fiery Path -> Lava Generator
- Fiery Storage -> Crumble Cavern
- Teleporter Shaft Access -> Interior Teleporter Access
- Teleporter Shaft -> Interior Teleporter
- Horseshoe Path -> Fleech Swarm Corridor
- High Jump Storage -> Dam Basement
- High Jump Secret -> Gullugg Hideout
- High Jump Room -> High Jump Chamber
- High Jump Shaft -> High Jump Chamber Access
- Wallfire Path -> Varia Chamber Access
- Fan Tunnel -> Teleporter Storage
- Fiery Balcony -> Generator Access
- Added Wave Beam Chamber (Split from Transport to Area 2 Dam Exterior)

Varia Chamber

![image](https://github.com/randovania/randovania/assets/38679103/d5e88cd6-f1e2-4b8f-b2fa-75d55ee59625)

Wave Beam Chamber

![image](https://github.com/randovania/randovania/assets/38679103/d4b3d968-c507-4f58-be4c-9825d2464b37)
