### PR TITLE
MP3: Add Rundas Quick-Kill + Other Fight Logic

### DIFF
--- a/randovania/games/prime3/logic_database/Bryyo - Fire.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.json
@@ -3043,7 +3043,7 @@
                     "pickup_index": 22,
                     "location_category": "minor",
                     "connections": {
-                        "Above Ground": {
+                        "Event - Gel Pickup": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3326,7 +3326,33 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Combat",
-                                                        "amount": 2,
+                                                        "amount": 3,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Collect Gel Pickup to Activate the Elevator to Kill Rundas",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "TempleOfBryyoGelPickup",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 4,
                                                         "negate": false
                                                     }
                                                 }
@@ -3400,6 +3426,27 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "event_name": "Event56",
+                    "connections": {
+                        "Above Ground": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Gel Pickup": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": null,
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "TempleOfBryyoGelPickup",
                     "connections": {
                         "Above Ground": {
                             "type": "and",

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.json
@@ -3043,7 +3043,7 @@
                     "pickup_index": 22,
                     "location_category": "minor",
                     "connections": {
-                        "Event - Gel Pickup": {
+                        "Above Ground": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3084,130 +3084,6 @@
                                             "name": "Event3",
                                             "amount": 1,
                                             "negate": false
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        "Pickup (Missile Expansion)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "NovaBeam",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "MorphBall",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "XRayVisor",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "InvisibleObjects",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Hazard Shield"
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "NoHazard",
-                                                                    "amount": 4,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "or",
-                                                                "data": {
-                                                                    "comment": null,
-                                                                    "items": [
-                                                                        {
-                                                                            "type": "resource",
-                                                                            "data": {
-                                                                                "type": "damage",
-                                                                                "name": "Damage",
-                                                                                "amount": 1000,
-                                                                                "negate": false
-                                                                            }
-                                                                        },
-                                                                        {
-                                                                            "type": "and",
-                                                                            "data": {
-                                                                                "comment": null,
-                                                                                "items": [
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "items",
-                                                                                            "name": "BoostBall",
-                                                                                            "amount": 1,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "damage",
-                                                                                            "name": "Damage",
-                                                                                            "amount": 700,
-                                                                                            "negate": false
-                                                                                        }
-                                                                                    }
-                                                                                ]
-                                                                            }
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
                                         }
                                     }
                                 ]
@@ -3391,6 +3267,130 @@
                                     }
                                 ]
                             }
+                        },
+                        "Event - Gel Pickup": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MorphBall",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "NovaBeam",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "XRayVisor",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "InvisibleObjects",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Hazard Shield"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "NoHazard",
+                                                                    "amount": 4,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "damage",
+                                                                                "name": "Damage",
+                                                                                "amount": 1000,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "and",
+                                                                            "data": {
+                                                                                "comment": null,
+                                                                                "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "items",
+                                                                                            "name": "BoostBall",
+                                                                                            "amount": 1,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "damage",
+                                                                                            "name": "Damage",
+                                                                                            "amount": 700,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -3448,7 +3448,7 @@
                     "valid_starting_location": false,
                     "event_name": "TempleOfBryyoGelPickup",
                     "connections": {
-                        "Above Ground": {
+                        "Pickup (Missile Expansion)": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.txt
@@ -419,7 +419,7 @@ Extra - asset_id: 13296637487518400273
 > Pickup (Missile Expansion); Heals? False
   * Layers: default
   * Pickup 22; Category? Minor
-  > Above Ground
+  > Event - Gel Pickup
       Trivial
 
 > Above Ground; Heals? False
@@ -448,7 +448,9 @@ Extra - asset_id: 13296637487518400273
                   Combat (Beginner) and Damage ≥ 100
                   # https://youtu.be/4OggF458OMI&t=65
                   After Hangar Bay Ship Upgrade and Before Temple of Bryyo Turret and Combat (Intermediate) and Use Ship Missile (Command Visor and Ship Missile)
-          Combat (Intermediate) and Use Screw Attack (Space Jump)
+          Combat (Advanced) and Use Screw Attack (Space Jump)
+          # Collect Gel Pickup to Activate the Elevator to Kill Rundas
+          After TempleOfBryyoGelPickup and Knowledge (Expert)
   > Event - Turret
       Grapple Lasso and After Hangar Bay Ship Upgrade and Use Ship Missile (Command Visor and Ship Missile)
 
@@ -461,6 +463,12 @@ Extra - asset_id: 13296637487518400273
 > Event - Turret; Heals? False
   * Layers: default
   * Event Temple of Bryyo Turret
+  > Above Ground
+      Trivial
+
+> Event - Gel Pickup; Heals? False
+  * Layers: default
+  * Event TempleOfBryyoGelPickup
   > Above Ground
       Trivial
 

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.txt
@@ -419,7 +419,7 @@ Extra - asset_id: 13296637487518400273
 > Pickup (Missile Expansion); Heals? False
   * Layers: default
   * Pickup 22; Category? Minor
-  > Event - Gel Pickup
+  > Above Ground
       Trivial
 
 > Above Ground; Heals? False
@@ -428,17 +428,6 @@ Extra - asset_id: 13296637487518400273
       After Rundas
   > Door to Temple Reservoir
       After Rundas
-  > Pickup (Missile Expansion)
-      All of the following:
-          Morph Ball and Nova Beam
-          X-Ray Visor or Invisible Objects (Beginner)
-          Any of the following:
-              Hazard Shield
-              All of the following:
-                  Hazards without Hazard Shield (Expert)
-                  Any of the following:
-                      Damage ≥ 1000
-                      Boost Ball and Damage ≥ 700
   > Event - Rundas
       Any of the following:
           All of the following:
@@ -450,9 +439,20 @@ Extra - asset_id: 13296637487518400273
                   After Hangar Bay Ship Upgrade and Before Temple of Bryyo Turret and Combat (Intermediate) and Use Ship Missile (Command Visor and Ship Missile)
           Combat (Advanced) and Use Screw Attack (Space Jump)
           # Collect Gel Pickup to Activate the Elevator to Kill Rundas
-          After TempleOfBryyoGelPickup and Knowledge (Expert)
+          After Temple of Bryyo Gel Pickup Collected and Knowledge (Expert)
   > Event - Turret
       Grapple Lasso and After Hangar Bay Ship Upgrade and Use Ship Missile (Command Visor and Ship Missile)
+  > Event - Gel Pickup
+      All of the following:
+          Morph Ball and Nova Beam
+          X-Ray Visor or Invisible Objects (Beginner)
+          Any of the following:
+              Hazard Shield
+              All of the following:
+                  Hazards without Hazard Shield (Expert)
+                  Any of the following:
+                      Damage ≥ 1000
+                      Boost Ball and Damage ≥ 700
 
 > Event - Rundas; Heals? False
   * Layers: default
@@ -468,8 +468,8 @@ Extra - asset_id: 13296637487518400273
 
 > Event - Gel Pickup; Heals? False
   * Layers: default
-  * Event TempleOfBryyoGelPickup
-  > Above Ground
+  * Event Temple of Bryyo Gel Pickup Collected
+  > Pickup (Missile Expansion)
       Trivial
 
 ----------------

--- a/randovania/games/prime3/logic_database/header.json
+++ b/randovania/games/prime3/logic_database/header.json
@@ -1133,7 +1133,7 @@
                 "extra": {}
             },
             "TempleOfBryyoGelPickup": {
-                "long_name": "TempleOfBryyoGelPickup",
+                "long_name": "Temple of Bryyo Gel Pickup Collected",
                 "extra": {}
             }
         },

--- a/randovania/games/prime3/logic_database/header.json
+++ b/randovania/games/prime3/logic_database/header.json
@@ -1131,6 +1131,10 @@
             "ScrapWorksTerminal": {
                 "long_name": "Scrapworks Terminal Bomb Slot",
                 "extra": {}
+            },
+            "TempleOfBryyoGelPickup": {
+                "long_name": "TempleOfBryyoGelPickup",
+                "extra": {}
             }
         },
         "tricks": {
@@ -1986,7 +1990,8 @@
     "used_trick_levels": {
         "Knowledge": [
             1,
-            2
+            2,
+            4
         ],
         "BSJ": [
             1,


### PR DESCRIPTION
Collecting the Pickup in the Fuel Gel will cause the elevator to become active again. The elevator will instantly kill Rundas when he makes contact. RE: https://discord.com/channels/458432177223368704/758832290838216704/1201387901674590332

Bumped combat logic for Screw-Only method from intermediate to advanced.
