### PR TITLE
MSR - Fix one-way logic loop in Area 5 Tower

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 5 - Tower Exterior.json
+++ b/randovania/games/samus_returns/logic_database/Area 5 - Tower Exterior.json
@@ -682,6 +682,75 @@
                                     }
                                 ]
                             }
+                        },
+                        "Top of Tower Right Side": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Boots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "DBoost",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Destroy Blob Throwers/Steel Orbs"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Phase",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 },
@@ -760,7 +829,7 @@
                                 ]
                             }
                         },
-                        "Top of Tower Right Side": {
+                        "Upper Right Ledge": {
                             "type": "template",
                             "data": "Climb Rooms Vertically (No High Jump)"
                         }
@@ -916,7 +985,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Top of Tower Right Side": {
+                        "Upper Right Ledge": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -1274,12 +1343,12 @@
                         }
                     }
                 },
-                "Top of Tower Right Side": {
+                "Upper Right Ledge": {
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 3791.798941798941,
-                        "y": 7057.420005039053,
+                        "x": 3791.8,
+                        "y": 7057.42,
                         "z": 0.0
                     },
                     "description": "",
@@ -1290,94 +1359,16 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Door to Dangerous Hallway": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Boots",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "Space",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "template",
-                                        "data": "Simple IBJ"
+                                        "data": "Use Spider Ball"
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Destroy Blob Throwers/Steel Orbs"
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Use Spider Ball"
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Bomb",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "Spring",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "AirMorph",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "tricks",
-                                            "name": "DBoost",
-                                            "amount": 2,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "and",
+                                        "type": "or",
                                         "data": {
                                             "comment": null,
                                             "items": [
@@ -1385,7 +1376,16 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "Phase",
+                                                        "name": "Bomb",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Spring",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -1394,8 +1394,8 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Movement",
-                                                        "amount": 2,
+                                                        "name": "AirMorph",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
@@ -1546,6 +1546,13 @@
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Top of Tower Right Side": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -2047,6 +2054,99 @@
                                         }
                                     }
                                 ]
+                            }
+                        }
+                    }
+                },
+                "Top of Tower Right Side": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 2996.72,
+                        "y": 5792.22,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "connections": {
+                        "Door to Dangerous Hallway": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Boots",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "Space",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "DBoost",
+                                            "amount": 2,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Destroy Blob Throwers/Steel Orbs"
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Simple IBJ"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "Phase",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Movement",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Door to Poison Plants Hallway": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }

--- a/randovania/games/samus_returns/logic_database/Area 5 - Tower Exterior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 5 - Tower Exterior.txt
@@ -99,6 +99,10 @@ Extra - asset_id: collision_camera_002
       Any of the following:
           High Jump Boots or Space Jump or Damage Boost (Intermediate) or Destroy Blob Throwers/Steel Orbs or Simple IBJ
           Phase Drift and Movement (Intermediate)
+  > Top of Tower Right Side
+      Any of the following:
+          High Jump Boots or Space Jump or Damage Boost (Intermediate) or Destroy Blob Throwers/Steel Orbs or Simple IBJ
+          Phase Drift and Movement (Intermediate)
 
 > Door to Poison Plants Hallway; Heals? False
   * Layers: default
@@ -109,7 +113,7 @@ Extra - asset_id: collision_camera_002
       Trivial
   > Door to Zeta Arena Access
       High Jump Boots or Space Jump or Single-wall Wall Jump (Intermediate) or Use Spider Ball
-  > Top of Tower Right Side
+  > Upper Right Ledge
       Climb Rooms Vertically (No High Jump)
 
 > Door to Transport to Area 5 Tower Interior; Heals? False
@@ -129,7 +133,7 @@ Extra - asset_id: collision_camera_002
   * Power Beam Door to Gamma+ Arena Access/Door to Tower
   * Extra - actor_name: Door009
   * Extra - actor_type: doorpowerpower
-  > Top of Tower Right Side
+  > Upper Right Ledge
       All of the following:
           Any of the following:
               # Reach the ledge
@@ -169,15 +173,12 @@ Extra - asset_id: collision_camera_002
           Morph Ball
           Space Jump or Spider Ball or Movement (Intermediate) or Walljump (Intermediate)
 
-> Top of Tower Right Side; Heals? False
+> Upper Right Ledge; Heals? False
   * Layers: default
   > Door to Dangerous Hallway
-      Any of the following:
-          High Jump Boots or Space Jump or Damage Boost (Intermediate) or Destroy Blob Throwers/Steel Orbs or Simple IBJ
-          All of the following:
-              Use Spider Ball
-              Bomb or Spring Ball or Mid-Air Morph (Beginner)
-          Phase Drift and Movement (Intermediate)
+      All of the following:
+          Use Spider Ball
+          Bomb or Spring Ball or Mid-Air Morph (Beginner)
   > Door to Poison Plants Hallway
       Trivial
   > Door to Gamma+ Arena Access
@@ -191,6 +192,8 @@ Extra - asset_id: collision_camera_002
               Spiderspark (Intermediate) and Can Spiderspark
           # Energy Requirements
           Lightning Armor or Plasma Beam or Screw Attack or Combat (Intermediate) or Normal Damage ≥ 150 or Shoot Beam Burst
+  > Top of Tower Right Side
+      Trivial
 
 > Underwater; Heals? False
   * Layers: default
@@ -246,6 +249,15 @@ Extra - asset_id: collision_camera_002
                           Destroy Blob Throwers/Steel Orbs
                           Phase Drift and Damage Boost (Beginner) and Movement (Intermediate)
                       Phase Drift or Spider Ball or Phase Drift Skip (Expert)
+
+> Top of Tower Right Side; Heals? False
+  * Layers: default
+  > Door to Dangerous Hallway
+      Any of the following:
+          High Jump Boots or Space Jump or Damage Boost (Intermediate) or Destroy Blob Throwers/Steel Orbs or Simple IBJ
+          Phase Drift and Movement (Intermediate)
+  > Door to Poison Plants Hallway
+      Trivial
 
 ----------------
 Dangerous Hallway


### PR DESCRIPTION
Fixes a database error where there was no connection from `Dangerous Hallway` to the right side of the Tower, which forced logic to always enter the Tower from the right elevator and prevented it from going backwards.

![image](https://github.com/randovania/randovania/assets/38679103/b900b294-859e-4e90-874e-61ad5320d4ce)
