### PR TITLE
AM2R: In MW, dont set item room to title screen

### DIFF
--- a/randovania/game_connection/connector/am2r_remote_connector.py
+++ b/randovania/game_connection/connector/am2r_remote_connector.py
@@ -81,7 +81,7 @@ class AM2RRemoteConnector(RemoteConnector):
         """
 
         # Dont update on pause screens/transitions
-        ignore_rooms = ("rm_transition", "rm_subscreen", "rm_loading")
+        ignore_rooms = ("rm_transition", "rm_subscreen", "rm_loading", "itemroom")
         if state_or_region in ignore_rooms:
             return
 


### PR DESCRIPTION
`itemroom` is a room where you get teleported to, during an item acquisition cutscene. Since this is still in-game, the connector shouldn't think that the player went to the title screen for the 1-2seconds.