### PR TITLE
Remove the generator log internally if it should be hidden

### DIFF
--- a/randovania/generator/filler/runner.py
+++ b/randovania/generator/filler/runner.py
@@ -87,4 +87,7 @@ async def run_filler(
             unassigned_pickups=player_state.pickups_left,
         )
 
+    if any(pool.configuration.should_hide_generation_log() for pool in player_pools):
+        actions_log = ()
+
     return FillerResults(results, actions_log)


### PR DESCRIPTION
It's already hidden in the UI, but too many people like looking at the file and being confused.

No change log entry being for me the rdvgame format is an internal detail.