### PR TITLE
MSR - Fix A6 Elevator Logic

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 6.json
+++ b/randovania/games/samus_returns/logic_database/Area 6.json
@@ -152,7 +152,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "events",
-                                            "name": "Area 6 - Transport to Area 7 Grapple Block Top",
+                                            "name": "Area 6 - Transport to Area 7 Grapple Block Pull",
                                             "amount": 1,
                                             "negate": false
                                         }

--- a/randovania/games/samus_returns/logic_database/Area 6.txt
+++ b/randovania/games/samus_returns/logic_database/Area 6.txt
@@ -19,7 +19,7 @@ Extra - asset_id: collision_camera_034
   * Extra - start_point_actor_name: ST_FromArea09
   > Before Diggernaut Area
       All of the following:
-          Morph Ball and After Area 6 - Transport to Area 7 Grapple Block Top
+          Morph Ball and After Area 6 - Transport to Area 7 Grapple Block Pull
           Plasma Beam or Defeat Non-Counterable Enemies
 
 > Save Station; Heals? False; Spawn Point; Default Node


### PR DESCRIPTION
Wrong event was being used to leave the elevator node in A6 to A7