### PR TITLE
MW: refactor executors to use a common socket holder

### DIFF
--- a/randovania/game_connection/executor/common_socket_holder.py
+++ b/randovania/game_connection/executor/common_socket_holder.py
@@ -1,0 +1,9 @@
+import dataclasses
+from asyncio import StreamReader, StreamWriter
+
+
+@dataclasses.dataclass()
+class CommonSocketHolder:
+    reader: StreamReader
+    writer: StreamWriter
+    api_version: int

--- a/randovania/game_connection/executor/cs_executor.py
+++ b/randovania/game_connection/executor/cs_executor.py
@@ -3,7 +3,7 @@ import dataclasses
 import json
 import logging
 import struct
-from asyncio import StreamReader, StreamWriter
+from asyncio import StreamReader
 from collections.abc import Collection
 from enum import IntEnum
 from typing import Self
@@ -13,6 +13,7 @@ from tsc_utils.flags import Address, flag_to_address
 from tsc_utils.numbers import TscInput, tsc_value_to_num
 
 from randovania.bitpacking.json_dataclass import JsonDataclass
+from randovania.game_connection.executor.common_socket_holder import CommonSocketHolder
 from randovania.lib import enum_lib
 
 
@@ -74,9 +75,8 @@ class CSServerInfo(JsonDataclass):
 
 
 @dataclasses.dataclass()
-class CSSocketHolder:
-    reader: StreamReader
-    writer: StreamWriter
+class CSSocketHolder(CommonSocketHolder):
+    pass
 
 
 @dataclasses.dataclass(frozen=True)
@@ -161,7 +161,7 @@ class CSExecutor:
 
             self.logger.debug("Connecting to %s:%d.", self._ip, self._port)
             reader, writer = await asyncio.open_connection(self._ip, self._port)
-            self._socket = CSSocketHolder(reader, writer)
+            self._socket = CSSocketHolder(reader, writer, 0)
 
             self.logger.debug("Connection open. Requesting API details...")
             server_info = await self.get_server_info()

--- a/randovania/game_connection/executor/dread_executor.py
+++ b/randovania/game_connection/executor/dread_executor.py
@@ -5,12 +5,12 @@ import dataclasses
 import logging
 import re
 import struct
-from asyncio import StreamReader, StreamWriter
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any
 
 from PySide6.QtCore import QObject, Signal
 
+from randovania.game_connection.executor.common_socket_holder import CommonSocketHolder
 from randovania.game_description import default_database
 from randovania.game_description.db.pickup_node import PickupNode
 from randovania.games.game import RandovaniaGame
@@ -26,11 +26,7 @@ class DreadLuaException(Exception):
 
 
 @dataclasses.dataclass()
-# TODO: AM2R, Dread and future MSR have here very similar attribute. Refactor this to a common SocketHolder
-class DreadSocketHolder:
-    reader: StreamReader
-    writer: StreamWriter
-    api_version: int
+class DreadSocketHolder(CommonSocketHolder):
     buffer_size: int
     request_number: int
 

--- a/randovania/game_connection/executor/nintendont_executor.py
+++ b/randovania/game_connection/executor/nintendont_executor.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import struct
-from asyncio import StreamReader, StreamWriter
 
+from randovania.game_connection.executor.common_socket_holder import CommonSocketHolder
 from randovania.game_connection.executor.memory_operation import (
     MemoryOperation,
     MemoryOperationException,
@@ -12,11 +12,8 @@ from randovania.game_connection.executor.memory_operation import (
 )
 
 
-@dataclasses.dataclass(frozen=True)
-class SocketHolder:
-    reader: StreamReader
-    writer: StreamWriter
-    api_version: int
+@dataclasses.dataclass()
+class SocketHolder(CommonSocketHolder):
     max_input: int
     max_output: int
     max_addresses: int

--- a/test/game_connection/executor/test_cs_executor.py
+++ b/test/game_connection/executor/test_cs_executor.py
@@ -25,7 +25,7 @@ def cs_executor():
     executor = CSExecutor("localhost")
     writer = MagicMock()
     writer.drain = AsyncMock()
-    executor._socket = CSSocketHolder(_get_reader(b""), writer)
+    executor._socket = CSSocketHolder(_get_reader(b""), writer, 1)
     executor.server_info = MagicMock()
     executor.server_info.offsets = defaultdict(lambda: 0)
     return executor


### PR DESCRIPTION
Fixes #5887 
Apparently almost every executor was affected, not just dread and am2r.