### PR TITLE
Show warning before genning, if item pool is more than max items.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.4.0] - 2024-03-??
 
+- Added: A warning will be shown when trying to generate a game where more items are in the pool than the maximum amount of items.
 - TODO: Fill.
 
 ## [7.3.2] - 2024-02-??

--- a/randovania/generator/base_patches_factory.py
+++ b/randovania/generator/base_patches_factory.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from randovania.game_description.game_patches import GamePatches
 from randovania.game_description.hint import HintItemPrecision, HintLocationPrecision
 from randovania.game_description.resources.pickup_index import PickupIndex
+from randovania.generator.pickup_pool import pool_creator
 from randovania.layout.exceptions import InvalidConfiguration
 
 if TYPE_CHECKING:
@@ -62,7 +63,23 @@ class BasePatchesFactory:
             if rng_required:
                 raise e
 
+        # Check Item Pool
+        self.check_item_pool(configuration)
+
         return patches
+
+    def check_item_pool(self, configuration: BaseConfiguration) -> None:
+        """
+        Raises an InvalidConfiguration Exception if there are more items in the pool than allowed
+        :param configuration:
+        :return:
+        """
+        per_category_pool = pool_creator.calculate_pool_pickup_count(configuration)
+        pool_items, maximum_size = pool_creator.get_total_pickup_count(per_category_pool)
+        if pool_items > maximum_size:
+            raise InvalidConfiguration(
+                f"{pool_items} items in the pool, but only {maximum_size} are allowed at maximum!"
+            )
 
     def dock_connections_assignment(
         self, configuration: BaseConfiguration, game: GameDescription, rng: Random
@@ -84,7 +101,7 @@ class BasePatchesFactory:
     ) -> NodeIdentifier:
         locations = list(configuration.starting_location.locations)
         if len(locations) == 0:
-            raise InvalidConfiguration("No starting locations are selected")
+            raise InvalidConfiguration("No starting locations are selected!")
         elif len(locations) == 1:
             location = locations[0]
         else:

--- a/test/generator/filler/test_pickup_list.py
+++ b/test/generator/filler/test_pickup_list.py
@@ -223,6 +223,10 @@ async def test_get_pickups_that_solves_unreachable_quad(
     mocker.patch(
         "randovania.game_description.default_database.game_description_for", return_value=small_echoes_game_description
     )
+    mocker.patch(
+        "randovania.generator.base_patches_factory.BasePatchesFactory.check_item_pool",
+        autospec=True,
+    )
 
     config = default_echoes_preset.configuration
     config = dataclasses.replace(

--- a/test/generator/test_generator_reach.py
+++ b/test/generator/test_generator_reach.py
@@ -154,12 +154,17 @@ _include_tricks_for_game = {
     ],
 )
 def test_database_collectable(
+    mocker,
     preset_manager,
     game_enum: RandovaniaGame,
     ignore_events: set[str],
     ignore_pickups: set[int],
     include_tricks: set[tuple[str, LayoutTrickLevel]],
 ):
+    mocker.patch(
+        "randovania.generator.base_patches_factory.BasePatchesFactory.check_item_pool",
+        autospec=True,
+    )
     game, initial_state, permalink = run_bootstrap(
         preset_manager.default_preset_for_game(game_enum).get_preset(), include_tricks
     )
@@ -295,6 +300,10 @@ def test_reach_size_from_start_echoes(small_echoes_game_description, default_ech
     ).get_mutable()
 
     mocker.patch("randovania.game_description.default_database.game_description_for", return_value=game)
+    mocker.patch(
+        "randovania.generator.base_patches_factory.BasePatchesFactory.check_item_pool",
+        autospec=True,
+    )
     generator = game.game.generator
 
     specific_levels = {trick.short_name: LayoutTrickLevel.maximum() for trick in game.resource_database.trick}


### PR DESCRIPTION
Fixes #5861 

Not sure if the base patches factory is the right place for it tbh. I just searched where the error message for starting locations was, and put it there.