### PR TITLE
add Missile Launcher and Super Missile Expansion offworld model for dread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
+- Added: New Missile Launcher model for Prime, Echoes, and AM2R multiworld pickups
+- Added: New Super Missile Expansion model for AM2R multiworld pickups
+- Fixed: Text is patched in all languages, not just English. 
+
 #### Logic Database
 
 ##### Ghavoran

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metroid Dread
 
-- Added: New Missile Launcher model for Prime, Echoes, and AM2R multiworld pickups
-- Added: New Super Missile Expansion model for AM2R multiworld pickups
+- Added: New Missile Launcher model for Prime, Echoes, and AM2R multiworld pickups.
+- Added: New Super Missile Expansion model for AM2R multiworld pickups.
+- Fixed: Wide Beam shields now require the Wide Beam to break, and cannot be cheesed with Wave or Plasma beam. 
+- Fixed: Saves from a different world in the same multiworld session are correctly handled as incompatible
 - Fixed: Text is patched in all languages, not just English. 
 
 #### Logic Database

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ exporters = [
     "tsc-utils>=0.2.5",
 
     # Metroid Dread
-    "open-dread-rando>=2.8.3",
+    "open-dread-rando>=2.9.0",
 
     # Metroid Prime 1
     "py_randomprime>=1.22.1",

--- a/randovania/games/am2r/pickup_database/pickup-database.json
+++ b/randovania/games/am2r/pickup_database/pickup-database.json
@@ -400,7 +400,7 @@
                 "prime1": "Missile",
                 "prime2": "MissileLauncher",
                 "samus_returns": "powerup_missilelauncher",
-                "dread": "powerup_icemissile"
+                "dread": "powerup_missile"
             },
             "progression": [
                 "Missile Launcher"
@@ -497,7 +497,7 @@
                 "prime1": "Missile",
                 "prime2": "MissileExpansionLarge",
                 "samus_returns": "item_supermissiletank",
-                "dread": "item_missiletankplus"
+                "dread": "super_missile_expansion"
             },
             "items": [
                 "Super Missiles"

--- a/randovania/games/dread/pickup_database/pickup-database.json
+++ b/randovania/games/dread/pickup_database/pickup-database.json
@@ -219,7 +219,7 @@
         "Missiles": {
             "pickup_category": "missile",
             "broad_category": "missile_related",
-            "model_name": "itemsphere",
+            "model_name": "powerup_missile",
             "offworld_models": {
                 "am2r": "sItemMissileLauncher",
                 "prime1": "Missile",

--- a/randovania/games/prime1/pickup_database/pickup-database.json
+++ b/randovania/games/prime1/pickup_database/pickup-database.json
@@ -176,7 +176,7 @@
             "model_name": "Missile",
             "offworld_models": {
                 "am2r": "sItemMissile",
-                "dread": "item_missiletank",
+                "dread": "powerup_missile",
                 "prime2": "MissileExpansionPrime1"
             },
             "progression": [

--- a/randovania/games/prime2/pickup_database/pickup-database.json
+++ b/randovania/games/prime2/pickup_database/pickup-database.json
@@ -607,7 +607,7 @@
             "offworld_models": {
                 "am2r": "sItemMissileLauncher",
                 "prime1": "Missile",
-                "dread": "powerup_icemissile"
+                "dread": "powerup_missile"
             },
             "progression": [
                 "MissileLauncher"

--- a/randovania/games/samus_returns/pickup_database/pickup-database.json
+++ b/randovania/games/samus_returns/pickup_database/pickup-database.json
@@ -112,7 +112,8 @@
             "broad_category": "beam_related",
             "model_name": "powerup_wavebeam",
             "offworld_models": {
-                "am2r": "sItemWaveBeam"
+                "am2r": "sItemWaveBeam",
+                "dread": "powerup_wavebeam"
             },
             "progression": [
                 "Wave"
@@ -126,7 +127,8 @@
             "broad_category": "beam_related",
             "model_name": "powerup_spazerbeam",
             "offworld_models": {
-                "am2r": "sItemSpazerBeam"
+                "am2r": "sItemSpazerBeam",
+                "dread": "powerup_widebeam"
             },
             "progression": [
                 "Spazer"
@@ -141,7 +143,8 @@
             "broad_category": "beam_related",
             "model_name": "powerup_plasmabeam",
             "offworld_models": {
-                "am2r": "sItemPlasmaBeam"
+                "am2r": "sItemPlasmaBeam",
+                "dread": "powerup_plasmabeam"
             },
             "progression": [
                 "Plasma"
@@ -171,7 +174,8 @@
             "broad_category": "beam_related",
             "model_name": "powerup_chargebeam",
             "offworld_models": {
-                "am2r": "sItemChargeBeam"
+                "am2r": "sItemChargeBeam",
+                "dread": "powerup_chargebeam"
             },
             "progression": [
                 "Charge"
@@ -185,7 +189,8 @@
             "broad_category": "beam_related",
             "model_name": "powerup_icebeam",
             "offworld_models": {
-                "am2r": "sItemIceBeam"
+                "am2r": "sItemIceBeam",
+                "dread": "powerup_icemissile"
             },
             "progression": [
                 "Ice"
@@ -198,7 +203,9 @@
             "pickup_category": "beam",
             "broad_category": "beam_related",
             "model_name": "powerup_grapplebeam",
-            "offworld_models": {},
+            "offworld_models": {
+                "dread": "powerup_grapplebeam"
+            },
             "progression": [
                 "Grapple"
             ],
@@ -211,7 +218,8 @@
             "broad_category": "missile_related",
             "model_name": "powerup_missilelauncher",
             "offworld_models": {
-                "am2r": "sItemMissileLauncher"
+                "am2r": "sItemMissileLauncher",
+                "dread": "powerup_missile"
             },
             "progression": [
                 "MissileLauncher"
@@ -228,7 +236,8 @@
             "broad_category": "missile_related",
             "model_name": "powerup_supermissile",
             "offworld_models": {
-                "am2r": "sItemSMissileLauncher"
+                "am2r": "sItemSMissileLauncher",
+                "dread": "powerup_supermissile"
             },
             "progression": [
                 "Supers"
@@ -245,7 +254,9 @@
             "pickup_category": "aeion",
             "broad_category": "aeion",
             "model_name": "powerup_scanningpulse",
-            "offworld_models": {},
+            "offworld_models": {
+                "dread": "powerup_sonar"
+            },
             "progression": [
                 "Pulse"
             ],
@@ -310,7 +321,8 @@
             "broad_category": "life_support",
             "model_name": "powerup_variasuit",
             "offworld_models": {
-                "am2r": "sItemVariaSuit"
+                "am2r": "sItemVariaSuit",
+                "dread": "powerup_variasuit"
             },
             "progression": [
                 "Varia"
@@ -324,7 +336,8 @@
             "broad_category": "life_support",
             "model_name": "powerup_gravitysuit",
             "offworld_models": {
-                "am2r": "sItemGravitySuit"
+                "am2r": "sItemGravitySuit",
+                "dread": "powerup_gravitysuit"
             },
             "progression": [
                 "Gravity"
@@ -353,7 +366,8 @@
             "broad_category": "morph_ball_related",
             "model_name": "powerup_morphball",
             "offworld_models": {
-                "am2r": "sItemMorphBall"
+                "am2r": "sItemMorphBall",
+                "dread": "powerup_morphball"
             },
             "progression": [
                 "Morph"
@@ -381,7 +395,8 @@
             "broad_category": "morph_ball_related",
             "model_name": "powerup_bomb",
             "offworld_models": {
-                "am2r": "sItemBomb"
+                "am2r": "sItemBomb",
+                "dread": "powerup_morphball"
             },
             "progression": [
                 "Bomb"
@@ -409,7 +424,8 @@
             "broad_category": "morph_ball_related",
             "model_name": "powerup_powerbomb",
             "offworld_models": {
-                "am2r": "sItemPBombLauncher"
+                "am2r": "sItemPBombLauncher",
+                "dread": "powerup_powerbomb"
             },
             "progression": [
                 "MainPB"
@@ -427,7 +443,8 @@
             "broad_category": "movement",
             "model_name": "powerup_highjumpboots",
             "offworld_models": {
-                "am2r": "sItemHijump"
+                "am2r": "sItemHijump",
+                "dread": "powerup_doublejump"
             },
             "progression": [
                 "Boots"
@@ -441,7 +458,8 @@
             "broad_category": "movement",
             "model_name": "powerup_spacejump",
             "offworld_models": {
-                "am2r": "sItemSpaceJump"
+                "am2r": "sItemSpaceJump",
+                "dread": "powerup_spacejump"
             },
             "progression": [
                 "Space"
@@ -469,7 +487,8 @@
             "broad_category": "misc",
             "model_name": "powerup_screwattack",
             "offworld_models": {
-                "am2r": "sItemScrewAttack"
+                "am2r": "sItemScrewAttack",
+                "dread": "powerup_screwattack"
             },
             "progression": [
                 "Screw"
@@ -495,7 +514,8 @@
             "broad_category": "life_support",
             "model_name": "item_energytank",
             "offworld_models": {
-                "am2r": "sItemEnergyTank"
+                "am2r": "sItemEnergyTank",
+                "dread": "item_energytank"
             },
             "progression": [
                 "ETank"
@@ -544,7 +564,8 @@
             "broad_category": "missile_related",
             "model_name": "item_missiletank",
             "offworld_models": {
-                "am2r": "sItemMissile"
+                "am2r": "sItemMissile",
+                "dread": "item_missiletank"
             },
             "items": [
                 "MissileAmmo"
@@ -557,7 +578,8 @@
             "broad_category": "missile_related",
             "model_name": "item_supermissiletank",
             "offworld_models": {
-                "am2r": "sItemSuperMissile"
+                "am2r": "sItemSuperMissile",
+                "dread": "super_missile_expansion"
             },
             "items": [
                 "SMAmmo"
@@ -570,7 +592,8 @@
             "broad_category": "morph_ball_related",
             "model_name": "item_powerbombtank",
             "offworld_models": {
-                "am2r": "sItemPowerBomb"
+                "am2r": "sItemPowerBomb",
+                "dread": "item_powerbombtank"
             },
             "items": [
                 "PBAmmo"

--- a/randovania/games/super_metroid/pickup_database/pickup-database.json
+++ b/randovania/games/super_metroid/pickup_database/pickup-database.json
@@ -175,7 +175,7 @@
                 "am2r": "sItemMissileLauncher",
                 "prime1": "Missile",
                 "prime2": "MissileLauncher",
-                "dread": "powerup_icemissile"
+                "dread": "powerup_missile"
             },
             "progression": [],
             "preferred_location_category": "major",

--- a/requirements.txt
+++ b/requirements.txt
@@ -179,7 +179,7 @@ oauthlib==3.2.2
     # via
     #   flask-discord
     #   requests-oauthlib
-open-dread-rando==2.8.3
+open-dread-rando==2.9.0
     # via randovania (setup.py)
 open-prime-rando==0.12.0
     # via randovania (setup.py)

--- a/test/test_files/patcher_data/dread/all_game_multi/world_4.json
+++ b/test/test_files/patcher_data/dread/all_game_multi/world_4.json
@@ -1613,12 +1613,12 @@
                 "actor": "item_missiletank_000"
             },
             "model": [
-                "powerup_icemissile"
+                "powerup_missile"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "WORLD 7'S MISSILE LAUNCHER",
-                    "base_icon": "powerup_icemissile"
+                    "base_icon": "powerup_missile"
                 }
             }
         },
@@ -3912,9 +3912,9 @@
     ],
     "text_patches": {
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Some Words (XXXXXXXX)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Some Words (XXXXXXXX)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Some Words (XXXXXXXX)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Some Words (XXXXXXXX)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Some Words (XXXXXXXX)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Some Words (XXXXXXXX)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Some Words (XXXXXXXX)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."

--- a/test/test_files/patcher_data/dread/all_game_multi/world_8.json
+++ b/test/test_files/patcher_data/dread/all_game_multi/world_8.json
@@ -3913,9 +3913,9 @@
     ],
     "text_patches": {
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Some Words (XXXXXXXX)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Some Words (XXXXXXXX)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Some Words (XXXXXXXX)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Some Words (XXXXXXXX)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Some Words (XXXXXXXX)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Some Words (XXXXXXXX)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Some Words (XXXXXXXX)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."

--- a/test/test_files/patcher_data/dread/crazy_settings.json
+++ b/test/test_files/patcher_data/dread/crazy_settings.json
@@ -3678,10 +3678,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."

--- a/test/test_files/patcher_data/dread/dread_dread_multiworld_expected.json
+++ b/test/test_files/patcher_data/dread/dread_dread_multiworld_expected.json
@@ -3823,10 +3823,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."

--- a/test/test_files/patcher_data/dread/dread_prime1_multiworld_expected.json
+++ b/test/test_files/patcher_data/dread/dread_prime1_multiworld_expected.json
@@ -218,12 +218,12 @@
                 "actor": "Item_MissileTank003"
             },
             "model": [
-                "item_missiletank"
+                "powerup_missile"
             ],
             "map_icon": {
                 "custom_icon": {
                     "label": "PLAYER 2'S MISSILE LAUNCHER",
-                    "base_icon": "item_missiletank"
+                    "base_icon": "powerup_missile"
                 }
             }
         },
@@ -3802,10 +3802,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."

--- a/test/test_files/patcher_data/dread/elevator_rando.json
+++ b/test/test_files/patcher_data/dread/elevator_rando.json
@@ -4023,10 +4023,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."

--- a/test/test_files/patcher_data/dread/starter_preset.json
+++ b/test/test_files/patcher_data/dread/starter_preset.json
@@ -3659,10 +3659,10 @@
         }
     ],
     "text_patches": {
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_NORMAL": "Words Hash ($$$$$)",
-        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EXPERT": "Words Hash ($$$$$)",
         "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_HARD_UNLOCKED": "Words Hash ($$$$$)",
+        "GUI_DIFSELECTOR_LABEL_DESCRIPTOR_EASY": "Words Hash ($$$$$)",
         "GUI_COMPANY_TITLE_SCREEN": "<versions>|Words Hash ($$$$$)",
         "GUI_WARNING_NOT_RANDO_GAME_1": "{c2}Error!{c0}|This save slot was created using a different Randomizer mod.",
         "GUI_WARNING_NOT_RANDO_GAME_2": "You must start a New Game from a blank save slot. Returning to title screen."


### PR DESCRIPTION
***waiting on ODR release***

- adds the Missile Launcher model to Metroid Dread's pickup database
- adds dread's Missile Launcher model to am2r, prime, echoes, and super metroid's pickup databases