### PR TITLE
MSR - Remove unnecessary reqs from A3 MC Ascending Alleyway

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 3 - Metroid Caverns.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Metroid Caverns.json
@@ -2521,54 +2521,12 @@
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Grapple",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Space",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Spiderspark",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Can Spiderspark"
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "template",
-                                                    "data": "Simple IBJ"
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "Grapple",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]

--- a/randovania/games/samus_returns/logic_database/Area 3 - Metroid Caverns.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Metroid Caverns.txt
@@ -413,11 +413,7 @@ Extra - asset_id: collision_camera_024
   > Tunnel to Gravitt Garden
       Lay Any Bomb
   > Left of Grapple Block
-      All of the following:
-          Morph Ball and Shoot Any Missile
-          Any of the following:
-              Grapple Beam or Space Jump or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+      Grapple Beam and Morph Ball and Shoot Any Missile
 
 > Tunnel to Gravitt Garden; Heals? False
   * Layers: default


### PR DESCRIPTION
Requiring anything other than grapple to leave out the top tunnel is pointless as you need grapple to even go that way