### PR TITLE
MSR: fix name of pickups, add vanilla test

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 1.json
+++ b/randovania/games/samus_returns/logic_database/Area 1.json
@@ -4346,12 +4346,12 @@
                 "asset_id": "collision_camera_028"
             },
             "nodes": {
-                "Pickup (Missile Tank)": {
+                "Pickup (Aeion Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
-                        "x": -4564.349142368491,
-                        "y": 2537.1944739638684,
+                        "x": -4564.35,
+                        "y": 2537.19,
                         "z": 0.0
                     },
                     "description": "",
@@ -4652,7 +4652,7 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Pickup (Missile Tank)": {
+                        "Pickup (Aeion Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/samus_returns/logic_database/Area 1.txt
+++ b/randovania/games/samus_returns/logic_database/Area 1.txt
@@ -721,7 +721,7 @@ Water Maze
 Extra - total_boundings: {'x1': -5498.08984375, 'x2': -4198.08984375, 'y1': 1600.0, 'y2': 3400.0}
 Extra - polygon: [[-4198.08984375, 1600.0], [-4198.08984375, 3400.0], [-5498.08984375, 3400.0], [-5498.08984375, 1600.0]]
 Extra - asset_id: collision_camera_028
-> Pickup (Missile Tank); Heals? False
+> Pickup (Aeion Tank); Heals? False
   * Layers: default
   * Pickup 17; Category? Minor
   * Extra - actor_name: LE_Item_004
@@ -769,7 +769,7 @@ Extra - asset_id: collision_camera_028
 
 > Next to Pickup; Heals? False
   * Layers: default
-  > Pickup (Missile Tank)
+  > Pickup (Aeion Tank)
       Trivial
   > Door to Gullugg Gangway
       Morph Ball and Shoot Any Missile

--- a/randovania/games/samus_returns/logic_database/Surface - East.json
+++ b/randovania/games/samus_returns/logic_database/Surface - East.json
@@ -1524,12 +1524,12 @@
                 "asset_id": "collision_camera_006"
             },
             "nodes": {
-                "Pickup (Missile Expansion)": {
+                "Pickup (Missile Tank)": {
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
-                        "x": 9896.971307120086,
-                        "y": -9226.62061636557,
+                        "x": 9896.97,
+                        "y": -9226.62,
                         "z": 0.0
                     },
                     "description": "",
@@ -1782,7 +1782,7 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Pickup (Missile Expansion)": {
+                        "Pickup (Missile Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/samus_returns/logic_database/Surface - East.txt
+++ b/randovania/games/samus_returns/logic_database/Surface - East.txt
@@ -256,7 +256,7 @@ Transport to Area 1
 Extra - total_boundings: {'x1': 6400.0, 'x2': 10700.0, 'y1': -10700.0, 'y2': -6800.0}
 Extra - polygon: [[6400.0, -6800.0], [6400.0, -10700.0], [10700.0, -10700.0], [10700.0, -6800.0]]
 Extra - asset_id: collision_camera_006
-> Pickup (Missile Expansion); Heals? False
+> Pickup (Missile Tank); Heals? False
   * Layers: default
   * Pickup 3; Category? Minor
   * Extra - actor_name: LE_Item_004
@@ -310,7 +310,7 @@ Extra - asset_id: collision_camera_006
 
 > Next to Teleporter; Heals? False
   * Layers: default
-  > Pickup (Missile Expansion)
+  > Pickup (Missile Tank)
       All of the following:
           Morph Ball
           Super Jump (Beginner) or Unmorph Extend (Beginner) or Climb Rooms Vertically (High Jump)

--- a/test/test_files/log_files/samus_returns/start_inventory.rdvgame
+++ b/test/test_files/log_files/samus_returns/start_inventory.rdvgame
@@ -311,7 +311,7 @@
                     "Inner Temple Ventilation Shaft/Pickup (Missile Tank)": "Energy Transfer Module",
                     "Magma Pool/Pickup (Missile Tank)": "Aeion Tank",
                     "Magma Pool/Pickup (Super Missile Tank)": "Super Missile Tank",
-                    "Water Maze/Pickup (Missile Tank)": "Aeion Tank",
+                    "Water Maze/Pickup (Aeion Tank)": "Aeion Tank",
                     "Temple Exterior/Pickup (Missile Tank Crevice)": "Energy Transfer Module",
                     "Temple Exterior/Pickup (Missile Tank Hidden)": "Energy Transfer Module",
                     "Temple Exterior/Pickup (Missile Tank Puzzle)": "Grapple Beam",
@@ -533,7 +533,7 @@
                     "Morph Ball Chamber/Pickup (Morph Ball)": "Missile Tank",
                     "Scan Pulse Chamber/Pickup (Scan Pulse)": "Missile Tank",
                     "Transport Cache/Pickup (Power Bomb Tank)": "Energy Transfer Module",
-                    "Transport to Area 1/Pickup (Missile Expansion)": "Energy Tank",
+                    "Transport to Area 1/Pickup (Missile Tank)": "Energy Tank",
                     "Cavern Alcove/Pickup (Missile Tank)": "Energy Transfer Module"
                 },
                 "Surface - West": {
@@ -677,7 +677,7 @@
         "Baby Metroid at Area 5 - Tower Exterior/Zeta Arena/Pickup (DNA) with hint at Area 5 - Tower Lobby/Transport to Areas 4 and 6/Chozo Seal",
         "Energy Tank at Area 3 - Factory Interior/Alpha Arena/Pickup (Super Missile Tank) with hint at Area 6/Chozo Seal West Intersection Terminal/Chozo Seal",
         "Energy Tank at Area 5 - Tower Interior/Interior Teleporter/Pickup (Missile Tank)",
-        "Energy Tank at Surface - East/Transport to Area 1/Pickup (Missile Expansion)",
+        "Energy Tank at Surface - East/Transport to Area 1/Pickup (Missile Tank)",
         "Energy Tank at Area 6/Diggernaut Arena/Pickup (Power Bomb)"
     ]
 }

--- a/test/test_files/log_files/samus_returns/starter_preset.rdvgame
+++ b/test/test_files/log_files/samus_returns/starter_preset.rdvgame
@@ -307,7 +307,7 @@
                     "Inner Temple Ventilation Shaft/Pickup (Missile Tank)": "Energy Transfer Module",
                     "Magma Pool/Pickup (Missile Tank)": "Missile Tank",
                     "Magma Pool/Pickup (Super Missile Tank)": "Energy Transfer Module",
-                    "Water Maze/Pickup (Missile Tank)": "Missile Tank",
+                    "Water Maze/Pickup (Aeion Tank)": "Missile Tank",
                     "Temple Exterior/Pickup (Missile Tank Crevice)": "Missile Tank",
                     "Temple Exterior/Pickup (Missile Tank Hidden)": "Power Bomb Tank",
                     "Temple Exterior/Pickup (Missile Tank Puzzle)": "Energy Transfer Module",
@@ -531,7 +531,7 @@
                     "Morph Ball Chamber/Pickup (Morph Ball)": "Morph Ball",
                     "Scan Pulse Chamber/Pickup (Scan Pulse)": "Missile Tank",
                     "Transport Cache/Pickup (Power Bomb Tank)": "Missile Tank",
-                    "Transport to Area 1/Pickup (Missile Expansion)": "Power Bomb Tank",
+                    "Transport to Area 1/Pickup (Missile Tank)": "Power Bomb Tank",
                     "Cavern Alcove/Pickup (Missile Tank)": "Missile Tank"
                 },
                 "Surface - West": {

--- a/test/test_files/log_files/samus_returns/vanilla_game.rdvgame
+++ b/test/test_files/log_files/samus_returns/vanilla_game.rdvgame
@@ -1,0 +1,622 @@
+{
+    "schema_version": 24,
+    "info": {
+        "randovania_version": "7.4.0.dev107",
+        "randovania_version_git": "822b334c",
+        "permalink": "DZbBQZ1nrIIrM0weQ9jMdTyfu9KmIKUrNtdb7NikZ8wfcFwQJ7xSoRsMAPtK",
+        "has_spoiler": true,
+        "seed": 1797425011,
+        "hash": "YFAZ2Z5M",
+        "word_hash": "Recharge Energy Burst",
+        "presets": [
+            {
+                "schema_version": 73,
+                "base_preset_uuid": null,
+                "name": "vanilla",
+                "uuid": "d4d24dd6-d41c-407b-a74d-d4e32faab785",
+                "description": "A copy version of Starter Preset.",
+                "game": "samus_returns",
+                "configuration": {
+                    "trick_level": {
+                        "minimal_logic": false,
+                        "specific_levels": {}
+                    },
+                    "starting_location": [
+                        {
+                            "region": "Surface - East",
+                            "area": "Landing Site",
+                            "node": "Ship"
+                        }
+                    ],
+                    "available_locations": {
+                        "randomization_mode": "full",
+                        "excluded_indices": []
+                    },
+                    "standard_pickup_configuration": {
+                        "pickups_state": {
+                            "Wave Beam": {},
+                            "Spazer Beam": {},
+                            "Plasma Beam": {},
+                            "Progressive Beam": {
+                                "num_shuffled_pickups": 3
+                            },
+                            "Charge Beam": {
+                                "include_copy_in_original_location": true
+                            },
+                            "Ice Beam": {
+                                "include_copy_in_original_location": true
+                            },
+                            "Grapple Beam": {
+                                "include_copy_in_original_location": true
+                            },
+                            "Missile Launcher": {
+                                "num_included_in_starting_pickups": 1,
+                                "included_ammo": [
+                                    24
+                                ]
+                            },
+                            "Super Missile Launcher": {
+                                "include_copy_in_original_location": true,
+                                "included_ammo": [
+                                    5
+                                ]
+                            },
+                            "Scan Pulse": {
+                                "include_copy_in_original_location": true,
+                                "included_ammo": [
+                                    0
+                                ]
+                            },
+                            "Lightning Armor": {
+                                "include_copy_in_original_location": true,
+                                "included_ammo": [
+                                    150
+                                ]
+                            },
+                            "Beam Burst": {
+                                "include_copy_in_original_location": true,
+                                "included_ammo": [
+                                    150
+                                ]
+                            },
+                            "Phase Drift": {
+                                "include_copy_in_original_location": true,
+                                "included_ammo": [
+                                    150
+                                ]
+                            },
+                            "Varia Suit": {},
+                            "Gravity Suit": {},
+                            "Progressive Suit": {
+                                "num_shuffled_pickups": 2
+                            },
+                            "Morph Ball": {
+                                "include_copy_in_original_location": true
+                            },
+                            "Spider Ball": {
+                                "include_copy_in_original_location": true
+                            },
+                            "Bomb": {
+                                "include_copy_in_original_location": true
+                            },
+                            "Spring Ball": {
+                                "include_copy_in_original_location": true
+                            },
+                            "Power Bomb Launcher": {
+                                "include_copy_in_original_location": true,
+                                "included_ammo": [
+                                    5
+                                ]
+                            },
+                            "High Jump Boots": {},
+                            "Space Jump": {},
+                            "Progressive Jump": {
+                                "num_shuffled_pickups": 2
+                            },
+                            "Screw Attack": {
+                                "include_copy_in_original_location": true
+                            },
+                            "Baby Metroid": {
+                                "include_copy_in_original_location": true
+                            },
+                            "Energy Tank": {
+                                "num_shuffled_pickups": 10
+                            },
+                            "Energy Reserve Tank": {},
+                            "Aeion Reserve Tank": {},
+                            "Missile Reserve Tank": {}
+                        },
+                        "default_pickups": {},
+                        "minimum_random_starting_pickups": 0,
+                        "maximum_random_starting_pickups": 0
+                    },
+                    "ammo_pickup_configuration": {
+                        "pickups_state": {
+                            "Missile Tank": {
+                                "ammo_count": [
+                                    3
+                                ],
+                                "pickup_count": 80,
+                                "requires_main_item": true
+                            },
+                            "Super Missile Tank": {
+                                "ammo_count": [
+                                    1
+                                ],
+                                "pickup_count": 30,
+                                "requires_main_item": true
+                            },
+                            "Power Bomb Tank": {
+                                "ammo_count": [
+                                    1
+                                ],
+                                "pickup_count": 15,
+                                "requires_main_item": true
+                            },
+                            "Aeion Tank": {
+                                "ammo_count": [
+                                    50
+                                ],
+                                "pickup_count": 15,
+                                "requires_main_item": true
+                            }
+                        }
+                    },
+                    "damage_strictness": 1.5,
+                    "pickup_model_style": "all-visible",
+                    "pickup_model_data_source": "etm",
+                    "logical_resource_action": "randomly",
+                    "first_progression_must_be_local": false,
+                    "minimum_available_locations_for_hint_placement": 0,
+                    "minimum_location_weight_for_hint_placement": 0.0,
+                    "dock_rando": {
+                        "mode": "vanilla",
+                        "types_state": {}
+                    },
+                    "single_set_for_pickups_that_solve": true,
+                    "staggered_multi_pickup_placement": true,
+                    "check_if_beatable_after_base_patches": false,
+                    "energy_per_tank": 100,
+                    "starting_energy": 99,
+                    "starting_aeion": 1000,
+                    "life_tank_size": 299,
+                    "aeion_tank_size": 500,
+                    "missile_tank_size": 30,
+                    "super_missile_tank_size": 10,
+                    "elevator_grapple_blocks": false,
+                    "area3_interior_shortcut_no_grapple": false,
+                    "charge_door_buff": false,
+                    "beam_door_buff": false,
+                    "nerf_super_missiles": false,
+                    "surface_crumbles": false,
+                    "area1_crumbles": false,
+                    "reverse_area8": false,
+                    "allow_highly_dangerous_logic": false,
+                    "artifacts": {
+                        "prefer_metroids": true,
+                        "prefer_stronger_metroids": true,
+                        "prefer_bosses": false,
+                        "prefer_anywhere": false,
+                        "required_artifacts": 39
+                    }
+                }
+            }
+        ]
+    },
+    "game_modifications": [
+        {
+            "game": "samus_returns",
+            "starting_equipment": {
+                "pickups": [
+                    "Missile Launcher"
+                ]
+            },
+            "starting_location": "Surface - East/Landing Site/Ship",
+            "dock_connections": {
+                "Surface - East/Transport to Area 1/Elevator to Area 1": "Area 1/Transport to Surface and Area 2/Elevator to Surface - East",
+                "Area 1/Transport to Surface and Area 2/Elevator to Surface - East": "Surface - East/Transport to Area 1/Elevator to Area 1",
+                "Area 1/Transport to Surface and Area 2/Elevator to Area 2 - Dam Entryway": "Area 2 - Dam Entryway/Transport to Areas 1 and 3/Elevator to Area 1",
+                "Area 2 - Dam Exterior/Dam Exterior/Elevator to Area 2 - Dam Interior": "Area 2 - Dam Interior/Wave Beam & Transport to Dam Exterior West/Elevator to Area 2 - Dam Exterior",
+                "Area 2 - Dam Exterior/Dam Exterior/Elevator to Area 2 - Dam Entryway": "Area 2 - Dam Entryway/Lightning Armor & Transport to Dam Exterior East/Elevator to Area 2 - Dam Exterior",
+                "Area 2 - Dam Interior/Wave Beam & Transport to Dam Exterior West/Elevator to Area 2 - Dam Exterior": "Area 2 - Dam Exterior/Dam Exterior/Elevator to Area 2 - Dam Interior",
+                "Area 2 - Dam Entryway/Transport to Areas 1 and 3/Elevator to Area 1": "Area 1/Transport to Surface and Area 2/Elevator to Area 2 - Dam Entryway",
+                "Area 2 - Dam Entryway/Transport to Areas 1 and 3/Elevator to Area 3 - Factory Exterior": "Area 3 - Factory Exterior/Transport to Area 2/Elevator to Area 2 - Dam Entryway",
+                "Area 2 - Dam Entryway/Lightning Armor & Transport to Dam Exterior East/Elevator to Area 2 - Dam Exterior": "Area 2 - Dam Exterior/Dam Exterior/Elevator to Area 2 - Dam Entryway",
+                "Area 3 - Factory Exterior/Transport to Area 2/Elevator to Area 2 - Dam Entryway": "Area 2 - Dam Entryway/Transport to Areas 1 and 3/Elevator to Area 3 - Factory Exterior",
+                "Area 3 - Factory Exterior/Factory Exterior/Elevator to Area 3 - Factory Interior": "Area 3 - Factory Interior/Transport to Factory Exterior East/Elevator to Area 3 - Factory Exterior",
+                "Area 3 - Factory Exterior/Transport to Metroid Caverns West/Elevator to Area 3 - Metroid Caverns": "Area 3 - Metroid Caverns/Transport to Factory Exterior West/Elevator to Area 3 - Factory Exterior",
+                "Area 3 - Factory Exterior/Transport to Area 4/Elevator to Area 4 - Central Caves": "Area 4 - Central Caves/Transport to Area 3 and Crystal Mines/Elevator to Area 3 - Factory Exterior",
+                "Area 3 - Factory Exterior/Transport to Metroid Caverns North/Elevator to Area 3 - Metroid Caverns": "Area 3 - Metroid Caverns/Transport to Factory Exterior North/Elevator to Area 3 - Factory Exterior",
+                "Area 3 - Factory Interior/Transport to Factory Exterior East/Elevator to Area 3 - Factory Exterior": "Area 3 - Factory Exterior/Factory Exterior/Elevator to Area 3 - Factory Interior",
+                "Area 3 - Factory Interior/Gamma Arena & Transport to Metroid Caverns East/Elevator to Area 3 - Metroid Caverns": "Area 3 - Metroid Caverns/Transport to Factory Interior South/Elevator to Area 3 - Factory Interior",
+                "Area 3 - Metroid Caverns/Transport to Factory Exterior North/Elevator to Area 3 - Factory Exterior": "Area 3 - Factory Exterior/Transport to Metroid Caverns North/Elevator to Area 3 - Metroid Caverns",
+                "Area 3 - Metroid Caverns/Transport to Factory Interior South/Elevator to Area 3 - Factory Interior": "Area 3 - Factory Interior/Gamma Arena & Transport to Metroid Caverns East/Elevator to Area 3 - Metroid Caverns",
+                "Area 3 - Metroid Caverns/Transport to Factory Exterior West/Elevator to Area 3 - Factory Exterior": "Area 3 - Factory Exterior/Transport to Metroid Caverns West/Elevator to Area 3 - Metroid Caverns",
+                "Area 4 - Central Caves/Transport to Area 3 and Crystal Mines/Elevator to Area 3 - Factory Exterior": "Area 3 - Factory Exterior/Transport to Area 4/Elevator to Area 4 - Central Caves",
+                "Area 4 - Central Caves/Transport to Area 3 and Crystal Mines/Elevator to Area 4 - Crystal Mines": "Area 4 - Crystal Mines/Transport to Central Caves/Elevator to Area 4 - Central Caves",
+                "Area 4 - Central Caves/Transport to Area 5/Elevator to Area 5 - Tower Lobby": "Area 5 - Tower Lobby/Transport to Areas 4 and 6/Elevator to Area 4 - Central Caves",
+                "Area 4 - Crystal Mines/Transport to Central Caves/Elevator to Area 4 - Central Caves": "Area 4 - Central Caves/Transport to Area 3 and Crystal Mines/Elevator to Area 4 - Crystal Mines",
+                "Area 5 - Tower Lobby/Transport to Tower Interior East/Elevator to Area 5 - Tower Interior": "Area 5 - Tower Interior/Transport to Tower Lobby East/Elevator to Area 5 - Tower Lobby",
+                "Area 5 - Tower Lobby/Transport to Areas 4 and 6/Elevator to Area 4 - Central Caves": "Area 4 - Central Caves/Transport to Area 5/Elevator to Area 5 - Tower Lobby",
+                "Area 5 - Tower Lobby/Transport to Areas 4 and 6/Elevator to Area 6": "Area 6/Transport to Area 5/Elevator to Area 5 - Tower Lobby",
+                "Area 5 - Tower Lobby/Transport to Tower Interior West/Elevator to Area 5 - Tower Interior": "Area 5 - Tower Interior/Transport to Tower Lobby West/Elevator to Area 5 - Tower Lobby",
+                "Area 5 - Tower Exterior/Tower Exterior/Elevator to Area 5 - Tower Interior": "Area 5 - Tower Interior/Transport to Tower Exterior East/Elevator to Area 5 - Tower Exterior",
+                "Area 5 - Tower Exterior/Transport to Tower Interior West/Elevator to Area 5 - Tower Interior": "Area 5 - Tower Interior/Transport to Tower Exterior West/Elevator to Area 5 - Tower Exterior",
+                "Area 5 - Tower Interior/Transport to Tower Lobby East/Elevator to Area 5 - Tower Lobby": "Area 5 - Tower Lobby/Transport to Tower Interior East/Elevator to Area 5 - Tower Interior",
+                "Area 5 - Tower Interior/Transport to Tower Exterior East/Elevator to Area 5 - Tower Exterior": "Area 5 - Tower Exterior/Tower Exterior/Elevator to Area 5 - Tower Interior",
+                "Area 5 - Tower Interior/Transport to Tower Lobby West/Elevator to Area 5 - Tower Lobby": "Area 5 - Tower Lobby/Transport to Tower Interior West/Elevator to Area 5 - Tower Interior",
+                "Area 5 - Tower Interior/Transport to Tower Exterior West/Elevator to Area 5 - Tower Exterior": "Area 5 - Tower Exterior/Transport to Tower Interior West/Elevator to Area 5 - Tower Interior",
+                "Area 6/Transport to Area 7/Elevator to Area 7": "Area 7/Transport to Area 6/Elevator to Area 6",
+                "Area 6/Transport to Area 5/Elevator to Area 5 - Tower Lobby": "Area 5 - Tower Lobby/Transport to Areas 4 and 6/Elevator to Area 6",
+                "Area 7/Transport to Area 6/Elevator to Area 6": "Area 6/Transport to Area 7/Elevator to Area 7",
+                "Area 7/Transport to Area 8/Elevator to Area 8": "Area 8/Transport to Area 7/Elevator to Area 7",
+                "Area 8/Transport to Surface/Elevator to Surface - West": "Surface - West/Transport to Area 8/Elevator to Area 8",
+                "Area 8/Transport to Area 7/Elevator to Area 7": "Area 7/Transport to Area 8/Elevator to Area 8",
+                "Surface - West/Transport to Area 8/Elevator to Area 8": "Area 8/Transport to Surface/Elevator to Surface - West"
+            },
+            "dock_weakness": {},
+            "configurable_nodes": {},
+            "locations": {
+                "Area 1": {
+                    "Bomb Chamber/Pickup (Bomb)": "Bomb",
+                    "Bomb Chamber/Pickup (Missile Tank)": "Missile Tank",
+                    "Destroyed Armory/Pickup (Aeion Tank)": "Aeion Tank",
+                    "Exterior Alpha Arena/Pickup (DNA)": "Metroid DNA 11",
+                    "Exterior Alpha Arena/Pickup (Energy Tank)": "Energy Tank",
+                    "Ice Beam Chamber/Pickup (Ice Beam)": "Ice Beam",
+                    "Ice Beam Chamber/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Inner Temple Ventilation Shaft/Pickup (Missile Tank)": "Missile Tank",
+                    "Magma Pool/Pickup (Missile Tank)": "Missile Tank",
+                    "Magma Pool/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Metroid Caverns Alpha Arena North East/Pickup (DNA)": "Metroid DNA 18",
+                    "Metroid Caverns Alpha Arena South East/Pickup (DNA)": "Metroid DNA 28",
+                    "Metroid Caverns Alpha Arena South West/Pickup (DNA)": "Metroid DNA 19",
+                    "Metroid Caverns Save Station/Pickup (Missile Tank)": "Missile Tank",
+                    "Spider Ball Chamber/Pickup (Missile Tank)": "Missile Tank",
+                    "Spider Ball Chamber/Pickup (Spider Ball)": "Spider Ball",
+                    "Temple Exterior/Pickup (Missile Tank Crevice)": "Missile Tank",
+                    "Temple Exterior/Pickup (Missile Tank Hidden)": "Missile Tank",
+                    "Temple Exterior/Pickup (Missile Tank Puzzle)": "Missile Tank",
+                    "Transport Cache/Pickup (Missile Tank)": "Missile Tank",
+                    "Water Maze/Pickup (Aeion Tank)": "Aeion Tank"
+                },
+                "Area 2 - Dam Entryway": {
+                    "Alpha+ Arena/Pickup (DNA)": "Metroid DNA 4",
+                    "Entryway Teleporter/Pickup (Missile Tank)": "Missile Tank",
+                    "Fleech Swarm Floodway/Pickup (Missile Tank)": "Missile Tank",
+                    "Lightning Armor & Transport to Dam Exterior East/Pickup (Lightning Armor)": "Lightning Armor",
+                    "Lightning Armor & Transport to Dam Exterior East/Pickup (Missile Tank)": "Missile Tank",
+                    "Transport to Areas 1 and 3/Pickup (Missile Tank)": "Missile Tank",
+                    "Transport to Areas 1 and 3/Pickup (Power Bomb Tank)": "Power Bomb Tank"
+                },
+                "Area 2 - Dam Exterior": {
+                    "Arachnus Arena/Pickup (Spring Ball)": "Spring Ball",
+                    "Critter Playground/Pickup (Missile Tank)": "Missile Tank",
+                    "Dam Exterior/Pickup (Missile Tank)": "Missile Tank",
+                    "Exterior Alpha+ Arena/Pickup (DNA)": "Metroid DNA 23",
+                    "Inner Alpha Arena/Pickup (DNA)": "Metroid DNA 27",
+                    "Metroid Caverns Alpha Arena East/Pickup (DNA)": "Metroid DNA 13",
+                    "Metroid Caverns Alpha Arena North West/Pickup (DNA)": "Metroid DNA 8",
+                    "Metroid Caverns Alpha Arena South West/Pickup (DNA)": "Metroid DNA 37",
+                    "Metroid Caverns Alpha+ Arena/Pickup (DNA)": "Metroid DNA 29",
+                    "Metroid Caverns Entrance/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Metroid Caverns Maze/Pickup (Missile Tank)": "Missile Tank",
+                    "Metroid Caverns Teleporter/Pickup (Missile Tank)": "Missile Tank",
+                    "Serene Shelter/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Spike Ravine/Pickup (Aeion Tank)": "Aeion Tank"
+                },
+                "Area 2 - Dam Interior": {
+                    "Crumble Cavern/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Dam Basement/Pickup (Energy Tank)": "Energy Tank",
+                    "Dam Basement/Pickup (Missile Tank)": "Missile Tank",
+                    "Gamma Arena/Pickup (DNA)": "Metroid DNA 34",
+                    "High Jump Boots Chamber/Pickup (High Jump Boots)": "Progressive Jump",
+                    "Lava Generator/Pickup (Missile Tank)": "Missile Tank",
+                    "Teleporter Storage/Pickup (Aeion Tank)": "Aeion Tank",
+                    "Varia Suit Chamber/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Varia Suit Chamber/Pickup (Varia Suit)": "Progressive Suit",
+                    "Wave Beam & Transport to Dam Exterior West/Pickup (Wave Beam)": "Progressive Beam"
+                },
+                "Area 3 - Factory Exterior": {
+                    "Beam Burst Chamber & Tsumuri Station/Pickup (Beam Burst)": "Beam Burst",
+                    "Entrance Maze/Pickup (Missile Tank)": "Missile Tank",
+                    "Exterior Maze/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Factory Exterior/Pickup (Missile Tank Ceiling)": "Missile Tank",
+                    "Factory Exterior/Pickup (Missile Tank Shaft)": "Missile Tank",
+                    "Gamma Arena/Pickup (DNA)": "Metroid DNA 32",
+                    "Grapple Beam Chamber/Pickup (Grapple Beam)": "Grapple Beam",
+                    "Halzyn Hangout/Pickup (Missile Tank)": "Missile Tank",
+                    "Halzyn Hangout/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Transport to Area 4/Pickup (Missile Tank)": "Missile Tank",
+                    "Transport to Metroid Caverns West/Pickup (Missile Tank)": "Missile Tank"
+                },
+                "Area 3 - Factory Interior": {
+                    "Alpha Arena/Pickup (DNA)": "Metroid DNA 33",
+                    "Alpha Arena/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Factory Intersection/Pickup (Aeion Tank)": "Aeion Tank",
+                    "Fan Control/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Gamma Arena & Transport to Metroid Caverns East/Pickup (DNA)": "Metroid DNA 22",
+                    "Gamma Arena South/Pickup (DNA)": "Metroid DNA 16",
+                    "Paraby Periphery/Pickup (Energy Tank)": "Energy Tank",
+                    "Security Site/Pickup (Power Bomb Tank)": "Power Bomb Tank"
+                },
+                "Area 3 - Metroid Caverns": {
+                    "Alpha+ Arena North/Pickup (DNA)": "Metroid DNA 30",
+                    "Alpha+ Arena West/Pickup (DNA)": "Metroid DNA 14",
+                    "Ascending Alleyway/Pickup (Missile Tank)": "Missile Tank",
+                    "Caverns Teleporter East/Pickup (Missile Tank)": "Missile Tank",
+                    "Gamma Arena Center/Pickup (DNA)": "Metroid DNA 35",
+                    "Gamma Arena South/Pickup (DNA)": "Metroid DNA 36",
+                    "Gamma Arena South/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Gamma+ Arena North/Pickup (DNA)": "Metroid DNA 10",
+                    "Gamma+ Arena South/Pickup (DNA)": "Metroid DNA 17",
+                    "Gravitt Garden/Pickup (Missile Tank)": "Missile Tank",
+                    "Quarry Shaft/Pickup (Aeion Tank)": "Aeion Tank",
+                    "Ramulken Rollway/Pickup (Missile Tank)": "Missile Tank",
+                    "Transport to Factory Exterior North/Pickup (Missile Tank)": "Missile Tank",
+                    "Transport to Factory Interior South/Pickup (Super Missile Tank)": "Super Missile Tank"
+                },
+                "Area 4 - Central Caves": {
+                    "Alpha+ Arena/Pickup (DNA)": "Metroid DNA 39",
+                    "Alpha+ Arena/Pickup (Missile Tank)": "Missile Tank",
+                    "Amethyst Altars/Pickup (Missile Tank)": "Missile Tank",
+                    "Caves Intersection Terminal/Pickup (Missile Tank)": "Missile Tank",
+                    "Crumble Catwalk/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Fleech Swarm Cave/Pickup (Aeion Tank)": "Aeion Tank",
+                    "Gamma Arena Access South/Pickup (Aeion Tank)": "Aeion Tank",
+                    "Gamma Arena/Pickup (DNA)": "Metroid DNA 25",
+                    "Gamma Arena/Pickup (Missile Tank)": "Missile Tank",
+                    "Spazer Beam Chamber/Pickup (Spazer Beam)": "Progressive Beam",
+                    "Transit Tunnel/Pickup (Missile Tank)": "Missile Tank",
+                    "Transport to Area 3 and Crystal Mines/Pickup (Energy Tank)": "Energy Tank",
+                    "Transport to Area 5/Pickup (Super Missile Tank)": "Super Missile Tank"
+                },
+                "Area 4 - Crystal Mines": {
+                    "Diggernaut Excavation Tunnels/Pickup (Aeion Tank)": "Aeion Tank",
+                    "Diggernaut Excavation Tunnels/Pickup (Missile Tank Bottom)": "Missile Tank",
+                    "Diggernaut Excavation Tunnels/Pickup (Missile Tank Middle)": "Missile Tank",
+                    "Diggernaut Excavation Tunnels/Pickup (Missile Tank Top)": "Missile Tank",
+                    "Dual Pond Alcove/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Gamma Arena/Pickup (DNA)": "Metroid DNA 9",
+                    "Gawron Groove/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Gemstone Gorge/Pickup (Energy Tank)": "Energy Tank",
+                    "Lava Reservoir/Pickup (Missile Tank)": "Missile Tank",
+                    "Mines Intersection Terminal/Pickup (Super Missile Tank Bottom)": "Super Missile Tank",
+                    "Mines Intersection Terminal/Pickup (Super Missile Tank Top)": "Super Missile Tank",
+                    "Pink Crystal Preserve/Pickup (Missile Tank)": "Missile Tank",
+                    "Space Jump Chamber/Pickup (Space Jump)": "Progressive Jump",
+                    "Super Missile Chamber/Pickup (Super Missile)": "Super Missile Launcher",
+                    "Zeta Arena/Pickup (DNA)": "Metroid DNA 6"
+                },
+                "Area 5 - Tower Exterior": {
+                    "Gamma Arena/Pickup (DNA)": "Metroid DNA 31",
+                    "Gamma Arena/Pickup (Missile Tank)": "Missile Tank",
+                    "Gamma+ Arena/Pickup (DNA)": "Metroid DNA 38",
+                    "Overgrown Maze/Pickup (Energy Tank)": "Energy Tank",
+                    "Overgrown Maze/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Red Plant Maze/Pickup (Aeion Tank)": "Aeion Tank",
+                    "Screw Attack Chamber/Pickup (Screw Attack)": "Screw Attack",
+                    "Tower Exterior/Pickup (Missile Tank Bottom)": "Missile Tank",
+                    "Tower Exterior/Pickup (Missile Tank Hidden)": "Missile Tank",
+                    "Tower Exterior/Pickup (Super Missile Tank Bottom)": "Super Missile Tank",
+                    "Tower Exterior/Pickup (Super Missile Tank Top)": "Super Missile Tank",
+                    "Zeta Arena/Pickup (DNA)": "Metroid DNA 2"
+                },
+                "Area 5 - Tower Interior": {
+                    "Gamma+ Arena/Pickup (DNA)": "Metroid DNA 3",
+                    "Grapple Shuffler/Pickup (Missile Tank)": "Missile Tank",
+                    "Gravity Suit Chamber Access/Pickup (Missile Tank)": "Missile Tank",
+                    "Gravity Suit Chamber/Pickup (Gravity Suit)": "Progressive Suit",
+                    "Interior Save Station/Pickup (Missile Tank)": "Missile Tank",
+                    "Interior Teleporter/Pickup (Missile Tank)": "Missile Tank",
+                    "Phase Drift Trial Reward Room/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Phase Drift Trial West/Pickup (Missile Tank)": "Missile Tank",
+                    "Phase Drift Trial West/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Plasma Beam Chamber/Pickup (Plasma Beam)": "Progressive Beam",
+                    "Zeta+ Arena Access/Pickup (Missile Tank)": "Missile Tank",
+                    "Zeta+ Arena/Pickup (DNA)": "Metroid DNA 5"
+                },
+                "Area 5 - Tower Lobby": {
+                    "Alpha+ Arena/Pickup (DNA)": "Metroid DNA 1",
+                    "Gamma+ Arena/Pickup (DNA)": "Metroid DNA 20",
+                    "Lobby Teleporter East/Pickup (Missile Tank)": "Missile Tank",
+                    "Lobby Teleporter West/Pickup (Aeion Tank)": "Aeion Tank",
+                    "Lobby Teleporter West/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Meboid Millpond/Pickup (Missile Tank)": "Missile Tank",
+                    "Phase Drift Chamber/Pickup (Phase Drift)": "Phase Drift",
+                    "Phase Drift Chamber/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Transport to Areas 4 and 6/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Transport to Areas 4 and 6/Pickup (Super Missile Tank)": "Super Missile Tank"
+                },
+                "Area 6": {
+                    "Chozo Seal East/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Chozo Seal West Intersection Terminal/Pickup (Missile Tank Ceiling)": "Missile Tank",
+                    "Chozo Seal West Intersection Terminal/Pickup (Missile Tank Save)": "Missile Tank",
+                    "Chozo Seal West Intersection Terminal/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Crumbling Bridge/Pickup (Energy Tank)": "Energy Tank",
+                    "Crumbling Bridge/Pickup (Missile Tank)": "Missile Tank",
+                    "Crumbling Stairwell/Pickup (Missile Tank)": "Missile Tank",
+                    "Diggernaut Arena/Pickup (Power Bomb)": "Power Bomb Launcher",
+                    "Electric Escalade/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Hideout Sprawl/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Hideout Sprawl/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Omega Arena/Pickup (DNA)": "Metroid DNA 12",
+                    "Poisonous Tunnel/Pickup (Missile Tank)": "Missile Tank",
+                    "Transport to Area 7/Pickup (Aeion Tank)": "Aeion Tank",
+                    "Zeta Arena/Pickup (DNA)": "Metroid DNA 7"
+                },
+                "Area 7": {
+                    "Grapple Puzzle Foyer/Pickup (Aeion Tank)": "Aeion Tank",
+                    "Laboratory Teleporter West/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Omega Arena North Access/Pickup (Missile Tank)": "Missile Tank",
+                    "Omega Arena North/Pickup (DNA)": "Metroid DNA 24",
+                    "Omega Arena South Access/Pickup (Missile Tank)": "Missile Tank",
+                    "Omega Arena South/Pickup (DNA)": "Metroid DNA 15",
+                    "Omega+ Arena/Pickup (DNA)": "Metroid DNA 26",
+                    "Robot Regime/Pickup (Aeion Tank)": "Aeion Tank",
+                    "Robot Regime/Pickup (Missile Tank)": "Missile Tank",
+                    "Spider Boost Tunnel North/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Spider Boost Tunnel South/Pickup (Energy Tank)": "Energy Tank",
+                    "Transport to Area 6/Pickup (Missile Tank Baby Locked)": "Missile Tank",
+                    "Transport to Area 6/Pickup (Missile Tank Hidden)": "Missile Tank",
+                    "Transport to Area 6/Pickup (Missile Tank West)": "Missile Tank",
+                    "Transport to Area 6/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Wallfire Workstation/Pickup (Missile Tank)": "Missile Tank"
+                },
+                "Area 8": {
+                    "Amphitheater/Pickup (Missile Tank Hidden)": "Missile Tank",
+                    "Amphitheater/Pickup (Missile Tank Left)": "Missile Tank",
+                    "Amphitheater/Pickup (Missile Tank Top)": "Missile Tank",
+                    "Amphitheater/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Amphitheater/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Entrance Teleporter/Pickup (Missile Tank)": "Missile Tank",
+                    "Hatchling Room/Pickup (Baby Metroid)": "Baby Metroid",
+                    "Metroid Nest Shaft West/Pickup (Missile Tank)": "Missile Tank",
+                    "Nest Network/Pickup (Missile Tank Baby Locked)": "Missile Tank",
+                    "Nest Network/Pickup (Missile Tank Hallway)": "Missile Tank",
+                    "Nest Nodule/Pickup (Missile Tank)": "Missile Tank",
+                    "Nest Nodule/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Nest Vestibule/Pickup (Energy Tank)": "Energy Tank",
+                    "Transport to Surface/Pickup (Missile Tank)": "Missile Tank",
+                    "Transport to Surface/Pickup (Super Missile Tank)": "Super Missile Tank"
+                },
+                "Surface - East": {
+                    "Alpha Arena/Pickup (DNA)": "Metroid DNA 21",
+                    "Alpha Arena/Pickup (Missile Tank)": "Missile Tank",
+                    "Cavern Alcove/Pickup (Missile Tank)": "Missile Tank",
+                    "Charge Beam Chamber Access/Pickup (Energy Tank)": "Energy Tank",
+                    "Charge Beam Chamber/Pickup (Charge Beam)": "Charge Beam",
+                    "Chozo Cache East/Pickup (Missile Tank)": "Missile Tank",
+                    "Chozo Cache West/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Chozo Seal/Pickup (Missile Tank)": "Missile Tank",
+                    "Energy Recharge Station Shaft/Pickup (Missile Tank)": "Missile Tank",
+                    "Morph Ball Chamber/Pickup (Morph Ball)": "Morph Ball",
+                    "Scan Pulse Chamber/Pickup (Scan Pulse)": "Scan Pulse",
+                    "Surface Crumble Block Challenge/Pickup (Super Missile Tank)": "Super Missile Tank",
+                    "Surface Stash/Pickup (Aeion Tank)": "Aeion Tank",
+                    "Transport Cache/Pickup (Power Bomb Tank)": "Power Bomb Tank",
+                    "Transport to Area 1/Pickup (Missile Tank)": "Missile Tank",
+                    "Twisty Tunnel/Pickup (Missile Tank)": "Missile Tank"
+                },
+                "Surface - West": {
+                    "Transport to Area 8/Pickup (Missile Tank)": "Missile Tank",
+                    "Transport to Area 8/Pickup (Super Missile Tank)": "Super Missile Tank"
+                }
+            },
+            "hints": {
+                "Area 5 - Tower Lobby/Transport to Areas 4 and 6/Chozo Seal": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 44,
+                    "dark_temple": null
+                },
+                "Surface - East/Chozo Seal/Chozo Seal": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 72,
+                    "dark_temple": null
+                },
+                "Area 3 - Factory Exterior/Transport to Area 2/Chozo Seal": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 24,
+                    "dark_temple": null
+                },
+                "Area 2 - Dam Entryway/Transport to Areas 1 and 3/Chozo Seal": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 97,
+                    "dark_temple": null
+                },
+                "Area 7/Transport to Area 6/Chozo Seal": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 139,
+                    "dark_temple": null
+                },
+                "Area 6/Chozo Seal East/Chozo Seal": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 117,
+                    "dark_temple": null
+                },
+                "Area 6/Chozo Seal West Intersection Terminal/Chozo Seal": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 98,
+                    "dark_temple": null
+                },
+                "Area 1/Transport to Surface and Area 2/Chozo Seal": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 107,
+                    "dark_temple": null
+                },
+                "Area 4 - Central Caves/Transport to Area 3 and Crystal Mines/Chozo Seal Bottom": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 60,
+                    "dark_temple": null
+                },
+                "Area 4 - Central Caves/Transport to Area 3 and Crystal Mines/Chozo Seal Top": {
+                    "hint_type": "location",
+                    "precision": {
+                        "location": "region-only",
+                        "item": "detailed",
+                        "include_owner": true,
+                        "relative": null
+                    },
+                    "target": 37,
+                    "dark_temple": null
+                }
+            }
+        }
+    ],
+    "item_order": [
+    ]
+}


### PR DESCRIPTION
- fix tank being named expansion
- fix aeion tank being named missile tank
- adds a test rdvgame with vanilla locations. does have progressives turned on tho.