### PR TITLE
MSR - Rename all instances of Spiderspark to Spider Boost

### DIFF
--- a/randovania/games/samus_returns/logic_database/Area 1.json
+++ b/randovania/games/samus_returns/logic_database/Area 1.json
@@ -3845,13 +3845,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -4050,13 +4050,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 3,
                                                                     "negate": false
                                                                 }
@@ -5489,13 +5489,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -7971,13 +7971,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }

--- a/randovania/games/samus_returns/logic_database/Area 1.txt
+++ b/randovania/games/samus_returns/logic_database/Area 1.txt
@@ -635,7 +635,7 @@ Extra - asset_id: collision_camera_024
               Any of the following:
                   Diagonal Bomb Jump (Intermediate)
                   Spring Ball and Mid-Air Morph (Intermediate) and Infinite Bomb Jump (Intermediate)
-          Power Bomb ≥ 2 and Spiderspark (Beginner) and Can Spiderspark
+          Power Bomb ≥ 2 and Spider Boost (Beginner) and Can Spider Boost
 
 > Tunnel to Metroid Caverns Alpha Arena South West (Top); Heals? False
   * Layers: default
@@ -660,7 +660,7 @@ Extra - asset_id: collision_camera_024
               All of the following:
                   Bomb and Infinite Bomb Jump (Intermediate)
                   Spring Ball or Mid-Air Morph (Intermediate)
-              Spiderspark (Advanced) and Can Spiderspark
+              Spider Boost (Advanced) and Can Spider Boost
 
 ----------------
 Metroid Caverns Alpha Arena South East
@@ -890,7 +890,7 @@ Extra - asset_id: collision_camera_033
                   Walljump (Beginner)
                   High Jump Boots or Damage Boost (Intermediate)
               High Jump Boots and Spider Ball and Spring Ball and Mid-Air Morph (Beginner)
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
 
 > Pickup (Super Missile Tank); Heals? False
   * Layers: default
@@ -1305,7 +1305,7 @@ Extra - asset_id: collision_camera_050
   > Dock to Inner Temple East Hall
       Any of the following:
           High Jump Boots or Ice Beam or Space Jump or Damage Boost (Intermediate) or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Morph Ball and Unmorph Extend (Beginner)
 
 > Dock to Inner Temple East Hall; Heals? False

--- a/randovania/games/samus_returns/logic_database/Area 2 - Dam Exterior.json
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Dam Exterior.json
@@ -321,13 +321,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -412,13 +412,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -750,14 +750,14 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 }
                                             ]
                                         }
@@ -2497,13 +2497,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }

--- a/randovania/games/samus_returns/logic_database/Area 2 - Dam Exterior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Dam Exterior.txt
@@ -37,7 +37,7 @@ Extra - asset_id: collision_camera_005
   > Pickup (Missile Tank)
       Any of the following:
           Morph Ball and Space Jump
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Infinite Bomb Jump (Intermediate) and Lay Bomb
   > Save Station Right
       Trivial
@@ -48,7 +48,7 @@ Extra - asset_id: collision_camera_005
   > Top of Wall
       Any of the following:
           Space Jump or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
 
 > Save Station Left; Heals? False
   * Layers: default
@@ -113,7 +113,7 @@ Extra - asset_id: collision_camera_005
   > Door to Exterior Alpha+ Arena
       Any of the following:
           Space Jump or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Lightning Armor and Use Spider Ball
   > Top of Wall
       Climb Rooms Vertically (No High Jump)
@@ -416,7 +416,7 @@ Extra - asset_id: collision_camera_024
       Any of the following:
           Simple IBJ
           Morph Ball and Space Jump and Movement (Intermediate)
-          Spiderspark (Beginner) and Can Spiderspark
+          Spider Boost (Beginner) and Can Spider Boost
   > Tunnel to Metroid Caverns Entrance (Top)
       Single-wall Wall Jump (Beginner) or Climb Rooms Vertically (No High Jump)
 

--- a/randovania/games/samus_returns/logic_database/Area 2 - Dam Interior.json
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Dam Interior.json
@@ -166,13 +166,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -2429,13 +2429,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 3,
                                                                     "negate": false
                                                                 }
@@ -3017,13 +3017,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -3687,14 +3687,14 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             }
                                                         ]
                                                     }
@@ -3971,13 +3971,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }

--- a/randovania/games/samus_returns/logic_database/Area 2 - Dam Interior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 2 - Dam Interior.txt
@@ -28,7 +28,7 @@ Extra - asset_id: collision_camera009
   > Elevator to Area 2 - Dam Exterior
       Any of the following:
           High Jump Boots or Space Jump or Super Jump (Intermediate) or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Stand on Frozen Enemy (Intermediate) and Fully Freeze Enemy
           Morph Ball and Unmorph Extend (Beginner)
           Phase Drift and Mid-Air Morph (Intermediate) and Use Spider Ball
@@ -382,7 +382,7 @@ Extra - asset_id: collision_camera013
           Any of the following:
               Phase Drift
               All of the following:
-                  Spiderspark (Advanced) and Can Spiderspark
+                  Spider Boost (Advanced) and Can Spider Boost
                   Any of the following:
                       Walljump (Expert)
                       Bomb and Movement (Intermediate)
@@ -473,7 +473,7 @@ Extra - asset_id: collision_camera016
           Morph Ball
           Any of the following:
               High Jump Boots or Space Jump or Unmorph Extend (Beginner) or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
 
 > Event - Teleporter Unlocked; Heals? False
   * Layers: default
@@ -570,7 +570,7 @@ Extra - asset_id: collision_camera019
           Any of the following:
               High Jump Boots or Space Jump or Infinite Bomb Jump (Beginner) or Unmorph Extend (Intermediate) or Walljump (Intermediate)
               Stand on Frozen Enemy (Beginner) and Fully Freeze Enemy
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
 
 ----------------
 High Jump Boots Chamber
@@ -624,7 +624,7 @@ Extra - asset_id: collision_camera022
           Morph Ball
           Any of the following:
               Space Jump
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
               All of the following:
                   Spider Ball
                   High Jump Boots or Walljump (Intermediate)

--- a/randovania/games/samus_returns/logic_database/Area 3 - Factory Exterior.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Factory Exterior.json
@@ -1484,14 +1484,14 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 }
                                             ]
                                         }
@@ -1752,14 +1752,14 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 }
                                             ]
                                         }

--- a/randovania/games/samus_returns/logic_database/Area 3 - Factory Exterior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Factory Exterior.txt
@@ -246,7 +246,7 @@ Extra - asset_id: collision_camera_030
   > Save Station
       Any of the following:
           Space Jump or Simple IBJ
-          Spiderspark (Beginner) and Can Spiderspark
+          Spider Boost (Beginner) and Can Spider Boost
           Grapple Beam and Use Spider Ball
 
 > Door to Factory Exterior Access; Heals? False
@@ -280,7 +280,7 @@ Extra - asset_id: collision_camera_030
   * Open Passage to Factory Exterior Teleporter Cave/Dock to Factory Exterior
   > Pickup (Missile Tank Ceiling)
       Any of the following:
-          Spiderspark (Beginner) and Can Spiderspark
+          Spider Boost (Beginner) and Can Spider Boost
           All of the following:
               Morph Ball
               Any of the following:

--- a/randovania/games/samus_returns/logic_database/Area 3 - Factory Interior.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Factory Interior.json
@@ -292,14 +292,14 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             }
                                                         ]
                                                     }
@@ -1811,13 +1811,13 @@
                                                                     "items": [
                                                                         {
                                                                             "type": "template",
-                                                                            "data": "Can Spiderspark"
+                                                                            "data": "Can Spider Boost"
                                                                         },
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
                                                                                 "type": "tricks",
-                                                                                "name": "Spiderspark",
+                                                                                "name": "Spider Boost",
                                                                                 "amount": 2,
                                                                                 "negate": false
                                                                             }
@@ -2046,13 +2046,13 @@
                                                                     "items": [
                                                                         {
                                                                             "type": "template",
-                                                                            "data": "Can Spiderspark"
+                                                                            "data": "Can Spider Boost"
                                                                         },
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
                                                                                 "type": "tricks",
-                                                                                "name": "Spiderspark",
+                                                                                "name": "Spider Boost",
                                                                                 "amount": 1,
                                                                                 "negate": false
                                                                             }
@@ -2122,13 +2122,13 @@
                                                                     "items": [
                                                                         {
                                                                             "type": "template",
-                                                                            "data": "Can Spiderspark"
+                                                                            "data": "Can Spider Boost"
                                                                         },
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
                                                                                 "type": "tricks",
-                                                                                "name": "Spiderspark",
+                                                                                "name": "Spider Boost",
                                                                                 "amount": 2,
                                                                                 "negate": false
                                                                             }
@@ -2517,13 +2517,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -2835,13 +2835,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -2903,13 +2903,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -3244,13 +3244,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -3617,13 +3617,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -3974,14 +3974,14 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             }
                                                         ]
                                                     }

--- a/randovania/games/samus_returns/logic_database/Area 3 - Factory Interior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Factory Interior.txt
@@ -40,7 +40,7 @@ Extra - asset_id: collision_camera_013
           Morph Ball
           Any of the following:
               Grapple Beam or Space Jump or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
   > Start Point
       Trivial
 
@@ -302,7 +302,7 @@ Extra - asset_id: collision_camera_022
               Varia Suit
               Any of the following:
                   Grapple Beam or Space Jump
-                  Power Bomb ≥ 2 and Spiderspark (Intermediate) and Can Spiderspark
+                  Power Bomb ≥ 2 and Spider Boost (Intermediate) and Can Spider Boost
 
 > Door to Alpha Arena; Heals? False
   * Layers: default
@@ -329,13 +329,13 @@ Extra - asset_id: collision_camera_022
               Varia Suit
               Any of the following:
                   Grapple Beam or Space Jump
-                  Spiderspark (Beginner) and Can Spiderspark
+                  Spider Boost (Beginner) and Can Spider Boost
   > Door to Alpha Arena
       All of the following:
           Morph Ball and Varia Suit
           Any of the following:
               Grapple Beam or Space Jump or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
               Damage Boost (Intermediate) and Unmorph Extend (Intermediate)
 
 > Start Point; Heals? False; Default Node
@@ -391,7 +391,7 @@ Extra - asset_id: collision_camera_023
   > Ammo Recharge Station
       Any of the following:
           Grapple Beam or Gravity Suit or Space Jump
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Underwater Bomb Jump (Intermediate) and Lay Bomb
   > Elevator to Area 3 - Metroid Caverns
       Morph Ball and After Area 3 (Factory Interior) - Gamma Arena & Transport to Metroid Caverns East Grapple Block
@@ -440,13 +440,13 @@ Extra - asset_id: collision_camera_023
           Morph Ball
           Any of the following:
               Grapple Beam or Space Jump or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
   > Tunnel to Gamma Arena Center Access (Top)
       All of the following:
           Morph Ball
           Any of the following:
               Grapple Beam or Space Jump or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
   > Event - Gamma Metroid
       After Area 3 (Factory Interior) - Gamma Metroid Upper Awakened and Defeat Gamma Metroid
 
@@ -505,7 +505,7 @@ Extra - asset_id: collision_camera_025
   * Extra - actor_type: doorpowerpower
   > Door to Fan Control
       Any of the following:
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           All of the following:
               Morph Ball
               Any of the following:
@@ -560,7 +560,7 @@ Extra - asset_id: collision_camera_026
           Grapple Beam and Gravity Suit and Super Missile
           Any of the following:
               High Jump Boots or Space Jump or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
   > Event - Alpha Metroid
       Varia Suit and Defeat Alpha Metroid
 
@@ -610,7 +610,7 @@ Extra - asset_id: collision_camera_027
           Morph Ball and After Area 3 (Factory Interior) - Gamma Metroid Lower
           Any of the following:
               Grapple Beam or Space Jump or Simple IBJ
-              Spiderspark (Beginner) and Can Spiderspark
+              Spider Boost (Beginner) and Can Spider Boost
   > Event - Gamma Metroid
       Defeat Gamma Metroid
 

--- a/randovania/games/samus_returns/logic_database/Area 3 - Metroid Caverns.json
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Metroid Caverns.json
@@ -172,14 +172,14 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             }
                                                         ]
                                                     }
@@ -1425,14 +1425,14 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 }
                                             ]
                                         }
@@ -2303,13 +2303,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -2610,14 +2610,14 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             }
                                                         ]
                                                     }
@@ -2980,14 +2980,14 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             }
                                                         ]
                                                     }
@@ -3237,13 +3237,13 @@
                                                                                 "items": [
                                                                                     {
                                                                                         "type": "template",
-                                                                                        "data": "Can Spiderspark"
+                                                                                        "data": "Can Spider Boost"
                                                                                     },
                                                                                     {
                                                                                         "type": "resource",
                                                                                         "data": {
                                                                                             "type": "tricks",
-                                                                                            "name": "Spiderspark",
+                                                                                            "name": "Spider Boost",
                                                                                             "amount": 1,
                                                                                             "negate": false
                                                                                         }
@@ -3664,13 +3664,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -4843,13 +4843,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }

--- a/randovania/games/samus_returns/logic_database/Area 3 - Metroid Caverns.txt
+++ b/randovania/games/samus_returns/logic_database/Area 3 - Metroid Caverns.txt
@@ -25,7 +25,7 @@ Extra - asset_id: collision_camera_006
       All of the following:
           Morph Ball and Super Missile
           Any of the following:
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
               All of the following:
                   Gravity Suit
                   High Jump Boots or Space Jump or Super Jump (Intermediate) or Unmorph Extend (Intermediate) or Simple IBJ
@@ -240,7 +240,7 @@ Extra - asset_id: collision_camera_009
       Morph Ball and Super Missile
   > Left of Missile Block
       Any of the following:
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           All of the following:
               Morph Ball
               Any of the following:
@@ -387,7 +387,7 @@ Extra - asset_id: collision_camera_012
   > Door to Save Station North
       Any of the following:
           High Jump Boots or Grapple Beam or Space Jump or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Stand on Frozen Enemy (Intermediate) and Fully Freeze Enemy
   > Pickup (Missile Tank)
       Morph Ball and Shoot Any Missile
@@ -423,7 +423,7 @@ Extra - asset_id: collision_camera_024
           Morph Ball and Shoot Any Missile
           Any of the following:
               Grapple Beam or Space Jump or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
 
 > Tunnel to Quarry Shaft; Heals? False
   * Layers: default
@@ -477,7 +477,7 @@ Extra - asset_id: collision_camera_025
           Lay Any Bomb
           Any of the following:
               Space Jump or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
               All of the following:
                   Grapple Beam
                   Spider Ball or Movement (Beginner)
@@ -502,7 +502,7 @@ Extra - asset_id: collision_camera_025
                   Missile ≥ 2 or Super Missile ≥ 2
                   Any of the following:
                       Gravity Suit
-                      Spiderspark (Beginner) and Can Spiderspark
+                      Spider Boost (Beginner) and Can Spider Boost
                       Bomb and Underwater Bomb Jump (Advanced)
   > Door to Gamma Arena South
       Trivial
@@ -560,7 +560,7 @@ Extra - asset_id: collision_camera_026
               Power Bomb and Knowledge (Beginner)
           Any of the following:
               High Jump Boots or Grapple Beam or Space Jump or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
   > Above Teleporter
       Trivial
 
@@ -746,7 +746,7 @@ Extra - asset_id: collision_camera_032
   > Elevator to Area 3 - Factory Interior
       Any of the following:
           Phase Drift
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           All of the following:
               Morph Ball
               Any of the following:

--- a/randovania/games/samus_returns/logic_database/Area 4 - Central Caves.json
+++ b/randovania/games/samus_returns/logic_database/Area 4 - Central Caves.json
@@ -1129,13 +1129,13 @@
                                                                     "items": [
                                                                         {
                                                                             "type": "template",
-                                                                            "data": "Can Spiderspark"
+                                                                            "data": "Can Spider Boost"
                                                                         },
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
                                                                                 "type": "tricks",
-                                                                                "name": "Spiderspark",
+                                                                                "name": "Spider Boost",
                                                                                 "amount": 3,
                                                                                 "negate": false
                                                                             }
@@ -1347,13 +1347,13 @@
                                                                     "items": [
                                                                         {
                                                                             "type": "template",
-                                                                            "data": "Can Spiderspark"
+                                                                            "data": "Can Spider Boost"
                                                                         },
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
                                                                                 "type": "tricks",
-                                                                                "name": "Spiderspark",
+                                                                                "name": "Spider Boost",
                                                                                 "amount": 2,
                                                                                 "negate": false
                                                                             }
@@ -1786,13 +1786,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -1849,13 +1849,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -2043,13 +2043,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -2188,13 +2188,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -2398,13 +2398,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -4287,13 +4287,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -4434,13 +4434,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -4942,13 +4942,13 @@
                                                                                 "items": [
                                                                                     {
                                                                                         "type": "template",
-                                                                                        "data": "Can Spiderspark"
+                                                                                        "data": "Can Spider Boost"
                                                                                     },
                                                                                     {
                                                                                         "type": "resource",
                                                                                         "data": {
                                                                                             "type": "tricks",
-                                                                                            "name": "Spiderspark",
+                                                                                            "name": "Spider Boost",
                                                                                             "amount": 2,
                                                                                             "negate": false
                                                                                         }
@@ -5077,13 +5077,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -5168,13 +5168,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -5525,13 +5525,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -5617,13 +5617,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -5725,13 +5725,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }

--- a/randovania/games/samus_returns/logic_database/Area 4 - Central Caves.txt
+++ b/randovania/games/samus_returns/logic_database/Area 4 - Central Caves.txt
@@ -192,7 +192,7 @@ Extra - asset_id: collision_camera_004
           Morph Ball
           Any of the following:
               Grapple Beam
-              Phase Drift and Movement (Advanced) and Spiderspark (Advanced) and Can Spiderspark
+              Phase Drift and Movement (Advanced) and Spider Boost (Advanced) and Can Spider Boost
               Bomb and Spider Ball and Infinite Bomb Jump (Advanced)
 
 ----------------
@@ -211,7 +211,7 @@ Extra - asset_id: collision_camera_005
           Any of the following:
               Grapple Beam or Space Jump
               Gravity Suit and Simple IBJ
-              Movement (Intermediate) and Spiderspark (Intermediate) and Can Spiderspark
+              Movement (Intermediate) and Spider Boost (Intermediate) and Can Spider Boost
   > Start Point
       Trivial
 
@@ -274,12 +274,12 @@ Extra - asset_id: collision_camera_006
       Any of the following:
           Use Spider Ball
           Space Jump and Movement (Beginner)
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
   > Door to Caves Intersection Terminal (Bottom)
       Any of the following:
           Space Jump or Simple IBJ
           Grapple Beam and Use Spider Ball
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
   > Tunnel to Transit Tunnel
       Morph Ball and Super Missile and After Area 4 (Central Caves) - Transport to Area 3 and Crystal Mines Grapple Block Left
   > Event - Grapple Block Pull Left
@@ -295,7 +295,7 @@ Extra - asset_id: collision_camera_006
                   All of the following:
                       Spider Ball
                       Bomb or Spring Ball or Mid-Air Morph (Beginner)
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Space Jump and Movement (Beginner)
   > Event - Grapple Block Left
       Grapple Beam
@@ -311,7 +311,7 @@ Extra - asset_id: collision_camera_006
   > Chozo Seal Top
       Any of the following:
           Space Jump and Movement (Beginner)
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           All of the following:
               Use Spider Ball
               Any of the following:
@@ -340,7 +340,7 @@ Extra - asset_id: collision_camera_006
   > Door to Caves Intersection Terminal (Top)
       Any of the following:
           Space Jump or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
 
 > Door to Transport to Area 5; Heals? False
   * Layers: default
@@ -662,7 +662,7 @@ Extra - asset_id: collision_camera_014
   > Dock to Outward Climb
       Any of the following:
           Lightning Armor or Grapple Beam or Space Jump
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
   > Dock to Gamma Arena
       Morph Ball and After Area 4 (Central Caves) - Gamma Arena Access South Grapple Block
 
@@ -678,7 +678,7 @@ Extra - asset_id: collision_camera_014
   > Door to Lava Pond
       Any of the following:
           Lightning Armor or Grapple Beam or Space Jump
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
 
 > Dock to Gamma Arena; Heals? False
   * Layers: default
@@ -759,7 +759,7 @@ Extra - asset_id: collision_camera_016
                   Movement (Beginner)
                   Any of the following:
                       Space Jump or Simple IBJ
-                      Spiderspark (Intermediate) and Can Spiderspark
+                      Spider Boost (Intermediate) and Can Spider Boost
   > Dock to Caves Intersection Terminal
       Trivial
 
@@ -776,7 +776,7 @@ Extra - asset_id: collision_camera_018
   > Dock to Outward Climb
       Any of the following:
           Lightning Armor or Grapple Beam or Space Jump
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
   > Start Point
       Trivial
 
@@ -786,7 +786,7 @@ Extra - asset_id: collision_camera_018
   > Door to Gamma Arena
       Any of the following:
           Lightning Armor or Grapple Beam or Space Jump
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
 
 > Start Point; Heals? False; Default Node
   * Layers: default
@@ -852,7 +852,7 @@ Extra - asset_id: collision_camera_022
   > Next to Acid Pool
       Any of the following:
           Space Jump
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
 
 > Tunnel to Transport to Area 3 and Crystal Mines; Heals? False
   * Layers: default
@@ -865,14 +865,14 @@ Extra - asset_id: collision_camera_022
   > Door to Transport to Area 5
       Any of the following:
           Space Jump
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Charge Beam and Ice Beam and Diagonal Bomb Jump (Hypermode) and Stand on Frozen Enemy (Intermediate) and Movement (Hypermode) and Lay Bomb
   > Tunnel to Transport to Area 3 and Crystal Mines
       All of the following:
           Lay Any Bomb
           Any of the following:
               Climb Rooms Vertically (No High Jump)
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
               Ice Beam and Stand on Frozen Enemy (Beginner)
               Unmorph Extend (Intermediate) and Walljump (Intermediate)
 

--- a/randovania/games/samus_returns/logic_database/Area 4 - Crystal Mines.json
+++ b/randovania/games/samus_returns/logic_database/Area 4 - Crystal Mines.json
@@ -888,13 +888,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 3,
                                                                     "negate": false
                                                                 }
@@ -960,13 +960,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
@@ -1681,13 +1681,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -1905,13 +1905,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -1947,13 +1947,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -2006,13 +2006,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -2035,13 +2035,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -2484,13 +2484,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -2583,13 +2583,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -2658,13 +2658,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -2878,13 +2878,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
@@ -3984,13 +3984,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -4952,13 +4952,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -5450,13 +5450,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -5570,13 +5570,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -5667,13 +5667,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -6200,13 +6200,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -6232,13 +6232,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }

--- a/randovania/games/samus_returns/logic_database/Area 4 - Crystal Mines.txt
+++ b/randovania/games/samus_returns/logic_database/Area 4 - Crystal Mines.txt
@@ -150,7 +150,7 @@ Extra - asset_id: collision_camera_001
           Power Bomb or Shoot Wave Beam
           Any of the following:
               Baby Metroid or Phase Drift
-              Spiderspark (Advanced) and Can Spiderspark
+              Spider Boost (Advanced) and Can Spider Boost
   > Door to Tsumuri Tunnel
       Morph Ball
 
@@ -160,7 +160,7 @@ Extra - asset_id: collision_camera_001
       All of the following:
           Super Missile
           Any of the following:
-              Spiderspark (Beginner) and Can Spiderspark
+              Spider Boost (Beginner) and Can Spider Boost
               All of the following:
                   Morph Ball
                   Any of the following:
@@ -257,7 +257,7 @@ Extra - asset_id: collision_camera_003
           High Jump Boots or Space Jump or Damage Boost (Intermediate)
           Charge Beam and Ice Beam and Stand on Frozen Enemy (Intermediate)
           Diagonal Bomb Jump (Beginner) and Lay Bomb
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
 
 > Tunnel to Zeta Arena; Heals? False
   * Layers: default
@@ -275,22 +275,22 @@ Extra - asset_id: collision_camera_003
               Bomb or Spring Ball or Mid-Air Morph (Beginner)
           Morph Ball and Stand on Frozen Enemy (Beginner) and Unmorph Extend (Intermediate) and Fully Freeze Enemy
           Charge Beam and Ice Beam and Stand on Frozen Enemy (Intermediate)
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
   > Under Pickup
       Any of the following:
           Space Jump or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
 
 > Under Pickup; Heals? False
   * Layers: default
   > Pickup (Missile Tank)
       Any of the following:
           Space Jump or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
   > Dock to Gemstone Gorge
       Any of the following:
           High Jump Boots or Space Jump or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Charge Beam and Ice Beam and Stand on Frozen Enemy (Intermediate)
           All of the following:
               Damage Boost (Expert)
@@ -361,7 +361,7 @@ Extra - asset_id: collision_camera_006
           Gravity Suit
           Any of the following:
               Space Jump or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
 
 ----------------
 Dual Pond Alcove
@@ -376,13 +376,13 @@ Extra - asset_id: collision_camera_007
   > Tunnel to Mines Intersection Terminal
       Any of the following:
           Grapple Beam
-          Spiderspark (Beginner) and Can Spiderspark
+          Spider Boost (Beginner) and Can Spider Boost
 
 > Tunnel to Mines Intersection Terminal; Heals? False
   * Layers: default
   * Tunnel to Mines Intersection Terminal/Tunnel to Dual Pond Alcove
   > Pickup (Power Bomb Tank)
-      Power Bomb ≥ 2 and Spiderspark (Beginner) and Can Spiderspark
+      Power Bomb ≥ 2 and Spider Boost (Beginner) and Can Spider Boost
 
 ----------------
 Zeta Arena
@@ -421,7 +421,7 @@ Extra - asset_id: collision_camera_008
           Morph Ball and Shoot Any Missile
           Any of the following:
               Space Jump or Single-wall Wall Jump (Advanced) or Simple IBJ
-              Spiderspark (Beginner) and Can Spiderspark
+              Spider Boost (Beginner) and Can Spider Boost
 
 > Pickup (DNA); Heals? False
   * Layers: default
@@ -576,7 +576,7 @@ Extra - asset_id: collision_camera_010
   > Door to Tsumuri Tunnel
       Any of the following:
           Space Jump or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
 
 ----------------
 Tsumuri Tunnel
@@ -721,7 +721,7 @@ Extra - asset_id: collision_camera_014
       Any of the following:
           Simple IBJ
           Morph Ball and Space Jump
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
 
 > Door from Lava Reservoir; Heals? False
   * Layers: default
@@ -797,7 +797,7 @@ Extra - asset_id: collision_camera_AfterChase
   > Door to Mines Intersection Terminal
       Any of the following:
           Space Jump or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
   > Tunnel to Diggernaut Excavation Tunnels (Top)
       Morph Ball and Super Missile
   > Under Grapple Block
@@ -811,7 +811,7 @@ Extra - asset_id: collision_camera_AfterChase
   > Bottom of Shaft
       Any of the following:
           Space Jump or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
   > Bottom Floor
       Trivial
 
@@ -825,7 +825,7 @@ Extra - asset_id: collision_camera_AfterChase
   > Under Grapple Block
       Any of the following:
           Space Jump or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
 
 ----------------
 Diggernaut Excavation Tunnels
@@ -919,10 +919,10 @@ Extra - asset_id: collision_camera_AfterChase_001
           Any of the following:
               Baby Metroid
               Phase Drift and Lay Any Bomb
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
   > Save Station
       Any of the following:
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Morph Ball and Space Jump
   > Tunnel to Space Jump Chamber (Top)
       Morph Ball and Super Missile

--- a/randovania/games/samus_returns/logic_database/Area 5 - Tower Exterior.json
+++ b/randovania/games/samus_returns/logic_database/Area 5 - Tower Exterior.json
@@ -1044,13 +1044,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -1471,13 +1471,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -2218,13 +2218,13 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -2244,13 +2244,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -2368,13 +2368,13 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -2434,13 +2434,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -3547,13 +3547,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -4873,13 +4873,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -5160,13 +5160,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -5255,13 +5255,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -5421,13 +5421,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -5590,13 +5590,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }

--- a/randovania/games/samus_returns/logic_database/Area 5 - Tower Exterior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 5 - Tower Exterior.txt
@@ -141,7 +141,7 @@ Extra - asset_id: collision_camera_002
               All of the following:
                   Lightning Armor
                   Simple IBJ or Use Spider Ball
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
           # Bypass the enemies
           Lightning Armor or Plasma Beam or Screw Attack or Combat (Intermediate) or Normal Damage ≥ 150 or Shoot Beam Burst
 
@@ -189,7 +189,7 @@ Extra - asset_id: collision_camera_002
               All of the following:
                   Lightning Armor
                   Simple IBJ or Use Spider Ball
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
           # Energy Requirements
           Lightning Armor or Plasma Beam or Screw Attack or Combat (Intermediate) or Normal Damage ≥ 150 or Shoot Beam Burst
   > Top of Tower Right Side
@@ -270,10 +270,10 @@ Extra - asset_id: collision_camera_004
   * Extra - actor_name: LE_Item_001
   * Extra - actor_type: item_energytank
   > Pickup (Power Bomb Tank)
-      Spiderspark (Beginner) and Can Spiderspark
+      Spider Boost (Beginner) and Can Spider Boost
   > Door to Tower Exterior
       Any of the following:
-          Spiderspark (Beginner) and Can Spiderspark
+          Spider Boost (Beginner) and Can Spider Boost
           All of the following:
               Morph Ball
               Any of the following:
@@ -286,7 +286,7 @@ Extra - asset_id: collision_camera_004
   * Extra - actor_name: LE_Item_007
   * Extra - actor_type: item_powerbombtank
   > Pickup (Energy Tank)
-      Spiderspark (Beginner) and Can Spiderspark
+      Spider Boost (Beginner) and Can Spider Boost
   > Tunnel to Tower Exterior
       Morph Ball
 
@@ -297,7 +297,7 @@ Extra - asset_id: collision_camera_004
   * Extra - actor_type: doorpowerpower
   > Pickup (Energy Tank)
       Any of the following:
-          Spiderspark (Beginner) and Can Spiderspark
+          Spider Boost (Beginner) and Can Spider Boost
           Morph Ball and Damage Boost (Advanced)
   > Bottom Path
       Morph Ball
@@ -471,7 +471,7 @@ Extra - asset_id: collision_camera_012
   > Door to Zeta Arena Access
       Any of the following:
           High Jump Boots or Space Jump or Super Jump (Intermediate) or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Morph Ball and Unmorph Extend (Beginner)
   > Event - Zeta Metroid
       Defeat Zeta Metroid
@@ -652,7 +652,7 @@ Extra - asset_id: collision_camera_016
   * Extra - actor_type: doorpowerpower
   > Door to Screw Attack Chamber
       Any of the following:
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           All of the following:
               Gravity Suit
               Space Jump or Simple IBJ
@@ -685,7 +685,7 @@ Extra - asset_id: collision_camera_014
           Varia Suit
           Any of the following:
               Lightning Armor or Space Jump
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
 
 > Door to Gamma+ Arena; Heals? False
   * Layers: default
@@ -697,7 +697,7 @@ Extra - asset_id: collision_camera_014
           Varia Suit
           Any of the following:
               Lightning Armor or Space Jump
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
   > Start Point
       Trivial
 
@@ -722,7 +722,7 @@ Extra - asset_id: collision_camera_014
           Varia Suit and Defeat Gamma Metroid+
           Any of the following:
               Gravity Suit or Space Jump
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
               Diagonal Bomb Jump (Intermediate) and Lay Bomb
   > Start Point
       Varia Suit
@@ -749,6 +749,6 @@ Extra - asset_id: collision_camera_014
           Varia Suit
           Any of the following:
               Gravity Suit or Space Jump
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
               Diagonal Bomb Jump (Intermediate) and Lay Bomb
 

--- a/randovania/games/samus_returns/logic_database/Area 5 - Tower Interior.json
+++ b/randovania/games/samus_returns/logic_database/Area 5 - Tower Interior.json
@@ -772,13 +772,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -1975,13 +1975,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -4524,14 +4524,14 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             }
                                                         ]
                                                     }
@@ -5092,7 +5092,7 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
@@ -5107,7 +5107,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -5734,13 +5734,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -6316,13 +6316,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -6471,13 +6471,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -6571,13 +6571,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }

--- a/randovania/games/samus_returns/logic_database/Area 5 - Tower Interior.txt
+++ b/randovania/games/samus_returns/logic_database/Area 5 - Tower Interior.txt
@@ -114,7 +114,7 @@ Extra - asset_id: collision_camera_003
           Any of the following:
               Grapple Beam or Movement (Intermediate)
               Bomb and Spider Ball and Diagonal Bomb Jump (Beginner)
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
   > Left of Grapple Block
       Trivial
   > Underwater
@@ -290,7 +290,7 @@ Extra - asset_id: collision_camera_007
           Morph Ball and Screw Attack and Shoot Any Missile
           Any of the following:
               Phase Drift or Movement (Intermediate)
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
   > Event - Grapple Block
       Grapple Beam
 
@@ -660,7 +660,7 @@ Extra - asset_id: collision_camera_017
   > Pickup (Missile Tank)
       Any of the following:
           Morph Ball and Shoot Any Missile
-          Power Bomb ≥ 2 and Spiderspark (Beginner) and Can Spiderspark
+          Power Bomb ≥ 2 and Spider Boost (Beginner) and Can Spider Boost
           Spider Ball and Simple IBJ
           High Jump Boots and Lay Any Bomb
   > Door to Zeta+ Arena
@@ -743,7 +743,7 @@ Extra - asset_id: collision_camera_020
   > Door to Transport to Tower Exterior West
       Gravity Suit or Climb Rooms Vertically (High Jump)
   > Pickup (Missile Tank)
-      Power Bomb ≥ 3 and Spiderspark (Beginner) and Can Spiderspark and Shoot Any Missile
+      Power Bomb ≥ 3 and Spider Boost (Beginner) and Can Spider Boost and Shoot Any Missile
   > Right of Pickup
       All of the following:
           Lay Any Bomb
@@ -846,7 +846,7 @@ Extra - asset_id: collision_camera_022
           Varia Suit
           Any of the following:
               Space Jump or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
 
 > Outside Arena; Heals? False; Default Node
   * Layers: default
@@ -950,7 +950,7 @@ Extra - asset_id: collision_camera_025
   > Door to Zeta+ Arena Access
       Any of the following:
           High Jump Boots or Space Jump or Super Jump (Expert) or Simple IBJ
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Morph Ball and Unmorph Extend (Beginner)
   > Event - Zeta Metroid+
       Defeat Zeta Metroid+
@@ -975,7 +975,7 @@ Extra - asset_id: collision_camera_026
   * Extra - actor_type: doorpowerpower
   > Tunnel to Interior Save Station
       Any of the following:
-          Spiderspark (Beginner) and Can Spiderspark
+          Spider Boost (Beginner) and Can Spider Boost
           All of the following:
               Morph Ball
               Lightning Armor or Space Jump
@@ -985,7 +985,7 @@ Extra - asset_id: collision_camera_026
   * Tunnel to Interior Save Station/Tunnel to Gamma+ Arena Access
   > Door to Gamma+ Arena
       Any of the following:
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           All of the following:
               Morph Ball
               Lightning Armor or Space Jump

--- a/randovania/games/samus_returns/logic_database/Area 5 - Tower Lobby.json
+++ b/randovania/games/samus_returns/logic_database/Area 5 - Tower Lobby.json
@@ -121,13 +121,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -452,13 +452,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 3,
                                                                     "negate": false
                                                                 }
@@ -849,14 +849,14 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 }
                                             ]
                                         }
@@ -928,13 +928,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -1112,13 +1112,13 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 2,
                                             "negate": false
                                         }
@@ -1695,13 +1695,13 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 2,
                                             "negate": false
                                         }
@@ -2070,14 +2070,14 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
                                                             },
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             }
                                                         ]
                                                     }
@@ -3074,14 +3074,14 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 }
                                             ]
                                         }
@@ -4689,13 +4689,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -4886,13 +4886,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -5182,14 +5182,14 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 }
                                             ]
                                         }

--- a/randovania/games/samus_returns/logic_database/Area 5 - Tower Lobby.txt
+++ b/randovania/games/samus_returns/logic_database/Area 5 - Tower Lobby.txt
@@ -15,7 +15,7 @@ Extra - asset_id: collision_camera_001
           Morph Ball
           Any of the following:
               Phase Drift or After Area 5 (Tower Lobby) - Lobby Save Station Grapple Block
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
               All of the following:
                   Bomb
                   Any of the following:
@@ -53,7 +53,7 @@ Extra - asset_id: collision_camera_001
                       Phase Drift Skip (Hypermode)
                       Space Jump and Phase Drift Skip (Expert)
               Melee Clip (Advanced) and Out of Bounds Movement (Intermediate) and Fully Freeze Enemy
-              Spiderspark (Advanced) and Can Spiderspark
+              Spider Boost (Advanced) and Can Spider Boost
   > Dock to Phase Drift Chamber
       Morph Ball
 
@@ -110,12 +110,12 @@ Extra - asset_id: collision_camera_002
   * Extra - actor_type: doorpowerpower
   > Elevator to Area 5 - Tower Interior
       Any of the following:
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Phase Drift and Space Jump
   > Door to Lobby Teleporter West
       Any of the following:
           Phase Drift and Space Jump
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Spider Ball and Infinite Bomb Jump (Advanced) and Movement (Expert) and Phase Drift Skip (Hypermode) and Lay Bomb
 
 ----------------
@@ -131,7 +131,7 @@ Extra - asset_id: collision_camera_004
   > Below Chozo Seal
       Morph Ball and Damage Boost (Beginner)
   > Above Center Tunnel
-      Spiderspark (Intermediate) and Can Spiderspark
+      Spider Boost (Intermediate) and Can Spider Boost
   > Ledge Under Left Pickup
       Screw Attack
 
@@ -231,7 +231,7 @@ Extra - asset_id: collision_camera_004
 > Above Center Tunnel; Heals? False
   * Layers: default
   > Pickup (Super Missile Tank)
-      Spiderspark (Intermediate) and Can Spiderspark
+      Spider Boost (Intermediate) and Can Spider Boost
   > Below Chozo Seal
       Any of the following:
           Lightning Armor
@@ -284,7 +284,7 @@ Extra - asset_id: collision_camera_004
       All of the following:
           After Area 5 (Tower Lobby) - Transport to Areas 4 and 6 Grapple Block Top
           Any of the following:
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
               Infinite Bomb Jump (Expert) and Lay Bomb
   > Below Center Tunnel
       Morph Ball
@@ -432,7 +432,7 @@ Extra - asset_id: collision_camera_006
   * Layers: default
   > Door to Gamma+ Arena Access
       Any of the following:
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           All of the following:
               Gravity Suit
               Space Jump or Simple IBJ
@@ -701,7 +701,7 @@ Extra - asset_id: collision_camera_014
           Morph Ball
           Any of the following:
               Phase Drift or Phase Drift Skip (Expert)
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
 
 > Dock to Lobby Save Station; Heals? False
   * Layers: default
@@ -729,7 +729,7 @@ Extra - asset_id: collision_camera_014
           All of the following:
               Lay Any Bomb
               Phase Drift or Phase Drift Skip (Intermediate)
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
   > Tunnel to Meboid Millpond (Top)
       Lay Any Bomb
   > Tunnel to Meboid Millpond (Bottom)
@@ -788,7 +788,7 @@ Extra - asset_id: collision_camera_015
   * Layers: default
   > Pickup (Missile Tank)
       Any of the following:
-          Spiderspark (Beginner) and Can Spiderspark
+          Spider Boost (Beginner) and Can Spider Boost
           All of the following:
               Morph Ball
               Any of the following:

--- a/randovania/games/samus_returns/logic_database/Area 6.json
+++ b/randovania/games/samus_returns/logic_database/Area 6.json
@@ -2494,7 +2494,7 @@
                                     },
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
@@ -2518,7 +2518,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -3014,13 +3014,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -3470,13 +3470,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -4294,13 +4294,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -5049,13 +5049,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }

--- a/randovania/games/samus_returns/logic_database/Area 6.txt
+++ b/randovania/games/samus_returns/logic_database/Area 6.txt
@@ -329,7 +329,7 @@ Extra - asset_id: collision_camera_038
               High Jump Boots or Space Jump or Single-wall Wall Jump (Advanced)
               Bomb and Infinite Bomb Jump (Advanced)
   > Pickup (Super Missile Tank)
-      Grapple Beam and Power Bomb ≥ 2 and Screw Attack and Spiderspark (Beginner) and Can Spiderspark
+      Grapple Beam and Power Bomb ≥ 2 and Screw Attack and Spider Boost (Beginner) and Can Spider Boost
   > Door to Omega Arena Access (Top)
       All of the following:
           Screw Attack
@@ -396,7 +396,7 @@ Extra - asset_id: collision_camera_040
       Morph Ball
   > Left of Bridge
       Any of the following:
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           All of the following:
               Morph Ball
               Any of the following:
@@ -448,7 +448,7 @@ Extra - asset_id: collision_camera_040
   > Door to Chozo Seal East
       Any of the following:
           Morph Ball and Phase Drift
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
   > Door to Zeta Arena
       Morph Ball
   > Under Bridge
@@ -553,7 +553,7 @@ Extra - asset_id: collision_camera_042
           Phase Drift
           Bomb and Spider Ball and Diagonal Bomb Jump (Beginner)
           Spring Ball and Phase Drift Skip (Advanced)
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Phase Drift Skip (Intermediate) and Walljump (Intermediate)
   > Door to Chozo Seal West Intersection Terminal
       Trivial
@@ -662,7 +662,7 @@ Extra - asset_id: collision_camera_045
   * Extra - actor_type: weightactivatedplatform
   > Pickup (Power Bomb Tank)
       Any of the following:
-          Spiderspark (Beginner) and Can Spiderspark
+          Spider Boost (Beginner) and Can Spider Boost
           Infinite Bomb Jump (Expert) and Lay Bomb
   > Door to Diggernaut Arena
       Trivial

--- a/randovania/games/samus_returns/logic_database/Area 7.json
+++ b/randovania/games/samus_returns/logic_database/Area 7.json
@@ -344,13 +344,13 @@
                                                                     "items": [
                                                                         {
                                                                             "type": "template",
-                                                                            "data": "Can Spiderspark"
+                                                                            "data": "Can Spider Boost"
                                                                         },
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
                                                                                 "type": "tricks",
-                                                                                "name": "Spiderspark",
+                                                                                "name": "Spider Boost",
                                                                                 "amount": 1,
                                                                                 "negate": false
                                                                             }
@@ -578,7 +578,7 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
@@ -593,7 +593,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -1345,13 +1345,13 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -2048,7 +2048,7 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
@@ -2063,7 +2063,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -3270,13 +3270,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -3380,13 +3380,13 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -3460,7 +3460,7 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
@@ -3475,7 +3475,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -3887,13 +3887,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -4096,13 +4096,13 @@
                                     },
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -4396,13 +4396,13 @@
                                                                     "items": [
                                                                         {
                                                                             "type": "template",
-                                                                            "data": "Can Spiderspark"
+                                                                            "data": "Can Spider Boost"
                                                                         },
                                                                         {
                                                                             "type": "resource",
                                                                             "data": {
                                                                                 "type": "tricks",
-                                                                                "name": "Spiderspark",
+                                                                                "name": "Spider Boost",
                                                                                 "amount": 3,
                                                                                 "negate": false
                                                                             }
@@ -5747,13 +5747,13 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -5856,13 +5856,13 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -6510,13 +6510,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -6595,13 +6595,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -8650,13 +8650,13 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -8736,13 +8736,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -8826,13 +8826,13 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Spiderspark"
+                                        "data": "Can Spider Boost"
                                     },
                                     {
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Spiderspark",
+                                            "name": "Spider Boost",
                                             "amount": 1,
                                             "negate": false
                                         }

--- a/randovania/games/samus_returns/logic_database/Area 7.txt
+++ b/randovania/games/samus_returns/logic_database/Area 7.txt
@@ -51,7 +51,7 @@ Extra - asset_id: collision_camera_005
           All of the following:
               Lightning Armor
               Any of the following:
-                  Movement (Intermediate) and Spiderspark (Beginner) and Can Spiderspark
+                  Movement (Intermediate) and Spider Boost (Beginner) and Can Spider Boost
                   All of the following:
                       Infinite Bomb Jump (Intermediate) and Lay Bomb
                       Spider Ball or Movement (Advanced)
@@ -67,7 +67,7 @@ Extra - asset_id: collision_camera_005
                           Infinite Bomb Jump (Intermediate) and Lay Bomb
                           Unmorph Extend (Beginner) and Lay Power Bomb
   > Next to Pickup
-      Power Bomb ≥ 2 and Spiderspark (Beginner) and Can Spiderspark
+      Power Bomb ≥ 2 and Spider Boost (Beginner) and Can Spider Boost
 
 > Door to Robot Retreat; Heals? False
   * Layers: default
@@ -162,7 +162,7 @@ Extra - asset_id: collision_camera_005
                   Bomb
                   Plasma Beam or Shoot Beam Burst
   > 2nd Level
-      Lightning Armor and Movement (Intermediate) and Spiderspark (Beginner) and Can Spiderspark
+      Lightning Armor and Movement (Intermediate) and Spider Boost (Beginner) and Can Spider Boost
   > Event - Teleporter Unlocked Mid-Air
       Trivial
 
@@ -269,7 +269,7 @@ Extra - asset_id: collision_camera_007
   > Dock to Robot Regime
       Any of the following:
           Lightning Armor and Morph Ball
-          After Area 7 - Spider Boost Tunnel South Grapple Block Top and Spiderspark (Beginner) and Can Spiderspark
+          After Area 7 - Spider Boost Tunnel South Grapple Block Top and Spider Boost (Beginner) and Can Spider Boost
   > Event - Grapple Block Top
       Grapple Beam and Morph Ball and Climb Rooms Vertically (No High Jump)
 
@@ -458,7 +458,7 @@ Extra - asset_id: collision_camera_010
   * Extra - actor_type: item_missiletank
   > Energy Recharge Station
       Any of the following:
-          Spiderspark (Beginner) and Can Spiderspark
+          Spider Boost (Beginner) and Can Spider Boost
           Grapple Beam and Morph Ball
 
 > Pickup (Aeion Tank); Heals? False
@@ -471,7 +471,7 @@ Extra - asset_id: collision_camera_010
           Morph Ball
           Lightning Armor or Defeat Gold Robots
   > Dock to Spider Boost Tunnel South
-      Spiderspark (Beginner) and Can Spiderspark
+      Spider Boost (Beginner) and Can Spider Boost
 
 > Ammo Recharge Station; Heals? False
   * Layers: default
@@ -488,7 +488,7 @@ Extra - asset_id: collision_camera_010
   * Extra - actor_type: weightactivatedplatform
   > Pickup (Missile Tank)
       Any of the following:
-          Power Bomb ≥ 2 and Spiderspark (Beginner) and Can Spiderspark
+          Power Bomb ≥ 2 and Spider Boost (Beginner) and Can Spider Boost
           All of the following:
               Grapple Beam and Morph Ball
               Any of the following:
@@ -525,7 +525,7 @@ Extra - asset_id: collision_camera_010
           Lightning Armor or Missile ≥ 10 or Super Missile ≥ 2 or Defeat Gold Robots
           Any of the following:
               High Jump Boots or Space Jump or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
               Lightning Armor and Walljump (Beginner)
               Morph Ball and Unmorph Extend (Intermediate) and Walljump (Intermediate)
   > Dock to Spider Boost Tunnel South
@@ -549,7 +549,7 @@ Extra - asset_id: collision_camera_010
   * Layers: default
   * Open Passage to Spider Boost Tunnel South/Dock to Robot Regime
   > Pickup (Aeion Tank)
-      After Area 7 - Spider Boost Tunnel South Grapple Block Top and Spiderspark (Beginner) and Can Spiderspark
+      After Area 7 - Spider Boost Tunnel South Grapple Block Top and Spider Boost (Beginner) and Can Spider Boost
   > Door to Spider Boost Tunnel South
       Lightning Armor
 
@@ -586,7 +586,7 @@ Extra - asset_id: collision_camera_011
               Morph Ball and Melee Clip (Intermediate) and Out of Bounds Movement (Beginner)
               Any of the following:
                   Baby Metroid or High Jump Boots or Space Jump
-                  Spiderspark (Advanced) and Can Spiderspark
+                  Spider Boost (Advanced) and Can Spider Boost
                   Bomb and Infinite Bomb Jump (Intermediate)
 
 > Chozo Seal; Heals? False
@@ -757,7 +757,7 @@ Extra - asset_id: collision_camera_012
           Morph Ball and Screw Attack
           Lightning Armor or Spider Ball
   > Door to Omega Arena South
-      Spiderspark (Beginner) and Can Spiderspark
+      Spider Boost (Beginner) and Can Spider Boost
 
 > Door to Laboratory Teleporter East; Heals? False
   * Layers: default
@@ -773,7 +773,7 @@ Extra - asset_id: collision_camera_012
   * Extra - actor_name: Door015
   * Extra - actor_type: doorpowerpower
   > Pickup (Missile Tank)
-      Spiderspark (Beginner) and Can Spiderspark
+      Spider Boost (Beginner) and Can Spider Boost
   > Door to Laboratory Teleporter East
       Lightning Armor or Screw Attack
   > Start Point
@@ -892,7 +892,7 @@ Extra - asset_id: collision_camera_015
   > Door to Robot Retreat
       Any of the following:
           Lightning Armor or Space Jump
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
   > Start Point
       Trivial
 
@@ -904,7 +904,7 @@ Extra - asset_id: collision_camera_015
   > Door to Omega Arena North
       Any of the following:
           Lightning Armor or Space Jump
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
 
 > Tunnel to Robot Retreat; Heals? False
   * Layers: default
@@ -1196,7 +1196,7 @@ Extra - asset_id: collision_camera_019
   * Layers: default
   * Tunnel with Bomb Block to Robot Retreat/Tunnel to Spider Boost Tunnel North (Top)
   > Tunnel to Robot Regime
-      Spiderspark (Beginner) and Can Spiderspark
+      Spider Boost (Beginner) and Can Spider Boost
 
 > Tunnel to Robot Retreat (Bottom); Heals? False
   * Layers: default
@@ -1207,14 +1207,14 @@ Extra - asset_id: collision_camera_019
           Any of the following:
               Phase Drift
               All of the following:
-                  Movement (Intermediate) and Spiderspark (Intermediate) and Can Spiderspark
+                  Movement (Intermediate) and Spider Boost (Intermediate) and Can Spider Boost
                   Bomb or Power Bomb ≥ 2
 
 > Tunnel to Robot Regime; Heals? False
   * Layers: default
   * Tunnel to Robot Regime/Tunnel to Spider Boost Tunnel North
   > Tunnel to Robot Retreat (Top)
-      Spiderspark (Beginner) and Can Spiderspark
+      Spider Boost (Beginner) and Can Spider Boost
 
 ----------------
 Transport to Area 8

--- a/randovania/games/samus_returns/logic_database/Area 8.json
+++ b/randovania/games/samus_returns/logic_database/Area 8.json
@@ -412,13 +412,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -721,13 +721,13 @@
                                                                                 "items": [
                                                                                     {
                                                                                         "type": "template",
-                                                                                        "data": "Can Spiderspark"
+                                                                                        "data": "Can Spider Boost"
                                                                                     },
                                                                                     {
                                                                                         "type": "resource",
                                                                                         "data": {
                                                                                             "type": "tricks",
-                                                                                            "name": "Spiderspark",
+                                                                                            "name": "Spider Boost",
                                                                                             "amount": 2,
                                                                                             "negate": false
                                                                                         }
@@ -1557,13 +1557,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -1700,13 +1700,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -2854,13 +2854,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -3067,13 +3067,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 3,
                                                                     "negate": false
                                                                 }
@@ -3273,13 +3273,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 3,
                                                                     "negate": false
                                                                 }
@@ -3557,13 +3557,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -4095,13 +4095,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
@@ -7104,13 +7104,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -7469,13 +7469,13 @@
                                                             },
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 3,
                                                                     "negate": false
                                                                 }
@@ -8262,13 +8262,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }

--- a/randovania/games/samus_returns/logic_database/Area 8.txt
+++ b/randovania/games/samus_returns/logic_database/Area 8.txt
@@ -62,7 +62,7 @@ Extra - asset_id: collision_camera_007
   * Extra - actor_type: weightactivatedplatform
   > Pickup (Super Missile Tank)
       Any of the following:
-          Spiderspark (Beginner) and Can Spiderspark
+          Spider Boost (Beginner) and Can Spider Boost
           Morph Ball and Phase Drift
   > Elevator to Surface - West
       Baby Metroid
@@ -101,7 +101,7 @@ Extra - asset_id: collision_camera_007
               All of the following:
                   Lightning Armor
                   Any of the following:
-                      Spiderspark (Intermediate) and Can Spiderspark
+                      Spider Boost (Intermediate) and Can Spider Boost
                       Infinite Bomb Jump (Advanced) and Lay Any Bomb
 
 > Dock to Hatchling Room; Heals? False
@@ -225,7 +225,7 @@ Extra - asset_id: collision_camera_009
   > Pickup (Missile Tank Hidden)
       Any of the following:
           Spider Ball and Infinite Bomb Jump (Intermediate) and Lay Bomb
-          Power Bomb ≥ 2 and Spiderspark (Intermediate) and Can Spiderspark
+          Power Bomb ≥ 2 and Spider Boost (Intermediate) and Can Spider Boost
           All of the following:
               Space Jump
               Any of the following:
@@ -240,7 +240,7 @@ Extra - asset_id: collision_camera_009
           Lay Any Bomb
           Any of the following:
               Space Jump or Simple IBJ
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
 
 > Energy Recharge Station; Heals? True
   * Layers: default
@@ -370,7 +370,7 @@ Extra - asset_id: collision_camera_009
                   Screw Attack or Movement (Beginner)
               Movement (Beginner) and Use Spider Ball
               Infinite Bomb Jump (Intermediate) and Lay Bomb
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
   > Event - Grapple Block Top
       Grapple Beam
   > Above Tunnels
@@ -388,7 +388,7 @@ Extra - asset_id: collision_camera_009
               All of the following:
                   Space Jump
                   Lightning Armor or Screw Attack
-              Spiderspark (Advanced) and Can Spiderspark
+              Spider Boost (Advanced) and Can Spider Boost
               Infinite Bomb Jump (Intermediate) and Lay Bomb
           Any of the following:
               Missile ≥ 20 or Plasma Beam or Super Missile ≥ 4 or Shoot Beam Burst
@@ -402,7 +402,7 @@ Extra - asset_id: collision_camera_009
           Any of the following:
               # Climbing the right side
               Single-wall Wall Jump (Intermediate) and Walljump (Intermediate)
-              Spiderspark (Advanced) and Can Spiderspark
+              Spider Boost (Advanced) and Can Spider Boost
               Infinite Bomb Jump (Intermediate) and Lay Bomb
               All of the following:
                   Space Jump
@@ -431,7 +431,7 @@ Extra - asset_id: collision_camera_010
   > Above Grapple Block
       Any of the following:
           Lightning Armor
-          Spiderspark (Beginner) and Can Spiderspark
+          Spider Boost (Beginner) and Can Spider Boost
 
 > Pickup (Missile Tank Baby Locked); Heals? False
   * Layers: default
@@ -508,7 +508,7 @@ Extra - asset_id: collision_camera_010
   > Pickup (Missile Tank Hallway)
       Any of the following:
           Lightning Armor
-          Spiderspark (Beginner) and Can Spiderspark
+          Spider Boost (Beginner) and Can Spider Boost
   > Door to Entrance Teleporter
       Lightning Armor
   > Tunnel to Entrance Teleporter
@@ -973,7 +973,7 @@ Extra - asset_id: collision_camera_019
   > Door to Metroid Nest Shaft West
       Any of the following:
           Lightning Armor or High Jump Boots or Space Jump
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Diagonal Bomb Jump (Intermediate) and Lay Bomb
           Morph Ball and Unmorph Extend (Intermediate)
   > Dock to Queen Arena
@@ -1015,7 +1015,7 @@ Extra - asset_id: collision_camera_021
           Screw Attack
           Any of the following:
               Space Jump
-              Spiderspark (Advanced) and Walljump (Intermediate) and Can Spiderspark
+              Spider Boost (Advanced) and Walljump (Intermediate) and Can Spider Boost
 
 > Save Station; Heals? False
   * Layers: default
@@ -1099,7 +1099,7 @@ Extra - asset_id: collision_camera_020
               # Dodging Plasma Balls/Fire
               Use Spider Ball
               # Launch into head to end attack early
-              Combat (Intermediate) and Spiderspark (Intermediate) and Can Spiderspark
+              Combat (Intermediate) and Spider Boost (Intermediate) and Can Spider Boost
 
 > Dock to Hatchling Room; Heals? False
   * Layers: default

--- a/randovania/games/samus_returns/logic_database/Surface - East.json
+++ b/randovania/games/samus_returns/logic_database/Surface - East.json
@@ -4350,13 +4350,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -4611,13 +4611,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }
@@ -4718,13 +4718,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }

--- a/randovania/games/samus_returns/logic_database/Surface - East.txt
+++ b/randovania/games/samus_returns/logic_database/Surface - East.txt
@@ -769,7 +769,7 @@ Extra - asset_id: collision_camera_018
           Morph Ball and Shoot Any Missile
           Any of the following:
               Grapple Beam or Phase Drift
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
               Bomb and Diagonal Bomb Jump (Intermediate)
 
 > Room Center; Heals? False
@@ -792,7 +792,7 @@ Extra - asset_id: collision_camera_018
           Morph Ball and Shoot Any Missile
           Any of the following:
               Phase Drift
-              Spiderspark (Intermediate) and Can Spiderspark
+              Spider Boost (Intermediate) and Can Spider Boost
               Bomb and Spider Ball and Diagonal Bomb Jump (Intermediate)
 
 > Below Right Crumble Blocks; Heals? False
@@ -802,7 +802,7 @@ Extra - asset_id: collision_camera_018
           Morph Ball
           Any of the following:
               Grapple Beam
-              Spiderspark (Beginner) and Can Spiderspark
+              Spider Boost (Beginner) and Can Spider Boost
   > Room Center
       Any of the following:
           Grapple Beam and Movement (Intermediate)

--- a/randovania/games/samus_returns/logic_database/Surface - West.json
+++ b/randovania/games/samus_returns/logic_database/Surface - West.json
@@ -671,13 +671,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -730,13 +730,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -1222,13 +1222,13 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Spiderspark"
+                                                    "data": "Can Spider Boost"
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Spiderspark",
+                                                        "name": "Spider Boost",
                                                         "amount": 2,
                                                         "negate": false
                                                     }
@@ -1372,13 +1372,13 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Spiderspark"
+                                                                "data": "Can Spider Boost"
                                                             },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Spiderspark",
+                                                                    "name": "Spider Boost",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }

--- a/randovania/games/samus_returns/logic_database/Surface - West.txt
+++ b/randovania/games/samus_returns/logic_database/Surface - West.txt
@@ -86,11 +86,11 @@ Extra - asset_id: collision_camera_017
               Space Jump
               Screw Attack or Movement (Beginner)
           Movement (Beginner) and Use Spider Ball
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Combat (Intermediate) and Infinite Bomb Jump (Advanced) and Lay Bomb
   > Below Ceiling Pickup
       Any of the following:
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Space Jump and Movement (Beginner)
           All of the following:
               Lightning Armor
@@ -167,7 +167,7 @@ Extra - asset_id: collision_camera_017
   * Layers: default
   > Energy Recharge Station
       Any of the following:
-          Spiderspark (Intermediate) and Can Spiderspark
+          Spider Boost (Intermediate) and Can Spider Boost
           Space Jump and Movement (Beginner)
           All of the following:
               Lightning Armor
@@ -180,7 +180,7 @@ Extra - asset_id: collision_camera_017
       All of the following:
           Baby Metroid
           Any of the following:
-              Spiderspark (Beginner) and Can Spiderspark
+              Spider Boost (Beginner) and Can Spider Boost
               Spider Ball and Simple IBJ
               All of the following:
                   Any of the following:

--- a/randovania/games/samus_returns/logic_database/header.json
+++ b/randovania/games/samus_returns/logic_database/header.json
@@ -1140,8 +1140,8 @@
                 "description": "By rapidly double tapping jump within a few frames, Samus can jump higher than normal.",
                 "extra": {}
             },
-            "Spiderspark": {
-                "long_name": "Spiderspark",
+            "Spider Boost": {
+                "long_name": "Spider Boost",
                 "description": "Movement ability used to cross rooms in unintended ways.",
                 "extra": {}
             },
@@ -1490,7 +1490,7 @@
                     ]
                 }
             },
-            "Can Spiderspark": {
+            "Can Spider Boost": {
                 "type": "and",
                 "data": {
                     "comment": null,
@@ -5118,7 +5118,7 @@
         "Freeze": [
             2
         ],
-        "Spiderspark": [
+        "Spider Boost": [
             1,
             2,
             3

--- a/randovania/games/samus_returns/logic_database/header.txt
+++ b/randovania/games/samus_returns/logic_database/header.txt
@@ -30,7 +30,7 @@ Templates
           Morph Ball
           Bomb or Power Bomb
 
-* Can Spiderspark:
+* Can Spider Boost:
       Spider Ball and Lay Power Bomb
 
 * Use Spider Ball:

--- a/test/generator/test_generator_reach.py
+++ b/test/generator/test_generator_reach.py
@@ -134,8 +134,9 @@ _include_tricks_for_game = {
     RandovaniaGame.METROID_DREAD: {("Speedbooster", LayoutTrickLevel.BEGINNER)},
     # Same reasons as above
     RandovaniaGame.SUPER_METROID: {("Shinespark", LayoutTrickLevel.BEGINNER)},
-    # Same reasons as above
-    RandovaniaGame.METROID_SAMUS_RETURNS: {("Spiderspark", LayoutTrickLevel.BEGINNER)},
+    # Some items require Spider Boosting to reach in vanilla, but since it is never explained there,
+    # it has been made into a trick.
+    RandovaniaGame.METROID_SAMUS_RETURNS: {("Spider Boost", LayoutTrickLevel.BEGINNER)},
 }
 
 


### PR DESCRIPTION
Using the more official name is better plus consistency with hints and the unused in game text (now used in game).