### PR TITLE
Fix StandardPickupWidget for entries where shuffle count don't match progressive count.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [7.4.0] - 2024-03-??
 
 - Added: A warning will be shown when trying to generate a game where more items are in the pool than the maximum amount of items.
+- Fixed: In the Item Pool tab, selecting Shuffled now works properly for non-progressive entries with multiple copies and certain other items.
 - Fixed: Changelog window properly displays images.
 - Fixed: Cancelling connecting to the server is better handled now.
 

--- a/randovania/gui/preset_settings/item_pool_tab.py
+++ b/randovania/gui/preset_settings/item_pool_tab.py
@@ -17,10 +17,10 @@ from randovania.gui.generated.preset_item_pool_ui import Ui_PresetItemPool
 from randovania.gui.lib import common_qt_lib
 from randovania.gui.lib.foldable import Foldable
 from randovania.gui.lib.scroll_protected import ScrollProtectedComboBox, ScrollProtectedSpinBox
-from randovania.gui.preset_settings.item_configuration_widget import StandardPickupWidget
 from randovania.gui.preset_settings.preset_tab import PresetTab
 from randovania.gui.preset_settings.progressive_item_widget import ProgressiveItemWidget
 from randovania.gui.preset_settings.split_ammo_widget import AmmoPickupWidgets
+from randovania.gui.preset_settings.standard_pickup_widget import StandardPickupWidget
 from randovania.layout.base.available_locations import RandomizationMode
 from randovania.layout.base.standard_pickup_state import StandardPickupState
 from randovania.layout.exceptions import InvalidConfiguration

--- a/randovania/gui/preset_settings/standard_pickup_widget.py
+++ b/randovania/gui/preset_settings/standard_pickup_widget.py
@@ -142,10 +142,14 @@ class StandardPickupWidget(QWidget, Ui_StandardPickupWidget):
             return StandardPickupState(include_copy_in_original_location=True, included_ammo=included_ammo)
 
         elif case == StandardPickupStateCase.STARTING_ITEM:
-            return StandardPickupState(num_included_in_starting_pickups=1, included_ammo=included_ammo)
+            return StandardPickupState(
+                num_included_in_starting_pickups=self._pickup.default_starting_count, included_ammo=included_ammo
+            )
 
         elif case == StandardPickupStateCase.SHUFFLED:
-            return StandardPickupState(num_shuffled_pickups=len(self._pickup.progression), included_ammo=included_ammo)
+            return StandardPickupState(
+                num_shuffled_pickups=self._pickup.default_shuffled_count, included_ammo=included_ammo
+            )
 
         else:
             return None
@@ -188,12 +192,6 @@ class StandardPickupWidget(QWidget, Ui_StandardPickupWidget):
             self.priority_combo.setCurrentIndex(priority_index)
 
         self.Changed.emit()
-
-    def button_box_accepted(self):
-        self.accept()
-
-    def button_box_rejected(self):
-        self.reject()
 
     def _on_select_case(self, _):
         self.set_custom_fields_visible(self.case == StandardPickupStateCase.CUSTOM)

--- a/test/gui/dialog/test_item_configuration_popup.py
+++ b/test/gui/dialog/test_item_configuration_popup.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from randovania.gui.lib.signal_handling import set_combo_with_value
-from randovania.gui.preset_settings.item_configuration_widget import StandardPickupWidget
+from randovania.gui.preset_settings.standard_pickup_widget import StandardPickupWidget
 from randovania.layout.base.standard_pickup_state import StandardPickupState, StandardPickupStateCase
 
 
@@ -44,6 +44,34 @@ def test_state_change_to_starting(skip_qtbot, echoes_pickup_database, echoes_res
         priority=1.0,
         included_ammo=(),
     )
+
+
+def test_state_change_to_shuffled(skip_qtbot, echoes_pickup_database, echoes_resource_database):
+    item = echoes_pickup_database.standard_pickups["Progressive Suit"]
+    state = StandardPickupState(
+        include_copy_in_original_location=False,
+        num_shuffled_pickups=1,
+        num_included_in_starting_pickups=0,
+        included_ammo=(),
+    )
+
+    # Run
+    popup = StandardPickupWidget(None, item, state, echoes_resource_database)
+    skip_qtbot.addWidget(popup)
+
+    # Initial State
+    assert popup.state == state
+    assert popup.case == StandardPickupStateCase.CUSTOM
+
+    # After Changing
+    set_combo_with_value(popup.state_case_combo, StandardPickupStateCase.SHUFFLED)
+    assert popup.state == StandardPickupState(
+        include_copy_in_original_location=False,
+        num_shuffled_pickups=2,
+        num_included_in_starting_pickups=0,
+        included_ammo=(),
+    )
+    assert popup.case == StandardPickupStateCase.SHUFFLED
 
 
 def test_state_must_be_starting(skip_qtbot, echoes_pickup_database, echoes_resource_database):


### PR DESCRIPTION


For example, Power Bombs in Echoes and Life Capsules for Cave Story.